### PR TITLE
Temporarily disable stdci on okd-4.1 lane

### DIFF
--- a/stdci.yaml
+++ b/stdci.yaml
@@ -1,6 +1,7 @@
+---
 sub-stages:
   - k8s-1.15.1
-  - okd-4.1
+#  - okd-4.1
 
 runtime_requirements:
   support_nesting_level: 2


### PR DESCRIPTION
Temporarily disable okd-4.1 lane until we can make it reliable.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>