### PR TITLE
WIP: Create HyperConverged resource on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,6 @@ spec:
 EOF
 ```
 
-Create an HCO CustomResource, which creates the KubeVirt CR, launching KubeVirt,
-CDI, Network-addons, and SSP.
-```bash
-kubectl create -f deploy/hco.cr.yaml -n kubevirt-hyperconverged
-```
-
 ## Create a Cluster & Launch the HCO
 1. Choose the provider  
 ```bash

--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/hyperconverged"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -70,9 +71,9 @@ func main() {
 
 	printVersion()
 
-	namespace, err := k8sutil.GetWatchNamespace()
+	hcoNamespacedName, err := hyperconverged.GetNamespacedName()
 	if err != nil {
-		log.Error(err, "Failed to get watch namespace")
+		log.Error(err, "Failed to get HyperConverged resource namespaced name")
 		os.Exit(1)
 	}
 
@@ -110,7 +111,7 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
+		Namespace:          hcoNamespacedName.Namespace,
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -33,6 +33,3 @@ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-clus
 kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/service_account.yaml
 kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/cluster_role_binding.yaml
 kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/operator.yaml
-
-# Create an HCO CustomResource, which creates the KubeVirt CR, launching KubeVirt.
-kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/hco.cr.yaml

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: hco.kubevirt.io/v1alpha1
-kind: HyperConverged
-metadata:
-  name: hyperconverged-cluster
-spec: {}

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
-    createdAt: "2019-12-13 11:09:13"
+    createdAt: "2019-12-17 14:10:45"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1265,6 +1265,12 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: HCO_NAME
+                  value: hyperconverged-cluster
+                - name: HCO_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: WATCH_NAMESPACE
                 - name: CONVERSION_CONTAINER
                   value: quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -29,6 +29,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: HCO_NAME
+          value: hyperconverged-cluster
+        - name: HCO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: WATCH_NAMESPACE
         - name: CONVERSION_CONTAINER
           value: quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0

--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -7,6 +7,20 @@ go get -v github.com/onsi/ginkgo/ginkgo
 go get -v github.com/onsi/gomega
 export PATH=$PATH:$HOME/gopath/bin
 JOB_TYPE="${JOB_TYPE:-}"
+CLEANUP_SERVICE_ACCOUNT_DIR=""
+
+secrets_dir="/var/run/secrets"
+service_account_dir="${secrets_dir}/kubernetes.io/serviceaccount"
+namespace_path="${service_account_dir}/namespace"
+if [ ! -s ${service_account_dir} ]; then
+    SUDO=''
+    if [ "$EUID" -ne 0 ]; then
+        SUDO='sudo'
+    fi
+    CLEANUP_SERVICE_ACCOUNT_DIR=true
+    $SUDO mkdir -p ${service_account_dir}
+    echo "kubevirt-hyperconverged" | $SUDO tee ${namespace_path}
+fi
 
 if [ "${JOB_TYPE}" == "travis" ]; then
     go get -v -t ./...
@@ -19,4 +33,8 @@ else
     mkdir -p ${test_out_path}
     ginkgo build ${test_path}
     mv ${test_path}/func-tests.test ${test_out_path}
+fi
+
+if [ -n ${CLEANUP_SERVICE_ACCOUNT_DIR} ]; then
+    sudo rm -r ${secrets_dir}
 fi

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -20,7 +20,6 @@
 source hack/common.sh
 
 # Remove HCO
-"${CMD}" delete -f _out/hco.cr.yaml --ignore-not-found || true
 "${CMD}" wait --for=delete hyperconverged.hco.kubevirt.io/hyperconverged-cluster || true
 # TODO: delete hangs on machine.crd.yaml. Only delete the ones that don't hang
 # from _out/crds/.

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -116,7 +116,7 @@ for op in cdi-operator cluster-network-addons-operator kubevirt-ssp-operator nod
     "${CMD}" wait deployment/"${op}" --for=condition=Available --timeout="360s" || CONTAINER_ERRORED+="${op} "
 done
 
-"${CMD}" create -f _out/hco.cr.yaml
+# HyperConverged resource should be created automatically
 sleep 10
 # Give 8 minutes to available condition become true
 if ! timeout 8m bash -c -- "until "${CMD}" get -n ${HCO_NAMESPACE} ${HCO_KIND} ${HCO_RESOURCE_NAME} -o go-template='{{ range .status.conditions }}{{ if eq .type \"Available\" }}{{ .status }}{{ end }}{{ end }}' | grep True; do sleep 1; done";

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -86,7 +86,6 @@ if [ -n "$KUBEVIRT_PROVIDER" ]; then
   make cluster-clean
 fi
 
