### PR TITLE
Upgrade Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ bundleRegistry:
 
 build-push-all: container-build-operator container-push-operator container-build-operator-courier bundle-push
 
+upgrade-test:
+	./hack/upgrade-test.sh
+ 
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
 	@echo ''

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -15,3 +15,9 @@ make cluster-down
 make cluster-up
 make cluster-sync
 CMD='cluster-up/kubectl.sh' make functest
+
+# Upgrade test requires OLM which is currently
+# only available with okd providers
+if [[ $TARGET =~ okd-.* ]]; then
+  make upgrade-test
+fi

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -20,14 +20,44 @@
 source hack/common.sh
 
 # Remove HCO
-"${CMD}" delete -f deploy/hco.cr.yaml --wait=false --ignore-not-found || true
+"${CMD}" delete -f _out/hco.cr.yaml --ignore-not-found || true
 "${CMD}" wait --for=delete hyperconverged.hco.kubevirt.io/hyperconverged-cluster || true
-"${CMD}" delete -f deploy/crds/hco.crd.yaml --wait=false --ignore-not-found || true
+# TODO: delete hangs on machine.crd.yaml. Only delete the ones that don't hang
+# from _out/crds/.
+"${CMD}" delete -f _out/crds/hco.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/crds/cdi.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/crds/cna.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/crds/common-template-bundles.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/crds/kubevirt.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/crds/metrics-aggregation.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/crds/mro.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/crds/node-labeller-bundles.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/crds/nodemaintenance.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/crds/template-validator.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/crds/v2vvmware.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/operator.yaml --ignore-not-found || true
+
+# Delete kubevirt-operator
+"${CMD}" delete -n kubevirt apiservice v1alpha3.kubevirt.io --ignore-not-found || true
+"${CMD}" delete -f "${KUBEVIRT_OPERATOR_URL}" --ignore-not-found || true
+
+# Delete cdi-operator
+"${CMD}" delete -n cdi apiservice v1alpha1.cdi.kubevirt.io --ignore-not-found || true
+"${CMD}" delete -f "${CDI_OPERATOR_URL}" --ignore-not-found || true
+
+# Delete cna-operator
+"${CMD}" delete -f "${CNA_URL_PREFIX}"/network-addons-config.crd.yaml --ignore-not-found || true
+"${CMD}" delete -f "${CNA_URL_PREFIX}"/operator.yaml --ignore-not-found || true
+"${CMD}" delete ns cluster-network-addons-operator --ignore-not-found || true
+
+# Delete ssp-operator
+"${CMD}" delete -f "${SSP_URL_PREFIX}"/kubevirt-ssp-operator-crd.yaml --ignore-not-found || true
+"${CMD}" delete -f "${SSP_URL_PREFIX}"/kubevirt-ssp-operator.yaml --ignore-not-found || true
 
 # Remove other settings
-"${CMD}" delete -f deploy/cluster_role_binding.yaml --wait=false --ignore-not-found || true
-"${CMD}" delete -f deploy/cluster_role.yaml --wait=false --ignore-not-found || true
-"${CMD}" delete -f deploy/service_account.yaml --wait=false --ignore-not-found || true
+"${CMD}" delete -f _out/cluster_role_binding.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/cluster_role.yaml --ignore-not-found || true
+"${CMD}" delete -f _out/service_account.yaml --ignore-not-found || true
 
 # Delete namespace at the end
-"${CMD}" delete ns kubevirt-hyperconverged --ignore-not-found || true
+# "${CMD}" delete ns kubevirt-hyperconverged --ignore-not-found || true

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -23,23 +23,11 @@ source hack/common.sh
 "${CMD}" delete -f deploy/hco.cr.yaml --wait=false --ignore-not-found || true
 "${CMD}" wait --for=delete hyperconverged.hco.kubevirt.io/hyperconverged-cluster || true
 "${CMD}" delete -f deploy/crds/hco.crd.yaml --wait=false --ignore-not-found || true
