### PR TITLE
ssp operator: add missing permission

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -941,6 +941,7 @@ rules:
   - services
   verbs:
   - create
+  - update
   - get
   - patch
   - list

--- a/templates/cluster_role.yaml.in
+++ b/templates/cluster_role.yaml.in
@@ -72,6 +72,7 @@ rules:
   - services
   verbs:
   - create
+  - update
   - get
   - patch
   - list

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion.yaml.in
@@ -285,6 +285,7 @@ spec:
             - services
             verbs:
             - create
+            - update
             - get
             - patch
             - list


### PR DESCRIPTION
add missing update service permission needed by ssp operator
Due to this missing permission, ssp operator failed to start on OCP 4.3.

I am not sure which command updates the CSV. Maybe @rthallisey or @djzager can help me with it?

Signed-off-by: Karel Šimon <ksimon@redhat.com>