### PR TITLE
Fix OpenShift CI Upgrade Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ upgrade-test:
 	./hack/upgrade-test.sh
 
 dump-state:
-	CMD="./cluster-up/kubectl.sh" ./hack/dump-state.sh 
+	./hack/dump-state.sh 
 
 
  

--- a/hack/dump-state.sh
+++ b/hack/dump-state.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+CMD=${CMD:-./cluster-up/kubectl.sh}
 
 function RunCmd {
     cmd=$@

--- a/hack/upgrade-openshiftci-config
+++ b/hack/upgrade-openshiftci-config
@@ -1,0 +1,10 @@
+# Prow OpenShift CI
+# IMAGE_FORMAT=registry.svc.ci.openshift.org/ci-op-b1qw1nxw/stable:hyperconverged-cluster-operator
+HCO_OPERATOR_IMAGE=`eval echo ${IMAGE_FORMAT}`
+CI_IMAGE_URL_PREFIX=$(echo $HCO_OPERATOR_IMAGE | cut -d ":" -f 1)
+echo "CI_IMAGE_URL_PREFIX: $CI_IMAGE_URL_PREFIX"
+REGISTRY_IMAGE="${CI_IMAGE_URL_PREFIX}:hco-registry"
+REGISTRY_IMAGE_UPGRADE="${CI_IMAGE_URL_PREFIX}:hco-registry-upgrade"
+REGISTRY_IMAGE_URL_PREFIX=$CI_IMAGE_URL_PREFIX
+HCO_CATALOG_NAMESPACE="openshift-marketplace"
+export CMD="oc"

--- a/hack/upgrade-stdci-config
+++ b/hack/upgrade-stdci-config
@@ -1,0 +1,6 @@
+# okd-* provider, STDCI
+REGISTRY_IMAGE="registry:5000/kubevirt/hco-registry"
+REGISTRY_IMAGE_UPGRADE="registry:5000/kubevirt/hco-registry-upgrade"
+REGISTRY_IMAGE_URL_PREFIX="registry:5000/kubevirt"
+export CMD="./cluster-up/kubectl.sh"
+HCO_CATALOG_NAMESPACE="openshift-operator-lifecycle-manager"

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -46,25 +46,11 @@
 echo "KUBEVIRT_PROVIDER: $KUBEVIRT_PROVIDER"
 
 if [ -n "$KUBEVIRT_PROVIDER" ]; then
-  # okd-* provider, STDCI
-  REGISTRY_IMAGE="registry:5000/kubevirt/hco-registry"
-  REGISTRY_IMAGE_UPGRADE="registry:5000/kubevirt/hco-registry-upgrade"
-  REGISTRY_IMAGE_URL_PREFIX="registry:5000/kubevirt"
-  export CMD="./cluster-up/kubectl.sh"
-  HCO_CATALOG_NAMESPACE="openshift-operator-lifecycle-manager"
   echo "Running on STDCI ${KUBEVIRT_PROVIDER}"
+  source ./hack/upgrade-stdci-config
 else
-  # Prow OpenShift CI
-  # IMAGE_FORMAT=registry.svc.ci.openshift.org/ci-op-b1qw1nxw/stable:hyperconverged-cluster-operator
-  HCO_OPERATOR_IMAGE=`eval echo ${IMAGE_FORMAT}`
-  CI_IMAGE_URL_PREFIX=$(echo $HCO_OPERATOR_IMAGE | cut -d ":" -f 1)
-  echo "CI_IMAGE_URL_PREFIX: $CI_IMAGE_URL_PREFIX"
-  REGISTRY_IMAGE="${CI_IMAGE_URL_PREFIX}:hco-registry"
-  REGISTRY_IMAGE_UPGRADE="${CI_IMAGE_URL_PREFIX}:hco-registry-upgrade"
-  REGISTRY_IMAGE_URL_PREFIX=$CI_IMAGE_URL_PREFIX
-  HCO_CATALOG_NAMESPACE="openshift-marketplace"
-  export CMD="oc"
   echo "Running on OpenShift CI"
+  source ./hack/upgrade-openshiftci-config
 fi
 
 function cleanup() {


### PR DESCRIPTION
Should not source ./hack/common.sh as it defaults a value
for KUBEVIRT_PROVIDER, which breaks the upgrade-test in
OpenShift CI.

Export CMD so that "make dump-state" works correctly
in OpenShift CI.

"make cluster-clean" should only be called in STDCI.

Hard-coding of ./cluster-up/kubectl.sh in "make dump-state"
makes it incompatible with clusters that are not
started by cluster-up.