### PR TITLE
Set spec.targetNamespaces from deploy scripts

### DIFF
--- a/deploy/deploy_imageregistry.sh
+++ b/deploy/deploy_imageregistry.sh
@@ -101,7 +101,9 @@ kind: OperatorGroup
 metadata:
   name: "${TARGET_NAMESPACE}-group"
   namespace: "${TARGET_NAMESPACE}"
-spec: {}
+spec:
+  targetNamespaces:
+  - "${TARGET_NAMESPACE}"
 EOF
     fi
 

--- a/deploy/deploy_marketplace.sh
+++ b/deploy/deploy_marketplace.sh
@@ -166,7 +166,9 @@ kind: OperatorGroup
 metadata:
   name: "${TARGET_NAMESPACE}-group"
   namespace: "${TARGET_NAMESPACE}"
-spec: {}
+spec:
+  targetNamespaces:
+  - "${TARGET_NAMESPACE}"
 EOF
     fi
 


### PR DESCRIPTION
Correctly set spec.targetNamespaces from deploy scripts
to mimic OLM console behaviour when the user select
to deploy in a single namespace and for
the documentation.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>