### PR TITLE
Allow custom names for relatedImages

### DIFF
--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -74,10 +74,11 @@ var (
 	metadataDescription = flag.String("metadata-description", "", "Metadata")
 	specDescription     = flag.String("spec-description", "", "Description")
 	specDisplayName     = flag.String("spec-displayname", "", "Display Name")
-	relatedImagesList   = flag.String("related-images-list", "", "Comma separated list of all the images referred in the CSV")
 	namespace           = flag.String("namespace", "kubevirt-hyperconverged", "Namespace")
 	crdDisplay          = flag.String("crd-display", "KubeVirt HyperConverged Cluster", "Label show in OLM UI about the primary CRD")
 	csvOverrides        = flag.String("csv-overrides", "", "CSV like string with punctual changes that will be recursively applied (if possible)")
+	relatedImagesList   = flag.String("related-images-list", "",
+		"Comma separated list of all the images referred in the CSV (just the image pull URLs or eventually a set of 'image|name' collations)")
 )
 
 func main() {
@@ -129,8 +130,15 @@ func main() {
 
 	for _, image := range strings.Split(*relatedImagesList, ",") {
 		if image != "" {
-			names := strings.Split(strings.Split(image, "@")[0], "/")
-			name := names[len(names)-1]
+			name := ""
+			if strings.Contains(image, "|") {
+				image_s := strings.Split(image, "|")
+				image = image_s[0]
+				name = image_s[1]
+			} else {
+				names := strings.Split(strings.Split(image, "@")[0], "/")
+				name = names[len(names)-1]
+			}
 			csvExtended.Spec.RelatedImages = append(
 				csvExtended.Spec.RelatedImages,
 				relatedImage{


### PR DESCRIPTION
Enhance the csv-merger tool to let the user
explicitly pass a custom name for each
of the images in relatedImages.

--related-images-list allow the user to pass a
comma separated list of all the images referred
in the CSV for relatedImages field.
relatedImages field contains a list of images where
for each image we can specify image (the pull url)
an name (a label); currently the name is derived from image
while, for different reasons, it could be convenient
let the user pass a custom name.
With this PR --related-images-list is still a comma separated list
but each element could be eventually (if not the code will keep the
old behaviour for backward compatibility) splitted with image|name
syntax.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>