### PR TITLE
Update README.md with the updated instructions for OCP 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: hco-catalogsource
-  namespace: openshift-operator-lifecycle-manager
+  namespace: openshift-marketplace
 spec:
   sourceType: grpc
   image: docker.io/$REGISTRY_NAMESPACE/hco-registry:example
@@ -83,7 +83,7 @@ spec:
   channel: alpha
   name: kubevirt-hyperconverged
   source: hco-catalogsource
-  sourceNamespace: openshift-operator-lifecycle-manager
+  sourceNamespace: openshift-marketplace
 EOF
 ```
 


### PR DESCRIPTION
The namespace for the global catalogs have been changed, and now
everyone is required to use the openshift-marketplace namespace.

Signed-off-by: Lev Veyde <lveyde@redhat.com>