### PR TITLE
change HCO OperatorGroup membership to select only one namespace

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional
     certified: "false"
+    olm.targetNamespaces: kubevirt-hyperconverged
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
     createdAt: "2020-02-11 19:49:42"
     description: |-
@@ -1277,6 +1278,9 @@ spec:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: CONVERSION_CONTAINER
                   value: quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0
                 - name: VMWARE_CONTAINER
@@ -1554,9 +1558,9 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - KubeVirt

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -114,6 +114,9 @@ kind: OperatorGroup
 metadata:
   name: hco-operatorgroup
   namespace: kubevirt-hyperconverged
+  spec:
+    targetNamespaces:
+    - kubevirt-hyperconverged
 EOF
 
 # TODO: The catalog source image here should point to the latest version in quay.io
@@ -162,6 +165,13 @@ spec:
   source: hco-catalogsource-example
   sourceNamespace: ${HCO_CATALOG_NAMESPACE}
 EOF
+
+# temporary debug show commands
+sleep 15
+${CMD} get csv -A
+${CMD} describe csv -A
+${CMD} get subscription -A -o yaml
+${CMD} get pods -n kubevirt-hyperconverged
 
 # Allow time for the install plan to be created a for the
 # hco-operator to be created. Otherwise kubectl wait will report EOF.

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -123,8 +123,12 @@ func GetDeploymentSpec(image, imagePullPolicy, conversionContainer, vmwareContai
 								},
 							},
 							{
-								Name:  "WATCH_NAMESPACE",
-								Value: "",
+								Name: "WATCH_NAMESPACE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
+								},
 							},
 							{
 								Name:  "CONVERSION_CONTAINER",
@@ -520,15 +524,16 @@ func GetCSVBase(name, hcCRNamespace, displayName, description, image, replaces s
 			Name:      fmt.Sprintf("%v.v%v", name, version.String()),
 			Namespace: "placeholder",
 			Annotations: map[string]string{
-				"alm-examples":   string(almExamples),
-				"capabilities":   "Full Lifecycle",
-				"certified":      "false",
-				"categories":     "OpenShift Optional",
-				"containerImage": image,
-				"createdAt":      time.Now().Format("2006-01-02 15:04:05"),
-				"description":    description,
-				"repository":     "https://github.com/kubevirt/hyperconverged-cluster-operator",
-				"support":        "false",
+				"alm-examples":         string(almExamples),
+				"capabilities":         "Full Lifecycle",
+				"certified":            "false",
+				"olm.targetNamespaces": "kubevirt-hyperconverged",
+				"categories":           "OpenShift Optional",
+				"containerImage":       image,
+				"createdAt":            time.Now().Format("2006-01-02 15:04:05"),
+				"description":          description,
+				"repository":           "https://github.com/kubevirt/hyperconverged-cluster-operator",
+				"support":              "false",
 			},
 		},
 		Spec: csvv1alpha1.ClusterServiceVersionSpec{
@@ -586,11 +591,11 @@ func GetCSVBase(name, hcCRNamespace, displayName, description, image, replaces s
 				},
 				csvv1alpha1.InstallMode{
 					Type:      csvv1alpha1.InstallModeTypeMultiNamespace,
-					Supported: true,
+					Supported: false,
 				},
 				csvv1alpha1.InstallMode{
 					Type:      csvv1alpha1.InstallModeTypeAllNamespaces,
-					Supported: true,
+					Supported: false,
 				},
 			},
 			// Skip this in favor of having a separate function to get

--- a/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion_merger.yaml.in
+++ b/templates/olm-catalog/kubevirt-hyperconverged/VERSION/kubevirt-hyperconverged-operator.VERSION.clusterserviceversion_merger.yaml.in
@@ -343,6 +343,9 @@ spec:
                       fieldRef:
                         fieldPath: metadata.name
                   - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
                   - name: CONVERSION_CONTAINER
                     value: quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0
                   - name: VMWARE_CONTAINER

--- a/templates/operator.yaml.in
+++ b/templates/operator.yaml.in
@@ -32,7 +32,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: WATCH_NAMESPACE
-              value: ""
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: VIRT_LAUNCHER_TAG
               value: {{.KubeVirt.ComponentTag}}
             - name: OPERATOR_NAME


### PR DESCRIPTION
This change is aimed to limit the visibility of HCO operator only to the target namespace, which is "kubevirt-hyperconverged" in upstream and "openshift-cnv" in downstream.
[This is according to official documentation](https://docs.openshift.com/container-platform/4.2/cnv/cnv_install/installing-container-native-virtualization.html#cnv-subscribing-to-hco-catalog_installing-container-native-virtualization).