### PR TITLE
Sync permissions between ssp operator and HCO.

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -865,12 +865,16 @@ metadata:
 rules:
 - apiGroups:
   - kubevirt.io
-  - oauth.openshift.io
   - template.openshift.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - create 
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -887,11 +891,8 @@ rules:
   - clusterroles
   verbs:
   - create
-  - get
-  - list
   - watch
   - patch
-  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -902,7 +903,6 @@ rules:
   - list
   - watch
   - patch
-  - update
 - apiGroups:
   - extensions
   - apps
@@ -910,40 +910,40 @@ rules:
   - deployments
   - replicasets
   - daemonsets
-  - statefulsets
   verbs:
-  - '*'
+  - create
+  - update
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
   - configmaps
-  - nodes
-  - endpoints
-  - events
-  - secrets
+  - services
   verbs:
   - create
   - get
   - patch
-  - update
   - list
   - watch
 - apiGroups:
   - ""
   resources:
-  - pods
+  - nodes
   verbs:
-  - '*'
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
-  - services
+  - pods
   verbs:
-  - create
   - get
   - list
-  - patch
   - watch
 - apiGroups:
   - ""
@@ -968,7 +968,7 @@ rules:
   resources:
   - securitycontextconstraints
   verbs:
-  - '*'
+  - 'use'
   resourceNames:
   - privileged
 

--- a/templates/cluster_role.yaml.in
+++ b/templates/cluster_role.yaml.in
@@ -11,12 +11,16 @@ metadata:
 rules:
 - apiGroups:
   - kubevirt.io
-  - oauth.openshift.io
   - template.openshift.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - create 
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -33,11 +37,8 @@ rules:
   - clusterroles
   verbs:
   - create
-  - get
-  - list
   - watch
   - patch
-  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -48,7 +49,6 @@ rules:
   - list
   - watch
   - patch
-  - update
 - apiGroups:
   - extensions
   - apps
@@ -56,40 +56,40 @@ rules:
   - deployments
   - replicasets
   - daemonsets
-  - statefulsets
   verbs:
-  - '*'
+  - create
+  - update
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
   - configmaps
-  - nodes
-  - endpoints
-  - events
-  - secrets
+  - services
   verbs:
   - create
   - get
   - patch
-  - update
   - list
   - watch
 - apiGroups:
   - ""
   resources:
-  - pods
+  - nodes
   verbs:
-  - '*'
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
-  - services
+  - pods
   verbs:
-  - create
   - get
   - list
-  - patch
   - watch
 - apiGroups:
   - ""
@@ -114,7 +114,7 @@ rules:
   resources:
   - securitycontextconstraints
   verbs:
-  - '*'
+  - 'use'
   resourceNames:
   - privileged
 

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -224,12 +224,16 @@ spec:
           rules:
           - apiGroups:
             - kubevirt.io
-            - oauth.openshift.io
             - template.openshift.io
             resources:
             - '*'
             verbs:
-            - '*'
+            - create 
+            - get
+            - list
+            - patch
+            - update
+            - watch
           - apiGroups:
             - monitoring.coreos.com
             resources:
@@ -246,11 +250,8 @@ spec:
             - clusterroles
             verbs:
             - create
-            - get
-            - list
             - watch
             - patch
-            - update
           - apiGroups:
             - rbac.authorization.k8s.io
             resources:
@@ -261,7 +262,6 @@ spec:
             - list
             - watch
             - patch
-            - update
           - apiGroups:
             - extensions
             - apps
@@ -269,40 +269,40 @@ spec:
             - deployments
             - replicasets
             - daemonsets
-            - statefulsets
             verbs:
-            - '*'
+            - create
+            - update
+            - get
+            - list
+            - patch
+            - watch
           - apiGroups:
             - ""
             resources:
             - serviceaccounts
             - configmaps
-            - nodes
-            - endpoints
-            - events
-            - secrets
+            - services
             verbs:
             - create
             - get
             - patch
-            - update
             - list
             - watch
           - apiGroups:
             - ""
             resources:
-            - pods
+            - nodes
             verbs:
-            - '*'
+            - get
+            - patch
+            - update
           - apiGroups:
             - ""
             resources:
-            - services
+            - pods
             verbs:
-            - create
             - get
             - list
-            - patch
             - watch
           - apiGroups:
             - ""
@@ -327,7 +327,7 @@ spec:
             resources:
             - securitycontextconstraints
             verbs:
-            - '*'
+            - 'use'
             resourceNames:
             - privileged
 


### PR DESCRIPTION
Sync permissions between ssp operator and HCO.
This PR reduces permission which are really needed for ssp operator.

Merge only after this PR: https://github.com/kubevirt/hyperconverged-cluster-operator/pull/341 is merged.
/cc @rthallisey, @fromanirh 
Signed-off-by: Karel Šimon <ksimon@redhat.com>