### PR TITLE
Replace COPY --chown with USER directive

### DIFF
--- a/deploy/Dockerfile.registry.upgrade
+++ b/deploy/Dockerfile.registry.upgrade
@@ -10,8 +10,8 @@ RUN export UPGRADE_VERSION=${UPGRADE_VERSION}; ./hack/upgrade-create-new-version
 FROM quay.io/openshift/origin-operator-registry:latest
 ARG KUBEVIRT_PROVIDER
 ARG UPGRADE_VERSION=100.0.0
-# sed fails if chown=1001 is not applied
-COPY --chown=1001 --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/deploy/olm-catalog /registry
+COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/deploy/olm-catalog /registry
+USER root
 
 RUN echo "UPGRADE_VERSION: ${UPGRADE_VERSION}"
 RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:latest|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; else sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:latest|registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; fi


### PR DESCRIPTION
OpenShift CI does not use docker to build images. It uses
imagebuilder: https://github.com/openshift/imagebuilder

Imagebuilder reads the Dockerfile format, but doesn't support
all options like COPY --chown.

The COPY --chown is now replaced with USER root. This works with
both docker build and imagebuilder and allows the sed replace 
command to run.

Signed-off-by: Richard Su <rwsu@redhat.com>