### PR TITLE
Overwrite the CatalogSourceConfig created by the OperatorSource

### DIFF
--- a/tools/quay-registry.sh
+++ b/tools/quay-registry.sh
@@ -68,7 +68,7 @@ cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1
 kind: CatalogSourceConfig
 metadata:
-  name: hco-catalogsource-config
+  name: "${APP_REGISTRY_NAMESPACE}"
   namespace: "${MARKETPLACE_NAMESPACE}"
 spec:
   targetNamespace: kubevirt-hyperconverged


### PR DESCRIPTION
When you create an OperatorSource, it creates a CatalogSourceConfig listing all the operators from that source.  Let's overwrite it to only use the HCO's content to avoid any packaging errors caused by other operators.