### PR TITLE
Adjust rotate script for older HCO installations

### DIFF
--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -24,7 +24,7 @@ if [[ ${JOB_TYPE} = "prow" ]]; then
 else
     export KUBECTL_BINARY="cluster-up/kubectl.sh"
 fi
-./${TEST_OUT_PATH}/func-tests.test -ginkgo.v -test.timeout 120m -kubeconfig="${KUBECONFIG}" -installed-namespace=kubevirt-hyperconverged
+./${TEST_OUT_PATH}/func-tests.test -ginkgo.v -test.timeout 120m -kubeconfig="${KUBECONFIG}" -installed-namespace=kubevirt-hyperconverged -cdi-namespace=kubevirt-hyperconverged
 
 if [ -f ${CSV_FILE} ]; then
   rm -f ${CSV_FILE}


### PR DESCRIPTION
In old HCO versions CDI and KubeVirt were not installed in the same
namespace. Adjusting the cert rotate script accordingly.

If the CDI and KubeVirt namespace differs, then one has to call the rotate script like this:

```bash
./rotate-certs.sh --namespace kubevirt --cdi-namespace cdi
```