### PR TITLE
controller: create storage configmap on reconcile

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/kubevirt-hyperconverged-operator.v0.0.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/kubevirt-hyperconverged-operator.v0.0.2.clusterserviceversion.yaml
@@ -10,6 +10,9 @@ metadata:
           "metadata": {
             "name": "kubevirt-hyperconverged",
             "namespace": "kubevirt-hyperconverged"
+          },
+          "spec": {
+            "BareMetalPlatform": "false",
           }
         },
         {

--- a/docs/kni.md
+++ b/docs/kni.md
@@ -1,0 +1,38 @@
+# ConfigMaps
+HCO creates ConfigMaps on deployment for supplying default values configuration.
+
+## Storage ConfigMap
+Defines default values for storage specs: 'accessMode' and 'volumeMode'.
+
+### Example
+```
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kubevirt-storage-class-defaults
+  namespace: openshift
+data:
+  accessMode: ReadWriteMany
+  volumeMode: Filesystem  # (Block for BareMetal infrastructure)
+  local-sc.accessMode: ReadWriteOnce
+  local-sc.volumeMode: Filesystem
+```
+
+# Config BareMetal platfrom
+Use 'BareMetalPlatform' spec when creating HyperConverged to enable BareMetal infrastructure.
+This will result in 'volumeMode: Block' in storage ConfigMap.
+
+# Config local storage class name
+Use 'LocalStorageClassName' spec to specify the name of the local class name.
+
+## Example
+```
+apiVersion: hco.kubevirt.io/v1alpha1
+kind: HyperConverged
+metadata:
+  name: hyperconverged-cluster
+spec:
+  BareMetalPlatform: true
+  LocalStorageClassName: "local-sc"
+```

--- a/pkg/apis/hco/v1alpha1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1alpha1/hyperconverged_types.go
@@ -17,6 +17,12 @@ type HyperConvergedSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+
+	// BareMetalPlatform indicates whether the infrastructure is baremetal.
+	BareMetalPlatform bool `json:"BareMetalPlatform,omitempty"`
+
+	// LocalStorageClassName the name of the local storage class.
+	LocalStorageClassName string `json:"LocalStorageClassName,omitempty"`
 }
 
 // HyperConvergedStatus defines the observed state of HyperConverged

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -190,6 +190,7 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 
 	for _, f := range []func(*hcov1alpha1.HyperConverged, logr.Logger, reconcile.Request) error{
 		r.ensureKubeVirtConfig,
+		r.ensureKubeVirtStorageConfig,
 		r.ensureKubeVirt,
 		r.ensureCDI,
 		r.ensureNetworkAddons,
@@ -958,6 +959,70 @@ func (r *ReconcileHyperConverged) ensureKubeVirtTemplateValidator(instance *hcov
 
 	handleConditionsSSP(r, logger, "KubevirtTemplateValidator", &found.Status)
 	return r.client.Status().Update(context.TODO(), instance)
+}
+
+func newKubeVirtStorageConfigForCR(cr *hcov1alpha1.HyperConverged, namespace string) *corev1.ConfigMap {
+	var volumeMode string
+	if *(&cr.Spec.BareMetalPlatform) {
+		volumeMode = "Block"
+	} else {
+		volumeMode = "Filesystem"
+	}
+
+	localSC := "local-sc"
+	if *(&cr.Spec.LocalStorageClassName) != "" {
+		localSC = *(&cr.Spec.LocalStorageClassName)
+	}
+
+	labels := map[string]string{
+		"app": cr.Name,
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-config-storage-class-defaults",
+			Labels:    labels,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"accessMode":            "ReadWriteMany",
+			"volumeMode":            volumeMode,
+			localSC + ".accessMode": "ReadWriteOnce",
+			localSC + ".volumeMode": "Filesystem",
+		},
+	}
+}
+
+func (r *ReconcileHyperConverged) ensureKubeVirtStorageConfig(instance *hcov1alpha1.HyperConverged, logger logr.Logger, request reconcile.Request) error {
+	kubevirtStorageConfig := newKubeVirtStorageConfigForCR(instance, request.Namespace)
+	if err := controllerutil.SetControllerReference(instance, kubevirtStorageConfig, r.scheme); err != nil {
+		return err
+	}
+
+	key, err := client.ObjectKeyFromObject(kubevirtStorageConfig)
+	if err != nil {
+		logger.Error(err, "Failed to get object key for kubevirt storage config")
+	}
+
+	found := &corev1.ConfigMap{}
+	err = r.client.Get(context.TODO(), key, found)
+	if err != nil && apierrors.IsNotFound(err) {
+		logger.Info("Creating kubevirt storage config")
+		return r.client.Create(context.TODO(), kubevirtStorageConfig)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	logger.Info("KubeVirt storage config already exists", "KubeVirtConfig.Namespace", found.Namespace, "KubeVirtConfig.Name", found.Name)
+	// Add it to the list of RelatedObjects if found
+	objectRef, err := reference.GetReference(r.scheme, found)
+	if err != nil {
+		return err
+	}
+	objectreferencesv1.SetObjectReference(&instance.Status.RelatedObjects, *objectRef)
+
+	return nil
 }
 
 func newKubeVirtMetricsAggregationForCR(cr *hcov1alpha1.HyperConverged, namespace string) *sspv1.KubevirtMetricsAggregation {

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -10,6 +10,9 @@ metadata:
           "metadata": {
             "name": "kubevirt-hyperconverged",
             "namespace": "kubevirt-hyperconverged"
+          },
+          "spec": {
+            "BareMetalPlatform": "false",
           }{{if .Converged}}
         },
         {


### PR DESCRIPTION
Added a new ConfigMap for defining default values for
storage according to the following logic:

- For a BareMetal infrastructure:
  - volumeMode: Block
  - accessMode: ReadWriteMany
- For all other deployments:
  - volumeMode: File
  - accessMode: ReadWriteMany