### PR TITLE
Additional custom values for CSV generator

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
-    createdAt: "2020-01-09 16:44:37"
+    createdAt: "2020-01-14 18:32:45"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -83,9 +83,8 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Represents the deployment of a KubeVirt HyperConverged Cluster
-        Operator
-      displayName: KubeVirt HyperConverged Cluster Operator Deployment
+    - description: Represents the deployment of HyperConverged Cluster Operator
+      displayName: HyperConverged Cluster Operator Deployment
       kind: HyperConverged
       name: hyperconvergeds.hco.kubevirt.io
       version: v1alpha1

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -226,6 +226,11 @@ ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
   --replaces-csv-version=${REPLACES_CSV_VERSION} \
   --spec-displayname="KubeVirt HyperConverged Cluster Operator" \
   --spec-description="$(<${PROJECT_ROOT}/docs/operator_description.md)" \
+  --crd-display="HyperConverged Cluster Operator" \
+  --provider-name="KubeVirt project" \
+  --maturity="alpha" \
+  --maintainer-name="KubeVirt project" \
+  --maintainer-email="kubevirt-dev@googlegroups.com" \
   --operator-image-name="${OPERATOR_IMAGE}" > "${CSV_DIR}/${OPERATOR_NAME}.v${CSV_VERSION}.${CSV_EXT}"
 (cd ${PROJECT_ROOT}/tools/csv-merger/ && go clean)
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -497,7 +497,7 @@ func GetInstallStrategyBase(image, imagePullPolicy, conversionContainer, vmwareC
 }
 
 // GetCSVBase returns a base HCO CSV without an InstallStrategy
-func GetCSVBase(name, displayName, description, image, replaces string, version semver.Version) *csvv1alpha1.ClusterServiceVersion {
+func GetCSVBase(name, displayName, description, image, replaces string, version semver.Version, crdDisplay string) *csvv1alpha1.ClusterServiceVersion {
 	almExamples, _ := json.Marshal([]interface{}{
 		map[string]interface{}{
 			"apiVersion": "hco.kubevirt.io/v1alpha1",
@@ -603,8 +603,8 @@ func GetCSVBase(name, displayName, description, image, replaces string, version 
 						Name:        "hyperconvergeds.hco.kubevirt.io",
 						Version:     "v1alpha1",
 						Kind:        "HyperConverged",
-						DisplayName: "KubeVirt HyperConverged Cluster Operator Deployment",
-						Description: "Represents the deployment of a KubeVirt HyperConverged Cluster Operator",
+						DisplayName: crdDisplay + " Deployment",
+						Description: "Represents the deployment of " + crdDisplay,
 					},
 					csvv1alpha1.CRDDescription{
 						Name:        "v2vvmwares.kubevirt.io",

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -74,6 +74,11 @@ var (
 	specDescription     = flag.String("spec-description", "", "Description")
 	specDisplayName     = flag.String("spec-displayname", "", "Display Name")
 	relatedImagesList   = flag.String("related-images-list", "", "Comma separated list of all the images referred in the CSV")
+	crdDisplay          = flag.String("crd-display", "KubeVirt HyperConverged Cluster", "Label show in OLM UI about the primary CRD")
+	providerName        = flag.String("provider-name", "", "Provider name")
+	maturity            = flag.String("maturity", "", "Maturity level")
+	maintainerName      = flag.String("maintainer-name", "", "Maintainer name")
+	maintainerEmail     = flag.String("maintainer-email", "", "Maintainer email address")
 )
 
 func main() {
@@ -106,6 +111,7 @@ func main() {
 		*operatorImage,
 		replaces,
 		version,
+		*crdDisplay,
 	)
 	csvExtended := ClusterServiceVersionExtended{
 		TypeMeta:   csvBase.TypeMeta,
@@ -242,6 +248,18 @@ func main() {
 	}
 	if *specDisplayName != "" {
 		csvExtended.Spec.DisplayName = *specDisplayName
+	}
+	if *providerName != "" {
+		csvExtended.Spec.Provider.Name = *providerName
+	}
+	if *maturity != "" {
+		csvExtended.Spec.Maturity = *maturity
+	}
+	if *maintainerName != "" {
+		csvExtended.Spec.Maintainers[0].Name = *maintainerName
+	}
+	if *maintainerEmail != "" {
+		csvExtended.Spec.Maintainers[0].Email = *maintainerEmail
 	}
 
 	util.MarshallObject(csvExtended, os.Stdout)


### PR DESCRIPTION
Modify the CSV generator to handle additional
custom values at CSV compose time.
More specificly:
- Label shown in OLM UI about the primary CRD
- Provider name
- Maturity level
- Maintainer name
- Maintainer email address

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>