### PR TITLE
Add missing courier code to templates

### DIFF
--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
@@ -5,8 +5,13 @@ metadata:
   namespace: placeholder
   annotations:
     capabilities: "Full Lifecycle"
-    categories: "Virtualization"
-    alm-examples: |
+    categories: "OpenShift Optional"
+    certified: "false"
+    support: "false"
+    containerImage: quay.io/community-operators/kubevirt/hyperconverged-cluster-operator:0.0.1
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    createdAt: 2019-04-17T16:01:59Z
+    alm-examples: >-
       [
         {
           "apiVersion":"hco.kubevirt.io/v1alpha1",
@@ -15,9 +20,27 @@ metadata:
             "name":"kubevirt-hyperconverged",
             "namespace":"kubevirt-hyperconverged"
           },
-          "spec": {
-            "CDIImagePullPolicy":"IfNotPresent",
-            "KubeVirtImagePullPolicy":"IfNotPresent"
+        },
+        {
+          "apiVersion": "cdi.kubevirt.io/v1alpha1",
+          "kind": "CDI",
+          "metadata": {
+            "name": "cdi"
+          }
+        },
+        {
+          "apiVersion": "kubevirt.io/v1alpha3",
+          "kind": "KubeVirt",
+          "metadata": {
+            "name": "kubevirt",
+            "namespace": "kubevirt"
+          }
+        },
+        {
+          "apiVersion": "networkaddonsoperator.network.kubevirt.io/v1alpha1",
+          "kind": "NetworkAddonsConfig",
+          "metadata": {
+            "name": "cluster"
           }
         }
       ]

--- a/deploy/standard/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/standard/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
@@ -5,8 +5,13 @@ metadata:
   namespace: placeholder
   annotations:
     capabilities: "Full Lifecycle"
-    categories: "Virtualization"
-    alm-examples: |
+    categories: "OpenShift Optional"
+    certified: "false"
+    support: "false"
+    containerImage: quay.io/community-operators/kubevirt/hyperconverged-cluster-operator:0.0.1
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    createdAt: 2019-04-17T16:01:59Z
+    alm-examples: >-
       [
         {
           "apiVersion":"hco.kubevirt.io/v1alpha1",
@@ -15,9 +20,27 @@ metadata:
             "name":"kubevirt-hyperconverged",
             "namespace":"kubevirt-hyperconverged"
           },
-          "spec": {
-            "CDIImagePullPolicy":"IfNotPresent",
-            "KubeVirtImagePullPolicy":"IfNotPresent"
+        },
+        {
+          "apiVersion": "cdi.kubevirt.io/v1alpha1",
+          "kind": "CDI",
+          "metadata": {
+            "name": "cdi"
+          }
+        },
+        {
+          "apiVersion": "kubevirt.io/v1alpha3",
+          "kind": "KubeVirt",
+          "metadata": {
+            "name": "kubevirt",
+            "namespace": "kubevirt"
+          }
+        },
+        {
+          "apiVersion": "networkaddonsoperator.network.kubevirt.io/v1alpha1",
+          "kind": "NetworkAddonsConfig",
+          "metadata": {
+            "name": "cluster"
           }
         }
       ]

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -5,8 +5,13 @@ metadata:
   namespace: placeholder
   annotations:
     capabilities: "Full Lifecycle"
-    categories: "Virtualization"
-    alm-examples: |
+    categories: "OpenShift Optional"
+    certified: "false"
+    support: "false"
+    containerImage: quay.io/community-operators/kubevirt/hyperconverged-cluster-operator:{{.CsvVersion}}
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    createdAt: 2019-04-17T16:01:59Z
+    alm-examples: >-
       [
         {
           "apiVersion":"hco.kubevirt.io/v1alpha1",
@@ -15,9 +20,27 @@ metadata:
             "name":"kubevirt-hyperconverged",
             "namespace":"kubevirt-hyperconverged"
           },
-          "spec": {
-            "CDIImagePullPolicy":"IfNotPresent",
-            "KubeVirtImagePullPolicy":"IfNotPresent"
+        },
+        {
+          "apiVersion": "cdi.kubevirt.io/v1alpha1",
+          "kind": "CDI",
+          "metadata": {
+            "name": "cdi"
+          }
+        },
+        {
+          "apiVersion": "kubevirt.io/v1alpha3",
+          "kind": "KubeVirt",
+          "metadata": {
+            "name": "kubevirt",
+            "namespace": "kubevirt"
+          }
+        },
+        {
+          "apiVersion": "networkaddonsoperator.network.kubevirt.io/v1alpha1",
+          "kind": "NetworkAddonsConfig",
+          "metadata": {
+            "name": "cluster"
           }
         }
       ]


### PR DESCRIPTION
The code to make operator-courier verify our CSVs needs to get added
to the manifest generation code.

Follow up to https://github.com/kubevirt/hyperconverged-cluster-operator/pull/37