### PR TITLE
SSP: update manifests to v1.0.4 (#120)

### DIFF
--- a/deploy/converged/cluster_role.yaml
+++ b/deploy/converged/cluster_role.yaml
@@ -771,6 +771,7 @@ metadata:
   name: kubevirt-ssp-operator
 rules:
 - apiGroups:
+  - kubevirt.io
   - oauth.openshift.io
   - template.openshift.io
   resources:
@@ -784,8 +785,10 @@ rules:
   verbs:
   - create
   - get
-  - patch
   - list
+  - watch
+  - patch
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -796,53 +799,57 @@ rules:
   - list
   - watch
   - patch
+  - update
 - apiGroups:
   - extensions
   - apps
   resources:
   - deployments
   - replicasets
-  verbs:
-  - create
-  - get
-  - patch
-  - list
-- apiGroups:
-  - apps
-  resources:
   - daemonsets
+  - statefulsets
   verbs:
-  - create
-  - get
-  - patch
+  - '*'
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
-  verbs:
-  - create
-  - get
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - pods
   - configmaps
   - nodes
+  - endpoints
+  - events
+  - secrets
   verbs:
   - create
   - get
   - patch
   - update
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   verbs:
-  - list
-  - get
   - create
+  - get
+  - list
   - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
@@ -936,6 +936,7 @@ spec:
         - serviceAccountName: kubevirt-ssp-operator
           rules:
           - apiGroups:
+            - kubevirt.io
             - oauth.openshift.io
             - template.openshift.io
             resources:
@@ -949,8 +950,10 @@ spec:
             verbs:
             - create
             - get
-            - patch
             - list
+            - watch
+            - patch
+            - update
           - apiGroups:
             - rbac.authorization.k8s.io
             resources:
@@ -961,53 +964,57 @@ spec:
             - list
             - watch
             - patch
+            - update
           - apiGroups:
             - extensions
             - apps
             resources:
             - deployments
             - replicasets
-            verbs:
-            - create
-            - get
-            - patch
-            - list
-          - apiGroups:
-            - apps
-            resources:
             - daemonsets
+            - statefulsets
             verbs:
-            - create
-            - get
-            - patch
+            - '*'
           - apiGroups:
             - ""
             resources:
             - serviceaccounts
-            verbs:
-            - create
-            - get
-            - patch
-          - apiGroups:
-            - ""
-            resources:
-            - pods
             - configmaps
             - nodes
+            - endpoints
+            - events
+            - secrets
             verbs:
             - create
             - get
             - patch
             - update
+            - list
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            verbs:
+            - '*'
           - apiGroups:
             - ""
             resources:
             - services
             verbs:
-            - list
-            - get
             - create
+            - get
+            - list
             - patch
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+            - list
+            - watch
           - apiGroups:
             - admissionregistration.k8s.io
             resources:

--- a/deploy/converged/ssp-op
+++ b/deploy/converged/ssp-op
@@ -10,6 +10,7 @@ metadata:
   name: kubevirt-ssp-operator
 rules:
 - apiGroups:
+  - kubevirt.io
   - oauth.openshift.io
   - template.openshift.io
   resources:
@@ -23,8 +24,10 @@ rules:
   verbs:
   - create
   - get
-  - patch
   - list
+  - watch
+  - patch
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -35,53 +38,57 @@ rules:
   - list
   - watch
   - patch
+  - update
 - apiGroups:
   - extensions
   - apps
   resources:
   - deployments
   - replicasets
-  verbs:
-  - create
-  - get
-  - patch
-  - list
-- apiGroups:
-  - apps
-  resources:
   - daemonsets
+  - statefulsets
   verbs:
-  - create
-  - get
-  - patch
+  - '*'
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
-  verbs:
-  - create
-  - get
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - pods
   - configmaps
   - nodes
+  - endpoints
+  - events
+  - secrets
   verbs:
   - create
   - get
   - patch
   - update
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   verbs:
-  - list
-  - get
   - create
+  - get
+  - list
   - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -151,6 +151,7 @@ spec:
         - serviceAccountName: kubevirt-ssp-operator
           rules:
           - apiGroups:
+            - kubevirt.io
             - oauth.openshift.io
             - template.openshift.io
             resources:
@@ -164,8 +165,10 @@ spec:
             verbs:
             - create
             - get
-            - patch
             - list
+            - watch
+            - patch
+            - update
           - apiGroups:
             - rbac.authorization.k8s.io
             resources:
@@ -176,53 +179,57 @@ spec:
             - list
             - watch
             - patch
+            - update
           - apiGroups:
             - extensions
             - apps
             resources:
             - deployments
             - replicasets
-            verbs:
-            - create
-            - get
-            - patch
-            - list
-          - apiGroups:
-            - apps
-            resources:
             - daemonsets
+            - statefulsets
             verbs:
-            - create
-            - get
-            - patch
+            - '*'
           - apiGroups:
             - ""
             resources:
             - serviceaccounts
-            verbs:
-            - create
-            - get
-            - patch
-          - apiGroups:
-            - ""
-            resources:
-            - pods
             - configmaps
             - nodes
+            - endpoints
+            - events
+            - secrets
             verbs:
             - create
             - get
             - patch
             - update
+            - list
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            verbs:
+            - '*'
           - apiGroups:
             - ""
             resources:
             - services
             verbs:
-            - list
-            - get
             - create
+            - get
+            - list
             - patch
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+            - list
+            - watch
           - apiGroups:
             - admissionregistration.k8s.io
             resources:


### PR DESCRIPTION
* SSP: update manifests to v1.0.4

Changes after 1.0.1 are only in manifests, not in the pkg/API.

Fixes: https://bugzilla.redhat.com/1719333
Signed-off-by: Francesco Romani <fromani@redhat.com>

* cluster_role: fix permissions

(cherry picked from commit c62165e0de48e62cd3759bc7820e2a25c196ef44)