### PR TITLE
Fix the name of hyperconverged resource in deploy scripts

### DIFF
--- a/deploy/deploy_imageregistry.sh
+++ b/deploy/deploy_imageregistry.sh
@@ -146,6 +146,6 @@ spec:
 EOF
 
     echo "Waiting for HCO to get fully deployed"
-    oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=15m
+    oc wait -n ${TARGET_NAMESPACE} hyperconverged kubevirt-hyperconverged --for condition=Available --timeout=15m
     oc wait "$(oc get pods -n ${TARGET_NAMESPACE} -l name=hyperconverged-cluster-operator -o name)" -n "${TARGET_NAMESPACE}" --for condition=Ready --timeout=15m
 fi

--- a/deploy/deploy_marketplace.sh
+++ b/deploy/deploy_marketplace.sh
@@ -211,6 +211,6 @@ spec:
 EOF
 
     echo "Waiting for HCO to get fully deployed"
-    oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=15m
+    oc wait -n ${TARGET_NAMESPACE} hyperconverged kubevirt-hyperconverged --for condition=Available --timeout=15m
     oc wait "$(oc get pods -n ${TARGET_NAMESPACE} -l name=hyperconverged-cluster-operator -o name)" -n "${TARGET_NAMESPACE}" --for condition=Ready --timeout=15m
 fi


### PR DESCRIPTION
Fix the name of hyperconverged resource also in the
last line of deployment scripts.
Properly align it also there.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>