### PR TITLE
Set Version and Status for the kubevirt-hyperconverged instance

### DIFF
--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -3,4 +3,5 @@ apiVersion: hco.kubevirt.io/v1alpha1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-spec: {}
+spec:
+  version: 1.0.0

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -554,7 +554,6 @@ func GetCSVBase(name, namespace, displayName, description, image, replaces strin
 			},
 			"spec": map[string]interface{}{
 				"BareMetalPlatform": false,
-				"version":           ownVersion.Version,
 			},
 		},
 	})

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -3,6 +3,7 @@ package components
 import (
 	"encoding/json"
 	"fmt"
+	ownVersion "github.com/kubevirt/hyperconverged-cluster-operator/version"
 	"time"
 
 	"github.com/blang/semver"
@@ -500,6 +501,11 @@ func GetV2VCRD() *extv1beta1.CustomResourceDefinition {
 }
 
 func GetOperatorCR() *hcov1alpha1.HyperConverged {
+	status := hcov1alpha1.HyperConvergedStatus{
+		Versions: hcov1alpha1.GetOperatorVersions(),
+	}
+	status.SetStatus(hcov1alpha1.HyperConvergedDeployingStatus)
+
 	return &hcov1alpha1.HyperConverged{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "hco.kubevirt.io/v1alpha1",
@@ -511,7 +517,9 @@ func GetOperatorCR() *hcov1alpha1.HyperConverged {
 		Spec: hcov1alpha1.HyperConvergedSpec{
 			BareMetalPlatform:     false,
 			LocalStorageClassName: "",
+			Version:               ownVersion.Version,
 		},
+		Status: status,
 	}
 }
 
@@ -546,6 +554,7 @@ func GetCSVBase(name, namespace, displayName, description, image, replaces strin
 			},
 			"spec": map[string]interface{}{
 				"BareMetalPlatform": false,
+				"version":           ownVersion.Version,
 			},
 		},
 	})


### PR DESCRIPTION
Partial fix for [Bug 1716329](https://bugzilla.redhat.com/show_bug.cgi?id=1716329)

Add version and status in the HCO page in openshift UI for the kubevirt-hyperconverged instance.

Signed-off-by: Nahshon Unna-Tsameret <nunntsa@redhat.com>