-"${CMD}" delete -f deploy/ --ignore-not-found || true
+
+# Remove other settings
+"${CMD}" delete -f deploy/cluster_role_binding.yaml --wait=false --ignore-not-found || true
+"${CMD}" delete -f deploy/cluster_role.yaml --wait=false --ignore-not-found || true
+"${CMD}" delete -f deploy/service_account.yaml --wait=false --ignore-not-found || true
+
+# Delete namespace at the end
 "${CMD}" delete ns kubevirt-hyperconverged --ignore-not-found || true
-
-# Delete kubevirt-operator
-"${CMD}" delete -n kubevirt apiservice v1alpha3.kubevirt.io --wait=false --ignore-not-found || true
-"${CMD}" delete -f "${KUBEVIRT_OPERATOR_URL}" --ignore-not-found || true
-
-# Delete cdi-operator
-"${CMD}" delete -n cdi apiservice v1alpha1.cdi.kubevirt.io --wait=false --ignore-not-found || true
-"${CMD}" delete -f "${CDI_OPERATOR_URL}" --ignore-not-found || true
-
-# Delete cna-operator
-"${CMD}" delete -f "${CNA_URL_PREFIX}"/network-addons-config.crd.yaml --ignore-not-found || true
-"${CMD}" delete -f "${CNA_URL_PREFIX}"/operator.yaml --ignore-not-found || true
-"${CMD}" delete ns cluster-network-addons-operator --ignore-not-found || true
-
-# Delete ssp-operator
-"${CMD}" delete -f "${SSP_URL_PREFIX}"/kubevirt-ssp-operator-crd.yaml --ignore-not-found || true
-"${CMD}" delete -f "${SSP_URL_PREFIX}"/kubevirt-ssp-operator.yaml --ignore-not-found || true
-

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -38,7 +38,7 @@ fi
 sed -i "s#image: quay.io/kubevirt/hyperconverged-cluster-operator:latest#image: ${HCO_IMAGE}#g" _out/operator.yaml
 
 # create namespaces
-"${CMD}" create ns kubevirt-hyperconverged
+"${CMD}" create ns kubevirt-hyperconverged | true
 
 # Create additional namespaces needed for HCO components
 namespaces=("openshift" "openshift-machine-api")

--- a/hack/retry.sh
+++ b/hack/retry.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 3 ]; then
+    echo 'Usage: retry <num retries> <wait retry secs> "<command>"'
+    exit 1
+fi
+
+retries=$1
+wait_retry=$2
+command=$3
+
+for i in `seq 1 $retries`; do
+    echo "$command"
+    bash -c "$command"
+    ret_value=$?
+    [ $ret_value -eq 0 ] && break
+    echo "> failed with exit code $ret_value, waiting $wait_retry seconds to retry..."
+    sleep $wait_retry
+done
+
+exit $ret_value

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -162,7 +162,7 @@ HCO_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n kubevirt-hyperconverged | 
 
 # Verify hco-operator has updated to the new version from the local registry
 # registry:5000/kubevirt/hyperconverged-cluster-operator:latest
-./hack/retry.sh 2 30 "./cluster-up/kubectl.sh get deployment hco-operator -n kubevirt-hyperconverged -o yaml | grep image | grep registry:5000"
+./hack/retry.sh 2 30 "./cluster-up/kubectl.sh get deployments -n kubevirt-hyperconverged -o yaml | grep image | grep hyperconverged-cluster | grep registry:5000"
 
 echo "----- Images after upgrade"
 ./cluster-up/kubectl.sh get deployments -n kubevirt-hyperconverged -o yaml | grep image | grep -v imagePullPolicy

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -135,9 +135,6 @@ done
 
 # Patch the HCO catalogsource image to the upgrade version
 ./cluster-up/kubectl.sh patch catalogsource hco-catalogsource-example -n openshift-operator-lifecycle-manager -p '{"spec":{"image": "registry:5000/kubevirt/hco-registry:upgrade"}}' --type merge
