### PR TITLE
Improve OperatorGroup count check in deploy_marketplace.sh

### DIFF
--- a/deploy/deploy_marketplace.sh
+++ b/deploy/deploy_marketplace.sh
@@ -91,7 +91,7 @@ EOF
 
 fi
 
-if [ `oc get operatorgroup -n "${TARGET_NAMESPACE}" 2> /dev/null | wc -l` -eq 0 ]; then
+if [ `oc get operatorgroup -n "${TARGET_NAMESPACE}" --no-headers 2> /dev/null | wc -l` -eq 0 ]; then
     echo "Creating OperatorGroup"
     cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
Improve OperatorGroup count check

deploy_marketplace.sh is trying to create an OperatorGroup
only if missing according to the output of oc.
oc already skips the headers when we don't
have entries in the output.
But in general headers are for humans and they
can confuse scripts. Let's drop it in advance
to make it safer.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>