### PR TITLE
Standarize conditions across component operators

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -8,15 +8,18 @@ Conditions are..
 Kubernetes conditions [documentation](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
 
 The HCO’s CR is a representation of the all the underlying component operators'
-state.  If the the HCO's CR exists, then all component CRs exist, and all
-applications exist.  If the object doesn’t exist, all component CRs don’t exist,
-and all applications don't exist.  However, the CR existence doesn’t help us with the
-state where the operators exist, but are they healthy?  This is where conditions
-on the HCO’s CR and component operator CRs will answer this question by
-reflecting the last known condition of the underlying applications.
+state.  In theory, if the HCO's CR exists, then all component CRs _should_
+exist, and all applications _should_ exist.  If the object doesn’t exist, then
+all component CRs _should not_ exist, and all applications _should not_ exist.
+However, the CR existence can only can tell us if the application should exist and
+doesn't help us observe the application's health. This is where the HCO and
+component operators will use conditions on their CRs to reflect the health of
+the underlying application.  Component operators store conditions that are
+watched by the HCO and the HCO will store conditions that reflect the
+[worst state](https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/docs/conditions.md#hco-conditions) of all component operator conditions.
 
 ## Condition Struct
-We can use some of the CVO's [conditions](https://github.com/openshift/api/blob/master/config/v1/types_cluster_operator.go#L121-L133) to standardize across components.
+We can use some of the CVO's [conditions](https://github.com/openshift/api/blob/b1bcdbc/config/v1/types_cluster_operator.go#L123-L134) to standardize across components.
 
 Here's how the Condition struct will look...
 

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -43,8 +43,9 @@ type OperatorStatusCondition struct {
 `ConditionType` _specifies the state of the operator's reconciliation functionality_.
 `ConditionType`s use `ConditionStatus` to report state.  The `ConditionStatus`es
 we will use are either `True` or `False`.  The `ConditionStatus` object can also
-be `Unknown`, but we won't use it because it's not clear what `Unknown` means in
-terms of an application's lifecycle.
+be `Unknown`, but only the HCO will use `Unknown` because it's not clear what
+`Unknown` means in terms of an application's lifecycle.  The HCO can assume
+`Unknown` for conditions while operators are starting up.
 
 #### OperatorAvailable
 ```
@@ -124,3 +125,25 @@ standardize values for `Reason`.
 `Message` is a _human-readable message indicating details about last transition_.
 
 Explain why your CR has `Reason`.
+
+
+## HCO conditions
+It's important to point out that the `ConditionTypes` on the HCO don't represent
+the condition the HCO is in, rather the condition of the component CRs.
+
+The HCO will use the same `ConditionType`s and `Reason`s, but it will be the
+only operator to use `Unknown` for `Status`.  If the HCO notices that a component
+CR is missing condition fields, the HCO will assume the status of
+`OperatorAvailable = false`, `OperatorProgressing = unknown` and
+`OperatorDegraded = unknown`.  If the HCO also detects there is no `Reason` value
+too, then it will assume `Reason = "InstallInvalid"`.
+
+The HCO's `ConditionType`s will always represent the _worst_ `Status` and the
+_most recently viewed_ `Reason`.
+
+The _worst_ `Status` for each `ConditionType`:
+| Condition   | Status  |
+| :------------- |:-------------:|
+| OperatorAvailable | False |
+| OperatorProgressing | False |
+| OperatorDegraded | True |

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -44,6 +44,13 @@ type ApplicationStatusCondition struct {
 }
 ```
 
+## Library
+We're going to use a shared library to provide the condition types to operators.
+This will ensure the code is not specific to any operator and it will allow
+products outside of CNV to also consume it.
+
+https://github.com/openshift-kni/operator-status
+
 ## ConditionType
 `ConditionType` _specifies the state of the operator's reconciliation functionality,
 which reflects the state of the application_. `ConditionType`s use `ConditionStatus`

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -111,14 +111,14 @@ We'll use a series of lifecycle inspired prefixes paired with postfixes to
 standardize values for `Reason`.
 
 |         | -Failed  | -Succeeded | -Invalid | -InProgress |
-| :------------- |:-------------:|:-----:|:-----:|
+| :------------- |:-------------:|:-----:|:-----:|:-----:|
 | Install- | InstallFailed | InstallSucceeded | InstallInvalid | InstallInProgress |
 | Upgrade- | UpgradeFailed | UpgradeSucceded | UpgradeInvalid | UpgradeInProgress |
 | Heal- | HealFailed | HealSucceeded | HealInvalid | HealInProgress |
 | Configuration- | ConfigurationFailed | ConfigurationSucceeded | ConfigurationInvalid | ConfigurationInProgress |
 
 |         | -Failed  | -Succeeded | -Invalid | -InProgress |
-| :------------- |:-------------:|:-----:|:-----:|
+| :------------- |:-------------:|:-----:|:-----:|:-----:|
 | Meaning | The attempted operation **Failed** and the error is clear to the operator | The attempted operation **Succeeded** |  The attempted operation is missing something or is **Invalid** at this time | The attempted operation is **InProgress** |
 
 ## Message
@@ -142,6 +142,7 @@ The HCO's `ConditionType`s will always represent the _worst_ `Status` and the
 _most recently viewed_ `Reason`.
 
 The _worst_ `Status` for each `ConditionType`:
+
 | Condition   | Status  |
 | :------------- |:-------------:|
 | OperatorAvailable | False |

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -112,25 +112,13 @@ instead of on all component operators.
 ## Reason
 `Reason` is _a one-word CamelCase reason for the condition's last transition_.
 
-We'll use a series of lifecycle inspired prefixes paired with postfixes to
-standardize values for `Reason`.
-
-|         | -Failed  | -Succeeded | -Invalid | -InProgress |
-| :------------- |:-------------:|:-----:|:-----:|:-----:|
-| Install- | InstallFailed | InstallSucceeded | InstallInvalid | InstallInProgress |
-| Upgrade- | UpgradeFailed | UpgradeSucceded | UpgradeInvalid | UpgradeInProgress |
-| Heal- | HealFailed | HealSucceeded | HealInvalid | HealInProgress |
-| Configuration- | ConfigurationFailed | ConfigurationSucceeded | ConfigurationInvalid | ConfigurationInProgress |
-
-|         | -Failed  | -Succeeded | -Invalid | -InProgress |
-| :------------- |:-------------:|:-----:|:-----:|:-----:|
-| Meaning | The attempted operation **Failed** and the error is clear to the operator | The attempted operation **Succeeded** |  The attempted operation is missing something or is **Invalid** at this time | The attempted operation is **InProgress** |
+Components will be responsible for reporting `Reason`, which will explain their
+condition.
 
 ## Message
 `Message` is a _human-readable message indicating details about last transition_.
 
 Explain why your CR has `Reason`.
-
 
 ## HCO conditions
 It's important to point out that the `ConditionTypes` on the HCO don't represent
@@ -144,7 +132,7 @@ CR is missing condition fields, the HCO will assume the status of
 too, then it will assume `Reason = "InstallInvalid"`.
 
 The HCO's `ConditionType`s will always represent the _worst_ `Status` and the
-_most recently viewed_ `Reason`.
+corresponding `Reason`.
 
 The _worst_ `Status` for each `ConditionType`:
 

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -139,5 +139,5 @@ The _worst_ `Status` for each `ConditionType`:
 | Condition   | Status  |
 | :------------- |:-------------:|
 | ApplicationAvailable | False |
-| OperatorProgressing | False |
+| OperatorProgressing | True |
 | ApplicationDegraded | True |

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -1,0 +1,73 @@
+# CR Conditions and Readiness Probe
+Conditions are..
+	   _the latest available observations of an object's state. They are
+	   an extension mechanism intended to be used when the details of an
+	   observation are not a priori known or would not apply to all
+	   instances of a given Kind._
+
+The HCO’s CR is a representation of the underlying component operators.  If the
+object exists, then all components exist.  If the object doesn’t exist, all
+components don’t exist.  However, the CR existence doesn’t help us with the
+state where the operators exist, but are they healthy?  This is where conditions
+on the HCO’s CR will answer this question by providing the observed health of
+the underlying components.
+
+## Condition List
+We can use some of the CVO's [conditions](https://github.com/openshift/api/blob/master/config/v1/types_cluster_operator.go#L121-L133) to standardize across components.
+
+#### OperatorAvailable
+```
+	OperatorAvailable ClusterStatusConditionType = "Available"
+```
+OperatorAvailable indicates that the binary maintained by the operator
+(eg: openshift-apiserver for the openshift-apiserver-operator), is functional
+and available in the cluster.
+
+#### OperatorProgressing
+```
+	OperatorProgressing ClusterStatusConditionType = "Progressing"
+```
+Progressing indicates that the operator is actively making changes to the binary
+maintained by the operator (eg: openshift-apiserver for the
+openshift-apiserver-operator).
+
+#### OperatorDegraded
+```
+	OperatorDegraded ClusterStatusConditionType = "Degraded"
+```
+Degraded indicates that the component operator is not functioning completely.
+An example of a degraded state would be if there should be 5 copies of the
+component running but only 4 are running. It may still be available, but it is
+degraded.
+
+#### Condition Matrix
+
+| Condition        | Status           | Status  | Status  |
+| :------------- |:-------------:|:-----:|:-----:|
+| OperatorAvailable | True | True | True |
+| OperatorProgressing | False | True | True |
+| OperatorDegraded | False | False | True |
+| Meaning | Component is 100% healthy and the Operator is idle | Component is functional but, either upgrading or healing | Component is functioning below capacity and an upgrade or heal is in progress |
+
+| Condition        | Status           | Status  |
+| :------------- |:-------------:|:-----:|
+| OperatorAvailable | False | False |
+| OperatorProgressing | False | True |
+| OperatorDegraded | True | True |
+| Meaning | Component and operator are in a failed state that requires human intervention.  Failed upgrade or failed heal | Component is in a failed state and an operator is healing |
+
+| Condition        | Status           |
+| :------------- |:-------------:|
+| OperatorAvailable | False |
+| OperatorProgressing | True |
+| OperatorDegraded | False |
+| Meaning | Operator is deploying the component |
+
+## Readiness Probe
+With a standardized set of conditions, the HCO should report the health of the
+overall application back to OLM and the user.  This will be critial for sensitive
+operations like upgrade, because OLM needs to know it shouldn't replace an
+operator when it is in the middle of imporant work.
+
+See this [issue](https://github.com/operator-framework/operator-lifecycle-manager/issues/922) for why we only want to report a readiness probe on the HCO
+instead of on all component operators.

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -18,6 +18,13 @@ the underlying application.  Component operators store conditions that are
 watched by the HCO and the HCO will store conditions that reflect the
 [worst state](https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/docs/conditions.md#hco-conditions) of all component operator conditions.
 
+## Outlook Model
+There's a long running [discussion](https://github.com/kubernetes/kubernetes/issues/7856) in the Kubernetes
+community about the use of Phases, Conditions, and using controllers as
+state machines that hasn't been resolved.  This design document follows the
+"outlook" approach described in this [comment](https://github.com/kubernetes/kubernetes/issues/7856#issuecomment-99667941), which
+we'll use until the Kubernetes community has a resolution we can adopt.
+
 ## Condition Struct
 We can use some of the CVO's [conditions](https://github.com/openshift/api/blob/b1bcdbc/config/v1/types_cluster_operator.go#L123-L134) to standardize across components.
 


### PR DESCRIPTION
Conditions are how component operators will report status to the HCO.  We want to pass that status on to the user and use a readiness probe to inform OLM of sensitive lifecycle operations.

Conditions will be reported on the component operator CRs.