### PR TITLE
SSP: watch all the namespaces

### DIFF
--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
@@ -1406,9 +1406,7 @@ spec:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.namespace
+                        value: ""
                       - name: OPERATOR_NAME
                         value: "kubevirt-ssp-operator"
 

--- a/deploy/converged/operator.yaml
+++ b/deploy/converged/operator.yaml
@@ -235,9 +235,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"
 

--- a/deploy/converged/ssp-op
+++ b/deploy/converged/ssp-op
@@ -218,9 +218,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"
 

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -404,9 +404,7 @@ spec:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.namespace
+                        value: ""
                       - name: OPERATOR_NAME
                         value: "kubevirt-ssp-operator"
 

--- a/templates/operator.yaml.in
+++ b/templates/operator.yaml.in
@@ -32,9 +32,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"
 


### PR DESCRIPTION
The SSP operator needs to deploy the common templates in a namespace specified in the CR.
The code already takes the namespace to deploy the templates into from the CR, but it _only_ watches the namespace on which the operator is running.

In other words, the SSP operator can potentially deploy the templates in any namespaces[1], but it just watches one namespace, actually voiding this option.

To fix this, this patchset makes the HCO configure the SSP operator to watch all the cluster namespaces, not just the one on which the SSP operator runs.

This way we can submit a CR to install templates in any namespace (say: `openshift` while the operator is running in the `kubevirt-hyperconverged` namespace), the SSP operator will pick it up, learn on which namespace it should deploy the templates from the CR, and finally deploy them.

+++

[1] according to the initial testing, the RBAC permissions we set for the SSP operator are already correct - this was the behaviour we wanted from the beginning: to watch just the current namespace
was an oversight.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1709268