### PR TITLE
operator-test.sh: add timeout parameter to oc-wait

### DIFF
--- a/hack/defaults
+++ b/hack/defaults
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TEMP_DIR=`mktemp -d`
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-30s}"
 
 # Use upstream manifests with downstream containers
 KUBEVIRT_MANIFEST_VERSION="v0.15.0"

--- a/hack/operator-test.sh
+++ b/hack/operator-test.sh
@@ -41,12 +41,12 @@ sleep 10
 VIRT_POD=`oc get pods -n kubevirt | grep virt-operator | head -1 | awk '{ print $1 }'`
 CDI_POD=`oc get pods -n cdi | grep cdi-operator | head -1 | awk '{ print $1 }'`
 NETWORK_ADDONS_POD=`oc get pods -n cluster-network-addons-operator | grep cluster-network-addons-operator | head -1 | awk '{ print $1 }'`
-oc wait pod $VIRT_POD --for condition=Ready -n kubevirt
-oc wait pod $CDI_POD --for condition=Ready -n cdi
-oc wait pod $NETWORK_ADDONS_POD --for condition=Ready -n cluster-network-addons-operator
+oc wait pod $VIRT_POD --for condition=Ready -n kubevirt --timeout="${WAIT_TIMEOUT}"
+oc wait pod $CDI_POD --for condition=Ready -n cdi --timeout="${WAIT_TIMEOUT}"
+oc wait pod $NETWORK_ADDONS_POD --for condition=Ready -n cluster-network-addons-operator --timeout="${WAIT_TIMEOUT}"
 
 oc create -f ${TEMP_DIR}/crs
 
 echo "Let the API server process the CRs"
 sleep 10
-oc wait kubevirt kubevirt --for condition=Ready -n kubevirt
+oc wait kubevirt kubevirt --for condition=Ready -n kubevirt --timeout="${WAIT_TIMEOUT}"


### PR DESCRIPTION
By default there is 30s timeout for oc-wait,
on weak or overloaded systems it takes more time.
And this script is failing on timeout.

This option should give me option to increase this timeout for my
systems.

Signed-off-by: Lukas Bednar <lbednar@redhat.com>