### PR TITLE
Update to KubeVirt 0.20.8 with new image-prefix flag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1175,7 +1175,7 @@
   version = "v1.6.0"
 
 [[projects]]
-  digest = "1:f480ee9162158c0c71e0fc7fe42d4a99c73676f46c0606a8ac1839cfce8a05f7"
+  digest = "1:76a310dcff15d3085ad45c80c47e9ba31057f2fa2d047ce407068e4242876af0"
   name = "kubevirt.io/client-go"
   packages = [
     "api/v1",
@@ -1187,8 +1187,8 @@
     "version",
   ]
   pruneopts = "NT"
-  revision = "71f52dc0e86915a09eccce25ae0b12095cbb74a5"
-  version = "v0.20.6"
+  revision = "c5d55802a4c27a4d1008c8e1ed7bf99999eb48f5"
+  version = "v0.20.8"
 
 [[projects]]
   digest = "1:0bdf550113bbc32c2b77bb1c521c64116bd4553d976b9d4903135660ec440539"
@@ -1221,7 +1221,7 @@
   version = "v1.10.3"
 
 [[projects]]
-  digest = "1:2ab6f903abfdae5567f18f1d7a5b07a541a7e36f278b6c3b4adb7a8efcfeb2a0"
+  digest = "1:f2e2cf0773aac7f46fb8f80278d1a303ee6a313f43370a747564044f5560dc3b"
   name = "kubevirt.io/kubevirt"
   packages = [
     ".",
@@ -1246,8 +1246,8 @@
     "pkg/virt-operator/util",
   ]
   pruneopts = "NT"
