### PR TITLE
Fixed cluster_role manifest

### DIFF
--- a/deploy/converged/cluster_role.yaml
+++ b/deploy/converged/cluster_role.yaml
@@ -808,7 +808,7 @@ rules:
   - securitycontextconstraints
   verbs:
   - '*'
-  resourceName:
+  resourceNames:
   - privileged
 
 ---

--- a/deploy/converged/ssp-op
+++ b/deploy/converged/ssp-op
@@ -159,7 +159,7 @@ rules:
   - securitycontextconstraints
   verbs:
   - '*'
-  resourceName:
+  resourceNames:
   - privileged
 
 ---

--- a/templates/cluster_role.yaml.in
+++ b/templates/cluster_role.yaml.in
@@ -98,7 +98,7 @@ rules:
   - securitycontextconstraints
   verbs:
   - '*'
-  resourceName:
+  resourceNames:
   - privileged
 
 ---


### PR DESCRIPTION
When applying the manifests, one gets the following error:

error: error validating "deploy/converged/cluster_role.yaml": error
validating data: ValidationError(ClusterRole.rules[9]): unknown field
"resourceName" in io.k8s.api.rbac.v1.PolicyRule; if you choose to ignore
these errors, turn validation off with --validate=false

The right name for the attribute is resourceNames (plural).

Fixes #67