### PR TITLE
Create a script to point at quay registries for operator bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
+QUAY_USERNAME ?=
+QUAY_PASSWORD ?=
+
 start:
 	./hack/deploy.sh
 
 clean:
 	./hack/clean.sh
+
+stageRegistry:
+	@REGISTRY_NAMESPACE=redhat-operators-stage ./hack/quay-registry.sh $(QUAY_USERNAME) $(QUAY_PASSWORD)
 
 .PHONY: start clean

--- a/hack/quay-registry.sh
+++ b/hack/quay-registry.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+QUAY_USERNAME="${1:-}"
+QUAY_PASSWORD="${2:-}"
+
+if [ -z "${QUAY_USERNAME}" ]; then
+    echo "QUAY_USERNAME not set"
+    exit 1
+fi
+if [ -z "${QUAY_PASSWORD}" ]; then
+    echo "QUAY_PASSWORD not set"
+    exit 1
+fi
+
+TOKEN=$(curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '
+{
+    "user": {
+        "username": "'"${QUAY_USERNAME}"'",
+        "password": "'"${QUAY_PASSWORD}"'"
+    }
+}' | jq -r '.token')
+
+echo $TOKEN
+if [ "${TOKEN}" == "null" ]; then
+   echo "TOKEN was 'null'.  Did you enter the correct quay Username & Password?"
+   exit 1
+fi
+
+cat <<EOF | oc create -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: quay-registry-$REGISTRY_NAMESPACE
+  namespace: openshift-marketplace
+type: Opaque
+stringData:
+      token: "$TOKEN"
+EOF
+
+cat <<EOF | oc create -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: "${REGISTRY_NAMESPACE}"
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: $REGISTRY_NAMESPACE
+  displayName: "${REGISTRY_NAMESPACE}"
+  publisher: "Red Hat"
+  authorizationToken:
+    secretName: quay-registry-$REGISTRY_NAMESPACE
+EOF


### PR DESCRIPTION
This script is going to be for consuming downstream quay bundles until operators are published in operatorhub.io, then it can be used for both.  Will mention this in the README when operatorhub.io integration is complete.