### PR TITLE
Remove " so for loop doesn't treat it as single string

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -50,7 +50,7 @@ CONTAINER_ERRORED=""
 function debug(){
     echo "Found pods with errors ${CONTAINER_ERRORED}"
 
-    for err in "${CONTAINER_ERRORED}"; do
+    for err in ${CONTAINER_ERRORED}; do
 	echo "------------- $err"
 	"${CMD}" logs $("${CMD}" get pods -n kubevirt-hyperconverged | grep $err | head -1 | awk '{ print $1 }')
     done


### PR DESCRIPTION
bash will not expand a quoted var like `"$VAR"`, so it's treated like a single argument to the for loop: `------------- cdi-operator cluster-network-addons-operator hyperconverged-cluster-operator`.  Removing the quotes causes bash to expand the var, so that each blank space is passed as an argument to the for loop resulting in: 
```
------------- cdi-operator
------------- cluster-network-addons-operator
------------- hyperconverged-cluster-operator
```