-# Delete the catalog operator. Sometimes the HCO catalogsource pod fails to come up after patching.
-#CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
-#./cluster-up/kubectl.sh delete pod $CATALOG_OPERATOR_POD -n openshift-operator-lifecycle-manager
 sleep 30
 HCO_CATALOGSOURCE_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep hco-catalogsource | head -1 | awk '{ print $1 }'`
 ./cluster-up/kubectl.sh wait pod $HCO_CATALOGSOURCE_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"
@@ -145,8 +142,6 @@ HCO_CATALOGSOURCE_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-li
 # Delete the catalog-operator to force it to reload and read the 
 # new HCO catalogsource. Otherwise it could take up to 10 mins
 # for it to detect that the catalogsource has been updated.
-#CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
-#./cluster-up/kubectl.sh delete pod $CATALOG_OPERATOR_POD -n openshift-operator-lifecycle-manager
 sleep 15
 CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
 ./cluster-up/kubectl.sh wait pod $CATALOG_OPERATOR_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -136,8 +136,8 @@ done
 # Patch the HCO catalogsource image to the upgrade version
 ./cluster-up/kubectl.sh patch catalogsource hco-catalogsource-example -n openshift-operator-lifecycle-manager -p '{"spec":{"image": "registry:5000/kubevirt/hco-registry:upgrade"}}' --type merge
 # Delete the catalog operator. Sometimes the HCO catalogsource pod fails to come up after patching.
-CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
-./cluster-up/kubectl.sh delete pod $CATALOG_OPERATOR_POD -n openshift-operator-lifecycle-manager
+#CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
+#./cluster-up/kubectl.sh delete pod $CATALOG_OPERATOR_POD -n openshift-operator-lifecycle-manager
 sleep 30
 HCO_CATALOGSOURCE_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep hco-catalogsource | head -1 | awk '{ print $1 }'`
 ./cluster-up/kubectl.sh wait pod $HCO_CATALOGSOURCE_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"
@@ -145,8 +145,8 @@ HCO_CATALOGSOURCE_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-li
 # Delete the catalog-operator to force it to reload and read the 
 # new HCO catalogsource. Otherwise it could take up to 10 mins
 # for it to detect that the catalogsource has been updated.
-CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
-./cluster-up/kubectl.sh delete pod $CATALOG_OPERATOR_POD -n openshift-operator-lifecycle-manager
+#CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
+#./cluster-up/kubectl.sh delete pod $CATALOG_OPERATOR_POD -n openshift-operator-lifecycle-manager
 sleep 15
 CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
 ./cluster-up/kubectl.sh wait pod $CATALOG_OPERATOR_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -30,7 +30,7 @@ done
 ./cluster-up/kubectl.sh wait deployment packageserver --for condition=Available -n openshift-operator-lifecycle-manager --timeout="1200s"
 ./cluster-up/kubectl.sh wait deployment catalog-operator --for condition=Available -n openshift-operator-lifecycle-manager --timeout="1200s"
 
-./cluster-up/kubectl.sh create ns kubevirt-hyperconverged
+./cluster-up/kubectl.sh create ns kubevirt-hyperconverged | true
 
 cat <<EOF | ./cluster-up/kubectl.sh create -f -
 apiVersion: operators.coreos.com/v1alpha2

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -135,7 +135,7 @@ done
 
 # Patch the HCO catalogsource image to the upgrade version
 ./cluster-up/kubectl.sh patch catalogsource hco-catalogsource-example -n openshift-operator-lifecycle-manager -p '{"spec":{"image": "registry:5000/kubevirt/hco-registry:upgrade"}}' --type merge
