### PR TITLE
Adding SuggestedNamespace annotation in HCO CSV for OLM

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
-    createdAt: "2020-02-18 14:13:09"
+    createdAt: "2020-02-19 12:16:33"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -75,6 +75,7 @@ metadata:
 
       KubeVirt is distributed under the
       [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+    operatorframework.io/suggested-namespace: kubevirt-hyperconverged
     repository: https://github.com/kubevirt/hyperconverged-cluster-operator
     support: "false"
   name: kubevirt-hyperconverged-operator.v1.0.0

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -529,6 +529,7 @@ func GetCSVBase(name, hcCRNamespace, displayName, description, image, replaces s
 				"description":    description,
 				"repository":     "https://github.com/kubevirt/hyperconverged-cluster-operator",
 				"support":        "false",
+				"operatorframework.io/suggested-namespace": hcCRNamespace,
 			},
 		},
 		Spec: csvv1alpha1.ClusterServiceVersionSpec{


### PR DESCRIPTION
By this annotation, UI would suggest the relevant
namespace for kubevirt/CNV deployment,
i.e. kubevirt-hyperconverged or openshfit-cnv

Bug-Url: https://bugzilla.redhat.com/1799055

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>