### PR TITLE
Emit a warning event on failed uninstall

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -25,6 +25,7 @@ import (
 	sspopv1 "github.com/MarSik/kubevirt-ssp-operator/pkg/apis"
 	networkaddons "github.com/kubevirt/cluster-network-addons-operator/pkg/apis"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	csvv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	corev1 "k8s.io/api/core/v1"
@@ -145,6 +146,7 @@ func main() {
 		cdiv1alpha1.AddToScheme,
 		networkaddons.AddToScheme,
 		sspopv1.AddToScheme,
+		csvv1alpha1.AddToScheme,
 	} {
 		if err := f(mgr.GetScheme()); err != nil {
 			log.Error(err, "Failed to add to scheme")

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -203,6 +203,14 @@ rules:
   verbs:
   - get
   - create
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -328,6 +328,14 @@ spec:
           verbs:
           - get
           - create
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: hyperconverged-cluster-operator
       - rules:
         - apiGroups:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
@@ -334,6 +334,14 @@ spec:
           verbs:
           - get
           - create
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: hyperconverged-cluster-operator
       - rules:
         - apiGroups:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -352,6 +352,19 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 				"create",
 			},
 		},
+		{
+			APIGroups: []string{
+				"operators.coreos.com",
+			},
+			Resources: []string{
+				"clusterserviceversions",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
 	}
 }
 

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -1345,12 +1345,17 @@ func ensureKubeVirtDeleted(c client.Client, instance *hcov1alpha1.HyperConverged
 	key, err := client.ObjectKeyFromObject(virt)
 	if err != nil {
 		log.Error(err, "Failed to get object key for KubeVirt")
+		return err
 	}
 
 	found := &kubevirtv1.KubeVirt{}
 	err = c.Get(context.TODO(), key, found)
 
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("KubeVirt resource doesn't exist, there is nothing to remove")
+			return nil
+		}
 		log.Error(err, "Failed to get KubeVirt from kubernetes")
 		return err
 	}
@@ -1364,12 +1369,17 @@ func ensureCDIDeleted(c client.Client, instance *hcov1alpha1.HyperConverged) err
 	key, err := client.ObjectKeyFromObject(cdi)
 	if err != nil {
 		log.Error(err, "Failed to get object key for CDI")
+		return err
 	}
 
 	found := &cdiv1alpha1.CDI{}
 	err = c.Get(context.TODO(), key, found)
 
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("CDI resource doesn't exist, there is nothing to remove")
+			return nil
+		}
 		log.Error(err, "Failed to get CDI from kubernetes")
 		return err
 	}
@@ -1382,12 +1392,17 @@ func ensureNetworkAddonsDeleted(c client.Client, instance *hcov1alpha1.HyperConv
 	key, err := client.ObjectKeyFromObject(networkAddons)
 	if err != nil {
 		log.Error(err, "Failed to get object key for Network Addons")
+		return err
 	}
 
 	found := &networkaddonsv1alpha1.NetworkAddonsConfig{}
 	err = c.Get(context.TODO(), key, found)
 
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("NetworkAddonsConfig doesn't exist, there is nothing to remove")
+			return nil
+		}
 		log.Error(err, "Failed to get NetworkAddonsConfig from kubernetes")
 		return err
 	}
@@ -1401,12 +1416,17 @@ func ensureKubeVirtCommonTemplateBundleDeleted(c client.Client, instance *hcov1a
 	key, err := client.ObjectKeyFromObject(kvCTB)
 	if err != nil {
 		log.Error(err, "Failed to get object key for KubeVirt Common Templates Bundle")
+		return err
 	}
 
 	found := &sspv1.KubevirtCommonTemplatesBundle{}
 	err = c.Get(context.TODO(), key, found)
 
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("KubevirtCommonTemplatesBundle doesn't exist, there is nothing to remove")
+			return nil
+		}
 		log.Error(err, "Failed to get KubeVirt Common Templates Bundle from kubernetes")
 		return err
 	}

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -60,6 +61,13 @@ const (
 	reconcileCompletedMessage   = "Reconcile completed successfully"
 	invalidRequestReason        = "InvalidRequest"
 	invalidRequestMessageFormat = "Request does not match expected name (%v) and namespace (%v)"
+
+	ErrCDIUninstall       = "ErrCDIUninstall"
+	uninstallCDIErrorMsg  = "The uninstall request failed on CDI component: "
+	ErrVirtUninstall      = "ErrVirtUninstall"
+	uninstallVirtErrorMsg = "The uninstall request failed on virt component: "
+	ErrHCOUninstall       = "ErrHCOUninstall"
+	uninstallHCOErrorMsg  = "The uninstall request failed on dependent components, please check their logs."
 )
 
 // Add creates a new HyperConverged Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -70,7 +78,7 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileHyperConverged{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileHyperConverged{client: mgr.GetClient(), scheme: mgr.GetScheme(), recorder: mgr.GetEventRecorderFor(hcov1alpha1.HyperConvergedName)}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -127,6 +135,7 @@ type ReconcileHyperConverged struct {
 	// that reads objects from the cache and writes to the apiserver
 	client     client.Client
 	scheme     *runtime.Scheme
