### PR TITLE
WIP: Provide a script to test glueing together operators

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -10,6 +10,8 @@ this script.
 The ```config``` file contains configurable options.
 
 **Launch**
+The script requires `python-jinja2`. ```yum install -y python-jinja2```
+
 ```bash
 ./hack/operator-test.sh
 ```

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,15 @@
+## Operator Test Script
+**WARNING** The operator test script is not a permanent solution to deploying
+KubeVirt component operators.  It's a stop-gap solution to provide automation
+for launching component operators.
+
+The hyperconverged-cluster-operator (HCO) will slowly replace the contents of
+this script.
+
+**Configure**
+The ```config``` file contains configurable options.
+
+**Launch**
+```bash
+./hack/operator-test.sh
+```

--- a/hack/config
+++ b/hack/config
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+KUBEVIRT_VERSION="0.15.0"
+CDI_VERSION="1.6.0"
+
+CONTAINER_REGISTRY="docker.io/kubevirt"
+#CONTAINER_REGISTRY="brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888"

--- a/hack/config
+++ b/hack/config
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-KUBEVIRT_VERSION="0.15.0"
-CDI_VERSION="1.6.0"
+KUBEVIRT_VERSION="v0.15.0"
+CDI_VERSION="v1.6.0"
 
 CONTAINER_REGISTRY="docker.io/kubevirt"
 #CONTAINER_REGISTRY="brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888"

--- a/hack/defaults
+++ b/hack/defaults
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+TEMP_DIR=`mktemp -d`
+
+KUBEVIRT_MANIFEST_VERSION="v0.15.0"
+CDI_MANIFEST_VERSION="v1.6.0"
+
+function kubevirt_sed {
+    sed -i "s|          image: \&image docker\.io\/kubevirt\/virt-operator:${KUBEVIRT_MANIFEST_VERSION}|          image: ${CONTAINER_REGISTRY}\/virt-operator:${KUBEVIRT_VERSION}|g" ${TEMP_DIR}/kubevirt-operator.yaml
+}
+
+function cdi_sed {
+    sed -i "s|          image: kubevirt\/cdi-operator:${CDI_MANIFEST_VERSION}|          image: ${CONTAINER_REGISTRY}\/cdi-operator:${CDI_VERSION}|g" ${TEMP_DIR}/cdi-operator.yaml
+}
+
+# Deploy upstream operators
+OPERATOR_MANIFESTS="https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_MANIFEST_VERSION}/kubevirt-operator.yaml
+https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_MANIFEST_VERSION}/kubevirt-cr.yaml
+https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_MANIFEST_VERSION}/cdi-operator.yaml
+https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_MANIFEST_VERSION}/cdi-operator-cr.yaml"

--- a/hack/defaults
+++ b/hack/defaults
@@ -2,18 +2,21 @@
 
 TEMP_DIR=`mktemp -d`
 
+# Use upstream manifests with downstream containers
 KUBEVIRT_MANIFEST_VERSION="v0.15.0"
 CDI_MANIFEST_VERSION="v1.6.0"
 
-CDI_CONTAINER_REGISTRY="${CONTAINER_REGISTRY}"
-KUBEVIRT_CONTAINER_REGISTRY="${CONTAINER_REGISTRY}"
+CDI_CONTAINER_REGISTRY="${CDI_CONTAINER_REGISTRY:-docker.io/kubevirt}"
+KUBEVIRT_CONTAINER_REGISTRY="${KUBEVIRT_CONTAINER_REGISTRY:-docker.io/kubevirt}"
+
+CDI_OPERATOR_NAME="${CDI_OPERATOR_NAME:-cdi-operator}"
 
 function kubevirt_sed {
     sed -i "s|          image: \&image docker\.io\/kubevirt\/virt-operator:${KUBEVIRT_MANIFEST_VERSION}|          image: \&image ${KUBEVIRT_CONTAINER_REGISTRY}\/virt-operator:${KUBEVIRT_VERSION}|g" ${TEMP_DIR}/kubevirt-operator.yaml
 }
 
 function cdi_sed {
-    sed -i "s|          image: kubevirt\/cdi-operator:${CDI_MANIFEST_VERSION}|          image: ${CDI_CONTAINER_REGISTRY}\/cdi-operator:${CDI_VERSION}|g" ${TEMP_DIR}/cdi-operator.yaml
+    sed -i "s|          image: kubevirt\/cdi-operator:${CDI_MANIFEST_VERSION}|          image: ${CDI_CONTAINER_REGISTRY}\/${CDI_OPERATOR_NAME}:${CDI_VERSION}|g" ${TEMP_DIR}/cdi-operator.yaml
 }
 
 # Deploy upstream operators

