### PR TITLE
Add a new simple, positive only test for HCO deletion

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -6,8 +6,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"os"
+	"time"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis"
+	k8sTime "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -1508,6 +1510,50 @@ var _ = Describe("HyperconvergedController", func() {
 				expected.kvTv.Status.Conditions = origConds
 				cl = expected.initClient()
 				checkAvailability(expected.hco, cl, corev1.ConditionTrue)
+			})
+
+			It(`should delete HCO`, func() {
+
+				// First, create HCO and check it
+				expected := getBasicDeployment()
+				cl := expected.initClient()
+				r := initReconciler(cl)
+				res, err := r.Reconcile(request)
+				Expect(err).To(BeNil())
+				Expect(res).Should(Equal(reconcile.Result{}))
+
+				foundResource := &hcov1alpha1.HyperConverged{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				Expect(foundResource.Status.RelatedObjects).ToNot(BeNil())
+				Expect(len(foundResource.Status.RelatedObjects)).Should(Equal(8))
+				Expect(foundResource.ObjectMeta.Finalizers).Should(Equal([]string{FinalizerName}))
+
+				// Now, delete HCO
+				delTime := time.Now().UTC().Add(-1 * time.Minute)
+				expected.hco.ObjectMeta.DeletionTimestamp = &k8sTime.Time{Time: delTime}
+				expected.hco.ObjectMeta.Finalizers = []string{FinalizerName}
+				cl = expected.initClient()
+
+				r = initReconciler(cl)
+				res, err = r.Reconcile(request)
+				Expect(err).To(BeNil())
+				Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+
+				foundResource = &hcov1alpha1.HyperConverged{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				Expect(foundResource.Status.RelatedObjects).To(BeNil())
+				Expect(foundResource.ObjectMeta.Finalizers).To(BeNil())
+
 			})
 		})
 	})


### PR DESCRIPTION
Add a new basic, positive only test for HCO deletion. 

This test was split from PR #508 

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
NONE
```

