### PR TITLE
[release-2.1]  chore(rbac): create operator metrics service

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -76,6 +76,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Get the namespace the operator is currently deployed in.
+	operatorNs, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
 	// Create a new file supporting readiness probe
 	r := ready.NewFileReady()
 	err = r.Set()
@@ -151,7 +158,7 @@ func main() {
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
 	// necessary to configure Prometheus to scrape metrics from this operator.
 	services := []*corev1.Service{service}
-	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
+	_, err = metrics.CreateServiceMonitors(cfg, operatorNs, services)
 	if err != nil {
 		log.Info("Could not create ServiceMonitor object", "error", err.Error())
 		// If this operator is deployed to a cluster without the prometheus-operator running, it will return

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -31,29 +31,26 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - machineremediation.kubevirt.io
+  resources:
+  - machineremediationoperators
+  - machineremediationoperators/status
+  verbs:
+  - '*'
+- apiGroups:
   - ""
   resources:
-  - configmaps
   - pods
-  - serviceaccounts
   - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
+  - '*'
 - apiGroups:
   - apps
   resources:
@@ -68,6 +65,16 @@ rules:
   - create
   - delete
   - update
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -112,12 +119,12 @@ rules:
   - patch
   - update
 - apiGroups:
-  - machineremediation.kubevirt.io
+  - monitoring.coreos.com
   resources:
-  - machineremediationoperators
-  - machineremediationoperators/status
+  - servicemonitors
   verbs:
-  - '*'
+  - get
+  - create
 
 
 ---

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -58,13 +58,16 @@ rules:
   - apps
   resources:
   - deployments
+  - deployments/finalizers
   - daemonsets
+  - replicasets
   verbs:
   - get
   - list
   - watch
   - create
   - delete
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/kubevirt-hyperconverged-operator.v0.0.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.2/kubevirt-hyperconverged-operator.v0.0.2.clusterserviceversion.yaml
@@ -88,7 +88,7 @@ metadata:
     categories: OpenShift Optional
     certified: 'false'
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
-    createdAt: 2019-09-27 09:10:51.169057148 +0200 CEST m=+0.017728632
+    createdAt: 2019-09-23 16:07:52.126069559 -0400 EDT m=+0.029901903
     description: Creates and maintains a HyperConverged KubeVirt Deployment
     repository: https://github.com/kubevirt/hyperconverged-cluster-operator
     support: 'false'
@@ -260,34 +260,44 @@ spec:
               verbs:
               - '*'
             - apiGroups:
+              - machineremediation.kubevirt.io
+              resources:
+              - machineremediationoperators
+              - machineremediationoperators/status
+              verbs:
+              - '*'
+            - apiGroups:
               - ""
               resources:
-              - configmaps
               - pods
-              - serviceaccounts
               - services
+              - services/finalizers
+              - endpoints
+              - persistentvolumeclaims
+              - events
+              - configmaps
+              - secrets
+              - serviceaccounts
               verbs:
-              - get
-              - list
-              - watch
-              - create
-              - update
-              - delete
-            - apiGroups:
-              - batch
-              resources:
-              - jobs
-              verbs:
-              - get
-              - list
-              - watch
-              - create
-              - delete
+              - '*'
             - apiGroups:
               - apps
               resources:
               - deployments
+              - deployments/finalizers
               - daemonsets
+              - replicasets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - update
+            - apiGroups:
+              - batch
+              resources:
+              - jobs
               verbs:
               - get
               - list
@@ -338,12 +348,12 @@ spec:
               - patch
               - update
             - apiGroups:
-              - machineremediation.kubevirt.io
+              - monitoring.coreos.com
               resources:
-              - machineremediationoperators
-              - machineremediationoperators/status
+              - servicemonitors
               verbs:
-              - '*'
+              - get
+              - create
 
 
         - serviceAccountName: kubevirt-operator

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -157,36 +157,33 @@ func GetClusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{
-					"",
+					"machineremediation.kubevirt.io",
 				},
 				Resources: []string{
-					"configmaps",
-					"pods",
-					"serviceaccounts",
-					"services",
+					"machineremediationoperators",
+					"machineremediationoperators/status",
 				},
 				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-					"create",
-					"update",
-					"delete",
+					rbacv1.VerbAll,
 				},
 			},
 			{
 				APIGroups: []string{
-					"batch",
+					"",
 				},
 				Resources: []string{
-					"jobs",
+					"pods",
+					"services",
+					"services/finalizers",
+					"endpoints",
+					"persistentvolumeclaims",
+					"events",
+					"configmaps",
+					"secrets",
+					"serviceaccounts",
 				},
 				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-					"create",
-					"delete",
+					"*",
 				},
 			},
 			{
@@ -206,6 +203,21 @@ func GetClusterRole() *rbacv1.ClusterRole {
 					"create",
 					"delete",
 					"update",
+				},
+			},
+			{
+				APIGroups: []string{
+					"batch",
+				},
+				Resources: []string{
+					"jobs",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+					"create",
+					"delete",
 				},
 			},
 			{
@@ -274,14 +286,14 @@ func GetClusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{
-					"machineremediation.kubevirt.io",
+					"monitoring.coreos.com",
 				},
 				Resources: []string{
-					"machineremediationoperators",
-					"machineremediationoperators/status",
+					"servicemonitors",
 				},
 				Verbs: []string{
-					rbacv1.VerbAll,
+					"get",
+					"create",
 				},
 			},
 		},

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -195,7 +195,9 @@ func GetClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					"deployments",
+					"deployments/finalizers",
 					"daemonsets",