--- a/hack/defaults
+++ b/hack/defaults
@@ -11,17 +11,41 @@ KUBEVIRT_CONTAINER_REGISTRY="${KUBEVIRT_CONTAINER_REGISTRY:-docker.io/kubevirt}"
 
 CDI_OPERATOR_NAME="${CDI_OPERATOR_NAME:-cdi-operator}"
 
+CDI_DOCKER_PREFIX=`basename "${CDI_CONTAINER_REGISTRY}"`
+
+CONTROLLER_IMAGE="${CONTROLLER_IMAGE:-cdi-controller}"
+IMPORTER_IMAGE="${IMPORTER_IMAGE:-cdi-importer}"
+CLONER_IMAGE="${CLONER_IMAGE:-cdi-cloner}"
+APISERVER_IMAGE="${APISERVER_IMAGE:-cdi-apiserver}"
+UPLOADPROXY_IMAGE="${UPLOADPROXY_IMAGE:-cdi-uploadproxy}"
+UPLOADSERVER_IMAGE="${UPLOADSERVER_IMAGE:-cdi-uploadserver}"
+
+if echo "${CDI_CONTAINER_REGISTRY}" | grep 'brew'; then
+    CONTROLLER_IMAGE="virt-${CONTROLLER_IMAGE}"
+    IMPORTER_IMAGE="virt-$IMPORTER_IMAGE"
+    CLONER_IMAGE="virt-$CLONER_IMAGE"
+    APISERVER_IMAGE="virt-$APISERVER_IMAGE"
+    UPLOADPROXY_IMAGE="virt-$UPLOADPROXY_IMAGE"
+    UPLOADSERVER_IMAGE="virt-$UPLOADSERVER_IMAGE"
+fi
+
 function kubevirt_sed {
     sed -i "s|          image: \&image docker\.io\/kubevirt\/virt-operator:${KUBEVIRT_MANIFEST_VERSION}|          image: \&image ${KUBEVIRT_CONTAINER_REGISTRY}\/virt-operator:${KUBEVIRT_VERSION}|g" ${TEMP_DIR}/kubevirt-operator.yaml
 }
 
 function cdi_sed {
-    sed -i "s|          image: kubevirt\/cdi-operator:${CDI_MANIFEST_VERSION}|          image: ${CDI_CONTAINER_REGISTRY}\/${CDI_OPERATOR_NAME}:${CDI_VERSION}|g" ${TEMP_DIR}/cdi-operator.yaml
+    sed -i "s|          image: kubevirt\/cdi-operator:${CDI_MANIFEST_VERSION}|          image: ${CDI_CONTAINER_REGISTRY}\/${CDI_OPERATOR_NAME}:${CDI_VERSION}|g" ${TEMP_DIR}/cdi-operator.yaml.j2
+
+    ls "${TEMP_DIR}"/cdi-operator.yaml.j2
+
+    python "${REPO_ROOT}"/hack/jinja2/cdi-j2.py "${TEMP_DIR}"/cdi-operator.yaml.j2 "${CDI_DOCKER_PREFIX}" "${CDI_OPERATOR_NAME}" "${CDI_VERSION}" "${CONTROLLER_IMAGE}" "${IMPORTER_IMAGE}" "${CLONER_IMAGE}" "${APISERVER_IMAGE}" "${UPLOADPROXY_IMAGE}" "${UPLOADSERVER_IMAGE}"
+
+    rm "${TEMP_DIR}"/cdi-operator.yaml.j2
 }
 
 # Deploy upstream operators
 OPERATOR_MANIFESTS="https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_MANIFEST_VERSION}/kubevirt-operator.yaml
-https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_MANIFEST_VERSION}/cdi-operator.yaml"
+https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_MANIFEST_VERSION}/cdi-operator.yaml.j2"
 
 OPERATOR_CRS="https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_MANIFEST_VERSION}/kubevirt-cr.yaml
 https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_MANIFEST_VERSION}/cdi-operator-cr.yaml"

