### PR TITLE
SSP: update operator APIs to 1.0.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,7 +10,7 @@
   version = "v0.37.4"
 
 [[projects]]
-  digest = "1:0c6944c0b0a1d2f4bd532983c0e591ec06ec6287d9262dcd7ce05273d4153c6f"
+  digest = "1:caa85a6c1bfe563d9ae4e9e54f54a8f182bba57d81715188e9fe79470bc314d5"
   name = "github.com/MarSik/kubevirt-ssp-operator"
   packages = [
     "pkg/apis",
@@ -18,8 +18,8 @@
     "pkg/versions",
   ]
   pruneopts = "NT"
-  revision = "dac8207d7df2668263ae5e7ce3611cba43fe78c4"
-  version = "v1.0.0"
+  revision = "0353c03465f6bcdc0fe42a10d655e8280ed091c4"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:0a111edd8693fd977f42a0c4f199a0efb13c20aec9da99ad8830c7bb6a87e8d6"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@ required = [
 
 [[override]]
   name = "github.com/MarSik/kubevirt-ssp-operator"
-  version = "v1.0.0"
+  version = "v1.0.1"
 
 [[override]]
   name = "github.com/kubevirt/web-ui-operator"

--- a/vendor/github.com/MarSik/kubevirt-ssp-operator/pkg/apis/kubevirt/v1/types.go
+++ b/vendor/github.com/MarSik/kubevirt-ssp-operator/pkg/apis/kubevirt/v1/types.go
@@ -33,7 +33,7 @@ type KubevirtTemplateValidator struct {
 
 // custom spec
 type VersionSpec struct {
-	Version string `json:"versopm,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/github.com/MarSik/kubevirt-ssp-operator/pkg/versions/versions.go
+++ b/vendor/github.com/MarSik/kubevirt-ssp-operator/pkg/versions/versions.go
@@ -5,9 +5,9 @@ package versions
 import "fmt"
 
 const (
-	KubevirtCommonTemplates   string = "0.4.1"
+	KubevirtCommonTemplates   string = "0.6.0"
 	KubevirtNodeLabeller      string = "0.0.5"
-	KubevirtTemplateValidator string = "0.3.0"
+	KubevirtTemplateValidator string = "0.4.8"
 )
 
 // TagForVersion converts the given version in a suitable tag


### PR DESCRIPTION
Update the SSP dep to pull the fixes to the go API pkg, and the latest default versions of the SSP components to deploy.

Resolves: https://bugzilla.redhat.com/1709268
Signed-off-by: Francesco Romani <fromani@redhat.com>