### PR TITLE
increase timeout to 15 mins

### DIFF
--- a/deploy/deploy_imageregistry.sh
+++ b/deploy/deploy_imageregistry.sh
@@ -127,5 +127,5 @@ spec:
 EOF
 
     echo "Waiting for HCO to get fully deployed"
-    oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=10m
+    oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=15m
 fi

--- a/deploy/deploy_marketplace.sh
+++ b/deploy/deploy_marketplace.sh
@@ -192,5 +192,5 @@ spec:
 EOF
 
     echo "Waiting for HCO to get fully deployed"
-    oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=10m
+    oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=15m
 fi


### PR DESCRIPTION
10 minutes is not enough time for HCO deployment.
Many of our deployments are on a failed state on Jenkins because of that even though HCO is successfully deployed - it just takes a few more minutes to finish.