### PR TITLE
[release-2.3] Avoid InstallModeTypeMultiNamespace and InstallModeTypeAllNamespaces

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
-    createdAt: "2020-02-27 14:00:45"
+    createdAt: "2020-02-29 10:06:45"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1589,9 +1589,9 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - KubeVirt

--- a/hack/dump-state.sh
+++ b/hack/dump-state.sh
@@ -64,6 +64,16 @@ done
 
 cat <<EOF
 
+==============
+OperatorGroups
+==============
+
+RunCmd "${CMD} get operatorgroups -n kubevirt-hyperconverged -o yaml"
+
+EOF
+
+cat <<EOF
+
 ========================
 HCO operator related CRD
 ========================

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -105,8 +105,12 @@ fi
 
 Msg "create catalogsource and subscription to install HCO"
 
-${CMD} create ns kubevirt-hyperconverged | true
-${CMD} get pods -n kubevirt-hyperconverged 
+HCO_NAMESPACE="kubevirt-hyperconverged"
+HCO_KIND="hyperconvergeds"
+HCO_RESOURCE_NAME="kubevirt-hyperconverged"
+
+${CMD} create ns ${HCO_NAMESPACE} | true
+${CMD} get pods -n ${HCO_NAMESPACE}
 
 cat <<EOF | ${CMD} create -f -
 apiVersion: operators.coreos.com/v1
@@ -114,6 +118,9 @@ kind: OperatorGroup
 metadata:
   name: hco-operatorgroup
   namespace: kubevirt-hyperconverged
+spec:
+  targetNamespaces:
+  - ${HCO_NAMESPACE}
 EOF
 
 # TODO: The catalog source image here should point to the latest version in quay.io
@@ -170,10 +177,6 @@ EOF
 
 HCO_OPERATOR_POD=`${CMD} get pods -n kubevirt-hyperconverged | grep hco-operator | head -1 | awk '{ print $1 }'`
 ${CMD} wait pod $HCO_OPERATOR_POD --for condition=Ready -n kubevirt-hyperconverged --timeout="600s"
-
-HCO_NAMESPACE="kubevirt-hyperconverged"
-HCO_KIND="hyperconvergeds"
-HCO_RESOURCE_NAME="kubevirt-hyperconverged"
 
 ${CMD} create -f ./deploy/hco.cr.yaml -n kubevirt-hyperconverged
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -587,11 +587,11 @@ func GetCSVBase(name, hcCRNamespace, displayName, description, image, replaces s
 				},
 				csvv1alpha1.InstallMode{
 					Type:      csvv1alpha1.InstallModeTypeMultiNamespace,
-					Supported: true,
+					Supported: false,
 				},
 				csvv1alpha1.InstallMode{
 					Type:      csvv1alpha1.InstallModeTypeAllNamespaces,
-					Supported: true,
+					Supported: false,
 				},
 			},
 			// Skip this in favor of having a separate function to get


### PR DESCRIPTION
This is a manual cherry-pick of #449

Avoid InstallModeTypeMultiNamespace and InstallModeTypeAllNamespaces

```release-note
Avoid InstallModeTypeMultiNamespace and InstallModeTypeAllNamespaces to gray out all namespaces option in OLM subscription dialog
```

/assign tiraboschi

Signed-off-by: Simone Tiraboschi stirabos@redhat.com