### PR TITLE
Hide internal CRDs

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
-    createdAt: "2020-03-04 08:25:27"
+    createdAt: "2020-03-04 23:40:03"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -76,6 +76,7 @@ metadata:
       KubeVirt is distributed under the
       [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
     operatorframework.io/suggested-namespace: kubevirt-hyperconverged
+    operators.operatorframework.io/internal-objects: '["networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","kubevirtcommontemplatesbundles.ssp.kubevirt.io","kubevirtmetricsaggregations.ssp.kubevirt.io","kubevirtnodelabellerbundles.ssp.kubevirt.io","kubevirttemplatevalidators.ssp.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.kubevirt.io"]'
     repository: https://github.com/kubevirt/hyperconverged-cluster-operator
     support: "false"
   name: kubevirt-hyperconverged-operator.v1.0.0


### PR DESCRIPTION
With github.com/operator-framework/operator-lifecycle-manager/pull/1097
OM supports a mechanism to hide internal CRDs on OLM console.
Start using it.
By default only
- hyperconvergeds.hco.kubevirt.io
- v2vvmwares.kubevirt.io
- hostpathprovisioners.hostpathprovisioner.kubevirt.io
are going to be visible.
The list of visible CRDs can be override as a CLI parameter
to the csv-merger tool.

```release-note
Hide internal CRDs: by default only hyperconvergeds.hco.kubevirt.io, v2vvmwares.kubevirt.io and hostpathprovisioners.hostpathprovisioner.kubevirt.io will be visible in OLM console
```

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>