### PR TITLE
Add pull request template to write release note

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- This form is for bug reports and feature requests ONLY!
+Also make sure that you visit our User Guide at https://kubevirt.io/user-guide/
+-->
+
+**Is this a BUG REPORT or FEATURE REQUEST?**:
+
+> Uncomment only one, leave it on its own line:
+>
+> /kind bug
+> /kind enhancement
+
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- HCO version (use `oc get csv -n kubevirt-hyperconverged`):
+- Kubernetes version (use `kubectl version`):
+- Cloud provider or hardware configuration:
+- Install tools:
+- Others:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+**Release note**:
+<!--  Write your release note:
+1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. If no release note is required, just write "NONE".
+-->
+```release-note
+
+```
+


### PR DESCRIPTION
Based on CDI's templates.

Hopefully they will remind people to write release notes instead of being pinged to fix it by kubevirt-bot :-)

```release-note
NONE
```
(ironic edit)