### PR TITLE
Fix CSV v0.0.1 manifests

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.1/common-template-bundles.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.1/common-template-bundles.crd.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.1/node-labeller-bundles.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.1/node-labeller-bundles.crd.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.1/nodemaintenance.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.1/nodemaintenance.crd.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.1/template-validator.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.1/template-validator.crd.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Some CSV v0.0.1 manifests have an empty heading line, which causes
issues w/ the registry-bundle builder. This patch fixes this.

Signed-off-by: Lev Veyde <lveyde@redhat.com>