+					"replicasets",
 				},
 				Verbs: []string{
 					"get",
@@ -203,6 +205,7 @@ func GetClusterRole() *rbacv1.ClusterRole {
 					"watch",
 					"create",
 					"delete",
+					"update",
 				},
 			},
 			{

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion_merger.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion_merger.yaml.in
@@ -227,34 +227,37 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - ''
+          - ""
           resources:
-          - configmaps
           - pods
-          - serviceaccounts
           - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
           verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - delete
-        - apiGroups:
-          - batch
-          resources:
-          - jobs
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - delete
+          - '*'
         - apiGroups:
           - apps
           resources:
           - deployments
+          - deployments/finalizers
           - daemonsets
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
           verbs:
           - get
           - list
@@ -305,12 +308,12 @@ spec:
           - patch
           - update
         - apiGroups:
-          - machineremediation.kubevirt.io
+          - monitoring.coreos.com
           resources:
-          - machineremediationoperators
-          - machineremediationoperators/status
+          - servicemonitors
           verbs:
-          - '*'
+          - get
+          - create
         serviceAccountName: hyperconverged-cluster-operator
       permissions:
       deployments:


### PR DESCRIPTION
This PR makes it so the HCO will create the metrics service. Making it
possible to scrape important details about how the HCO is doing, like
reconcile totals, errors, and time.

```
$ kubectl run -n kubevirt-hyperconverged -it --rm --restart=Never hco-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl http://hyperconverged-cluster-operator-metrics.kubevirt-hyperconverged.svc.cluster.local:8383/metrics | grep 'reconcile'

controller_runtime_reconcile_errors_total{controller="hyperconverged-controller"} 51
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="0.005"} 23
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="0.01"} 23
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="0.025"} 23
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="0.05"} 23
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="0.1"} 23
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="0.25"} 24
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="0.5"} 74
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="1"} 75
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="2.5"} 613
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="5"} 613
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="10"} 613
controller_runtime_reconcile_time_seconds_bucket{controller="hyperconverged-controller",le="+Inf"} 614
controller_runtime_reconcile_time_seconds_sum{controller="hyperconverged-controller"} 2282.7855683989997
controller_runtime_reconcile_time_seconds_count{controller="hyperconverged-controller"} 614
controller_runtime_reconcile_total{controller="hyperconverged-controller",result="error"} 51
controller_runtime_reconcile_total{controller="hyperconverged-controller",result="requeue"} 1
controller_runtime_reconcile_total{controller="hyperconverged-controller",result="success"} 562
```

Signed-off-by: David Zager <dzager@redhat.com>