### PR TITLE
Set component versions based on Gopkg.toml

### DIFF
--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
@@ -1026,6 +1026,8 @@ spec:
             - securitycontextconstraints
             verbs:
             - '*'
+            resourceNames:
+            - privileged
 
         - serviceAccountName: node-maintenance-operator
           rules:
@@ -1161,12 +1163,12 @@ spec:
                   - "2"
                   env:
                   - name: OPERATOR_IMAGE
-                    value: kubevirt/virt-operator:latest
+                    value: kubevirt/virt-operator:v0.18.1
                   - name: WATCH_NAMESPACE
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.annotations['olm.targetNamespaces']
-                  image: kubevirt/virt-operator:latest
+                  image: kubevirt/virt-operator:v0.18.1
                   imagePullPolicy: IfNotPresent
                   name: virt-operator
                   ports:
@@ -1304,9 +1306,9 @@ spec:
                   - name: OPERATOR_REGISTRY
                     value: quay.io/kubevirt
                   - name: OPERATOR_TAG
-                    value: latest
+                    value: v0.1.10
                   - name: WEBUI_TAG
-                    value: latest
+                    value: v0.1.10
                   - name: BRANDING
                     value: okdvirt
                   - name: IMAGE_PULL_POLICY
@@ -1323,7 +1325,7 @@ spec:
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.namespace
-                  image: quay.io/kubevirt/kubevirt-web-ui-operator:latest
+                  image: quay.io/kubevirt/kubevirt-web-ui-operator:v0.1.10
                   imagePullPolicy: IfNotPresent
                   name: kubevirt-web-ui-operator
                   ports:
@@ -1355,7 +1357,7 @@ spec:
                 serviceAccountName: kubevirt-ssp-operator
                 containers:
                   - name: kubevirt-ssp-operator
-                    image: quay.io/fromani/kubevirt-ssp-operator-container:latest
+                    image: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.1
                     ports:
                     - containerPort: 60000
                       name: metrics

--- a/deploy/converged/operator.yaml
+++ b/deploy/converged/operator.yaml
@@ -72,12 +72,12 @@ spec:
         - "2"
         env:
         - name: OPERATOR_IMAGE
-          value: kubevirt/virt-operator:latest
+          value: kubevirt/virt-operator:v0.18.1
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
-        image: kubevirt/virt-operator:latest
+        image: kubevirt/virt-operator:v0.18.1
         imagePullPolicy: IfNotPresent
         name: virt-operator
         ports:
@@ -226,7 +226,7 @@ spec:
       serviceAccountName: kubevirt-ssp-operator
       containers:
         - name: kubevirt-ssp-operator
-          image: quay.io/fromani/kubevirt-ssp-operator-container:latest
+          image: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.1
           ports:
           - containerPort: 60000
             name: metrics
@@ -308,9 +308,9 @@ spec:
         - name: OPERATOR_REGISTRY
           value: quay.io/kubevirt
         - name: OPERATOR_TAG
-          value: latest
+          value: v0.1.10
         - name: WEBUI_TAG
-          value: latest
+          value: v0.1.10
         - name: BRANDING
           value: okdvirt
         - name: IMAGE_PULL_POLICY
@@ -327,7 +327,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kubevirt/kubevirt-web-ui-operator:latest
+        image: quay.io/kubevirt/kubevirt-web-ui-operator:v0.1.10
         imagePullPolicy: IfNotPresent
         name: kubevirt-web-ui-operator
         ports:

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -15,10 +15,58 @@ CSV_VERSION="${CSV_VERSION:-0.0.1}"
 CONTAINER_PREFIX="${CONTAINER_PREFIX:-kubevirt}"
 CNA_CONTAINER_PREFIX="${CNA_CONTAINER_PREFIX:-quay.io/kubevirt}"
 WEBUI_CONTAINER_PREFIX="${WEBUI_CONTAINER_PREFIX:-quay.io/kubevirt}"
-CONTAINER_TAG="${CONTAINER_TAG:-latest}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
 
