### PR TITLE
Include manifest generation in sanity tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ endif
 sanity:
 	go fmt ./...
 	go mod vendor
-	git diff --exit-code
+	./hack/build-manifests.sh
+	git diff -G'^[^    createdAt: ]' --exit-code
 
 build: $(SOURCES) ## Build binary from source
 	go build -i -ldflags="-s -w" -o _out/hyperconverged-cluster-operator ./cmd/hyperconverged-cluster-operator


### PR DESCRIPTION
Run manifest generation in sanity tests
to ensure that we can only merge PRs where
the automatically generated manifests that are going
to be merged matches what can be generated with their
source configuration.
In order to do that, we have to explicitly tell to
git diff to ignore lines starting with '    createdAt: '
because it will be always updated on freshly generated
CSV files.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>