### PR TITLE
Enable CPU feature discovery for kubevirt

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -298,7 +298,7 @@ func newKubeVirtConfigForCR(cr *hcov1alpha1.HyperConverged) *corev1.ConfigMap {
 			Labels: labels,
 		},
 		Data: map[string]string{
-			"feature-gates": "DataVolumes,SRIOV,LiveMigration,CPUManager",
+			"feature-gates": "DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery",
 		},
 	}
 }


### PR DESCRIPTION
This patch enables the CPUNodeDiscovery feature gate that enables cpu model and feature based scheduling in kubevirt.