### PR TITLE
Set default value (BlockUninstallIfWorkloadsExist) for UninstallStrategy on CDI

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -428,6 +428,34 @@ var _ = Describe("HyperconvergedController", func() {
 				})))
 			})
 
+			It("should set default UninstallStrategy if missing", func() {
+				hco := &hcov1alpha1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+					Spec: hcov1alpha1.HyperConvergedSpec{},
+				}
+
+				expectedResource := newCDIForCR(hco, namespace)
+				expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
+				missingUSResource := newCDIForCR(hco, namespace)
+				missingUSResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", missingUSResource.Namespace, missingUSResource.Name)
+				missingUSResource.Spec.UninstallStrategy = nil
+
+				cl := initClient([]runtime.Object{hco, missingUSResource})
+				r := initReconciler(cl)
+				Expect(r.ensureCDI(hco, log, request)).To(BeNil())
+
+				foundResource := &cdiv1alpha1.CDI{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
+						foundResource),
+				).To(BeNil())
+				Expect(*foundResource.Spec.UninstallStrategy).To(Equal(*expectedResource.Spec.UninstallStrategy))
+			})
+
 			It("should handle conditions", func() {
 				hco := &hcov1alpha1.HyperConverged{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Set default value (BlockUninstallIfWorkloadsExist) for UninstallStrategy on CDI

github.com/kubevirt/containerized-data-importer/pull/1118 introduced uninstall
strategies for the CDI-operator.
This PR will:

- set BlockUninstallIfWorkloadsExist as the UninstallStrategy creating CDI CR
- set UninstallStrategy=BlockUninstallIfWorkloadsExist if unset on an existing CDI CR
- test it

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>