### PR TITLE
metrics aggr: add content to csv template

### DIFF
--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -221,6 +221,16 @@ spec:
             verbs:
             - '*'
           - apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - prometheusrules
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - watch
+          - apiGroups:
             - rbac.authorization.k8s.io
             resources:
             - clusterroles
@@ -504,6 +514,11 @@ spec:
         kind: KubevirtTemplateValidator
         displayName: KubeVirt Template Validator
         description: KubeVirt Template Validator
+      - name: kubevirtmetricsaggregations.kubevirt.io
+        version: v1
+        kind: KubevirtMetricsAggregation
+        displayName: KubeVirt Metrics Aggregation Rules
+        description: KubeVirt Metrics Aggregation Rules
       - name: nodemaintenances.kubevirt.io
         version: v1alpha1
         kind: NodeMaintenance


### PR DESCRIPTION
PR https://github.com/kubevirt/hyperconverged-cluster-operator/pull/199
mistakenly didn't update the CSV template. This patch fixes that.

Signed-off-by: Francesco Romani <fromani@redhat.com>