### PR TITLE
[release-2.1] disable IMS Configmap

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -199,7 +199,7 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 		r.ensureKubeVirtTemplateValidator,
 		r.ensureKubeVirtMetricsAggregation,
 		r.ensureMachineRemediationOperator,
-		r.ensureIMSConfig,
+		//r.ensureIMSConfig,
 	} {
 		err = f(instance, reqLogger, request)
 		if err != nil {


### PR DESCRIPTION
QE IMS testing is not going well so far. In the event it can't be sorted out the desire is to disable the configmap creation which should make it unavailable as an option in the UI.