-sleep 30
+./hack/retry.sh 20 30 "./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep hco-catalogsource"
 HCO_CATALOGSOURCE_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep hco-catalogsource | head -1 | awk '{ print $1 }'`
 ./cluster-up/kubectl.sh wait pod $HCO_CATALOGSOURCE_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"
 

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -1,17 +1,58 @@
 #!/bin/bash -e
 #
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
 # Usage:
-# export KUBEVIRT_PROVIDER=okd-4.1.0
+# export KUBEVIRT_PROVIDER=okd-4.1
 # make cluster-up
 # make upgrade-test
+#
+# Deploys the HCO cluster using the latest version in the git repo.
+# This latest version deploys the hco-operator using the :latest tag 
+# on quay.io.
+#
+# A new version, named 100.0.0, is then created. A new hco-operator
+# image is created based off of the code in the current checkout.  
+# A CSV and registry image is created for this version. The CSV
+# uses the new hco-operator image in the hco deployment.
+#
+# Both the hco-operator image and new registry image is pushed
+# to the local registry.
+#
+# The hco-catalogsource pod is then patched to use the new registry
+# image.
+#
+# The subscription is checked to verify that it progresses
+# to the new version. 
+# 
+# The hyperconverged-cluster deployment's image is also checked
+# to verify that it is updated to the new operator image from 
+# the local registry.
+
+echo "-- Upgrade Step 1/8: clean cluster"
+make cluster-clean
+
+echo "-- Upgrade Step 2/8: build registry image (tag:latest)"
 
 container_id=$(docker ps | grep kubevirtci | cut -d ' ' -f 1)
 registry_port=$(docker port $container_id | grep 5000 | cut -d ':' -f 2)
 registry=localhost:$registry_port
 
 echo "INFO: registry: $registry"
-
-make cluster-clean
 
 export REGISTRY_NAMESPACE=kubevirt
 export IMAGE_REGISTRY=$registry
@@ -29,6 +70,8 @@ done
 
 ./cluster-up/kubectl.sh wait deployment packageserver --for condition=Available -n openshift-operator-lifecycle-manager --timeout="1200s"
 ./cluster-up/kubectl.sh wait deployment catalog-operator --for condition=Available -n openshift-operator-lifecycle-manager --timeout="1200s"
+
+echo "-- Upgrade Step 3/8: create catalogsource and subscription to install HCO"
 
 ./cluster-up/kubectl.sh create ns kubevirt-hyperconverged | true
 
@@ -110,6 +153,9 @@ echo "----- Images before upgrade"
 
 LATEST_VERSION=`ls -d ./deploy/olm-catalog/kubevirt-hyperconverged/*/ | sort -r | head -1 | cut -d '/' -f 5`
 UPGRADE_VERSION=100.0.0
+
+echo "-- Upgrade Step 4/8: create version $UPGRADE_VERSION, the target for upgrade"
+
 cp -r ./deploy/olm-catalog/kubevirt-hyperconverged/$LATEST_VERSION ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION
 
 mv ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION/kubevirt-hyperconverged-operator.v$LATEST_VERSION.clusterserviceversion.yaml ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION/kubevirt-hyperconverged-operator.v$UPGRADE_VERSION.clusterserviceversion.yaml
@@ -120,6 +166,8 @@ sed -i "s|  version: $LATEST_VERSION|  version: $UPGRADE_VERSION|g" ./deploy/olm
 sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:latest|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION/kubevirt-hyperconverged-operator.v$UPGRADE_VERSION.clusterserviceversion.yaml
 
 sed -i "s|currentCSV: kubevirt-hyperconverged-operator.v$LATEST_VERSION|currentCSV: kubevirt-hyperconverged-operator.v$UPGRADE_VERSION|g" ./deploy/olm-catalog/kubevirt-hyperconverged/kubevirt-hyperconverged.package.yaml
+
+echo "-- Upgrade Step 5/8: build new HCO operator image and HCO registry image (tag:upgrade) and push to local registry"
 
 # Build a new registry image for the new version.
 export CONTAINER_TAG=upgrade
@@ -133,15 +181,15 @@ for NODE in $CLUSTER_NODES; do
     ./cluster-up/ssh.sh $NODE 'sudo sysctl -w user.max_user_namespaces=1024'
 done
 
+echo "-- Upgrade Step 6/8: patch existing catalog source with new registry image"
+echo "-- and wait for hco-catalogsource pod to be in Ready state"
+
 # Patch the HCO catalogsource image to the upgrade version
 ./cluster-up/kubectl.sh patch catalogsource hco-catalogsource-example -n openshift-operator-lifecycle-manager -p '{"spec":{"image": "registry:5000/kubevirt/hco-registry:upgrade"}}' --type merge
 ./hack/retry.sh 20 30 "./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep hco-catalogsource"
 HCO_CATALOGSOURCE_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep hco-catalogsource | head -1 | awk '{ print $1 }'`
 ./cluster-up/kubectl.sh wait pod $HCO_CATALOGSOURCE_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"
 
-# Delete the catalog-operator to force it to reload and read the 
-# new HCO catalogsource. Otherwise it could take up to 10 mins
-# for it to detect that the catalogsource has been updated.
 sleep 15
 CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
 ./cluster-up/kubectl.sh wait pod $CATALOG_OPERATOR_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"
@@ -149,6 +197,7 @@ CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lif
 # Verify the subscription has changed to the new version
 #  currentCSV: kubevirt-hyperconverged-operator.v100.0.0
 #  installedCSV: kubevirt-hyperconverged-operator.v100.0.0
+echo "-- Upgrade Step 7/8: verify the subscription's currentCSV and installedCSV have moved to the new version"
 sleep 10
 HCO_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n kubevirt-hyperconverged | grep hco-operator | head -1 | awk '{ print $1 }'`
 ./cluster-up/kubectl.sh wait pod $HCO_OPERATOR_POD --for condition=Ready -n kubevirt-hyperconverged --timeout="600s"
@@ -157,6 +206,7 @@ HCO_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n kubevirt-hyperconverged | 
 
 # Verify hco-operator has updated to the new version from the local registry
 # registry:5000/kubevirt/hyperconverged-cluster-operator:latest
+echo "-- Upgrade Step 8/8: verify the hyperconverged-cluster deployment is using the new image from local registry"
 ./hack/retry.sh 2 30 "./cluster-up/kubectl.sh get deployments -n kubevirt-hyperconverged -o yaml | grep image | grep hyperconverged-cluster | grep registry:5000"
 
 echo "----- Images after upgrade"

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash -e
+#
+# Usage:
+# export KUBEVIRT_PROVIDER=okd-4.1.0
+# make cluster-up
+# make upgrade-test
+
+container_id=$(docker ps | grep kubevirtci | cut -d ' ' -f 1)
+registry_port=$(docker port $container_id | grep 5000 | cut -d ':' -f 2)
+registry=localhost:$registry_port
+
+echo "INFO: registry: $registry"
+
+make cluster-clean
+
+export REGISTRY_NAMESPACE=kubevirt
+export IMAGE_REGISTRY=$registry
+export CONTAINER_TAG=latest
+make bundleRegistry
+
+# check images are accessible
+CLUSTER_NODES=$(./cluster-up/kubectl.sh get nodes | grep Ready | cut -d ' ' -f 1)
+for NODE in $CLUSTER_NODES; do
+    ./cluster-up/ssh.sh $NODE 'sudo podman pull registry:5000/kubevirt/hco-registry:latest'
+    # Temporary until image is updated with provisioner that sets this field
+    # This field is required by buildah tool
+    ./cluster-up/ssh.sh $NODE 'sudo sysctl -w user.max_user_namespaces=1024'
+done
+
+./cluster-up/kubectl.sh create ns kubevirt-hyperconverged
+
+cat <<EOF | ./cluster-up/kubectl.sh create -f -
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: hco-operatorgroup
+  namespace: kubevirt-hyperconverged
+EOF
+
+# TODO: The catalog source image here should point to the latest version in quay.io
+# once that is published.
+cat <<EOF | ./cluster-up/kubectl.sh create -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: hco-catalogsource-example
+  namespace: openshift-operator-lifecycle-manager
+spec:
+  sourceType: grpc
+  image: registry:5000/kubevirt/hco-registry
+  displayName: KubeVirt HyperConverged
+  publisher: Red Hat
+EOF
+
+sleep 15
+
+HCO_CATALOGSOURCE_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep hco-catalogsource | head -1 | awk '{ print $1 }'`
+./cluster-up/kubectl.sh wait pod $HCO_CATALOGSOURCE_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"
+
+CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
+./cluster-up/kubectl.sh wait pod $CATALOG_OPERATOR_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"
+
+PACKAGESERVER_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep packageserver | head -1 | awk '{ print $1 }'`
+./cluster-up/kubectl.sh wait pod $PACKAGESERVER_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"
+
+# Creating a subscription immediately after the catalog
+# source is ready can cause delays. Sometimes the catalog-operator
+# isn't ready to create the install plan. As a temporary workaround
+# we wait for 15 seconds here. 
+sleep 15
+
+cat <<EOF | ./cluster-up/kubectl.sh create -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: hco-subscription-example
+  namespace: kubevirt-hyperconverged
+spec:
+  channel: 0.0.2
+  name: kubevirt-hyperconverged
+  source: hco-catalogsource-example
+  sourceNamespace: openshift-operator-lifecycle-manager
+EOF
+
+# Allow time for the install plan to be created a for the
+# hco-operator to be created. Otherwise kubectl wait will report EOF.
+sleep 30
+
+HCO_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n kubevirt-hyperconverged | grep hco-operator | head -1 | awk '{ print $1 }'`
+./cluster-up/kubectl.sh wait pod $HCO_OPERATOR_POD --for condition=Ready -n kubevirt-hyperconverged --timeout="600s"
+./cluster-up/kubectl.sh get pods -n kubevirt-hyperconverged 
+
+./cluster-up/kubectl.sh create -f ./deploy/hco.cr.yaml -n kubevirt-hyperconverged
+
+./cluster-up/kubectl.sh get subscription -n kubevirt-hyperconverged -o yaml
+
+echo "----- Images before upgrade"
+./cluster-up/kubectl.sh get deployments -n kubevirt-hyperconverged -o yaml | grep image | grep -v imagePullPolicy
+./cluster-up/kubectl.sh get pod $HCO_CATALOGSOURCE_POD -n openshift-operator-lifecycle-manager -o yaml | grep image | grep -v imagePullPolicy
+
+# Create a new version based off of latest. The new version appends ".1" to the latest version.
+# The new version replaces the hco-operator image from quay.io with the image pushed to the local registry.
+# We create a new CSV based off of the latest version and update the replaces attribute so that the new
+# version updates the latest version.
+# The currentCSV in the package manifest is also updated to point to the new version.
+
+LATEST_VERSION=`ls -d ./deploy/olm-catalog/kubevirt-hyperconverged/*/ | sort -r | head -1 | cut -d '/' -f 5`
+UPGRADE_VERSION=100.0.0
+cp -r ./deploy/olm-catalog/kubevirt-hyperconverged/$LATEST_VERSION ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION
+
+mv ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION/kubevirt-hyperconverged-operator.v$LATEST_VERSION.clusterserviceversion.yaml ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION/kubevirt-hyperconverged-operator.v$UPGRADE_VERSION.clusterserviceversion.yaml
+sed -i "s|name: kubevirt-hyperconverged-operator.v$LATEST_VERSION|name: kubevirt-hyperconverged-operator.v$UPGRADE_VERSION|g" ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION/kubevirt-hyperconverged-operator.v$UPGRADE_VERSION.clusterserviceversion.yaml
+REPLACES_LINE=`grep "replaces" ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION/kubevirt-hyperconverged-operator.v$UPGRADE_VERSION.clusterserviceversion.yaml`
+sed -i "s|$REPLACES_LINE|  replaces: kubevirt-hyperconverged-operator.v$LATEST_VERSION|g" ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION/kubevirt-hyperconverged-operator.v$UPGRADE_VERSION.clusterserviceversion.yaml
+sed -i "s|  version: $LATEST_VERSION|  version: $UPGRADE_VERSION|g" ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION/kubevirt-hyperconverged-operator.v$UPGRADE_VERSION.clusterserviceversion.yaml
+sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:latest|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" ./deploy/olm-catalog/kubevirt-hyperconverged/$UPGRADE_VERSION/kubevirt-hyperconverged-operator.v$UPGRADE_VERSION.clusterserviceversion.yaml
+
+sed -i "s|currentCSV: kubevirt-hyperconverged-operator.v$LATEST_VERSION|currentCSV: kubevirt-hyperconverged-operator.v$UPGRADE_VERSION|g" ./deploy/olm-catalog/kubevirt-hyperconverged/kubevirt-hyperconverged.package.yaml
+
+# Build a new registry image for the new version.
+export CONTAINER_TAG=upgrade
+make container-build-operator container-push-operator bundleRegistry
+CLUSTER_NODES=$(./cluster-up/kubectl.sh get nodes | grep Ready | cut -d ' ' -f 1)
+for NODE in $CLUSTER_NODES; do
+    ./cluster-up/ssh.sh $NODE 'sudo podman pull registry:5000/kubevirt/hyperconverged-cluster-operator'
+    ./cluster-up/ssh.sh $NODE 'sudo podman pull registry:5000/kubevirt/hco-registry:upgrade'
+    # Temporary until image is updated with provisioner that sets this field
+    # This field is required by buildah tool
+    ./cluster-up/ssh.sh $NODE 'sudo sysctl -w user.max_user_namespaces=1024'
+done
+
+# Patch the HCO catalogsource image to the upgrade version
+./cluster-up/kubectl.sh patch catalogsource hco-catalogsource-example -n openshift-operator-lifecycle-manager -p '{"spec":{"image": "registry:5000/kubevirt/hco-registry:upgrade"}}' --type merge
+# Delete the catalog operator. Sometimes the HCO catalogsource pod fails to come up after patching.
+CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
+./cluster-up/kubectl.sh delete pod $CATALOG_OPERATOR_POD -n openshift-operator-lifecycle-manager
+sleep 30
+HCO_CATALOGSOURCE_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep hco-catalogsource | head -1 | awk '{ print $1 }'`
+./cluster-up/kubectl.sh wait pod $HCO_CATALOGSOURCE_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"
+
+# Delete the catalog-operator to force it to reload and read the 
+# new HCO catalogsource. Otherwise it could take up to 10 mins
+# for it to detect that the catalogsource has been updated.
+CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
+./cluster-up/kubectl.sh delete pod $CATALOG_OPERATOR_POD -n openshift-operator-lifecycle-manager
+sleep 15
+CATALOG_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n openshift-operator-lifecycle-manager | grep catalog-operator | head -1 | awk '{ print $1 }'`
+./cluster-up/kubectl.sh wait pod $CATALOG_OPERATOR_POD --for condition=Ready -n openshift-operator-lifecycle-manager --timeout="120s"
+
+# Verify the subscription has changed to the new version
+#  currentCSV: kubevirt-hyperconverged-operator.v100.0.0
+#  installedCSV: kubevirt-hyperconverged-operator.v100.0.0
+sleep 10
+HCO_OPERATOR_POD=`./cluster-up/kubectl.sh get pods -n kubevirt-hyperconverged | grep hco-operator | head -1 | awk '{ print $1 }'`
+./cluster-up/kubectl.sh wait pod $HCO_OPERATOR_POD --for condition=Ready -n kubevirt-hyperconverged --timeout="600s"
+./hack/retry.sh 15 60 "./cluster-up/kubectl.sh get subscriptions -n kubevirt-hyperconverged -o yaml | grep currentCSV | grep v100.0.0"
+./hack/retry.sh 2 30 "./cluster-up/kubectl.sh get subscriptions -n kubevirt-hyperconverged -o yaml | grep installedCSV | grep v100.0.0"
+
+# Verify hco-operator has updated to the new version from the local registry
+# registry:5000/kubevirt/hyperconverged-cluster-operator:latest
+./hack/retry.sh 2 30 "./cluster-up/kubectl.sh get deployment hco-operator -n kubevirt-hyperconverged -o yaml | grep image | grep registry:5000"
+
+echo "----- Images after upgrade"
+./cluster-up/kubectl.sh get deployments -n kubevirt-hyperconverged -o yaml | grep image | grep -v imagePullPolicy
+./cluster-up/kubectl.sh get pod $HCO_CATALOGSOURCE_POD -n openshift-operator-lifecycle-manager -o yaml | grep image | grep -v imagePullPolicy


### PR DESCRIPTION
Adds a "upgrade-test" make target.

The upgrade test
1. Deploys the HCO using a local catalog source and the latest version
of the hyperconverged-cluster-operator image on quay.io.
2. Creates a new hyperconverged-cluster-operator image based on
the contents of PR + master.
3. Clones the olm-catalog/latest-version directory to create a new
version that will be upgraded to.
4. Creates a new local catalog source that incorporates the new version.
5. Patches the running HCO catalog source to use the new image.
6. Validates that the HCO subscription installs the new version.
7. Validates that the HCO operator runs the new image.