### PR TITLE
Additional custom values for CSV generator

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
-    createdAt: "2020-01-16 13:33:38"
+    createdAt: "2020-01-16 17:24:40"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -83,9 +83,8 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Represents the deployment of a KubeVirt HyperConverged Cluster
-        Operator
-      displayName: KubeVirt HyperConverged Cluster Operator Deployment
+    - description: Represents the deployment of HyperConverged Cluster Operator
+      displayName: HyperConverged Cluster Operator Deployment
       kind: HyperConverged
       name: hyperconvergeds.hco.kubevirt.io
       version: v1alpha1

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -190,6 +190,22 @@ sspCsv="${TEMPDIR}/$(create_ssp_csv).${CSV_EXT}"
 cdiCsv="${TEMPDIR}/$(create_cdi_csv).${CSV_EXT}"
 nmoCsv="${TEMPDIR}/$(create_nmo_csv).${CSV_EXT}"
 hppCsv="${TEMPDIR}/$(create_hpp_csv).${CSV_EXT}"
+csvOverrides="${TEMPDIR}/csv_overrides.${CSV_EXT}"
+cat > ${csvOverrides} <<- EOM
+---
+spec:
+  links:
+  - name: KubeVirt project
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/hyperconverged-cluster-operator
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+EOM
 popd
 
 mkdir -p "${CSV_DIR}"
@@ -226,6 +242,8 @@ ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
   --replaces-csv-version=${REPLACES_CSV_VERSION} \
   --spec-displayname="KubeVirt HyperConverged Cluster Operator" \
   --spec-description="$(<${PROJECT_ROOT}/docs/operator_description.md)" \
+  --crd-display="HyperConverged Cluster Operator" \
+  --csv-overrides="$(<${csvOverrides})" \
   --operator-image-name="${OPERATOR_IMAGE}" > "${CSV_DIR}/${OPERATOR_NAME}.v${CSV_VERSION}.${CSV_EXT}"
 (cd ${PROJECT_ROOT}/tools/csv-merger/ && go clean)
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -497,7 +497,7 @@ func GetInstallStrategyBase(image, imagePullPolicy, conversionContainer, vmwareC
 }
 
 // GetCSVBase returns a base HCO CSV without an InstallStrategy
-func GetCSVBase(name, hcCRNamespace, displayName, description, image, replaces string, version semver.Version) *csvv1alpha1.ClusterServiceVersion {
+func GetCSVBase(name, hcCRNamespace, displayName, description, image, replaces string, version semver.Version, crdDisplay string) *csvv1alpha1.ClusterServiceVersion {
 	almExamples, _ := json.Marshal([]interface{}{
 		map[string]interface{}{
 			"apiVersion": "hco.kubevirt.io/v1alpha1",
@@ -603,8 +603,8 @@ func GetCSVBase(name, hcCRNamespace, displayName, description, image, replaces s
 						Name:        "hyperconvergeds.hco.kubevirt.io",
 						Version:     "v1alpha1",
 						Kind:        "HyperConverged",
-						DisplayName: "KubeVirt HyperConverged Cluster Operator Deployment",
-						Description: "Represents the deployment of a KubeVirt HyperConverged Cluster Operator",
+						DisplayName: crdDisplay + " Deployment",
+						Description: "Represents the deployment of " + crdDisplay,
 					},
 					csvv1alpha1.CRDDescription{
 						Name:        "v2vvmwares.kubevirt.io",


### PR DESCRIPTION
Modify the CSV generator to handle additional
custom values at CSV compose time.
More specificaly:
- Label shown in OLM UI about the primary CRD
- A yaml file with puntual overrides to be applied with imdario/mergo

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>