### PR TITLE
Use HCO v0.0.1 in CSV v0.0.1

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.1/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
@@ -1148,7 +1148,7 @@ spec:
                   - hyperconverged-cluster-operator
                   env:
                   - name: OPERATOR_IMAGE
-                    value: quay.io/kubevirt/hyperconverged-cluster-operator:latest
+                    value: quay.io/kubevirt/hyperconverged-cluster-operator:v0.0.1
                   - name: OPERATOR_NAME
                     value: hyperconverged-cluster-operator
                   - name: POD_NAME
@@ -1159,7 +1159,7 @@ spec:
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.namespace
-                  image: quay.io/kubevirt/hyperconverged-cluster-operator:latest
+                  image: quay.io/kubevirt/hyperconverged-cluster-operator:v0.0.1
                   imagePullPolicy: Always
                   name: hyperconverged-cluster-operator
                   readinessProbe:


### PR DESCRIPTION
Make sure we use HCO v0.0.1 in CSV v0.0.1, instead of the latest version,
to prevent issues that arise from that.

Signed-off-by: Lev Veyde <lveyde@redhat.com>