-"${CMD}" delete -f ./deploy/hco.cr.yaml -n kubevirt-hyperconverged | true
 "${CMD}" delete subscription hco-subscription-example -n kubevirt-hyperconverged | true
 "${CMD}" delete catalogsource hco-catalogsource-example -n ${HCO_CATALOG_NAMESPACE} | true
 "${CMD}" delete operatorgroup hco-operatorgroup -n kubevirt-hyperconverged | true
@@ -175,7 +174,7 @@ HCO_NAMESPACE="kubevirt-hyperconverged"
 HCO_KIND="hyperconvergeds"
 HCO_RESOURCE_NAME="hyperconverged-cluster"
 
-${CMD} create -f ./deploy/hco.cr.yaml -n kubevirt-hyperconverged
+# HyperConverged resource should be created automatically
 
 HCO_OPERATOR_POD=`${CMD} get pods -n kubevirt-hyperconverged | grep hco-operator | head -1 | awk '{ print $1 }'`
 ${CMD} wait pod $HCO_OPERATOR_POD --for condition=Ready -n kubevirt-hyperconverged --timeout="600s"

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -115,6 +115,18 @@ func GetDeploymentSpec(image, imagePullPolicy, conversionContainer, vmwareContai
 								},
 							},
 							{
+								Name: "HCO_NAME",
+								Value: "hyperconverged-cluster",
+							},
+							{
+								Name: "HCO_NAMESPACE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
+								},
+							},
+							{
 								Name:  "WATCH_NAMESPACE",
 								Value: "",
 							},

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -115,18 +115,6 @@ func GetDeploymentSpec(image, imagePullPolicy, conversionContainer, vmwareContai
 								},
 							},
 							{
-								Name: "HCO_NAME",
-								Value: "hyperconverged-cluster",
-							},
-							{
-								Name: "HCO_NAMESPACE",
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "metadata.namespace",
-									},
-								},
-							},
-							{
 								Name:  "WATCH_NAMESPACE",
 								Value: "",
 							},

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -46,9 +47,7 @@ const (
 	// TODO: Research whether there is a better way.
 	foregroundDeletionFinalizer = "foregroundDeletion"
 
-	HyperConvergedNameEnv      = "HCO_NAME"
-	HyperConvergedNameDefault  = "hyperconverged-cluster"
-	HyperConvergedNamespaceEnv = "HCO_NAMESPACE"
+	HyperConvergedName = "hyperconverged-cluster"
 
 	// UndefinedNamespace is for cluster scoped resources
 	UndefinedNamespace string = ""
@@ -1128,17 +1127,13 @@ func isKVMAvailable() bool {
 // GetNamespacedName returns the name/namespace of the HyperConverged resource
 func GetNamespacedName() (types.NamespacedName, error) {
 	hco := types.NamespacedName{
-		Name: HyperConvergedNameDefault,
+		Name: HyperConvergedName,
 	}
 
-	if name, ok := os.LookupEnv(HyperConvergedNameEnv); ok {
-		hco.Name = name
+	namespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return hco, err
 	}
-
-	if namespace, ok := os.LookupEnv(HyperConvergedNamespaceEnv); ok {
-		hco.Namespace = namespace
-	} else {
-		return hco, fmt.Errorf("%s unset or empty", HyperConvergedNamespaceEnv)
-	}
+	hco.Namespace = namespace
 	return hco, nil
 }

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -44,6 +45,10 @@ const (
 	// Foreground deletion finalizer is blocking removal of HyperConverged until explicitly dropped.
 	// TODO: Research whether there is a better way.
 	foregroundDeletionFinalizer = "foregroundDeletion"
+
+	HyperConvergedNameEnv      = "HCO_NAME"
+	HyperConvergedNameDefault  = "hyperconverged-cluster"
+	HyperConvergedNamespaceEnv = "HCO_NAMESPACE"
 
 	// UndefinedNamespace is for cluster scoped resources
 	UndefinedNamespace string = ""
@@ -1084,4 +1089,22 @@ func isKVMAvailable() bool {
 	}
 	log.Info("Running with KVM available")
 	return true
+}
+
+// GetNamespacedName returns the name/namespace of the HyperConverged resource
+func GetNamespacedName() (types.NamespacedName, error) {
+	hco := types.NamespacedName{
+		Name: HyperConvergedNameDefault,
+	}
+
+	if name, ok := os.LookupEnv(HyperConvergedNameEnv); ok {
+		hco.Name = name
+	}
+
+	if namespace, ok := os.LookupEnv(HyperConvergedNamespaceEnv); ok {
+		hco.Namespace = namespace
+	} else {
+		return hco, fmt.Errorf("%s unset or empty", HyperConvergedNamespaceEnv)
+	}
+	return hco, nil
 }

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -1035,9 +1035,12 @@ var _ = Describe("HyperconvergedController", func() {
 	Describe("Reconcile HyperConverged", func() {
 		Context("HCO Lifecycle", func() {
 
-			It("should handle not found", func() {
+			BeforeEach(func() {
 				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
 				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
+			})
+
+			It("should handle not found", func() {
 				cl := initClient([]runtime.Object{})
 				r := initReconciler(cl)
 
@@ -1046,10 +1049,49 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(res).Should(Equal(reconcile.Result{}))
 			})
 
+			It("should ignore invalid requests", func() {
+
+				hco := &hcov1alpha1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "invalid",
+						Namespace: "invalid",
+					},
+					Spec: hcov1alpha1.HyperConvergedSpec{},
+					Status: hcov1alpha1.HyperConvergedStatus{
+						Conditions: []conditionsv1.Condition{},
+					},
+				}
+				cl := initClient([]runtime.Object{hco})
+				r := initReconciler(cl)
+
+				// Do the reconcile
+				var invalidRequest = reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      "invalid",
+						Namespace: "invalid",
+					},
+				}
+				res, err := r.Reconcile(invalidRequest)
+				Expect(err).To(BeNil())
+				Expect(res).Should(Equal(reconcile.Result{}))
+
+				// Get the HCO
+				foundResource := &hcov1alpha1.HyperConverged{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
+						foundResource),
+				).To(BeNil())
+				// Check conditions
+				Expect(foundResource.Status.Conditions).To(ContainElement(testlib.RepresentCondition(conditionsv1.Condition{
+					Type:    hcov1alpha1.ConditionReconcileComplete,
+					Status:  corev1.ConditionFalse,
+					Reason:  invalidNamespacedName,
+					Message: invalidNamespacedNameMessage,
+				})))
+			})
+
 			It("should create all managed resources", func() {
-				os.Setenv("HCO_NAMESPACE", namespace)
-				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
-				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
 				hco := &hcov1alpha1.HyperConverged{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
@@ -1106,9 +1148,6 @@ var _ = Describe("HyperconvergedController", func() {
 			})
 
 			It("should find all managed resources", func() {
-				os.Setenv("HCO_NAMESPACE", namespace)
-				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
-				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
 				hco := &hcov1alpha1.HyperConverged{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
@@ -1189,9 +1228,6 @@ var _ = Describe("HyperconvergedController", func() {
 			})
 
 			It("should complete when components are finished", func() {
-				os.Setenv("HCO_NAMESPACE", namespace)
-				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
-				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
 				hco := &hcov1alpha1.HyperConverged{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -1047,6 +1047,7 @@ var _ = Describe("HyperconvergedController", func() {
 			})
 
 			It("should create all managed resources", func() {
+				os.Setenv("HCO_NAMESPACE", namespace)
 				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
 				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
 				hco := &hcov1alpha1.HyperConverged{
@@ -1105,6 +1106,7 @@ var _ = Describe("HyperconvergedController", func() {
 			})
 
 			It("should find all managed resources", func() {
+				os.Setenv("HCO_NAMESPACE", namespace)
 				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
 				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
 				hco := &hcov1alpha1.HyperConverged{
@@ -1187,6 +1189,7 @@ var _ = Describe("HyperconvergedController", func() {
 			})
 
 			It("should complete when components are finished", func() {
+				os.Setenv("HCO_NAMESPACE", namespace)
 				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
 				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
 				hco := &hcov1alpha1.HyperConverged{

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -75,14 +75,11 @@ func main() {
 	check(err)
 	v2vCrd, err := os.Create(path.Join(*deployDir, "crds/v2vvmware.crd.yaml"))
 	check(err)
-	operatorCr, err := os.Create(path.Join(*deployDir, "hco.cr.yaml"))
-	check(err)
 	defer operatorYaml.Close()
 	defer saYaml.Close()
 	defer crbYaml.Close()
 	defer crYaml.Close()
 	defer operatorCrd.Close()
-	defer operatorCr.Close()
 	defer v2vCrd.Close()
 
 	// the CSVs we expect to handle
@@ -277,7 +274,6 @@ func main() {
 	// Write out CRDs and CR
 	util.MarshallObject(components.GetOperatorCRD(), operatorCrd)
 	util.MarshallObject(components.GetV2VCRD(), v2vCrd)
-	util.MarshallObject(components.GetOperatorCR(), operatorCr)
 
 	// Write out deployments
 	for _, deployment := range deployments {


### PR DESCRIPTION
- Lock down the name and namespace of the HyperConverged resource
- Create the HyperConverged resource on startup
- Ignore requests of a different name and namespace than configured on Deployment
- Map all events on our secondary watches to requests on our HyperConverged resource