### PR TITLE
Add selinuxLauncherType to kubevirt configmap

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -367,8 +367,9 @@ func newKubeVirtConfigForCR(cr *hcov1alpha1.HyperConverged, namespace string) *c
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			"feature-gates": "DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Sidecar",
-			"migrations":    `{"nodeDrainTaintKey" : "node.kubernetes.io/unschedulable"}`,
+			"feature-gates":       "DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Sidecar",
+			"migrations":          `{"nodeDrainTaintKey" : "node.kubernetes.io/unschedulable"}`,
+			"selinuxLauncherType": "spc_t",
 		},
 	}
 }


### PR DESCRIPTION
Add selinuxLauncherType setting to kubevirt-config. This will ensure KubeVirt defaults to use privileged containers: virt_launcher.process can't be added to all runtime environments.

```release-note
Run Kubevirt's virt-launcher as spc_t
```