### PR TITLE
Correctly wait for a successful deployment

### DIFF
--- a/deploy/deploy_imageregistry.sh
+++ b/deploy/deploy_imageregistry.sh
@@ -144,4 +144,5 @@ EOF
 
     echo "Waiting for HCO to get fully deployed"
     oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=15m
+    oc wait "$(oc get pods -n ${TARGET_NAMESPACE} -l name=hyperconverged-cluster-operator -o name)" -n "${TARGET_NAMESPACE}" --for condition=Ready --timeout=15m
 fi

--- a/deploy/deploy_marketplace.sh
+++ b/deploy/deploy_marketplace.sh
@@ -209,4 +209,5 @@ EOF
 
     echo "Waiting for HCO to get fully deployed"
     oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=15m
+    oc wait "$(oc get pods -n ${TARGET_NAMESPACE} -l name=hyperconverged-cluster-operator -o name)" -n "${TARGET_NAMESPACE}" --for condition=Ready --timeout=15m
 fi


### PR DESCRIPTION
Checking availability of the hyperconverged
resource is not enough; we have to check also
the readiness of HCO operator to be sure that
it correctly completed its reconciliation.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>