### PR TITLE
Enforce a structural schema for HCO CRD

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -27,9 +27,8 @@ spec:
             name:
               pattern: kubevirt-hyperconverged
               type: string
-            namespace:
-              pattern: kubevirt-hyperconverged
-              type: string
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/hco00.crd.yaml
@@ -27,9 +27,8 @@ spec:
             name:
               pattern: kubevirt-hyperconverged
               type: string
-            namespace:
-              pattern: kubevirt-hyperconverged
-              type: string
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -457,16 +457,14 @@ func GetOperatorCRD(namespace string) *extv1beta1.CustomResourceDefinition {
 
 			Validation: &extv1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &extv1beta1.JSONSchemaProps{
+					Type: "object",
 					Properties: map[string]extv1beta1.JSONSchemaProps{
 						"metadata": {
+							Type: "object",
 							Properties: map[string]extv1beta1.JSONSchemaProps{
 								"name": extv1beta1.JSONSchemaProps{
 									Type:    "string",
 									Pattern: hcov1alpha1.HyperConvergedName,
-								},
-								"namespace": extv1beta1.JSONSchemaProps{
-									Type:    "string",
-									Pattern: namespace,
 								},
 							},
 						},


### PR DESCRIPTION
https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190425-structural-openapi.md
defines what's a structural schema for a CRD and currently HCO CRD doens't match.

Try to move back to a fully structural schema.
Please notice that the most relevant change is removing the
namespace restriction (which is explictly forbidden) that
can lead HCO CR to be potentially created in any namespace.

We should eventually consider again about moving to a cluster scoped CR.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Enforce a structural schema for HCO CRD
```

