### PR TITLE
SSP: update manifests to v1.0.3 (backport to release-2.0)

### DIFF
--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
@@ -152,62 +152,6 @@ spec:
               - update
               - delete
 
-        - serviceAccountName: kubevirt-ssp-operator
-          rules:
-          - apiGroups:
-            - ""
-            resources:
-            - pods
-            - services
-            - endpoints
-            - persistentvolumeclaims
-            - events
-            - configmaps
-            - secrets
-            - replicationcontrollers
-            - serviceaccounts
-            - templates
-            verbs:
-            - '*'
-          - apiGroups:
-            - extensions
-            - apps
-            resources:
-            - deployments
-            - replicasets
-            verbs:
-            - '*'
-          - apiGroups:
-            - ""
-            resources:
-            - namespaces
-            verbs:
-            - get
-          - apiGroups:
-            - apps
-            resources:
-            - deployments
-            - daemonsets
-            - replicasets
-            - statefulsets
-            verbs:
-            - '*'
-          - apiGroups:
-            - monitoring.coreos.com
-            resources:
-            - servicemonitors
-            verbs:
-            - get
-            - create
-          - apiGroups:
-            - kubevirt.io
-            - template.openshift.io
-            - route.openshift.io
-            resources:
-            - '*'
-            verbs:
-            - '*'
-
       clusterPermissions:
         - serviceAccountName: hyperconverged-cluster-operator
           rules:
@@ -1407,6 +1351,8 @@ spec:
                             fieldPath: metadata.name
                       - name: WATCH_NAMESPACE
                         value: ""
+                      - name: VIRT_LAUNCHER_TAG
+                        value: v0.17.0
                       - name: OPERATOR_NAME
                         value: "kubevirt-ssp-operator"
 

--- a/deploy/converged/operator.yaml
+++ b/deploy/converged/operator.yaml
@@ -236,6 +236,8 @@ spec:
                   fieldPath: metadata.name
             - name: WATCH_NAMESPACE
               value: ""
+            - name: VIRT_LAUNCHER_TAG
+              value: v0.17.0
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"
 

--- a/deploy/converged/ssp-op
+++ b/deploy/converged/ssp-op
@@ -5,67 +5,6 @@ metadata:
   name: kubevirt-ssp-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  name: kubevirt-ssp-operator
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  - replicationcontrollers
-  - serviceaccounts
-  - templates
-  verbs:
-  - '*'
-- apiGroups:
-  - extensions
-  - apps
-  resources:
-  - deployments
-  - replicasets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - kubevirt.io
-  - template.openshift.io
-  - route.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kubevirt-ssp-operator
@@ -163,19 +102,6 @@ rules:
   - privileged
 
 ---
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kubevirt-ssp-operator
-subjects:
-- kind: ServiceAccount
-  name: kubevirt-ssp-operator
-roleRef:
-  kind: Role
-  name: kubevirt-ssp-operator
-  apiGroup: rbac.authorization.k8s.io
-
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -219,6 +145,8 @@ spec:
                   fieldPath: metadata.name
             - name: WATCH_NAMESPACE
               value: ""
+            - name: VIRT_LAUNCHER_TAG
+              value: v0.17.0
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"
 

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -126,61 +126,6 @@ spec:
         - serviceAccountName: cluster-network-addons-operator
           rules:
 {{.CNA.Rules}}
-        - serviceAccountName: kubevirt-ssp-operator
-          rules:
-          - apiGroups:
-            - ""
-            resources:
-            - pods
-            - services
-            - endpoints
-            - persistentvolumeclaims
-            - events
-            - configmaps
-            - secrets
-            - replicationcontrollers
-            - serviceaccounts
-            - templates
-            verbs:
-            - '*'
-          - apiGroups:
-            - extensions
-            - apps
-            resources:
-            - deployments
-            - replicasets
-            verbs:
-            - '*'
-          - apiGroups:
-            - ""
-            resources:
-            - namespaces
-            verbs:
-            - get
-          - apiGroups:
-            - apps
-            resources:
-            - deployments
-            - daemonsets
-            - replicasets
-            - statefulsets
-            verbs:
-            - '*'
-          - apiGroups:
-            - monitoring.coreos.com
-            resources:
-            - servicemonitors
-            verbs:
-            - get
-            - create
-          - apiGroups:
-            - kubevirt.io
-            - template.openshift.io
-            - route.openshift.io
-            resources:
-            - '*'
-            verbs:
-            - '*'
 {{end}}
       clusterPermissions:
         - serviceAccountName: hyperconverged-cluster-operator
@@ -405,6 +350,8 @@ spec:
                             fieldPath: metadata.name
                       - name: WATCH_NAMESPACE
                         value: ""
+                      - name: VIRT_LAUNCHER_TAG
+                        value: v0.17.0
                       - name: OPERATOR_NAME
                         value: "kubevirt-ssp-operator"
 

--- a/templates/operator.yaml.in
+++ b/templates/operator.yaml.in
@@ -33,6 +33,8 @@ spec:
                   fieldPath: metadata.name
             - name: WATCH_NAMESPACE
               value: ""
+            - name: VIRT_LAUNCHER_TAG
+              value: v0.17.0
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"
 


### PR DESCRIPTION
Changes after 1.0.1 are only in manifests, not in the pkg/API.

Signed-off-by: Francesco Romani <fromani@redhat.com>