### PR TITLE
remove CNV from cert-rotate README

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,7 @@
 
 ## Rotating Certificates
 
-To rotate certificates for all CNV components, type:
+To rotate certificates for all components managed by the HyperConverged Operator, type:
 
 ```
 export KUBECONFIG=<wherever>


### PR DESCRIPTION
CNV is a Red Hat downstream trademark, it not relevant in upstream context.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

