### PR TITLE
use finalizers for NetworkAddonsConfig cleanup

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -2,6 +2,7 @@ package hyperconverged
 
 import (
 	"context"
+	"time"
 
 	sspv1 "github.com/MarSik/kubevirt-ssp-operator/pkg/apis/kubevirt/v1"
 	networkaddons "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
@@ -11,10 +12,13 @@ import (
 	cdi "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	kubevirt "kubevirt.io/kubevirt/pkg/api/v1"
 
+	"encoding/json"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -26,6 +30,16 @@ import (
 )
 
 var log = logf.Log.WithName("controller_hyperconverged")
+
+const (
+	// We cannot set owner reference of cluster-wide resources to namespaced HyperConverged object. Therefore,
+	// use finalizers to manage the cleanup.
+	FinalizerName = "hyperconvergeds.hco.kubevirt.io"
+
+	// Foreground deletion finalizer is blocking removal of HyperConverged until explicitly dropped.
+	// TODO: Research whether there is a better way.
+	foregroundDeletionFinalizer = "foregroundDeletion"
+)
 
 // Add creates a new HyperConverged Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -142,6 +156,36 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
+	// Handle finalizers
+	if instance.ObjectMeta.DeletionTimestamp.IsZero() {
+		// Add the finalizer if it's not there
+		if !contains(instance.ObjectMeta.Finalizers, FinalizerName) {
+			instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, FinalizerName)
+			// Need to requeue because finalizer update does not change metadata.generation
+			return reconcile.Result{}, r.client.Update(context.TODO(), instance)
+		}
+	} else {
+		// If HyperConverged is to be removed and it contains its finalizer, perform cleanup of cluster-wide resources
+		if contains(instance.ObjectMeta.Finalizers, FinalizerName) {
+			result, err := manageComponentResourceRemoval(newNetworkAddonsForCR(instance), r.client, instance)
+			if err != nil {
+				log.Error(err, "Failed during NetworkAddonsConfig cleanup")
+				return result, nil
+			}
+
+			// Remove the finalizer
+			instance.ObjectMeta.Finalizers = drop(instance.ObjectMeta.Finalizers, FinalizerName)
+
+			// Remove foregroundDeletion finalizer if it is the last one to unblock resource removal
+			if len(instance.ObjectMeta.Finalizers) == 1 && contains(instance.ObjectMeta.Finalizers, foregroundDeletionFinalizer) {
+				instance.ObjectMeta.Finalizers = drop(instance.ObjectMeta.Finalizers, foregroundDeletionFinalizer)
+			}
+
+			// Need to requeue because finalizer update does not change metadata.generation
+			return reconcile.Result{}, r.client.Update(context.TODO(), instance)
+		}
+	}
+
 	// Define KubeVirt's configuration ConfigMap first
 	kvConfig := newKubeVirtConfigForCR(instance)
 	kvConfig.ObjectMeta.Namespace = request.Namespace
@@ -195,11 +239,6 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 
 	// Define a new NetworkAddonsConfig object
 	networkAddonsCR := newNetworkAddonsForCR(instance)
-
-	// Set HyperConverged instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, networkAddonsCR, r.scheme); err != nil {
-		return reconcile.Result{}, err
-	}
 
 	// Create the NetworkAddonsConfig CR if it doesn't already exist
 	result, err = manageComponentResource(networkAddonsCR, "NetworkAddonsConfig", r.client)
@@ -271,7 +310,14 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 	if err != nil {
 		return result, err
 	}
-	return result, nil
+
+	// Everything went fine, automatically reconcile after after a minute without observed activity to
+	// make sure that even deployed objects without owner reference will be re-created if removed.
+	// TODO djzager: What I think we should do is to lock down the HCO CR to a specified name
+	// (via environment variable on the operator deployment) and a specified namespace (can use the
+	// downward API to set an environment variable on the operator deployment getting the namespace
+	// where the operator was deployed).
+	return reconcile.Result{RequeueAfter: time.Minute}, nil
 }
 
 func manageComponentResource(o runtime.Object, kind string, c client.Client) (reconcile.Result, error) {
@@ -285,6 +331,32 @@ func manageComponentResource(o runtime.Object, kind string, c client.Client) (re
 
 	log.Info("Creating new resource", "Kind", kind)
 	return reconcile.Result{}, nil
+}
+
+func manageComponentResourceRemoval(o interface{}, c client.Client, cr *hcov1alpha1.HyperConverged) (reconcile.Result, error) {
+	resource, err := toUnstructured(o)
+	if err != nil {
+		log.Error(err, "Failed to convert object to Unstructured")
+		return reconcile.Result{}, err
+	}
+
+	err = c.Get(context.TODO(), types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}, resource)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Resource doesn't exist, there is nothing to remove", "Kind", resource.GetObjectKind())
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	labels := resource.GetLabels()
+	if app, labelExists := labels["app"]; !labelExists || app != cr.Name {
+		log.Info("Existing resource wasn't deployed by HCO, ignoring", "Kind", resource.GetObjectKind())
+		return reconcile.Result{}, nil
+	}
+
+	err = c.Delete(context.TODO(), resource)
+	return reconcile.Result{}, err
 }
 
 func newKubeVirtConfigForCR(cr *hcov1alpha1.HyperConverged) *corev1.ConfigMap {
@@ -334,6 +406,10 @@ func newNetworkAddonsForCR(cr *hcov1alpha1.HyperConverged) *networkaddons.Networ
 		"app": cr.Name,
 	}
 	return &networkaddons.NetworkAddonsConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NetworkAddonsConfig",
+			APIVersion: "networkaddonsoperator.network.kubevirt.io/v1alpha1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   networkaddonsnames.OPERATOR_CONFIG,
 			Labels: labels,
@@ -399,4 +475,37 @@ func newKWebUIForCR(cr *hcov1alpha1.HyperConverged) *kwebuis.KWebUI {
 			Version:                         "automatic",                          // special value to determine version dynamically from env variables; empty or missing value is reserved for deprovision
 		},
 	}
+}
+
+func contains(l []string, s string) bool {
+	for _, elem := range l {
+		if elem == s {
+			return true
+		}
+	}
+	return false
+}
+
+func drop(l []string, s string) []string {
+	newL := []string{}
+	for _, elem := range l {
+		if elem != s {
+			newL = append(newL, elem)
+		}
+	}
+	return newL
+}
+
+// toUnstructured convers an arbitrary object (which MUST obey the
+// k8s object conventions) to an Unstructured
+func toUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(b, u); err != nil {
+		return nil, err
+	}
+	return u, nil
 }


### PR DESCRIPTION
Kubernetes garbage collector doesn't support setting namespaced
resource as an owner reference of a cluster-wide resource. Due to
that, we have to perform cleanup of NetworkAddonsConfig via
a finalizer.