### PR TITLE
ssp-operator: update manifests to export POD_NAME

### DIFF
--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
@@ -1340,6 +1340,10 @@ spec:
                       name: metrics
                     imagePullPolicy: Always
                     env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:

--- a/deploy/converged/operator.yaml
+++ b/deploy/converged/operator.yaml
@@ -237,6 +237,10 @@ spec:
             name: metrics
           imagePullPolicy: Always
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/converged/ssp-op
+++ b/deploy/converged/ssp-op
@@ -213,6 +213,10 @@ spec:
             name: metrics
           imagePullPolicy: Always
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -399,6 +399,10 @@ spec:
                       name: metrics
                     imagePullPolicy: Always
                     env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:

--- a/templates/operator.yaml.in
+++ b/templates/operator.yaml.in
@@ -27,6 +27,10 @@ spec:
             name: metrics
           imagePullPolicy: Always
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This environment variable is needed to run
the SSP operator on top of ansible-operator >= 0.4

Signed-off-by: Francesco Romani <fromani@redhat.com>