### PR TITLE
Add cluster-monitoring label to the deployment namespace

### DIFF
--- a/deploy/hco.yaml
+++ b/deploy/hco.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kubevirt-hyperconverged
+  labels:
+    openshift.io/cluster-monitoring: "true"
 
 ---
 apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
The openshift monitoring-operator is looking for rules
under namespaces that are labeled with the cluster-monitoring
label. Since the components that we deploy require this label,
we should set this label on our namespace.

* When deployed on Kubernetes, this label will have no effect.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>