### PR TITLE
Let the user set a custom value for smbios at CSV level

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
-    createdAt: "2020-03-09 14:34:54"
+    createdAt: "2020-03-13 13:02:31"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1298,6 +1298,12 @@ spec:
                   value: quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0
                 - name: VMWARE_CONTAINER
                   value: quay.io/kubevirt/kubevirt-vmware:v2.0.0
+                - name: SMBIOS
+                  value: |-
+                    Family: KubeVirt
+                    Manufacturer: KubeVirt
+                    Product: None
+                - name: MACHINETYPE
                 image: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
                 imagePullPolicy: IfNotPresent
                 name: hyperconverged-cluster-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -36,6 +36,12 @@ spec:
           value: quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0
         - name: VMWARE_CONTAINER
           value: quay.io/kubevirt/kubevirt-vmware:v2.0.0
+        - name: SMBIOS
+          value: |-
+            Family: KubeVirt
+            Manufacturer: KubeVirt
+            Product: None
+        - name: MACHINETYPE
         image: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
         imagePullPolicy: IfNotPresent
         name: hyperconverged-cluster-operator

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -222,6 +222,13 @@ popd
 mkdir -p "${CSV_DIR}"
 rm -f ${CSV_DIR}/*
 
+SMBIOS=$(cat <<- EOM
+Family: KubeVirt
+Manufacturer: KubeVirt
+Product: None
+EOM
+)
+
 # Build and write deploy dir
 (cd ${PROJECT_ROOT}/tools/manifest-templator/ && go build)
 ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
@@ -233,6 +240,7 @@ ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
   --ims-conversion-image-name="${CONVERSION_CONTAINER}" \
   --ims-vmware-image-name="${VMWARE_CONTAINER}" \
   --operator-namespace="${OPERATOR_NAMESPACE}" \
+  --smbios="${SMBIOS}" \
   --operator-image="${OPERATOR_IMAGE}"
 (cd ${PROJECT_ROOT}/tools/manifest-templator/ && go clean)
 
@@ -250,6 +258,7 @@ ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
   --spec-displayname="KubeVirt HyperConverged Cluster Operator" \
   --spec-description="$(<${PROJECT_ROOT}/docs/operator_description.md)" \
   --crd-display="HyperConverged Cluster Operator" \
+  --smbios="${SMBIOS}" \
   --csv-overrides="$(<${csvOverrides})" \
   --operator-image-name="${OPERATOR_IMAGE}" > "${CSV_DIR}/${OPERATOR_NAME}.v${CSV_VERSION}.${CSV_EXT}"
 (cd ${PROJECT_ROOT}/tools/csv-merger/ && go clean)

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -41,7 +41,7 @@ type StrategyDetailsDeployment struct {
 
 const hcoName = "hyperconverged-cluster-operator"
 
-func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString string) appsv1.Deployment {
+func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype string) appsv1.Deployment {
 	return appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -53,11 +53,11 @@ func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwar
 				"name": hcoName,
 			},
 		},
-		Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString),
+		Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype),
 	}
 }
 
-func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer string) appsv1.DeploymentSpec {
+func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype string) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
 		Replicas: int32Ptr(1),
 		Selector: &metav1.LabelSelector{
@@ -129,6 +129,14 @@ func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, v
 							{
 								Name:  "VMWARE_CONTAINER",
 								Value: vmwareContainer,
+							},
+							{
+								Name:  "SMBIOS",
+								Value: smbios,
+							},
+							{
+								Name:  "MACHINETYPE",
+								Value: machinetype,
 							},
 						},
 					},
@@ -516,12 +524,12 @@ func GetOperatorCR() *hcov1alpha1.HyperConverged {
 }
 
 // GetInstallStrategyBase returns the basics of an HCO InstallStrategy
-func GetInstallStrategyBase(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer string) *StrategyDetailsDeployment {
+func GetInstallStrategyBase(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype string) *StrategyDetailsDeployment {
 	return &StrategyDetailsDeployment{
 		DeploymentSpecs: []StrategyDeploymentSpec{
 			StrategyDeploymentSpec{
 				Name: "hco-operator",
-				Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer),
+				Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype),
 			},
 		},
 		Permissions: []StrategyDeploymentPermissions{},

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -50,6 +50,8 @@ var (
 	operatorImage      = flag.String("operator-image", "", "HyperConverged Cluster Operator image")
 	imsConversionImage = flag.String("ims-conversion-image-name", "", "IMS conversion image")
 	imsVMWareImage     = flag.String("ims-vmware-image-name", "", "IMS VMWare image")
+	smbios             = flag.String("smbios", "", "Custom SMBIOS string for KubeVirt ConfigMap")
+	machinetype        = flag.String("machinetype", "", "Custom MACHINETYPE string for KubeVirt ConfigMap")
 )
 
 // check handles errors
@@ -112,6 +114,8 @@ func main() {
 			"IfNotPresent",
 			*imsConversionImage,
 			*imsVMWareImage,
+			*smbios,
+			*machinetype,
 		),
 	}
 	serviceAccounts := map[string]v1.ServiceAccount{


### PR DESCRIPTION
Let the user set a custom value for smbios in
KubeVirt ConfigMap consuming a new env variable
set in the CSV.

Set it on new deployemnts.
Update to the value in the CSV on upgrades.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>