### PR TITLE
fix: node maintenance operator namespace

### DIFF
--- a/deploy/converged/operator.yaml
+++ b/deploy/converged/operator.yaml
@@ -248,7 +248,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: node-maintenance-operator
-  namespace: node-maintenance-operator
+  namespace: kubevirt-hyperconverged
 spec:
   replicas: 1
   selector:

--- a/templates/operator.yaml.in
+++ b/templates/operator.yaml.in
@@ -43,7 +43,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: node-maintenance-operator
-  namespace: node-maintenance-operator
+  namespace: {{.Namespace}}
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
* Fix #66
* Force node maintenance operator to run on the HCO default namespace
* Re-generate manifests