### PR TITLE
Fix CRDs, with versions sub-section

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/common-template-bundles.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/common-template-bundles.crd.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -12,5 +12,9 @@ spec:
     singular: kubevirtcommontemplatesbundle
   scope: Namespaced
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   subresources:
     status: {}

--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/kubevirt.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/kubevirt.crd.yaml
@@ -25,3 +25,7 @@ spec:
     singular: kubevirt
   scope: Namespaced
   version: v1alpha3
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true

--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/metrics-aggregation.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/metrics-aggregation.crd.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtmetricsaggregations.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtMetricsAggregation
+    listKind: KubevirtMetricsAggregationList
+    plural: kubevirtmetricsaggregations
+    singular: kubevirtmetricsaggregation
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  subresources:
+    status: {}

--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/node-labeller-bundles.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/node-labeller-bundles.crd.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -12,5 +12,9 @@ spec:
     singular: kubevirtnodelabellerbundle
   scope: Namespaced
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   subresources:
     status: {}

--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/nodemaintenance.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/nodemaintenance.crd.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/template-validator.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/template-validator.crd.yaml
@@ -12,5 +12,9 @@ spec:
     singular: kubevirttemplatevalidator
   scope: Namespaced
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   subresources:
     status: {}

--- a/deploy/olm-catalog/kubevirt-hyperconverged/kubevirt-hyperconverged.package.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/kubevirt-hyperconverged.package.yaml
@@ -1,4 +1,4 @@
-packageName: hco-operatorhub
+packageName: kubevirt-hyperconverged
 channels:
 - name: "0.0.2"
   currentCSV: kubevirt-hyperconverged-operator.v0.0.2


### PR DESCRIPTION
Some CRDs miss this sub-section, which causes issues with the OLM.

This patch fixes the issue for the generated files.