### PR TITLE
rbac: add permissions for SSP operator

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -796,6 +796,16 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles

--- a/templates/cluster_role.yaml.in
+++ b/templates/cluster_role.yaml.in
@@ -18,6 +18,16 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles


### PR DESCRIPTION
Due a to a rebase glitch, the RBAC permissions for the SSP-operator
to work with Prometheus Rule were not included in
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/199

Signed-off-by: Francesco Romani <fromani@redhat.com>