--- a/hack/defaults
+++ b/hack/defaults
@@ -6,7 +6,7 @@ KUBEVIRT_MANIFEST_VERSION="v0.15.0"
 CDI_MANIFEST_VERSION="v1.6.0"
 
 function kubevirt_sed {
-    sed -i "s|          image: \&image docker\.io\/kubevirt\/virt-operator:${KUBEVIRT_MANIFEST_VERSION}|          image: ${CONTAINER_REGISTRY}\/virt-operator:${KUBEVIRT_VERSION}|g" ${TEMP_DIR}/kubevirt-operator.yaml
+    sed -i "s|          image: \&image docker\.io\/kubevirt\/virt-operator:${KUBEVIRT_MANIFEST_VERSION}|          image: \&image ${CONTAINER_REGISTRY}\/virt-operator:${KUBEVIRT_VERSION}|g" ${TEMP_DIR}/kubevirt-operator.yaml
 }
 
 function cdi_sed {
@@ -15,6 +15,7 @@ function cdi_sed {
 
 # Deploy upstream operators
 OPERATOR_MANIFESTS="https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_MANIFEST_VERSION}/kubevirt-operator.yaml
-https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_MANIFEST_VERSION}/kubevirt-cr.yaml
-https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_MANIFEST_VERSION}/cdi-operator.yaml
+https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_MANIFEST_VERSION}/cdi-operator.yaml"
+
+OPERATOR_CRS="https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_MANIFEST_VERSION}/kubevirt-cr.yaml
 https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_MANIFEST_VERSION}/cdi-operator-cr.yaml"

--- a/hack/defaults
+++ b/hack/defaults
@@ -5,12 +5,15 @@ TEMP_DIR=`mktemp -d`
 KUBEVIRT_MANIFEST_VERSION="v0.15.0"
 CDI_MANIFEST_VERSION="v1.6.0"
 
+CDI_CONTAINER_REGISTRY="${CONTAINER_REGISTRY}"
+KUBEVIRT_CONTAINER_REGISTRY="${CONTAINER_REGISTRY}"
+
 function kubevirt_sed {
-    sed -i "s|          image: \&image docker\.io\/kubevirt\/virt-operator:${KUBEVIRT_MANIFEST_VERSION}|          image: \&image ${CONTAINER_REGISTRY}\/virt-operator:${KUBEVIRT_VERSION}|g" ${TEMP_DIR}/kubevirt-operator.yaml
+    sed -i "s|          image: \&image docker\.io\/kubevirt\/virt-operator:${KUBEVIRT_MANIFEST_VERSION}|          image: \&image ${KUBEVIRT_CONTAINER_REGISTRY}\/virt-operator:${KUBEVIRT_VERSION}|g" ${TEMP_DIR}/kubevirt-operator.yaml
 }
 
 function cdi_sed {
-    sed -i "s|          image: kubevirt\/cdi-operator:${CDI_MANIFEST_VERSION}|          image: ${CONTAINER_REGISTRY}\/cdi-operator:${CDI_VERSION}|g" ${TEMP_DIR}/cdi-operator.yaml
+    sed -i "s|          image: kubevirt\/cdi-operator:${CDI_MANIFEST_VERSION}|          image: ${CDI_CONTAINER_REGISTRY}\/cdi-operator:${CDI_VERSION}|g" ${TEMP_DIR}/cdi-operator.yaml
 }
 
 # Deploy upstream operators

