### PR TITLE
KubevirtCommonTemplatesBundle CR Namespace Rectification

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -47,10 +47,7 @@ const (
 
 	// UndefinedNamespace is for cluster scoped resources
 	UndefinedNamespace string = ""
-
-	// OpenshiftNamespace is for resources that belong in the openshift namespace
-	OpenshiftNamespace string = "openshift"
-
+	
 	reconcileInit             = "Init"
 	reconcileInitMessage      = "Initializing HyperConverged cluster"
 	reconcileFailed           = "ReconcileFailed"
@@ -765,13 +762,13 @@ func newKubeVirtCommonTemplateBundleForCR(cr *hcov1alpha1.HyperConverged, namesp
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "common-templates-" + cr.Name,
 			Labels:    labels,
-			Namespace: OpenshiftNamespace,
+			Namespace: namespace,
 		},
 	}
 }
 
 func (r *ReconcileHyperConverged) ensureKubeVirtCommonTemplateBundle(instance *hcov1alpha1.HyperConverged, logger logr.Logger, request reconcile.Request) error {
-	kvCTB := newKubeVirtCommonTemplateBundleForCR(instance, OpenshiftNamespace)
+	kvCTB := newKubeVirtCommonTemplateBundleForCR(instance, request.Namespace)
 	if err := controllerutil.SetControllerReference(instance, kvCTB, r.scheme); err != nil {
 		return err
 	}

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -619,7 +619,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Spec: hcov1alpha1.HyperConvergedSpec{},
 				}
 
-				expectedResource := newKubeVirtCommonTemplateBundleForCR(hco, OpenshiftNamespace)
+				expectedResource := newKubeVirtCommonTemplateBundleForCR(hco, namespace)
 				cl := initClient([]runtime.Object{})
 				r := initReconciler(cl)
 				Expect(r.ensureKubeVirtCommonTemplateBundle(hco, log, request)).To(BeNil())
@@ -644,7 +644,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Spec: hcov1alpha1.HyperConvergedSpec{},
 				}
 
-				expectedResource := newKubeVirtCommonTemplateBundleForCR(hco, OpenshiftNamespace)
+				expectedResource := newKubeVirtCommonTemplateBundleForCR(hco, namespace)
 				expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 				cl := initClient([]runtime.Object{hco, expectedResource})
 				r := initReconciler(cl)
@@ -667,7 +667,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Spec: hcov1alpha1.HyperConvergedSpec{},
 				}
 
-				expectedResource := newKubeVirtCommonTemplateBundleForCR(hco, OpenshiftNamespace)
+				expectedResource := newKubeVirtCommonTemplateBundleForCR(hco, namespace)
 				expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 				expectedResource.Status.Conditions = []conditionsv1.Condition{
 					conditionsv1.Condition{
@@ -1136,7 +1136,7 @@ var _ = Describe("HyperconvergedController", func() {
 				expectedCDI.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/cdis/%s", expectedCDI.Namespace, expectedCDI.Name)
 				expectedCNA := newNetworkAddonsForCR(hco, UndefinedNamespace)
 				expectedCNA.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/cnas/%s", expectedCNA.Namespace, expectedCNA.Name)
-				expectedKVCTB := newKubeVirtCommonTemplateBundleForCR(hco, OpenshiftNamespace)
+				expectedKVCTB := newKubeVirtCommonTemplateBundleForCR(hco, namespace)
 				expectedKVCTB.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/ctbs/%s", expectedKVCTB.Namespace, expectedKVCTB.Name)
 				expectedKVNLB := newKubeVirtNodeLabellerBundleForCR(hco, namespace)
 				expectedKVNLB.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/nlb/%s", expectedKVNLB.Namespace, expectedKVNLB.Name)
@@ -1260,7 +1260,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Status: corev1.ConditionFalse,
 					},
 				}
-				expectedKVCTB := newKubeVirtCommonTemplateBundleForCR(hco, OpenshiftNamespace)
+				expectedKVCTB := newKubeVirtCommonTemplateBundleForCR(hco, namespace)
 				expectedKVCTB.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/ctbs/%s", expectedKVCTB.Namespace, expectedKVCTB.Name)
 				expectedKVCTB.Status.Conditions = getGenericCompletedConditions()
 				expectedKVNLB := newKubeVirtNodeLabellerBundleForCR(hco, namespace)


### PR DESCRIPTION
This PR addresses a single case of an issue of objects unintended deletion by GC because of cross-namepsaces ownerships.
KubevirtCommonTemplatesBundle CR's owner is HyperConverged.
Currently these are in different namespaces.
KubevirtCommonTemplatesBundle is hard-codes to be in "openshift" namespace, while other CRs, including the HyperConverged are in "request.Namespace", which is kubevirt-hyperconverged in the upstream.
Issue depicted also in BZ https://bugzilla.redhat.com/show_bug.cgi?id=1788640