### PR TITLE
change TARGET to TARGET_NAMESPACE in cleanup_marketplace.sh to match deploy_marketplace.sh

### DIFF
--- a/deploy/cleanup_marketplace.sh
+++ b/deploy/cleanup_marketplace.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 MARKETPLACE="${MARKETPLACE:-openshift-marketplace}"
-TARGET="${TARGET:-kubevirt-hyperconverged}"
+TARGET_NAMESPACE="${TARGET_NAMESPACE:-kubevirt-hyperconverged}"
 APP_REGISTRY="${APP_REGISTRY:-kubevirt-hyperconverged}"
 HCO_VERSION="${HCO_VERSION:-1.0.0}"
 
 oc delete csc hco-catalogsource-config -n $MARKETPLACE
 oc delete catalogsource $APP_REGISTRY -n $MARKETPLACE
 oc delete operatorsource $APP_REGISTRY -n $MARKETPLACE
-oc delete hco kubevirt-hyperconverged -n $TARGET
+oc delete hco kubevirt-hyperconverged -n $TARGET_NAMESPACE
 sleep 10
-oc delete sub hco-operatorhub -n $TARGET
-oc delete csv kubevirt-hyperconverged-operator.v${HCO_VERSION} -n $TARGET
-oc delete operatorgroup $TARGET-group -n $TARGET
+oc delete sub hco-operatorhub -n $TARGET_NAMESPACE
+oc delete csv kubevirt-hyperconverged-operator.v${HCO_VERSION} -n $TARGET_NAMESPACE
+oc delete operatorgroup $TARGET_NAMESPACE-group -n $TARGET_NAMESPACE
 oc delete secret $(oc get secret -n $MARKETPLACE | grep quay-registry | awk '{print $1}') -n $MARKETPLACE


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The deploy_marketplace.sh script uses $TARGET_NAMESPACE for the namespace to deploy to but the cleanup_marketplace.sh uses $TARGET. This change corrects that in the cleanup_marketplace.sh script.
```

