### PR TITLE
[release-2.3] Hide internal CRDs

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.0.0/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.0.0
-    createdAt: "2020-03-04 23:58:09"
+    createdAt: "2020-03-05 10:38:55"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -76,6 +76,7 @@ metadata:
       KubeVirt is distributed under the
       [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
     operatorframework.io/suggested-namespace: kubevirt-hyperconverged
+    operators.operatorframework.io/internal-objects: '["networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","kubevirtcommontemplatesbundles.kubevirt.io","kubevirtmetricsaggregations.kubevirt.io","kubevirtnodelabellerbundles.kubevirt.io","kubevirttemplatevalidators.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.kubevirt.io"]'
     repository: https://github.com/kubevirt/hyperconverged-cluster-operator
     support: "false"
   name: kubevirt-hyperconverged-operator.v1.0.0


### PR DESCRIPTION
Hide internal CRDs

```release-note
Hide internal CRDs: by default only hyperconvergeds.hco.kubevirt.io, v2vvmwares.kubevirt.io and hostpathprovisioners.hostpathprovisioner.kubevirt.io will be visible in OLM console
```

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>