### PR TITLE
Fix kubevirt-storage-class-defaults ConfigMap name

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -982,7 +982,7 @@ func newKubeVirtStorageConfigForCR(cr *hcov1alpha1.HyperConverged, namespace str
 	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubevirt-config-storage-class-defaults",
+			Name:      "kubevirt-storage-class-defaults",
 			Labels:    labels,
 			Namespace: namespace,
 		},


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1751183