### PR TITLE
Add recipe to build-push all the operator content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ stageRegistry:
 bundleRegistry:
 	REGISTRY_NAMESPACE=$(REGISTRY_NAMESPACE) IMAGE_REGISTRY=$(IMAGE_REGISTRY) ./hack/build-registry-bundle.sh
 
+build-push-all: docker-build-operator docker-push-operator docker-build-operator-courier bundle-push
+
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
 	@echo ''
@@ -93,4 +95,5 @@ test: test-unit
 		stageRegistry \
 		functest \
 		quay-token \
-		bundle-push
+		bundle-push \
+		build-push-all

--- a/tools/operator-courier/push.sh
+++ b/tools/operator-courier/push.sh
@@ -3,6 +3,8 @@ set -e
 
 PROJECT_ROOT="$(readlink -e $(dirname "$BASH_SOURCE[0]")/../../)"
 
+QUAY_REPOSITORY="${QUAY_REPOSITORY:-kubevirt-hyperconverged}"
+PACKAGE_NAME="${PACKAGE_NAME:-kubevirt-hyperconverged}"
 SOURCE_DIR="${SOURCE_DIR:-/manifests}"
 REPO_DIR="${QUAY_REPOSITORY:-kubevirt-hyperconverged}"
 NAMESPACE="${PACKAGE_NAME:-kubevirt-hyperconverged}"


### PR DESCRIPTION
- Add `make build-push-all` to push the HCO & bundle content
- Add registry defaults to bundle-push script