### PR TITLE
Let the user set a custom namespace in alm-example at CSV compose time

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
-    createdAt: "2020-01-09 16:44:37"
+    createdAt: "2020-01-16 13:33:38"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -497,14 +497,14 @@ func GetInstallStrategyBase(image, imagePullPolicy, conversionContainer, vmwareC
 }
 
 // GetCSVBase returns a base HCO CSV without an InstallStrategy
-func GetCSVBase(name, displayName, description, image, replaces string, version semver.Version) *csvv1alpha1.ClusterServiceVersion {
+func GetCSVBase(name, hcCRNamespace, displayName, description, image, replaces string, version semver.Version) *csvv1alpha1.ClusterServiceVersion {
 	almExamples, _ := json.Marshal([]interface{}{
 		map[string]interface{}{
 			"apiVersion": "hco.kubevirt.io/v1alpha1",
 			"kind":       "HyperConverged",
 			"metadata": map[string]string{
 				"name":      "kubevirt-hyperconverged",
-				"namespace": "kubevirt-hyperconverged",
+				"namespace": hcCRNamespace,
 			},
 			"spec": map[string]interface{}{
 				"BareMetalPlatform": false,

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -74,6 +74,7 @@ var (
 	specDescription     = flag.String("spec-description", "", "Description")
 	specDisplayName     = flag.String("spec-displayname", "", "Display Name")
 	relatedImagesList   = flag.String("related-images-list", "", "Comma separated list of all the images referred in the CSV")
+	namespace           = flag.String("namespace", "kubevirt-hyperconverged", "Namespace")
 )
 
 func main() {
@@ -101,6 +102,7 @@ func main() {
 	// This is the basic CSV without an InstallStrategy defined
 	csvBase := components.GetCSVBase(
 		operatorName,
+		*namespace,
 		*specDisplayName,
 		*specDescription,
 		*operatorImage,


### PR DESCRIPTION
Let the user set a custom name and namespace for Hyperconverged CR at CSV compose time.
For now this is used only in the alm-example section.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>