--- a/hack/jinja2/cdi-j2.py
+++ b/hack/jinja2/cdi-j2.py
@@ -1,0 +1,45 @@
+#!/bin/env python
+
+import sys
+import os
+from jinja2 import Environment, FileSystemLoader
+
+j2FilePath = sys.argv[1]
+dockerPrefix = sys.argv[2]
+operatorImage = sys.argv[3]
+dockerTag = sys.argv[4]
+
+controllerImage = sys.argv[5]
+importerImage = sys.argv[6]
+clonerImage = sys.argv[7]
+apiserverImage = sys.argv[8]
+uploadproxyImage = sys.argv[9]
+uploadserverImage = sys.argv[10]
+
+cdiNamespace = "cdi"
+pullPolicy = "IfNotPresent"
+verbosity = "1"
+
+
+env = Environment(loader=FileSystemLoader(os.path.dirname(j2FilePath)),
+                  trim_blocks=True)
+
+template = env.get_template("cdi-operator.yaml.j2")
+rendered_template = template.render(docker_prefix=dockerPrefix,
+                                    operator_image=operatorImage,
+                                    docker_tag=dockerTag,
+                                    controller_image=controllerImage,
+                                    importer_image=importerImage,
+                                    cloner_image=clonerImage,
+                                    apiserver_image=apiserverImage,
+                                    uploadproxy_image=uploadproxyImage,
+                                    uploadserver_image=uploadserverImage,
+
+                                    cdi_namespace=cdiNamespace,
+                                    pull_policy=pullPolicy,
+                                    verbosity=verbosity
+                                    )
+
+cdi = open(os.path.dirname(j2FilePath) + "/cdi-operator.yaml", "w")
+cdi.write(rendered_template)
+cdi.close()

--- a/hack/operator-test.sh
+++ b/hack/operator-test.sh
@@ -34,6 +34,9 @@ set -x
 
 oc create -f ${TEMP_DIR}/
 
+echo "Give resources time to show up"
+sleep 10
+
 VIRT_POD=`oc get pods -n kubevirt | grep virt-operator | head -1 | awk '{ print $1 }'`
 CDI_POD=`oc get pods -n cdi | grep cdi-operator | head -1 | awk '{ print $1 }'`
 oc wait pod $VIRT_POD --for condition=Ready -n kubevirt
@@ -42,5 +45,5 @@ oc wait pod $CDI_POD --for condition=Ready -n cdi
 oc create -f ${TEMP_DIR}/crs
 
 echo "Let the API server process the CRs"
-sleep 5
+sleep 10
 oc wait kubevirt kubevirt --for condition=Ready -n kubevirt

--- a/hack/operator-test.sh
+++ b/hack/operator-test.sh
@@ -20,8 +20,27 @@ for manifest in $OPERATOR_MANIFESTS; do
     wget -P "${TEMP_DIR}" "${manifest}"
 done
 
+for crs in $OPERATOR_CRS; do
+    echo "${crs}"
+    wget -P "${TEMP_DIR}/crs" "${crs}"
+done
+
 kubevirt_sed
 cdi_sed
 echo "Replaced image strings"
 
+set +e
+set -x
+
 oc create -f ${TEMP_DIR}/
+
+VIRT_POD=`oc get pods -n kubevirt | grep virt-operator | head -1 | awk '{ print $1 }'`
+CDI_POD=`oc get pods -n cdi | grep cdi-operator | head -1 | awk '{ print $1 }'`
+oc wait pod $VIRT_POD --for condition=Ready -n kubevirt
+oc wait pod $CDI_POD --for condition=Ready -n cdi
+
+oc create -f ${TEMP_DIR}/crs
+
+echo "Let the API server process the CRs"
+sleep 5
+oc wait kubevirt kubevirt --for condition=Ready -n kubevirt

--- a/hack/operator-test.sh
+++ b/hack/operator-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+TMP_ROOT="$(dirname "${BASH_SOURCE[@]}")/.."
+REPO_ROOT=$(readlink -e "${TMP_ROOT}" 2> /dev/null || perl -MCwd -e 'print Cwd::abs_path shift' "${TMP_ROOT}")
+
+function clean {
+    rm -rf "${TEMP_DIR}"
+    echo "Deleted working dir ${TEMP_DIR}"
+}
+
+source "${REPO_ROOT}"/hack/config
+source "${REPO_ROOT}"/hack/defaults
+
+trap clean EXIT
+
+for manifest in $OPERATOR_MANIFESTS; do
+    echo "${manifest}"
+    wget -P "${TEMP_DIR}" "${manifest}"
+done
+
+kubevirt_sed
+cdi_sed
+echo "Replaced image strings"
+
+oc create -f ${TEMP_DIR}/


### PR DESCRIPTION
This script is meant to glue together existing operators while the HCO is being developed.   Essentially, this script will do a bunch of `oc create -f` commands of upstream operators manifests so folks can see all the operators deployed together.  This script doesn't not currently employ OLM.  Expect configuration of this script to be very limited.