### PR TITLE
add missing permission for ssp operator

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -908,6 +908,7 @@ rules:
   - apps
   resources:
   - deployments
+  - deployments/finalizers
   - replicasets
   - daemonsets
   - statefulsets

--- a/templates/cluster_role.yaml.in
+++ b/templates/cluster_role.yaml.in
@@ -54,6 +54,7 @@ rules:
   - apps
   resources:
   - deployments
+  - deployments/finalizers
   - replicasets
   - daemonsets
   - statefulsets

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -267,6 +267,7 @@ spec:
             - apps
             resources:
             - deployments
+            - deployment/finalizers
             - replicasets
             - daemonsets
             - statefulsets


### PR DESCRIPTION
Add missing permission for ssp operator
This permission is needed due to garbage collection (https://github.com/operator-framework/operator-sdk/blob/ee54f0cf84a845bca7a92ac86e6e8f062fe268ed/doc/user/metrics/README.md#garbage-collection)

Signed-off-by: Karel Šimon <ksimon@redhat.com>
/cc @fromanirh, @rthallisey 