### PR TITLE
Update OperatorGroups api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ kubectl create ns kubevirt-hyperconverged
 Create an OperatorGroup.
 ```bash
 cat <<EOF | kubectl create -f -
-apiVersion: operators.coreos.com/v1alpha2
+apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: hco-operatorgroup

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -109,7 +109,7 @@ ${CMD} create ns kubevirt-hyperconverged | true
 ${CMD} get pods -n kubevirt-hyperconverged 
 
 cat <<EOF | ${CMD} create -f -
-apiVersion: operators.coreos.com/v1alpha2
+apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: hco-operatorgroup


### PR DESCRIPTION
OLM dropped v1alpha2 in https://github.com/operator-framework/operator-lifecycle-manager/pull/1157

Signed-off-by: Richard Su <rwsu@redhat.com>