### PR TITLE
Use "kubevirt-hyperconverged" as the hco resource name

### DIFF
--- a/deploy/cleanup_marketplace.sh
+++ b/deploy/cleanup_marketplace.sh
@@ -8,7 +8,7 @@ HCO_VERSION="${HCO_VERSION:-1.0.0}"
 oc delete csc hco-catalogsource-config -n $MARKETPLACE
 oc delete catalogsource $APP_REGISTRY -n $MARKETPLACE
 oc delete operatorsource $APP_REGISTRY -n $MARKETPLACE
-oc delete hco hyperconverged-cluster -n $TARGET
+oc delete hco kubevirt-hyperconverged -n $TARGET
 sleep 10
 oc delete sub hco-operatorhub -n $TARGET
 oc delete csv kubevirt-hyperconverged-operator.v${HCO_VERSION} -n $TARGET

--- a/deploy/deploy_imageregistry.sh
+++ b/deploy/deploy_imageregistry.sh
@@ -139,7 +139,7 @@ EOF
 apiVersion: hco.kubevirt.io/v1alpha1
 kind: HyperConverged
 metadata:
-  name: hyperconverged-cluster
+  name: kubevirt-hyperconverged
   namespace: "${TARGET_NAMESPACE}"
 spec:
   BareMetalPlatform: true

--- a/deploy/deploy_marketplace.sh
+++ b/deploy/deploy_marketplace.sh
@@ -204,7 +204,7 @@ EOF
 apiVersion: hco.kubevirt.io/v1alpha1
 kind: HyperConverged
 metadata:
-  name: hyperconverged-cluster
+  name: kubevirt-hyperconverged
   namespace: "${TARGET_NAMESPACE}"
 spec:
   BareMetalPlatform: true

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -2,5 +2,5 @@
 apiVersion: hco.kubevirt.io/v1alpha1
 kind: HyperConverged
 metadata:
-  name: hyperconverged-cluster
+  name: kubevirt-hyperconverged
 spec: {}

--- a/hack/check-state.sh
+++ b/hack/check-state.sh
@@ -11,7 +11,7 @@ EXIT_STATUS=0
 MAX_GET_HCO_RETRY=500
 
 HCO_KIND="hyperconvergeds.hco.kubevirt.io"
