### PR TITLE
Skip OperatorGroup creation with CONTENT_ONLY option

### DIFF
--- a/deploy/deploy_imageregistry.sh
+++ b/deploy/deploy_imageregistry.sh
@@ -44,18 +44,6 @@ trap cleanup_tmp EXIT
 
 cleanup_tmp
 
-if [ `oc get operatorgroup -n "${TARGET_NAMESPACE}" 2> /dev/null | wc -l` -eq 0 ]; then
-    echo "Creating OperatorGroup"
-    cat <<EOF | oc create -f -
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: "${TARGET_NAMESPACE}-group"
-  namespace: "${TARGET_NAMESPACE}"
-spec: {}
-EOF
-fi
-
 # Create a Catalog Source backed by a grpc registry
 cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1alpha1
@@ -104,6 +92,19 @@ fi
 
 echo "Content Successfully Created"
 if [ -z "${CONTENT_ONLY}" ]; then
+
+    if [ `oc get operatorgroup -n "${TARGET_NAMESPACE}" 2> /dev/null | wc -l` -eq 0 ]; then
+    echo "Creating OperatorGroup"
+    cat <<EOF | oc create -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: "${TARGET_NAMESPACE}-group"
+  namespace: "${TARGET_NAMESPACE}"
+spec: {}
+EOF
+    fi
+
     echo "Creating Subscription"
     cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1alpha1

--- a/deploy/deploy_marketplace.sh
+++ b/deploy/deploy_marketplace.sh
@@ -92,18 +92,6 @@ EOF
 
 fi
 
-if [ `oc get operatorgroup -n "${TARGET_NAMESPACE}" --no-headers 2> /dev/null | wc -l` -eq 0 ]; then
-    echo "Creating OperatorGroup"
-    cat <<EOF | oc create -f -
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: "${TARGET_NAMESPACE}-group"
-  namespace: "${TARGET_NAMESPACE}"
-spec: {}
-EOF
-fi
-
 if [ `oc get OperatorSource "${APP_REGISTRY}" -n "${MARKETPLACE_NAMESPACE}" --no-headers 2> /dev/null | wc -l` -eq 0 ]; then
     echo "Creating OperatorSource"
     cat <<EOF | oc create -f -
@@ -169,6 +157,19 @@ fi
 
 echo "Content Successfully Created"
 if [ -z "${CONTENT_ONLY}" ]; then
+
+    if [ `oc get operatorgroup -n "${TARGET_NAMESPACE}" --no-headers 2> /dev/null | wc -l` -eq 0 ]; then
+    echo "Creating OperatorGroup"
+    cat <<EOF | oc create -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: "${TARGET_NAMESPACE}-group"
+  namespace: "${TARGET_NAMESPACE}"
+spec: {}
+EOF
+    fi
+
     echo "Creating Subscription"
     cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Fix the deployment scripts to avoid creating
the OperatorGroup when the user set CONTENT_ONLY mode.

In CONTENT_ONLY mode the script will configure
the environment to be ready for the user
to simply trigger the deployment from OLM UI.
In that case the OperatorGroup will be created
by OLM console according to the user choices
(one or multiple namespaces and which one)
so it should not be created by the deployment script.

Bug-Url: https://bugzilla.redhat.com/1795227

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>