+# HCO Tag hardcoded to latest
+CONTAINER_TAG="${CONTAINER_TAG:-}"
+
 (cd ${PROJECT_ROOT}/tools/manifest-templator/ && go build)
+
+function versions {
+    KUBEVIRT_TAG="$(dep status -f='{{if eq .ProjectRoot "kubevirt.io/kubevirt"}}{{.Version}} {{end}}')"
+    echo "KubeVirt: ${KUBEVIRT_TAG}"
+
+    CDI_TAG="$(dep status -f='{{if eq .ProjectRoot "kubevirt.io/containerized-data-importer"}}{{.Version}} {{end}}')"
+    echo "CDI: ${CDI_TAG}"
+
+    SSP_TAG="$(dep status -f='{{if eq .ProjectRoot "github.com/MarSik/kubevirt-ssp-operator"}}{{.Version}} {{end}}')"
+    echo "SSP: ${SSP_TAG}"
+
+    WEB_UI_TAG="$(dep status -f='{{if eq .ProjectRoot "github.com/kubevirt/web-ui-operator"}}{{.Version}} {{end}}')"
+    echo "Web UI: ${WEB_UI_TAG}"
+
+    NETWORK_ADDONS_TAG="$(dep status -f='{{if eq .ProjectRoot "github.com/kubevirt/cluster-network-addons-operator"}}{{.Version}} {{end}}')"
+    echo "Network Addons: ${NETWORK_ADDONS_TAG}"
+
+    NMO_TAG=$(curl --silent "https://api.github.com/repos/kubevirt/node-maintenance-operator/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+    echo "NMO: ${NMO_TAG}   WARNING: Not using Gopkg.toml version"
+}
+
+function buildFlags {
+
+    BUILD_FLAGS="--hco-tag=latest \
+    --namespace=${NAMESPACE} \
+    --csv-version=${CSV_VERSION} \
+    --container-prefix=${CONTAINER_PREFIX} \
+    --image-pull-policy=${IMAGE_PULL_POLICY}"
+
+    if [ -z "${CONTAINER_TAG}" ]; then
+	versions
+
+	BUILD_FLAGS="${BUILD_FLAGS} \
+	--kubevirt-tag=${KUBEVIRT_TAG} \
+	--cdi-tag=${CDI_TAG} \
+	--ssp-tag=${SSP_TAG} \
+	--web-ui-tag=${WEB_UI_TAG} \
+	--nmo-tag=${NMO_TAG} \
+	--network-addons-tag=${NETWORK_ADDONS_TAG}"
+    else
+	BUILD_FLAGS="${BUILD_FLAGS} \
+	--container-tag=${CONTAINER_TAG}"
+    fi
+}
+
+buildFlags
 
 templates=$(cd ${PROJECT_ROOT}/templates && find . -type f -name "*.yaml.in")
 for template in $templates; do
@@ -30,14 +78,11 @@ for template in $templates; do
 
 	std_out_file="${std_out_dir}/$(basename -s .in $template)"
 	std_out_file=${std_out_file/VERSION/v$CSV_VERSION}
+
 	rendered=$( \
-		${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
-		--namespace=${NAMESPACE} \
-		--csv-version=${CSV_VERSION} \
-		--container-prefix=${CONTAINER_PREFIX} \
-		--container-tag=${CONTAINER_TAG} \
-		--image-pull-policy=${IMAGE_PULL_POLICY} \
-		--input-file=${infile} \
+                 ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
+                 ${BUILD_FLAGS} \
+                 --input-file=${infile} \
 	)
 	if [[ ! -z "$rendered" ]]; then
 		echo -e "$rendered" > $std_out_file
@@ -49,17 +94,14 @@ for template in $templates; do
 
 	converged_out_file="${converged_out_dir}/$(basename -s .in $template)"
 	converged_out_file=${converged_out_file/VERSION/v$CSV_VERSION}
+
 	rendered=$( \
-		${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
-		--converged \
-		--namespace=${NAMESPACE} \
-		--csv-version=${CSV_VERSION} \
-		--container-prefix=${CONTAINER_PREFIX} \
-		--cna-container-prefix=${CNA_CONTAINER_PREFIX} \
-		--webui-container-prefix=${WEBUI_CONTAINER_PREFIX} \
-		--container-tag=${CONTAINER_TAG} \
-		--image-pull-policy=${IMAGE_PULL_POLICY} \
-		--input-file=${infile} \
+                 ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
+                 ${BUILD_FLAGS} \
+                 --converged \
+                 --cna-container-prefix=${CNA_CONTAINER_PREFIX} \
+                 --webui-container-prefix=${WEBUI_CONTAINER_PREFIX} \
+                 --input-file=${infile} \
 	)
 	if [[ ! -z "$rendered" ]]; then
 		echo -e "$rendered" > $converged_out_file

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -246,6 +246,8 @@ spec:
             - securitycontextconstraints
             verbs:
             - '*'
+            resourceNames:
+            - privileged
 
         - serviceAccountName: node-maintenance-operator
           rules:
@@ -349,7 +351,7 @@ spec:
                 serviceAccountName: kubevirt-ssp-operator
                 containers:
                   - name: kubevirt-ssp-operator
-                    image: quay.io/fromani/kubevirt-ssp-operator-container:latest
+                    image: quay.io/fromani/kubevirt-ssp-operator-container:{{.SSP.Tag}}
                     ports:
                     - containerPort: 60000
                       name: metrics
@@ -362,7 +364,7 @@ spec:
                       - name: WATCH_NAMESPACE
                         value: ""
                       - name: VIRT_LAUNCHER_TAG
-                        value: v0.18.1
+                        value: {{.KubeVirt.Tag}}
                       - name: OPERATOR_NAME
                         value: "kubevirt-ssp-operator"
 
@@ -394,7 +396,7 @@ spec:
                         fieldPath: metadata.name
                   - name: OPERATOR_NAME
                     value: node-maintenance-operator
-                  image: quay.io/kubevirt/node-maintenance-operator:v0.3.0
+                  image: quay.io/kubevirt/node-maintenance-operator:{{.NMO.Tag}}
                   imagePullPolicy: Always
                   name: node-maintenance-operator
                   resources: {}

--- a/templates/operator.yaml.in
+++ b/templates/operator.yaml.in
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: kubevirt-ssp-operator
       containers:
         - name: kubevirt-ssp-operator
-          image: quay.io/fromani/kubevirt-ssp-operator-container:latest
+          image: quay.io/fromani/kubevirt-ssp-operator-container:{{.SSP.Tag}}
           ports:
           - containerPort: 60000
             name: metrics
@@ -34,7 +34,7 @@ spec:
             - name: WATCH_NAMESPACE
               value: ""
             - name: VIRT_LAUNCHER_TAG
-              value: v0.18.1
+              value: {{.KubeVirt.Tag}}
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"
 
@@ -67,7 +67,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: node-maintenance-operator
-          image: quay.io/kubevirt/node-maintenance-operator:v0.3.0
+          image: quay.io/kubevirt/node-maintenance-operator:{{.NMO.Tag}}
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -52,6 +52,7 @@ type operatorData struct {
 	CRD               *extv1beta1.CustomResourceDefinition
 	CRDString         string
 	CRString          string
+	Tag               string
 }
 
 type templateData struct {
@@ -61,13 +62,14 @@ type templateData struct {
 	ContainerPrefix      string
 	CnaContainerPrefix   string
 	WebuiContainerPrefix string
-	ContainerTag         string
 	ImagePullPolicy      string
 	HCO                  *operatorData
 	KubeVirt             *operatorData
 	CDI                  *operatorData
 	CNA                  *operatorData
 	KWEBUI               *operatorData
+	SSP                  *operatorData
+	NMO                  *operatorData
 }
 
 func check(err error) {
@@ -147,7 +149,7 @@ func getHCO(data *templateData) {
 	// Get HCO Deployment
 	hcodeployment := hcocomponents.GetDeployment(
 		"quay.io",
-		"latest",
+		data.HCO.Tag,
 		"Always",
 	)
 	err := marshallObject(hcodeployment, &writer)
@@ -187,16 +189,13 @@ func getHCO(data *templateData) {
 	marshallObject(cr, &writer)
 	crString := writer.String()
 
-	hcoData := operatorData{
-		Deployment:        deployment,
-		DeploymentSpec:    deploymentSpec,
-		ClusterRoleString: clusterRoleString,
-		Rules:             rules,
-		CRD:               crd,
-		CRDString:         crdString,
-		CRString:          crString,
-	}
-	data.HCO = &hcoData
+	data.HCO.Deployment = deployment
+	data.HCO.DeploymentSpec = deploymentSpec
+	data.HCO.ClusterRoleString = clusterRoleString
+	data.HCO.Rules = rules
+	data.HCO.CRD = crd
+	data.HCO.CRDString = crdString
+	data.HCO.CRString = crString
 }
 
 func getKubeVirt(data *templateData) {
@@ -206,7 +205,7 @@ func getKubeVirt(data *templateData) {
 	kvdeployment, err := kvcomponents.NewOperatorDeployment(
 		"kubevirt",
 		data.ContainerPrefix,
-		data.ContainerTag,
+		data.KubeVirt.Tag,
 		v1.PullPolicy(data.ImagePullPolicy),
 		"2",
 	)
@@ -243,15 +242,12 @@ func getKubeVirt(data *templateData) {
 	marshallObject(crd, &writer)
 	crdString := writer.String()
 
-	kvData := operatorData{
-		Deployment:        deployment,
-		DeploymentSpec:    deploymentSpec,
-		ClusterRoleString: clusterRoleString,
-		Rules:             rules,
-		CRD:               crd,
-		CRDString:         crdString,
-	}
-	data.KubeVirt = &kvData
+	data.KubeVirt.Deployment = deployment
+	data.KubeVirt.DeploymentSpec = deploymentSpec
+	data.KubeVirt.ClusterRoleString = clusterRoleString
+	data.KubeVirt.Rules = rules
+	data.KubeVirt.CRD = crd
+	data.KubeVirt.CRDString = crdString
 }
 
 func getCDI(data *templateData) {
@@ -298,15 +294,12 @@ func getCDI(data *templateData) {
 	marshallObject(crd, &writer)
 	crdString := writer.String()
 
-	cdiData := operatorData{
-		Deployment:        deployment,
-		DeploymentSpec:    deploymentSpec,
-		ClusterRoleString: clusterRoleString,
-		Rules:             rules,
-		CRD:               crd,
-		CRDString:         crdString,
-	}
-	data.CDI = &cdiData
+	data.CDI.Deployment = deployment
+	data.CDI.DeploymentSpec = deploymentSpec
+	data.CDI.ClusterRoleString = clusterRoleString
+	data.CDI.Rules = rules
+	data.CDI.CRD = crd
+	data.CDI.CRDString = crdString
 }
 
 func getCNA(data *templateData) {
@@ -366,27 +359,24 @@ func getCNA(data *templateData) {
 	marshallObject(crd, &writer)
 	crdString := writer.String()
 
-	cnaData := operatorData{
-		Deployment:        deployment,
-		DeploymentSpec:    deploymentSpec,
-		RoleString:        roleString,
-		Rules:             rules,
-		ClusterRoleString: clusterRoleString,
-		ClusterRules:      clusterRules,
-		CRD:               crd,
-		CRDString:         crdString,
-	}
-	data.CNA = &cnaData
+	data.CNA.Deployment = deployment
+	data.CNA.DeploymentSpec = deploymentSpec
+	data.CNA.RoleString = roleString
+	data.CNA.Rules = rules
+	data.CNA.ClusterRoleString = clusterRoleString
+	data.CNA.ClusterRules = clusterRules
+	data.CNA.CRD = crd
+	data.CNA.CRDString = crdString
 }
 
-func getKWWEBUI(data *templateData) {
+func getKWEBUI(data *templateData) {
 	writer := strings.Builder{}
 
 	// Get KWEBUI Deployment
 	kwebuideployment := kwebuicomponents.GetDeployment(
 		data.Namespace,
 		data.WebuiContainerPrefix,
-		data.ContainerTag,
+		data.KWEBUI.Tag,
 		data.ImagePullPolicy,
 	)
 	err := marshallObject(kwebuideployment, &writer)
@@ -435,17 +425,14 @@ func getKWWEBUI(data *templateData) {
 	marshallObject(crd, &writer)
 	crdString := writer.String()
 
-	kwebuiData := operatorData{
-		Deployment:        deployment,
-		DeploymentSpec:    deploymentSpec,
-		RoleString:        roleString,
-		Rules:             rules,
-		ClusterRoleString: clusterRoleString,
-		ClusterRules:      clusterRules,
-		CRD:               crd,
-		CRDString:         crdString,
-	}
-	data.KWEBUI = &kwebuiData
+	data.KWEBUI.Deployment = deployment
+	data.KWEBUI.DeploymentSpec = deploymentSpec
+	data.KWEBUI.RoleString = roleString
+	data.KWEBUI.Rules = rules
+	data.KWEBUI.ClusterRoleString = clusterRoleString
+	data.KWEBUI.ClusterRules = clusterRules
+	data.KWEBUI.CRD = crd
+	data.KWEBUI.CRDString = crdString
 }
 
 func main() {
@@ -455,9 +442,18 @@ func main() {
 	containerPrefix := flag.String("container-prefix", "kubevirt", "")
 	cnaContainerPrefix := flag.String("cna-container-prefix", *containerPrefix, "")
 	webuiContainerPrefix := flag.String("webui-container-prefix", *containerPrefix, "")
-	containerTag := flag.String("container-tag", "latest", "")
 	imagePullPolicy := flag.String("image-pull-policy", "IfNotPresent", "")
 	inputFile := flag.String("input-file", "", "")
+
+	containerTag := flag.String("container-tag", "latest", "")
+	hcoTag := flag.String("hco-tag", *containerTag, "")
+	kubevirtTag := flag.String("kubevirt-tag", *containerTag, "")
+	cdiTag := flag.String("cdi-tag", *containerTag, "")
+	sspTag := flag.String("ssp-tag", *containerTag, "")
+	webUITag := flag.String("web-ui-tag", *containerTag, "")
+	nmoTag := flag.String("nmo-tag", *containerTag, "")
+	networkAddonsTag := flag.String("network-addons-tag", *containerTag, "")
+
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
 	pflag.Parse()
@@ -469,8 +465,15 @@ func main() {
 		ContainerPrefix:      *containerPrefix,
 		CnaContainerPrefix:   *cnaContainerPrefix,
 		WebuiContainerPrefix: *webuiContainerPrefix,
-		ContainerTag:         *containerTag,
 		ImagePullPolicy:      *imagePullPolicy,
+
+		HCO:      &operatorData{Tag: *hcoTag},
+		KubeVirt: &operatorData{Tag: *kubevirtTag},
+		CDI:      &operatorData{Tag: *cdiTag},
+		CNA:      &operatorData{Tag: *networkAddonsTag},
+		KWEBUI:   &operatorData{Tag: *webUITag},
+		SSP:      &operatorData{Tag: *sspTag},
+		NMO:      &operatorData{Tag: *nmoTag},
 	}
 
 	// Load in all HCO Resources
@@ -482,7 +485,7 @@ func main() {
 	// Load in all CNA Resources
 	getCNA(&data)
 	// Load in all KWEBUI Resources
-	getKWWEBUI(&data)
+	getKWEBUI(&data)
 
 	if *inputFile == "" {
 		panic("Must specify input file")


### PR DESCRIPTION
Set image tags to what's currently in Gopkg.toml.   This will make sure that any CSV we publish will always reflect the code we vendor in.

fixes: https://github.com/kubevirt/hyperconverged-cluster-operator/issues/143