### PR TITLE
Add missing nmstate and ovs to networkaddonsconfig

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -583,6 +583,8 @@ func newNetworkAddonsForCR(cr *hcov1alpha1.HyperConverged, namespace string) *ne
 			Multus:      &networkaddonsv1alpha1.Multus{},
 			LinuxBridge: &networkaddonsv1alpha1.LinuxBridge{},
 			KubeMacPool: &networkaddonsv1alpha1.KubeMacPool{},
+			Ovs:         &networkaddonsv1alpha1.Ovs{},
+			NMState:     &networkaddonsv1alpha1.NMState{},
 		},
 	}
 }


### PR DESCRIPTION
was removed as part of 

https://github.com/kubevirt/hyperconverged-cluster-operator/commit/77be1be9ebd4e18c1850cd42a2b494ae7b351ccd#diff-64e1e2b9251fa5137c91d5a7c8427b88L12
