### PR TITLE
Ignore invalid requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _out
 .idea
 _ci-configs/*
+*.coverprofile

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
-    createdAt: "2019-12-13 11:09:13"
+    createdAt: "2020-01-09 16:44:37"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1261,6 +1261,10 @@ spec:
                   value: quay.io/kubevirt/hyperconverged-cluster-operator:latest
                 - name: OPERATOR_NAME
                   value: hyperconverged-cluster-operator
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: POD_NAME
                   valueFrom:
                     fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,6 +25,10 @@ spec:
           value: quay.io/kubevirt/hyperconverged-cluster-operator:latest
         - name: OPERATOR_NAME
           value: hyperconverged-cluster-operator
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -107,6 +107,14 @@ func GetDeploymentSpec(image, imagePullPolicy, conversionContainer, vmwareContai
 								Value: hcoName,
 							},
 							{
+								Name:  "OPERATOR_NAMESPACE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
+								},
+							},
+							{
 								Name: "POD_NAME",
 								ValueFrom: &corev1.EnvVarSource{
 									FieldRef: &corev1.ObjectFieldSelector{

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -107,7 +107,7 @@ func GetDeploymentSpec(image, imagePullPolicy, conversionContainer, vmwareContai
 								Value: hcoName,
 							},
 							{
-								Name:  "OPERATOR_NAMESPACE",
+								Name: "OPERATOR_NAMESPACE",
 								ValueFrom: &corev1.EnvVarSource{
 									FieldRef: &corev1.ObjectFieldSelector{
 										FieldPath: "metadata.namespace",

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -10,7 +10,6 @@ import (
 
 	"encoding/json"
 	"github.com/go-logr/logr"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,7 +44,8 @@ const (
 	// use finalizers to manage the cleanup.
 	FinalizerName = "hyperconvergeds.hco.kubevirt.io"
 
-	HyperConvergedName = "hyperconverged-cluster"
+	HyperConvergedName   = "hyperconverged-cluster"
+	OperatorNamespaceEnv = "OPERATOR_NAMESPACE"
 
 	// UndefinedNamespace is for cluster scoped resources
 	UndefinedNamespace string = ""
@@ -1169,11 +1169,12 @@ func getHyperconverged() (types.NamespacedName, error) {
 		Name: HyperConvergedName,
 	}
 
-	namespace, err := k8sutil.GetOperatorNamespace()
-	if err != nil {
-		return hco, err
+	if namespace, ok := os.LookupEnv(OperatorNamespaceEnv); ok {
+		hco.Namespace = namespace
+	} else {
+		return hco, fmt.Errorf("%s unset or empty in environment", OperatorNamespaceEnv)
 	}
-	hco.Namespace = namespace
+
 	return hco, nil
 }
 


### PR DESCRIPTION
The chief reason for this change is that we allow only a single deployment of HCO, controlled by a single CR with a well-known name living in a well-known namespace. Any other CR is invalid, and we would like to report this fact to the user who created it.