### PR TITLE
Disable KubeMacPool for CNV 2.0

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -417,7 +417,6 @@ func newNetworkAddonsForCR(cr *hcov1alpha1.HyperConverged) *networkaddons.Networ
 		Spec: networkaddons.NetworkAddonsConfigSpec{
 			Multus:      &networkaddons.Multus{},
 			LinuxBridge: &networkaddons.LinuxBridge{},
-			KubeMacPool: &networkaddons.KubeMacPool{},
 		},
 	}
 }


### PR DESCRIPTION
It has issues [1] handling certificates at the admission controller.

[1] [Bug 1723756] kubemacpool causes live migration to fail