### PR TITLE
Use cnv-sriov for converged operator manifest

### DIFF
--- a/deploy/converged/operator.yaml
+++ b/deploy/converged/operator.yaml
@@ -190,7 +190,7 @@ spec:
         - name: SRIOV_NETWORK_NAME
           value: sriov-network
         - name: SRIOV_NETWORK_TYPE
-          value: sriov
+          value: cnv-sriov
         - name: KUBEMACPOOL_IMAGE
           value: quay.io/schseba/mac-controller:latest
         - name: OPERATOR_IMAGE

--- a/hack/defaults
+++ b/hack/defaults
@@ -28,7 +28,6 @@ NETWORK_ADDONS_LINUX_BRIDGE_CNI_IMAGE="${NETWORK_ADDONS_LINUX_BRIDGE_CNI_IMAGE:-
 NETWORK_ADDONS_SRIOV_DP_IMAGE="${NETWORK_ADDONS_SRIOV_DP_IMAGE:-quay.io/booxter/sriov-device-plugin:latest}"
 NETWORK_ADDONS_SRIOV_CNI_IMAGE="${NETWORK_ADDONS_SRIOV_CNI_IMAGE:-docker.io/nfvpe/sriov-cni:latest}"
 NETWORK_ADDONS_KUBEMACPOOL_IMAGE="${NETWORK_ADDONS_KUBEMACPOOL_IMAGE:-quay.io/schseba/mac-controller:latest}"
-NETWORK_ADDONS_SRIOV_NETWORK_TYPE="${NETWORK_ADDONS_SRIOV_NETWORK_TYPE:-sriov}"
 
 if echo "${CDI_CONTAINER_REGISTRY}" | grep 'brew'; then
     CONTROLLER_IMAGE="virt-${CONTROLLER_IMAGE}"
@@ -60,7 +59,6 @@ function network_addons_sed {
     sed -i "s|value: .*sriov-device-plugin.*|value: ${NETWORK_ADDONS_SRIOV_DP_IMAGE}|g" ${TEMP_DIR}/operator.yaml
     sed -i "s|value: .*sriov-cni.*|value: ${NETWORK_ADDONS_SRIOV_CNI_IMAGE}|g" ${TEMP_DIR}/operator.yaml
     sed -i "s|value: .*mac-controller.*|value: ${NETWORK_ADDONS_KUBEMACPOOL_IMAGE}|g" ${TEMP_DIR}/operator.yaml
-    sed -i "s|value: sriov$|value: ${NETWORK_ADDONS_SRIOV_NETWORK_TYPE}|g" ${TEMP_DIR}/operator.yaml
 }
 
 # Deploy upstream operators


### PR DESCRIPTION
The manifest is for CNV, and we should always use cnv- prefix for sriov
plugin there. Since there is no need to override the type for regular
deployments, general ability to override it is removed from
hack/defaults.

Fixes #39