### PR TITLE
Enable KVM emulation for periodic cnv tests in OpenShift CI

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -30,7 +30,7 @@ CI=""
 if [ "$1" == "CI" ]; then
 	echo "deploying on CI"
 	CI="true"
-elif [ "$HOSTNAME" == "hco-e2e-aws" ]; then
+elif [ "$HOSTNAME" == "hco-e2e-aws" ] || [ "$HOSTNAME" == "e2e-aws-cnv" ]; then
 	echo "deploying on AWS CI"
 	CI="true"
 fi


### PR DESCRIPTION
The canary tests are currently broken because KVM emulation is not
enabled for them.

hack/deploy.sh enables KVM emulation when $HOSTNAME = hco-e2e-aws.
The hostname is actually the test name.

For the periodic jobs, the value for $HOSTNAME is e2e-aws-cnv and
that is why emulation was not turned on for them.

Signed-off-by: Richard Su <rwsu@redhat.com>