### PR TITLE
Correct behaviour for ocp-* providers.

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -19,7 +19,7 @@ CMD="./cluster/kubectl.sh" ./hack/clean.sh
 IMAGE_REGISTRY=$registry make container-build-operator container-push-operator
 
 nodes=()
-if [[ $KUBEVIRT_PROVIDER =~ okd.* ]]; then
+if [[ $KUBEVIRT_PROVIDER =~ (okd|ocp).* ]]; then
     for okd_node in "master-0" "worker-0"; do
         node=$(./cluster/kubectl.sh get nodes | grep -o '[^ ]*'${okd_node}'[^ ]*')
         nodes+=(${node})


### PR DESCRIPTION
ocp-* calls the nodes master-0 and worker-0 as well.

````release-note
NONE
````