### PR TITLE
Pass kubevirt configurations through HCO CR

### DIFF
--- a/pkg/apis/hco/v1alpha1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1alpha1/hyperconverged_types.go
@@ -1,10 +1,11 @@
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -23,6 +24,9 @@ type HyperConvergedSpec struct {
 
 	// LocalStorageClassName the name of the local storage class.
 	LocalStorageClassName string `json:"LocalStorageClassName,omitempty"`
+
+	// KubevirtConfigurations is the configurations to be passed on to virt-configMap.
+	KubevirtConfigurations KubevirtConfigurations `json:"KubevirtConfigurations,omitempty"`
 }
 
 // HyperConvergedStatus defines the observed state of HyperConverged
@@ -68,4 +72,44 @@ type HyperConvergedList struct {
 
 func init() {
 	SchemeBuilder.Register(&HyperConverged{}, &HyperConvergedList{})
+}
+
+type KubevirtConfigurations struct {
+	ResourceVersion                   string            `json:"ResourceVersion,omitempty"`
+	UseEmulation                      bool              `json:"UseEmulation,omitempty"`
+	MigrationConfig                   *MigrationConfig  `json:"MigrationConfig,omitempty"`
+	ImagePullPolicy                   corev1.PullPolicy `json:"ImagePullPolicy,omitempty"`
+	MachineType                       string            `json:"MachineType,omitempty"`
+	CPUModel                          string            `json:"CPUModel,omitempty"`
+	CPURequest                        resource.Quantity `json:"CPURequest,omitempty"`
+	MemoryOvercommit                  int               `json:"MemoryOvercommit,omitempty"`
+	EmulatedMachines                  []string          `json:"EmulatedMachines,omitempty"`
+	FeatureGates                      *FeatureGates     `json:"FeatureGates,omitempty"`
+	LessPVCSpaceToleration            int               `json:"LessPVCSpaceToleration,omitempty"`
+	NodeSelectors                     map[string]string `json:"NodeSelectors,omitempty"`
+	NetworkInterface                  string            `json:"NetworkInterface,omitempty"`
+	PermitSlirpInterface              bool              `json:"PermitSlirpInterface,omitempty"`
+	PermitBridgeInterfaceOnPodNetwork bool              `json:"PermitBridgeInterfaceOnPodNetwork,omitempty"`
+	SmbiosConfig                      *cmdv1.SMBios     `json:"SmbiosConfig,omitempty"`
+}
+
+type MigrationConfig struct {
+	ParallelOutboundMigrationsPerNode *uint32            `json:"parallelOutboundMigrationsPerNode,omitempty"`
+	ParallelMigrationsPerCluster      *uint32            `json:"parallelMigrationsPerCluster,omitempty"`
+	BandwidthPerMigration             *resource.Quantity `json:"bandwidthPerMigration,omitempty"`
+	NodeDrainTaintKey                 *string            `json:"nodeDrainTaintKey,omitempty"`
+	ProgressTimeout                   *int64             `json:"progressTimeout,omitempty"`
+	CompletionTimeoutPerGiB           *int64             `json:"completionTimeoutPerGiB,omitempty"`
+	UnsafeMigrationOverride           bool               `json:"unsafeMigrationOverride"`
+	AllowAutoConverge                 bool               `json:"allowAutoConverge"`
+}
+
+// FeatureGates represents feature-gates to be enabled or disabled in kubevirt configMap
+type FeatureGates struct {
+	DataVolumes      string `json:"DataVolumes,omitempty"`
+	SRIOV            string `json:"SRIOV,omitempty"`
+	LiveMigration    string `json:"LiveMigration,omitempty"`
+	CPUManager       string `json:"CPUManager,omitempty"`
+	CPUNodeDiscovery string `json:"CPUNodeDiscovery,omitempty"`
+	Sidecar          string `json:"Sidecar,omitempty"`
 }

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/kubevirt/hyperconverged-cluster-operator/tools/util"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/reference"
@@ -295,16 +296,14 @@ func newKubeVirtConfigForCR(cr *hcov1alpha1.HyperConverged, namespace string) *c
 	labels := map[string]string{
 		"app": cr.Name,
 	}
+	data := util.InterfaceToMap(cr.Spec.KubevirtConfigurations)
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubevirt-config",
 			Labels:    labels,
 			Namespace: namespace,
 		},
-		Data: map[string]string{
-			"feature-gates": "DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Sidecar",
-			"migrations":    `{"nodeDrainTaintKey" : "node.kubernetes.io/unschedulable"}`,
-		},
+		Data: data,
 	}
 }
 

--- a/tools/util/marshaller.go
+++ b/tools/util/marshaller.go
@@ -128,3 +128,18 @@ func MarshallObject(obj interface{}, writer io.Writer) error {
 
 	return nil
 }
+
+func InterfaceToMap(iface interface{}) map[string]string {
+	m := make(map[string]string)
+	writer, err := json.Marshal(iface)
+	check(err)
+	err = json.Unmarshal((writer), &m)
+	check(err)
+	return m
+}
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
expose all kubevirt configurations in HCO-CR,
making the HCO controller create virt-configMap using those
configurations.

Signed-off-by: alonSadan <asadan@redhat.com>