### PR TITLE
Add 'go mod vendor' to sanity tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- "1.10.x"
+- "1.13.x"
 sudo: required
 dist: trusty
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ endif
 
 sanity:
 	go fmt ./...
+	go mod vendor
 	git diff --exit-code
 
 build: $(SOURCES) ## Build binary from source


### PR DESCRIPTION
Add 'go mod vendor' to sanity tests
to ensure that we can only merge
PRs with up-to-date and correctly
vendored dependencies.

Configure travis to use go "1.13.x"

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>