-  revision = "0ca091bb179c87f605111494f2e7e7d54fcd2c41"
-  version = "v0.20.6"
+  revision = "d5430eaea926b9367e19079dedfe0df5d518ef67"
+  version = "v0.20.8"
 
 [[projects]]
   digest = "1:06035489efbd51ccface65fc878ceeb849aba05b2f9443c8993f363fc96e80ac"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,11 +23,11 @@ required = [
 
 [[override]]
   name = "kubevirt.io/kubevirt"
-  version = "=v0.20.6"
+  version = "=v0.20.8"
 
 [[constraint]]
   name = "kubevirt.io/client-go"
-  version = "=v0.20.6"
+  version = "=v0.20.8"
 
 [[override]]
   name = "github.com/go-kit/kit"

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -63,6 +63,7 @@ type templateData struct {
 	ReplacesVersion     string
 	Replaces            bool
 	ContainerPrefix     string
+	ImagePrefix         string
 	CnaContainerPrefix  string
 	ImagePullPolicy     string
 	CreatedAt           string
@@ -211,6 +212,7 @@ func getKubeVirt(data *templateData) {
 	kvdeployment, err := kvcomponents.NewOperatorDeployment(
 		"kubevirt",
 		data.ContainerPrefix,
+		data.ImagePrefix,
 		data.KubeVirt.OperatorTag,
 		v1.PullPolicy(data.ImagePullPolicy),
 		"2",
@@ -386,6 +388,7 @@ func main() {
 	csvVersion := flag.String("csv-version", "0.0.2", "")
 	replacesVersion := flag.String("replaces-version", "0.0.1", "")
 	containerPrefix := flag.String("container-prefix", "kubevirt", "")
+	imagePrefix := flag.String("image-prefix", "", "")
 	cnaContainerPrefix := flag.String("cna-container-prefix", *containerPrefix, "")
 	imsConversionContainer := flag.String("ims-conversion-container", "", "")
 	imsVMWareContainer := flag.String("ims-vmware-container", "", "")
@@ -416,6 +419,7 @@ func main() {
 		ReplacesVersion:     *replacesVersion,
 		Replaces:            Replaces,
 		ContainerPrefix:     *containerPrefix,
+		ImagePrefix:         *imagePrefix,
 		CnaContainerPrefix:  *cnaContainerPrefix,
 		ImagePullPolicy:     *imagePullPolicy,
 		ConversionContainer: *imsConversionContainer,

--- a/vendor/kubevirt.io/kubevirt/pkg/container-disk/container-disk.go
+++ b/vendor/kubevirt.io/kubevirt/pkg/container-disk/container-disk.go
@@ -126,14 +126,14 @@ func GenerateContainers(vmi *v1.VirtualMachineInstance, podVolumeName string, bi
 			if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
 				resources.Limits = make(kubev1.ResourceList)
 				resources.Limits[kubev1.ResourceCPU] = resource.MustParse("10m")
-				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("20M")
+				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("40M")
 				resources.Requests = make(kubev1.ResourceList)
 				resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
-				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("20M")
+				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("40M")
 			} else {
 				resources.Limits = make(kubev1.ResourceList)
 				resources.Limits[kubev1.ResourceCPU] = resource.MustParse("100m")
-				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("20M")
+				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("40M")
 				resources.Requests = make(kubev1.ResourceList)
 				resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
 				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("1M")

--- a/vendor/kubevirt.io/kubevirt/pkg/virt-handler/vm.go
+++ b/vendor/kubevirt.io/kubevirt/pkg/virt-handler/vm.go
@@ -641,6 +641,25 @@ func (d *VirtualMachineController) migrationOrphanedSourceNodeExecute(key string
 	return nil
 }
 
+func isMigrating(vmi *v1.VirtualMachineInstance) bool {
+
+	now := v12.Now()
+
+	running := false
+	if vmi.Status.MigrationState != nil {
+		start := vmi.Status.MigrationState.StartTimestamp
+		stop := vmi.Status.MigrationState.EndTimestamp
+		if start != nil && (now.After(start.Time) || now.Equal(start)) {
+			running = true
+		}
+
+		if stop != nil && (now.After(stop.Time) || now.Equal(stop)) {
+			running = false
+		}
+	}
+	return running
+}
+
 func (d *VirtualMachineController) migrationTargetExecute(key string,
 	vmi *v1.VirtualMachineInstance,
 	vmiExists bool,
@@ -1361,21 +1380,23 @@ func (d *VirtualMachineController) processVmUpdate(origVMI *v1.VirtualMachineIns
 	}
 
 	if d.isPreMigrationTarget(vmi) {
+		if !isMigrating(vmi) {
 
-		// Mount container disks
-		if err := d.containerDiskMounter.Mount(vmi, false); err != nil {
-			return err
-		}
+			// Mount container disks
+			if err := d.containerDiskMounter.Mount(vmi, false); err != nil {
+				return err
+			}
 
-		if err := client.SyncMigrationTarget(vmi); err != nil {
-			return fmt.Errorf("syncing migration target failed: %v", err)
+			if err := client.SyncMigrationTarget(vmi); err != nil {
+				return fmt.Errorf("syncing migration target failed: %v", err)
 
-		}
-		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), "VirtualMachineInstance Migration Target Prepared.")
+			}
+			d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), "VirtualMachineInstance Migration Target Prepared.")
 
-		err := d.handlePostSyncMigrationProxy(vmi)
-		if err != nil {
-			return fmt.Errorf("failed to handle post sync migration proxy: %v", err)
+			err := d.handlePostSyncMigrationProxy(vmi)
+			if err != nil {
+				return fmt.Errorf("failed to handle post sync migration proxy: %v", err)
+			}
 		}
 	} else if d.isMigrationSource(vmi) {
 		if vmi.Status.MigrationState.AbortRequested {

--- a/vendor/kubevirt.io/kubevirt/pkg/virt-operator/creation/components/deployments.go
+++ b/vendor/kubevirt.io/kubevirt/pkg/virt-operator/creation/components/deployments.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"strings"
 
-	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
@@ -100,11 +99,7 @@ func NewApiServerService(namespace string) *corev1.Service {
 	}
 }
 
-func something() *csvv1.ClusterServiceVersion {
-	return &csvv1.ClusterServiceVersion{}
-}
-
-func newPodTemplateSpec(name string, repository string, version string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity) (*corev1.PodTemplateSpec, error) {
+func newPodTemplateSpec(podName string, imageName string, repository string, version string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity) (*corev1.PodTemplateSpec, error) {
 
 	version = AddVersionSeparatorPrefix(version)
 
@@ -116,21 +111,21 @@ func newPodTemplateSpec(name string, repository string, version string, pullPoli
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				virtv1.AppLabel:          name,
+				virtv1.AppLabel:          podName,
 				"prometheus.kubevirt.io": "",
 			},
 			Annotations: map[string]string{
 				"scheduler.alpha.kubernetes.io/critical-pod": "",
 				"scheduler.alpha.kubernetes.io/tolerations":  string(tolerations),
 			},
-			Name: name,
+			Name: podName,
 		},
 		Spec: corev1.PodSpec{
 			Affinity: podAffinity,
 			Containers: []corev1.Container{
 				{
-					Name:            name,
-					Image:           fmt.Sprintf("%s/%s%s", repository, name, version),
+					Name:            podName,
+					Image:           fmt.Sprintf("%s/%s%s", repository, imageName, version),
 					ImagePullPolicy: pullPolicy,
 				},
 			},
@@ -138,9 +133,9 @@ func newPodTemplateSpec(name string, repository string, version string, pullPoli
 	}, nil
 }
 
-func newBaseDeployment(name string, namespace string, repository string, version string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity) (*appsv1.Deployment, error) {
+func newBaseDeployment(deploymentName string, imageName string, namespace string, repository string, version string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity) (*appsv1.Deployment, error) {
 
-	podTemplateSpec, err := newPodTemplateSpec(name, repository, version, pullPolicy, podAffinity)
+	podTemplateSpec, err := newPodTemplateSpec(deploymentName, imageName, repository, version, pullPolicy, podAffinity)
 	if err != nil {
 		return nil, err
 	}
@@ -152,16 +147,16 @@ func newBaseDeployment(name string, namespace string, repository string, version
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      name,
+			Name:      deploymentName,
 			Labels: map[string]string{
-				virtv1.AppLabel: name,
+				virtv1.AppLabel: deploymentName,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: int32Ptr(2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"kubevirt.io": name,
+					"kubevirt.io": deploymentName,
 				},
 			},
 			Template: *podTemplateSpec,
@@ -193,9 +188,11 @@ func newPodAntiAffinity(key, topologyKey string, operator metav1.LabelSelectorOp
 	}
 }
 
-func NewApiServerDeployment(namespace string, repository string, version string, pullPolicy corev1.PullPolicy, verbosity string) (*appsv1.Deployment, error) {
+func NewApiServerDeployment(namespace string, repository string, imagePrefix string, version string, pullPolicy corev1.PullPolicy, verbosity string) (*appsv1.Deployment, error) {
 	podAntiAffinity := newPodAntiAffinity("kubevirt.io", "kubernetes.io/hostname", metav1.LabelSelectorOpIn, []string{"virt-api"})
-	deployment, err := newBaseDeployment("virt-api", namespace, repository, version, pullPolicy, podAntiAffinity)
+	deploymentName := "virt-api"
+	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
+	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, version, pullPolicy, podAntiAffinity)
 	if err != nil {
 		return nil, err
 	}
@@ -246,9 +243,11 @@ func NewApiServerDeployment(namespace string, repository string, version string,
 	return deployment, nil
 }
 
-func NewControllerDeployment(namespace string, repository string, controllerVersion string, launcherVersion string, pullPolicy corev1.PullPolicy, verbosity string) (*appsv1.Deployment, error) {
+func NewControllerDeployment(namespace string, repository string, imagePrefix string, controllerVersion string, launcherVersion string, pullPolicy corev1.PullPolicy, verbosity string) (*appsv1.Deployment, error) {
 	podAntiAffinity := newPodAntiAffinity("kubevirt.io", "kubernetes.io/hostname", metav1.LabelSelectorOpIn, []string{"virt-controller"})
-	deployment, err := newBaseDeployment("virt-controller", namespace, repository, controllerVersion, pullPolicy, podAntiAffinity)
+	deploymentName := "virt-controller"
+	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
+	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, controllerVersion, pullPolicy, podAntiAffinity)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +264,7 @@ func NewControllerDeployment(namespace string, repository string, controllerVers
 	container.Command = []string{
 		"virt-controller",
 		"--launcher-image",
-		fmt.Sprintf("%s/%s%s", repository, "virt-launcher", launcherVersion),
+		fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-launcher", launcherVersion),
 		"--port",
 		"8443",
 		"-v",
@@ -310,8 +309,11 @@ func NewControllerDeployment(namespace string, repository string, controllerVers
 	return deployment, nil
 }
 
-func NewHandlerDaemonSet(namespace string, repository string, version string, pullPolicy corev1.PullPolicy, verbosity string) (*appsv1.DaemonSet, error) {
-	podTemplateSpec, err := newPodTemplateSpec("virt-handler", repository, version, pullPolicy, nil)
+func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string, version string, pullPolicy corev1.PullPolicy, verbosity string) (*appsv1.DaemonSet, error) {
+
+	deploymentName := "virt-handler"
+	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
+	podTemplateSpec, err := newPodTemplateSpec(deploymentName, imageName, repository, version, pullPolicy, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -429,14 +431,14 @@ func NewHandlerDaemonSet(namespace string, repository string, version string, pu
 }
 
 // Used for manifest generation only
-func NewOperatorDeployment(namespace string, repository string, version string,
+func NewOperatorDeployment(namespace string, repository string, imagePrefix string, version string,
 	pullPolicy corev1.PullPolicy, verbosity string,
 	kubeVirtVersionEnv string, virtApiShaEnv string, virtControllerShaEnv string,
 	virtHandlerShaEnv string, virtLauncherShaEnv string) (*appsv1.Deployment, error) {
 
 	name := "virt-operator"
 	version = AddVersionSeparatorPrefix(version)
-	image := fmt.Sprintf("%s/%s%s", repository, name, version)
+	image := fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, name, version)
 
 	tolerations, err := criticalAddonsToleration()
 	if err != nil {
@@ -514,7 +516,7 @@ func NewOperatorDeployment(namespace string, repository string, version string,
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "OPERATOR_IMAGE",
+									Name:  operatorutil.OperatorImageEnvName,
 									Value: image,
 								},
 								{

--- a/vendor/kubevirt.io/kubevirt/pkg/virt-operator/creation/csv/csv.go
+++ b/vendor/kubevirt.io/kubevirt/pkg/virt-operator/creation/csv/csv.go
@@ -37,6 +37,7 @@ type NewClusterServiceVersionData struct {
 	KubeVirtVersion      string
 	OperatorImageVersion string
 	DockerPrefix         string
+	ImagePrefix          string
 	ImagePullPolicy      string
 	Verbosity            string
 	CsvVersion           string
@@ -132,6 +133,7 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 	deployment, err := components.NewOperatorDeployment(
 		data.Namespace,
 		data.DockerPrefix,
+		data.ImagePrefix,
 		data.OperatorImageVersion,
 		v1.PullPolicy(data.ImagePullPolicy),
 		data.Verbosity,

--- a/vendor/kubevirt.io/kubevirt/pkg/virt-operator/install-strategy/strategy.go
+++ b/vendor/kubevirt.io/kubevirt/pkg/virt-operator/install-strategy/strategy.go
@@ -234,19 +234,19 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	strategy.serviceMonitors = append(strategy.serviceMonitors, components.NewServiceMonitorCR(config.GetNamespace(), monitorNamespace, true))
 
 	strategy.services = append(strategy.services, components.NewApiServerService(config.GetNamespace()))
-	apiDeployment, err := components.NewApiServerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetApiVersion(), config.GetImagePullPolicy(), config.GetVerbosity())
+	apiDeployment, err := components.NewApiServerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), config.GetImagePullPolicy(), config.GetVerbosity())
 	if err != nil {
 		return nil, fmt.Errorf("error generating virt-apiserver deployment %v", err)
 	}
 	strategy.deployments = append(strategy.deployments, apiDeployment)
 
-	controller, err := components.NewControllerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetControllerVersion(), config.GetLauncherVersion(), config.GetImagePullPolicy(), config.GetVerbosity())
+	controller, err := components.NewControllerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), config.GetImagePullPolicy(), config.GetVerbosity())
 	if err != nil {
 		return nil, fmt.Errorf("error generating virt-controller deployment %v", err)
 	}
 	strategy.deployments = append(strategy.deployments, controller)
 
-	handler, err := components.NewHandlerDaemonSet(config.GetNamespace(), config.GetImageRegistry(), config.GetHandlerVersion(), config.GetImagePullPolicy(), config.GetVerbosity())
+	handler, err := components.NewHandlerDaemonSet(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), config.GetImagePullPolicy(), config.GetVerbosity())
 	if err != nil {
 		return nil, fmt.Errorf("error generating virt-handler deployment %v", err)
 	}

--- a/vendor/kubevirt.io/kubevirt/pkg/virt-operator/kubevirt.go
+++ b/vendor/kubevirt.io/kubevirt/pkg/virt-operator/kubevirt.go
@@ -568,7 +568,7 @@ func (c *KubeVirtController) execute(key string) error {
 
 func (c *KubeVirtController) generateInstallStrategyJob(config *operatorutil.KubeVirtDeploymentConfig) (*batchv1.Job, error) {
 
-	operatorImage := fmt.Sprintf("%s/%s%s", config.GetImageRegistry(), "virt-operator", components.AddVersionSeparatorPrefix(config.GetOperatorVersion()))
+	operatorImage := fmt.Sprintf("%s/%s%s%s", config.GetImageRegistry(), config.GetImagePrefix(), "virt-operator", components.AddVersionSeparatorPrefix(config.GetOperatorVersion()))
 	deploymentConfigJson, err := config.GetJson()
 	if err != nil {
 		return nil, err

--- a/vendor/kubevirt.io/kubevirt/pkg/virt-operator/util/config.go
+++ b/vendor/kubevirt.io/kubevirt/pkg/virt-operator/util/config.go
@@ -67,13 +67,14 @@ const (
 	DefaultMonitorAccount = "prometheus-k8s"
 
 	// the regex used to parse the operator image
-	operatorImageRegex = "^(.*)/virt-operator([@:].*)?$"
+	operatorImageRegex = "^(.*)/(.*)virt-operator([@:].*)?$"
 )
 
 type KubeVirtDeploymentConfig struct {
-	ID        string `json:"id,omitempty" optional:"true"`
-	Namespace string `json:"namespace,omitempty" optional:"true"`
-	Registry  string `json:"registry,omitempty" optional:"true"`
+	ID          string `json:"id,omitempty" optional:"true"`
+	Namespace   string `json:"namespace,omitempty" optional:"true"`
+	Registry    string `json:"registry,omitempty" optional:"true"`
+	ImagePrefix string `json:"imagePrefix,omitempty" optional:"true"`
 
 	// the KubeVirt version
 	// matches the image tag, if tags are used, either by the manifest, or by the KubeVirt CR
@@ -155,14 +156,16 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 	tagFromOperator := ""
 	operatorSha := ""
 	skipShasums := false
+	imagePrefix := ""
 
 	if len(matches) == 1 {
 		// only use registry from operator image if it was not given yet
 		if registry == "" {
 			registry = matches[0][1]
 		}
+		imagePrefix = matches[0][2]
 
-		version := matches[0][2]
+		version := matches[0][3]
 		if version == "" {
 			tagFromOperator = "latest"
 		} else if strings.HasPrefix(version, ":") {
@@ -183,7 +186,7 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 		}
 	}
 
-	config := newDeploymentConfigWithTag(registry, tag, namespace, additionalProperties)
+	config := newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, additionalProperties)
 	if skipShasums {
 		return config
 	}
@@ -195,7 +198,7 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 	launcherSha := os.Getenv(VirtLauncherShasumEnvName)
 	kubeVirtVersion := os.Getenv(KubeVirtVersionEnvName)
 	if operatorSha != "" && apiSha != "" && controllerSha != "" && handlerSha != "" && launcherSha != "" && kubeVirtVersion != "" {
-		config = newDeploymentConfigWithShasums(registry, kubeVirtVersion, operatorSha, apiSha, controllerSha, handlerSha, launcherSha, namespace, additionalProperties)
+		config = newDeploymentConfigWithShasums(registry, imagePrefix, kubeVirtVersion, operatorSha, apiSha, controllerSha, handlerSha, launcherSha, namespace, additionalProperties)
 	}
 
 	return config
@@ -209,7 +212,7 @@ func VerifyEnv() error {
 	}
 	imageRegEx := regexp.MustCompile(operatorImageRegex)
 	matches := imageRegEx.FindAllStringSubmatch(imageString, 1)
-	if len(matches) != 1 || len(matches[0]) != 3 {
+	if len(matches) != 1 || len(matches[0]) != 4 {
 		return fmt.Errorf("can not parse operator image env var %s", imageString)
 	}
 
@@ -230,9 +233,10 @@ func VerifyEnv() error {
 	return nil
 }
 
-func newDeploymentConfigWithTag(registry, tag, namespace string, kvSpec map[string]string) *KubeVirtDeploymentConfig {
+func newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace string, kvSpec map[string]string) *KubeVirtDeploymentConfig {
 	c := &KubeVirtDeploymentConfig{
 		Registry:             registry,
+		ImagePrefix:          imagePrefix,
 		KubeVirtVersion:      tag,
 		Namespace:            namespace,
 		AdditionalProperties: kvSpec,
@@ -241,9 +245,10 @@ func newDeploymentConfigWithTag(registry, tag, namespace string, kvSpec map[stri
 	return c
 }
 
-func newDeploymentConfigWithShasums(registry, kubeVirtVersion, operatorSha, apiSha, controllerSha, handlerSha, launcherSha, namespace string, additionalProperties map[string]string) *KubeVirtDeploymentConfig {
+func newDeploymentConfigWithShasums(registry, imagePrefix, kubeVirtVersion, operatorSha, apiSha, controllerSha, handlerSha, launcherSha, namespace string, additionalProperties map[string]string) *KubeVirtDeploymentConfig {
 	c := &KubeVirtDeploymentConfig{
 		Registry:             registry,
+		ImagePrefix:          imagePrefix,
 		KubeVirtVersion:      kubeVirtVersion,
 		VirtOperatorSha:      operatorSha,
 		VirtApiSha:           apiSha,
@@ -298,6 +303,10 @@ func (c *KubeVirtDeploymentConfig) GetKubeVirtVersion() string {
 
 func (c *KubeVirtDeploymentConfig) GetImageRegistry() string {
 	return c.Registry
+}
+
+func (c *KubeVirtDeploymentConfig) GetImagePrefix() string {
+	return c.ImagePrefix
 }
 
 func (c *KubeVirtDeploymentConfig) UseShasums() bool {

--- a/vendor/kubevirt.io/kubevirt/tools/csv-generator/csv-generator.go
+++ b/vendor/kubevirt.io/kubevirt/tools/csv-generator/csv-generator.go
@@ -31,6 +31,7 @@ import (
 func main() {
 	namespace := flag.String("namespace", "placeholder", "Namespace to use.")
 	operatorImageVersion := flag.String("operatorImageVersion", "latest", "Image sha256 hash or image tag used to uniquely identify the operator container image to use in the CSV")
+	imagePrefix := flag.String("imagePrefix", "", "Optional prefix for virt-* image names.")
 	dockerPrefix := flag.String("dockerPrefix", "kubevirt", "Image Repository to use.")
 	kubeVirtVersion := flag.String("kubeVirtVersion", "", "represents the KubeVirt releaseassociated with this CSV. Required when image SHAs are used.")
 	pullPolicy := flag.String("pullPolicy", "IfNotPresent", "ImagePullPolicy to use.")
@@ -52,6 +53,7 @@ func main() {
 		KubeVirtVersion:      *kubeVirtVersion,
 		OperatorImageVersion: *operatorImageVersion,
 		DockerPrefix:         *dockerPrefix,
+		ImagePrefix:          *imagePrefix,
 		ImagePullPolicy:      *pullPolicy,
 		Verbosity:            *verbosity,
 		CsvVersion:           *csvVersion,

--- a/vendor/kubevirt.io/kubevirt/tools/manifest-templator/manifest-templator.go
+++ b/vendor/kubevirt.io/kubevirt/tools/manifest-templator/manifest-templator.go
@@ -47,6 +47,7 @@ type templateData struct {
 	CSVNamespace           string
 	DockerTag              string
 	DockerPrefix           string
+	ImagePrefix            string
 	ImagePullPolicy        string
 	Verbosity              string
 	CsvVersion             string
@@ -71,6 +72,7 @@ func main() {
 	csvNamespace := flag.String("csv-namespace", "placeholder", "")
 	cdiNamespace := flag.String("cdi-namespace", "", "")
 	dockerPrefix := flag.String("container-prefix", "", "")
+	imagePrefix := flag.String("image-prefix", "", "")
 	dockerTag := flag.String("container-tag", "", "")
 	csvVersion := flag.String("csv-version", "", "")
 	imagePullPolicy := flag.String("image-pull-policy", "IfNotPresent", "")
@@ -107,6 +109,7 @@ func main() {
 		data.CDINamespace = *cdiNamespace
 		data.DockerTag = *dockerTag
 		data.DockerPrefix = *dockerPrefix
+		data.ImagePrefix = *imagePrefix
 		data.ImagePullPolicy = *imagePullPolicy
 		data.Verbosity = fmt.Sprintf("\"%s\"", *verbosity)
 		data.CsvVersion = *csvVersion
@@ -150,6 +153,7 @@ func main() {
 		data.CDINamespace = "{{.CDINamespace}}"
 		data.DockerTag = "{{.DockerTag}}"
 		data.DockerPrefix = "{{.DockerPrefix}}"
+		data.ImagePrefix = "{{.ImagePrefix}}"
 		data.ImagePullPolicy = "{{.ImagePullPolicy}}"
 		data.Verbosity = "{{.Verbosity}}"
 		data.CsvVersion = "{{.CsvVersion}}"
@@ -211,8 +215,10 @@ func getOperatorDeploymentSpec(data templateData, indentation int) string {
 		version = data.VirtOperatorSha
 	}
 
-	deployment, err := components.NewOperatorDeployment(data.Namespace,
+	deployment, err := components.NewOperatorDeployment(
+		data.Namespace,
 		data.DockerPrefix,
+		data.ImagePrefix,
 		version,
 		v1.PullPolicy(data.ImagePullPolicy),
 		data.Verbosity,

--- a/vendor/kubevirt.io/kubevirt/tools/resource-generator/resource-generator.go
+++ b/vendor/kubevirt.io/kubevirt/tools/resource-generator/resource-generator.go
@@ -35,6 +35,7 @@ func main() {
 	resourceType := flag.String("type", "", "Type of resource to generate. vmi | vmipreset | vmirs | vm | vmim | kv | rbac")
 	namespace := flag.String("namespace", "kube-system", "Namespace to use.")
 	repository := flag.String("repository", "kubevirt", "Image Repository to use.")
+	imagePrefix := flag.String("imagePrefix", "", "Optional prefix for virt-* image names.")
 	version := flag.String("version", "latest", "Version to use.")
 	launcherVersion := flag.String("launcherVersion", "latest", "Version to use for virt-launcher. Only relevant for controller manifest.")
 	pullPolicy := flag.String("pullPolicy", "IfNotPresent", "ImagePullPolicy to use.")
@@ -83,25 +84,25 @@ func main() {
 	case "prometheus":
 		util.MarshallObject(components.NewPrometheusService(*namespace), os.Stdout)
 	case "virt-api":
-		apisService := components.NewApiServerService(*namespace)
-		apiDeployment, err := components.NewApiServerDeployment(*namespace, *repository, *version, imagePullPolicy, *verbosity)
+		apiService := components.NewApiServerService(*namespace)
+		apiDeployment, err := components.NewApiServerDeployment(*namespace, *repository, *imagePrefix, *version, imagePullPolicy, *verbosity)
 		if err != nil {
 			panic(fmt.Errorf("error generating virt-apiserver deployment %v", err))
 
 		}
-		all := []interface{}{apisService, apiDeployment}
+		all := []interface{}{apiService, apiDeployment}
 		for _, r := range all {
 			util.MarshallObject(r, os.Stdout)
 		}
 	case "virt-controller":
-		controller, err := components.NewControllerDeployment(*namespace, *repository, *version, *launcherVersion, imagePullPolicy, *verbosity)
+		controller, err := components.NewControllerDeployment(*namespace, *repository, *imagePrefix, *version, *launcherVersion, imagePullPolicy, *verbosity)
 		if err != nil {
 			panic(fmt.Errorf("error generating virt-controller deployment %v", err))
 
 		}
 		util.MarshallObject(controller, os.Stdout)
 	case "virt-handler":
-		handler, err := components.NewHandlerDaemonSet(*namespace, *repository, *version, imagePullPolicy, *verbosity)
+		handler, err := components.NewHandlerDaemonSet(*namespace, *repository, *imagePrefix, *version, imagePullPolicy, *verbosity)
 		if err != nil {
 			panic(fmt.Errorf("error generating virt-handler deployment %v", err))
 		}


### PR DESCRIPTION
heads up, if you call virt-operator's csv-generator directly in its image, the flag name is `-imagePrefix`

/cc @tiraboschi 