### PR TITLE
Add marketplace deployment script

### DIFF
--- a/deploy/deploy_marketplace.sh
+++ b/deploy/deploy_marketplace.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+set -ex
+
+RED='\033[0;31m'
+NO_COLOR='\033[0m'
+
+globalNamespace=`oc -n openshift-operator-lifecycle-manager get deployments catalog-operator -o jsonpath='{.spec.template.spec.containers[].args[1]}'`
+echo "Global Namespace: ${globalNamespace}"
+
+APP_REGISTRY="${APP_REGISTRY:-kubevirt-hyperconverged}"
+PACKAGE="${PACKAGE:-kubevirt-hyperconverged}"
+CSC_SOURCE="${CSC_SOURCE:-hco-catalogsource-config}"
+TARGET_NAMESPACE="${TARGET_NAMESPACE:-kubevirt-hyperconverged}"
+CLUSTER="${CLUSTER:-OPENSHIFT}"
+MARKETPLACE_NAMESPACE="${MARKETPLACE_NAMESPACE:-openshift-marketplace}"
+GLOBAL_NAMESPACE="${GLOBAL_NAMESPACE:-$globalNamespace}"
+HCO_VERSION="${HCO_VERSION:-1.0.0}"
+HCO_CHANNEL="${HCO_CHANNEL:-1.0.0}"
+APPROVAL="${APPROVAL:-Manual}"
+CONTENT_ONLY="${CONTENT_ONLY:-}"
+
+RETRIES="${RETRIES:-10}"
+
+oc create ns $TARGET_NAMESPACE || true
+
+if [ "${CLUSTER}" == "KUBERNETES" ]; then
+    MARKETPLACE_NAMESPACE="marketplace"
+fi
+
+TMP_DIR=$(mktemp -d)
+
+function cleanup_tmp {
+    rm -rf $TMP_DIR
+}
+
+trap cleanup_tmp EXIT
+
+cleanup_tmp
+
+if [ `oc get operatorgroup -n "${TARGET_NAMESPACE}" 2> /dev/null | wc -l` -eq 0 ]; then
+    echo "Creating OperatorGroup"
+    cat <<EOF | oc create -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: "${TARGET_NAMESPACE}-group"
+  namespace: "${TARGET_NAMESPACE}"
+spec: {}
+EOF
+fi
+
+echo "Creating OperatorSource"
+cat <<EOF | oc create -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: "${APP_REGISTRY}"
+  namespace: "${MARKETPLACE_NAMESPACE}"
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: "${APP_REGISTRY}"
+  displayName: "${APP_REGISTRY}"
+  publisher: "Kubevirt"
+EOF
+
+echo "Give the cluster 30 seconds to create the catalogSourceConfig..."
+sleep 30
+
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: CatalogSourceConfig
+metadata:
+  name: "${CSC_SOURCE}"
+  namespace: "${MARKETPLACE_NAMESPACE}"
+spec:
+  source: "${APP_REGISTRY}"
+  targetNamespace: "${GLOBAL_NAMESPACE}"
+  packages: "${PACKAGE}"
+  csDisplayName: "HCO Operator"
+  csPublisher: "Red Hat"
+EOF
+
+echo "Give the cluster 30 seconds to process catalogSourceConfig..."
+sleep 30
+oc wait deploy $CSC_SOURCE --for condition=available -n $MARKETPLACE_NAMESPACE --timeout="360s"
+
+for i in $(seq 1 $RETRIES); do
+    echo "Waiting for packagemanifest '${PACKAGE}' to be created in namespace '${TARGET_NAMESPACE}'..."
+    oc get packagemanifest -n "${TARGET_NAMESPACE}" "${PACKAGE}" && break
+    sleep $i
+    if [ "$i" -eq "${RETRIES}" ]; then
+	    echo "packagemanifest '${PACKAGE}' was never created in namespace '${TARGET_NAMESPACE}'"
+	    exit 1
+    fi
+done
+
+echo "Content Successfully Created"
+if [ -z "${CONTENT_ONLY}" ]; then
+    echo "Creating Subscription"
+    cat <<EOF | oc create -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: hco-operatorhub
+  namespace: "${TARGET_NAMESPACE}"
+spec:
+  source: "${CSC_SOURCE}"
+  sourceNamespace: "${GLOBAL_NAMESPACE}"
+  name: kubevirt-hyperconverged
+  startingCSV: "kubevirt-hyperconverged-operator.v${HCO_VERSION}"
+  channel: "${HCO_CHANNEL}"
+  installPlanApproval: "${APPROVAL}"
+EOF
+
+    echo "Give OLM 60 seconds to process the subscription..."
+    sleep 60
+
+    oc get installplan -o yaml -n "${TARGET_NAMESPACE}" $(oc get installplan -n "${TARGET_NAMESPACE}" --no-headers | grep "kubevirt-hyperconverged-operator.v${HCO_VERSION}" | awk '{print $1}') | sed 's/approved: false/approved: true/' | oc apply -n "${TARGET_NAMESPACE}" -f -
+
+    echo "Give OLM 60 seconds to process the installplan..."
+    sleep 60
+
+    oc wait pod $(oc get pods -n ${TARGET_NAMESPACE} | grep hco-operator | head -1 | awk '{ print $1 }') --for condition=Ready -n ${TARGET_NAMESPACE} --timeout="360s"
+
+    echo "Creating the HCO's Custom Resource"
+    cat <<EOF | oc create -f -
+apiVersion: hco.kubevirt.io/v1alpha1
+kind: HyperConverged
+metadata:
+  name: hyperconverged-cluster
+  namespace: "${TARGET_NAMESPACE}"
+spec:
+  BareMetalPlatform: true
+EOF
+
+    echo "Waiting for HCO to get fully deployed"
+    oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=10m
+fi


### PR DESCRIPTION
Add a script to let the user deploy
a kubevirt hyperconverged cluster
from a bundle exposed in a public
app-registry available here:
https://quay.io/application/kubevirt-hyperconverged/kubevirt-hyperconverged?tab=releases

The script behaviour can be customized
via env variables to point to a different
app-registry.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>