### PR TITLE
Set default value (BlockUninstallIfWorkloadsExist) for UninstallStrategy on Kubevirt

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -417,6 +417,9 @@ func newKubeVirtForCR(cr *hcov1alpha1.HyperConverged, namespace string) *kubevir
 			Labels:    labels,
 			Namespace: namespace,
 		},
+		Spec: kubevirtv1.KubeVirtSpec{
+			UninstallStrategy: kubevirtv1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist,
+		},
 	}
 }
 
@@ -443,6 +446,14 @@ func (r *ReconcileHyperConverged) ensureKubeVirt(instance *hcov1alpha1.HyperConv
 	}
 
 	logger.Info("KubeVirt already exists", "KubeVirt.Namespace", found.Namespace, "KubeVirt.Name", found.Name)
+
+	if !reflect.DeepEqual(found.Spec, virt.Spec) {
+		if found.Spec.UninstallStrategy == "" {
+			logger.Info("Updating UninstallStrategy on existing KubeVirt to its default value")
+			found.Spec.UninstallStrategy = virt.Spec.UninstallStrategy
+		}
+		return r.client.Update(context.TODO(), found)
+	}
 
 	// Add it to the list of RelatedObjects if found
 	objectRef, err := reference.GetReference(r.scheme, found)


### PR DESCRIPTION
Set default value (BlockUninstallIfWorkloadsExist) for UninstallStrategy on Kubevirt

github.com/kubevirt/kubevirt/pull/2976 introduced uninstall strategies for the virt-operator.
This PR will:
- set BlockUninstallIfWorkloadsExist as the UninstallStrategy creating Kubevirt CR
- set UninstallStrategy=BlockUninstallIfWorkloadsExist if unset on an existing Kubevirt CR
- test it

```release-note
set default value (BlockUninstallIfWorkloadsExist) for UninstallStrategy on Kubevirt on new deployments and on upgrades when missing
```

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>