### PR TITLE
SSP: don't specify component versions

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -357,9 +357,6 @@ func newKubevirtCommonTemplateBundleForCR(cr *hcov1alpha1.HyperConverged) *sspv1
 			Labels:    labels,
 			Namespace: "openshift",
 		},
-		Spec: sspv1.VersionSpec{
-			Version: sspversions.TagForVersion(sspversions.KubevirtCommonTemplates),
-		},
 	}
 }
 
@@ -372,9 +369,6 @@ func newKubevirtNodeLabellerBundleForCR(cr *hcov1alpha1.HyperConverged) *sspv1.K
 			Name:   "node-labeller-" + cr.Name,
 			Labels: labels,
 		},
-		Spec: sspv1.VersionSpec{
-			Version: sspversions.TagForVersion(sspversions.KubevirtNodeLabeller),
-		},
 	}
 }
 
@@ -386,9 +380,6 @@ func newKubevirtTemplateValidatorForCR(cr *hcov1alpha1.HyperConverged) *sspv1.Ku
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "template-validator-" + cr.Name,
 			Labels: labels,
-		},
-		Spec: sspv1.VersionSpec{
-			Version: sspversions.TagForVersion(sspversions.KubevirtTemplateValidator),
 		},
 	}
 }


### PR DESCRIPTION
Just request the sub-components presence and let the operator
decide which version should be pulled.

Signed-off-by: Francesco Romani <fromani@redhat.com>