### PR TITLE
Add GIT_URL and GIT_SHA to docker labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,12 @@ QUAY_USERNAME      ?=
 QUAY_PASSWORD      ?=
 SOURCE_DIRS        = cmd pkg
 SOURCES            := $(shell find . -name '*.go' -not -path "*/vendor/*")
+SHA                := $(shell git describe --no-match  --always --abbrev=40 --dirty)
 IMAGE_REGISTRY     ?= quay.io
 IMAGE_TAG          ?= latest
 OPERATOR_IMAGE     ?= kubevirt/hyperconverged-cluster-operator
 REGISTRY_NAMESPACE ?=
+
 
 # Prow doesn't have docker command
 DO=./hack/in-docker.sh
@@ -39,7 +41,7 @@ hack-clean: ## Run ./hack/clean.sh
 container-build: container-build-operator container-build-operator-courier
 
 container-build-operator:
-	docker build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) .
+	docker build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-build-operator-courier:
 	docker build -f tools/operator-courier/Dockerfile -t hco-courier .

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,3 +19,9 @@ COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion_merger.yaml.in $CSV_TEMPLATE
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 USER ${USER_UID}
+
+ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git
+ARG git_sha=NONE
+
+LABEL multi.GIT_URL=${git_url} \
+      multi.GIT_SHA=${git_sha}


### PR DESCRIPTION
In order to be able to resolve for each image what is the git
commit it was built from using docker inspect.

Signed-off-by: Or Shoval <oshoval@redhat.com>

can be inspected by using

docker inspect --format "{{ index .Config.Labels \"multi.GIT_URL\"}}" <IMAGE>
docker inspect --format "{{ index .Config.Labels \"multi.GIT_SHA\"}}" <IMAGE>