+	recorder   record.EventRecorder
 	conditions []conditionsv1.Condition
 }
 
@@ -228,7 +237,10 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 		}
 	} else {
 		if contains(instance.ObjectMeta.Finalizers, FinalizerName) {
-			for _, f := range []func(c client.Client, cr *hcov1alpha1.HyperConverged) error{
+			for i, f := range []func(c client.Client, cr *hcov1alpha1.HyperConverged) error{
+				// Keep ensuring that we are trying to delete
+				// protected resources first
+				ensureKubeVirtDeleted,
 				ensureCDIDeleted,
 				ensureNetworkAddonsDeleted,
 				ensureKubeVirtCommonTemplateBundleDeleted,
@@ -236,6 +248,33 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 				err = f(r.client, instance)
 				if err != nil {
 					reqLogger.Error(err, "Failed to manually delete objects")
+
+					// TODO: ask to other components to expose something like
+					// func IsDeleteRefused(err error) bool
+					// to be able to clearly distinguish between an explicit
+					// refuse from other operator and any other kind of error that
+					// could potentially happen in the process
+					errT := ErrHCOUninstall
+					errMsg := uninstallHCOErrorMsg
+					switch i {
+					case 0:
+						errT = ErrVirtUninstall
+						errMsg = uninstallVirtErrorMsg + err.Error()
+					case 1:
+						errT = ErrCDIUninstall
+						errMsg = uninstallCDIErrorMsg + err.Error()
+					}
+
+					errE := r.emitEvent(instance, reqLogger, corev1.EventTypeWarning, errT, errMsg)
+					if errE != nil {
+						reqLogger.Error(errE, "Failed emitting uninstall error event")
+					}
+
+					// TODO: implement a validating webhook to try to delete virt and CDI CRs
+					// in dry run mode before really accepting the deletion request.
+					// This event should still stay here because no strategy can ensure we are
+					// 100% race conditions free
+
 					return reconcile.Result{}, err
 				}
 			}
@@ -351,6 +390,32 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 		}
 	}
 	return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
+}
+
+func (r *ReconcileHyperConverged) emitEvent(instance *hcov1alpha1.HyperConverged, logger logr.Logger, kind string, errT string, errMsg string) error {
+	r.recorder.Event(instance, kind, errT, errMsg)
+
+	pod, pod_err := hcoutil.GetPod(r.client, logger)
+	if pod_err != nil {
+		if logger != nil {
+			logger.Error(pod_err, "Failed to identify HCO POD, emitting warning event only on hyperconverged instance")
+		}
+		return pod_err
+	}
+
+	r.recorder.Event(pod, kind, errT, errMsg)
+
+	csv, csv_err := hcoutil.GetCSVfromPod(pod, r.client, logger)
+	if csv_err != nil {
+		if logger != nil {
+			logger.Error(csv_err, "Failed to identify HCO CSV, emitting warning event only on HCO pod and hyperconverged instance")
+		}
+		return csv_err
+	}
+
+	r.recorder.Event(csv, kind, errT, errMsg)
+	return nil
+
 }
 
 func newKubeVirtConfigForCR(cr *hcov1alpha1.HyperConverged, namespace string) *corev1.ConfigMap {
@@ -1273,6 +1338,25 @@ func componentResourceRemoval(o interface{}, c client.Client, cr *hcov1alpha1.Hy
 
 	err = c.Delete(context.TODO(), resource)
 	return err
+}
+
+func ensureKubeVirtDeleted(c client.Client, instance *hcov1alpha1.HyperConverged) error {
+	virt := newKubeVirtForCR(instance, instance.Namespace)
+	key, err := client.ObjectKeyFromObject(virt)
+	if err != nil {
+		log.Error(err, "Failed to get object key for KubeVirt")
+	}
+
+	found := &kubevirtv1.KubeVirt{}
+	err = c.Get(context.TODO(), key, found)
+
+	if err != nil {
+		log.Error(err, "Failed to get KubeVirt from kubernetes")
+		return err
+	}
+
+	return componentResourceRemoval(found, c, instance)
+
 }
 
 func ensureCDIDeleted(c client.Client, instance *hcov1alpha1.HyperConverged) error {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,8 +1,19 @@
 package util
 
 import (
+	"context"
 	"fmt"
+
+	"errors"
+	"github.com/go-logr/logr"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	csvv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const OperatorNamespaceEnv = "OPERATOR_NAMESPACE"
@@ -13,4 +24,77 @@ func GetOperatorNamespaceFromEnv() (string, error) {
 	}
 
 	return "", fmt.Errorf("%s unset or empty in environment", OperatorNamespaceEnv)
+}
+
+func GetPod(c client.Client, logger logr.Logger) (*corev1.Pod, error) {
+	operatorNs, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		logger.Error(err, "Failed to get HCO namespace")
+		return nil, err
+	}
+	pod, err := k8sutil.GetPod(context.TODO(), c, operatorNs)
+	if err != nil {
+		logger.Error(err, "Failed to get HCO pod")
+		return nil, err
+	}
+
+	return pod, nil
+}
+
+func GetCSVfromPod(pod *corev1.Pod, c client.Client, logger logr.Logger) (*csvv1alpha1.ClusterServiceVersion, error) {
+	operatorNs, err := k8sutil.GetOperatorNamespace()
+	rs_reference := metav1.GetControllerOf(pod)
+	if rs_reference == nil || rs_reference.Kind != "ReplicaSet" {
+		err = errors.New("Failed getting HCO replicaSet reference")
+		logger.Error(err, "Failed getting HCO replicaSet reference")
+		return nil, err
+	}
+	rs := &appsv1.ReplicaSet{}
+	err = c.Get(context.TODO(), client.ObjectKey{
+		Namespace: operatorNs,
+		Name:      rs_reference.Name,
+	}, rs)
+	if err != nil {
+		logger.Error(err, "Failed to get HCO ReplicaSet")
+		return nil, err
+	}
+
+	d_reference := metav1.GetControllerOf(rs)
+	if d_reference == nil || d_reference.Kind != "Deployment" {
+		err = errors.New("Failed getting HCO deployment reference")
+		logger.Error(err, "Failed getting HCO deployment reference")
+		return nil, err
+	}
+	d := &appsv1.Deployment{}
+	err = c.Get(context.TODO(), client.ObjectKey{
+		Namespace: operatorNs,
+		Name:      d_reference.Name,
+	}, d)
+	if err != nil {
+		logger.Error(err, "Failed to get HCO Deployment")
+		return nil, err
+	}
+
+	var csv_reference *metav1.OwnerReference
+	for _, owner := range d.GetOwnerReferences() {
+		if owner.Kind == "ClusterServiceVersion" {
+			csv_reference = &owner
+		}
+	}
+	if csv_reference == nil {
+		err = errors.New("Failed getting HCO CSV reference")
+		logger.Error(err, "Failed getting HCO CSV reference")
+		return nil, err
+	}
+	csv := &csvv1alpha1.ClusterServiceVersion{}
+	err = c.Get(context.TODO(), client.ObjectKey{
+		Namespace: operatorNs,
+		Name:      csv_reference.Name,
+	}, csv)
+	if err != nil {
+		logger.Error(err, "Failed to get HCO CSV")
+		return nil, err
+	}
+
+	return csv, nil
 }


### PR DESCRIPTION
```release-note
Emit a warning event on failed uninstall
```

Now Virt and CDI operators implements a validating
webhook that can prevent their CRs from being deleted
when we have existing VMs or DVs.
When the user will try to delete HCO CR, HCO will try
to delete Virt and CDI CRs and so it can fail there.
In that case, HCO CR is flagged for deletion and HCO
will periodically retry with an exponential
backoff mechanism.

Adding here the code to emit a warning event
to make it more evident to the user.

A better approach will be implemented in a future PR:
we are going to implement a validating webhook also here
that will try to delete virt and CDI resources in dry-run
mode and it will reject the deletion of HCO CR with a
clear error message if virt or cdi CRs cannot be deleted.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>