-HCO_NAME="hyperconverged-cluster"
+HCO_NAME="kubevirt-hyperconverged"
 HCO_NAMESPACE="kubevirt-hyperconverged"
 
 function get_operator_json() {
@@ -202,7 +202,7 @@ EOF
 
 function check_dependent_operators_up {
     # get all operators mentioned as related objects of hco operator 
-    RELATED_OBJECTS=`${CMD} get hyperconvergeds.hco.kubevirt.io hyperconverged-cluster -n kubevirt-hyperconverged -o go-template='{{range .status.relatedObjects }}{{if .namespace }}{{ printf "%s %s %s\n" .kind .name .namespace }}{{ else }}{{ printf "%s %s .\n" .kind .name }}{{ end }}{{ end }}'`
+    RELATED_OBJECTS=`${CMD} get hyperconvergeds.hco.kubevirt.io kubevirt-hyperconverged -n kubevirt-hyperconverged -o go-template='{{range .status.relatedObjects }}{{if .namespace }}{{ printf "%s %s %s\n" .kind .name .namespace }}{{ else }}{{ printf "%s %s .\n" .kind .name }}{{ end }}{{ end }}'`
 
     # check that each operator is up
      while read line; do 

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -21,7 +21,7 @@ source hack/common.sh
 
 # Remove HCO
 "${CMD}" delete -f _out/hco.cr.yaml --ignore-not-found || true
-"${CMD}" wait --for=delete hyperconverged.hco.kubevirt.io/hyperconverged-cluster || true
+"${CMD}" wait --for=delete hyperconverged.hco.kubevirt.io/kubevirt-hyperconverged || true
 # TODO: delete hangs on machine.crd.yaml. Only delete the ones that don't hang
 # from _out/crds/.
 "${CMD}" delete -f _out/crds --ignore-not-found || true

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -24,7 +24,7 @@ source hack/common.sh
 HCO_IMAGE=${HCO_IMAGE:-quay.io/kubevirt/hyperconverged-cluster-operator:latest}
 HCO_NAMESPACE="kubevirt-hyperconverged"
 HCO_KIND="hyperconvergeds"
-HCO_RESOURCE_NAME="hyperconverged-cluster"
+HCO_RESOURCE_NAME="kubevirt-hyperconverged"
 
 CI=""
 if [ "$1" == "CI" ]; then
@@ -71,7 +71,7 @@ fi
 function status(){
     "${CMD}" get hco -n "${HCO_NAMESPACE}" -o yaml || true
     "${CMD}" get pods -n "${HCO_NAMESPACE}" || true
-    "${CMD}" get hco hyperconverged-cluster -n "${HCO_NAMESPACE}" -o=jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}' || true
+    "${CMD}" get hco "${HCO_RESOURCE_NAME}" -n "${HCO_NAMESPACE}" -o=jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}' || true
     # Get logs of all the pods
     for PNAME in $( ${CMD} get pods -n ${HCO_NAMESPACE} --field-selector=status.phase!=Running -o custom-columns=:metadata.name )
     do

--- a/hack/dump-state.sh
+++ b/hack/dump-state.sh
@@ -46,9 +46,9 @@ RunCmd "${CMD} get pods -n kubevirt-hyperconverged"
 RunCmd "${CMD} get subscription -n kubevirt-hyperconverged -o yaml"
 RunCmd "${CMD} get deployment/hco-operator -n kubevirt-hyperconverged -o yaml"
 
-ShowOperatorSummary  hyperconvergeds.hco.kubevirt.io hyperconverged-cluster kubevirt-hyperconverged  
+ShowOperatorSummary  hyperconvergeds.hco.kubevirt.io kubevirt-hyperconverged kubevirt-hyperconverged
 
-RELATED_OBJECTS=`${CMD} get hyperconvergeds.hco.kubevirt.io hyperconverged-cluster -n kubevirt-hyperconverged -o go-template='{{range .status.relatedObjects }}{{if .namespace }}{{ printf "%s %s %s\n" .kind .name .namespace }}{{ else }}{{ printf "%s %s .\n" .kind .name }}{{ end }}{{ end }}'`
+RELATED_OBJECTS=`${CMD} get hyperconvergeds.hco.kubevirt.io kubevirt-hyperconverged -n kubevirt-hyperconverged -o go-template='{{range .status.relatedObjects }}{{if .namespace }}{{ printf "%s %s %s\n" .kind .name .namespace }}{{ else }}{{ printf "%s %s .\n" .kind .name }}{{ end }}{{ end }}'`
 
 echo "${RELATED_OBJECTS}" | while read line; do 
 

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -173,7 +173,7 @@ ${CMD} wait pod $HCO_OPERATOR_POD --for condition=Ready -n kubevirt-hyperconverg
 
 HCO_NAMESPACE="kubevirt-hyperconverged"
 HCO_KIND="hyperconvergeds"
-HCO_RESOURCE_NAME="hyperconverged-cluster"
+HCO_RESOURCE_NAME="kubevirt-hyperconverged"
 
 ${CMD} create -f ./deploy/hco.cr.yaml -n kubevirt-hyperconverged
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -467,7 +467,7 @@ func GetOperatorCR() *hcov1alpha1.HyperConverged {
 			Kind:       "HyperConverged",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "hyperconverged-cluster",
+			Name: "kubevirt-hyperconverged",
 		},
 		Spec: hcov1alpha1.HyperConvergedSpec{
 			BareMetalPlatform:     false,

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -44,7 +44,7 @@ const (
 	// use finalizers to manage the cleanup.
 	FinalizerName = "hyperconvergeds.hco.kubevirt.io"
 
-	HyperConvergedName   = "hyperconverged-cluster"
+	HyperConvergedName   = "kubevirt-hyperconverged"
 	OperatorNamespaceEnv = "OPERATOR_NAMESPACE"
 
 	// UndefinedNamespace is for cluster scoped resources

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 // name and namespace of our primary resource
-var name = "hyperconverged-cluster"
+var name = "kubevirt-hyperconverged"
 var namespace = "kubevirt-hyperconverged"
 
 // Mock request to simulate Reconcile() being called on an event for a watched resource


### PR DESCRIPTION
Use "kubevirt-hyperconverged" as the hco resource name to promote a smoother upgrade experience

Use "kubevirt-hyperconverged" as the hco resource name
everywhere: in alm-example section (see:
https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/pkg/components/components.go#L505
in the CSV we were already suggesting "kubevirt-hyperconverged"
as the name of the hco resource so who deployed from
OLM console, without manually editing the CR, is already
using "kubevirt-hyperconverged".
Before https://github.com/kubevirt/hyperconverged-cluster-operator/pull/400
the name of the HCO resource was not that relevant but after
it the operator will ignore all the reconciliation requests
on resource with a name different from the expected.
So align it to "kubevirt-hyperconverged" everywhere to provide
a smoother upgrade experience.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>