### PR TITLE
Move unit test package install setup into a script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ go:
 sudo: required
 dist: trusty
 
-install:
-    - go get github.com/mattn/goveralls
-    - go get -v github.com/onsi/ginkgo/ginkgo
-    - go get -v github.com/onsi/gomega
-    - go get -v -t ./...
-    - export PATH=$PATH:$HOME/gopath/bin
-
 services:
 - docker
 

--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,8 @@ help: ## Show this help screen
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 	@echo ''
 
-test-unit-install:
-	go get -u github.com/evanphx/json-patch 
-
-test-unit: test-unit-install
-	ginkgo -r -cover
+test-unit: 
+	./hack/unit-test.sh
 
 test: test-unit
 

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+go get github.com/mattn/goveralls
+go get -v github.com/onsi/ginkgo/ginkgo
+go get -v github.com/onsi/gomega
+go get -v -t ./...
+go get -u github.com/evanphx/json-patch 
+export PATH=$PATH:$HOME/gopath/bin
+
+ginkgo -r -cover


### PR DESCRIPTION
The packages required for unit testing also need to be
installed for other continous integration systems, and not just
for travis-ci. Let's move the install commands into a shell
script and have it integrated with the command that executes
the unit tests.

This way, running "make test" will install the required packages
and also run the unit tests.