### PR TITLE
Add KVM_EMULATION flag to templates

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/0.0.3/kubevirt-hyperconverged-operator.v0.0.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/0.0.3/kubevirt-hyperconverged-operator.v0.0.3.clusterserviceversion.yaml
@@ -88,7 +88,7 @@ metadata:
     categories: OpenShift Optional
     certified: 'false'
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
-    createdAt: 2019-10-30 16:13:52.498487962 -0400 EDT m=+0.024737598
+    createdAt: 2019-11-05 06:34:07.576911673 -0500 EST m=+0.025574981
     description: Creates and maintains a HyperConverged KubeVirt Deployment
     repository: https://github.com/kubevirt/hyperconverged-cluster-operator
     support: 'false'
@@ -1267,6 +1267,7 @@ spec:
                 - command:
                   - hyperconverged-cluster-operator
                   env:
+                  - name: KVM_EMULATION
                   - name: OPERATOR_IMAGE
                     value: quay.io/kubevirt/hyperconverged-cluster-operator:latest
                   - name: OPERATOR_NAME

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,7 +20,6 @@ spec:
         - hyperconverged-cluster-operator
         env:
         - name: KVM_EMULATION
-          value: ##-enable-only-in-CI-##
         - name: OPERATOR_IMAGE
           value: quay.io/kubevirt/hyperconverged-cluster-operator:latest
         - name: OPERATOR_NAME

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -103,7 +103,7 @@ fi
 if [ "${CI}" != "true" ]; then
 	"${CMD}" create -f _out/operator.yaml
 else
-	sed 's|##-enable-only-in-CI-##|"true"|' < _out/operator.yaml > _out/operator-ci.yaml
+	sed 's|name: KVM_EMULATION|name: KVM_EMULATION\n          value: "true"|' < _out/operator.yaml > _out/operator-ci.yaml
 	cat _out/operator-ci.yaml
 	"${CMD}" create -f _out/operator-ci.yaml
 fi

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -60,6 +60,10 @@ func GetDeployment(repository string, tag string, imagePullPolicy string, Conver
 							},
 							Env: []corev1.EnvVar{
 								{
+									Name:  "KVM_EMULATION",
+									Value: "",
+								},
+								{
 									Name:  "OPERATOR_IMAGE",
 									Value: image,
 								},


### PR DESCRIPTION
The KVM_EMULATION flag was missing from the templates.  Adding it
will prevent it from being removed by accident when updating the templates.

Signed-off-by: rthallisey <rhallise@redhat.com>