### PR TITLE
Set KVM_EMULATION in deploy_marketplace.sh and deploy_imageregistry.sh 

### DIFF
--- a/deploy/deploy_imageregistry.sh
+++ b/deploy/deploy_imageregistry.sh
@@ -24,6 +24,7 @@ GLOBAL_NAMESPACE="${GLOBAL_NAMESPACE:-$globalNamespace}"
 
 APPROVAL="${APPROVAL:-Manual}"
 CONTENT_ONLY="${CONTENT_ONLY:-}"
+KVM_EMULATION="${KVM_EMULATION:-false}"
 
 RETRIES="${RETRIES:-10}"
 
@@ -87,6 +88,20 @@ for i in $(seq 1 $RETRIES); do
     fi
 done
 
+SUBSCRIPTION_CONFIG=""
+if [ "$KVM_EMULATION" = true ]; then
+  SUBSCRIPTION_CONFIG=$(cat <<EOF
+  config:
+    selector:
+      matchLabels:
+        name: hyperconverged-cluster-operator
+    env:
+      - name: KVM_EMULATION
+        value: "true"
+EOF
+)
+fi
+
 echo "Content Successfully Created"
 if [ -z "${CONTENT_ONLY}" ]; then
     echo "Creating Subscription"
@@ -103,6 +118,7 @@ spec:
   startingCSV: "kubevirt-hyperconverged-operator.v${HCO_VERSION}"
   channel: "${HCO_CHANNEL}"
   installPlanApproval: "${APPROVAL}"
+${SUBSCRIPTION_CONFIG}
 EOF
 
     echo "Give OLM 60 seconds to process the subscription..."

--- a/deploy/deploy_marketplace.sh
+++ b/deploy/deploy_marketplace.sh
@@ -19,6 +19,7 @@ HCO_VERSION="${HCO_VERSION:-1.0.0}"
 HCO_CHANNEL="${HCO_CHANNEL:-1.0.0}"
 APPROVAL="${APPROVAL:-Manual}"
 CONTENT_ONLY="${CONTENT_ONLY:-}"
+KVM_EMULATION="${KVM_EMULATION:-false}"
 PRIVATE_REPO="${PRIVATE_REPO:-false}"
 QUAY_USERNAME="${QUAY_USERNAME:-}"
 QUAY_PASSWORD="${QUAY_PASSWORD:-}"
@@ -152,6 +153,20 @@ for i in $(seq 1 $RETRIES); do
     fi
 done
 
+SUBSCRIPTION_CONFIG=""
+if [ "$KVM_EMULATION" = true ]; then
+  SUBSCRIPTION_CONFIG=$(cat <<EOF
+  config:
+    selector:
+      matchLabels:
+        name: hyperconverged-cluster-operator
+    env:
+      - name: KVM_EMULATION
+        value: "true"
+EOF
+)
+fi
+
 echo "Content Successfully Created"
 if [ -z "${CONTENT_ONLY}" ]; then
     echo "Creating Subscription"
@@ -168,6 +183,7 @@ spec:
   startingCSV: "kubevirt-hyperconverged-operator.v${HCO_VERSION}"
   channel: "${HCO_CHANNEL}"
   installPlanApproval: "${APPROVAL}"
+${SUBSCRIPTION_CONFIG}
 EOF
 
     echo "Give OLM 60 seconds to process the subscription..."


### PR DESCRIPTION
Set KVM_EMULATION in deploy_marketplace.sh

Let the user optionally force KVM_EMULATION
deploying with deploy_marketplace.sh in order
to be able to sucesfully deploy on environments
without virtualization capabilities for testing
purposes.

The env value will be configured on the OLM
subscription to be propagated to the right
deployment via Operator Configuration: see
https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/contributors/design-proposals/operator-config.md

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>