### PR TITLE
Move v2vvmware CRD under v2v.kubevirt.io API group

### DIFF
--- a/deploy/crds/hco01.crd.yaml
+++ b/deploy/crds/hco01.crd.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: v2vvmwares.kubevirt.io
+  name: v2vvmwares.v2v.kubevirt.io
 spec:
-  group: kubevirt.io
+  group: v2v.kubevirt.io
   names:
     kind: V2VVmware
     listKind: V2VVmwareList

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/hco01.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/hco01.crd.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: v2vvmwares.kubevirt.io
+  name: v2vvmwares.v2v.kubevirt.io
 spec:
-  group: kubevirt.io
+  group: v2v.kubevirt.io
   names:
     kind: V2VVmware
     listKind: V2VVmwareList

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
       KubeVirt is distributed under the
       [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
     operatorframework.io/suggested-namespace: kubevirt-hyperconverged
-    operators.operatorframework.io/internal-objects: '["v2vvmwares.kubevirt.io","networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","kubevirtcommontemplatesbundles.ssp.kubevirt.io","kubevirtmetricsaggregations.ssp.kubevirt.io","kubevirtnodelabellerbundles.ssp.kubevirt.io","kubevirttemplatevalidators.ssp.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.kubevirt.io"]'
+    operators.operatorframework.io/internal-objects: '["v2vvmwares.v2v.kubevirt.io","networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","kubevirtcommontemplatesbundles.ssp.kubevirt.io","kubevirtmetricsaggregations.ssp.kubevirt.io","kubevirtnodelabellerbundles.ssp.kubevirt.io","kubevirttemplatevalidators.ssp.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.kubevirt.io"]'
     repository: https://github.com/kubevirt/hyperconverged-cluster-operator
     support: "false"
   name: kubevirt-hyperconverged-operator.v1.1.0
@@ -93,7 +93,7 @@ spec:
     - description: V2V Vmware
       displayName: V2V Vmware
       kind: V2VVmware
-      name: v2vvmwares.kubevirt.io
+      name: v2vvmwares.v2v.kubevirt.io
       version: v1alpha1
     - description: Cluster Network Addons
       displayName: Cluster Network Addons

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -484,10 +484,10 @@ func GetV2VCRD() *extv1beta1.CustomResourceDefinition {
 			Kind:       "CustomResourceDefinition",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "v2vvmwares.kubevirt.io",
+			Name: "v2vvmwares.v2v.kubevirt.io",
 		},
 		Spec: extv1beta1.CustomResourceDefinitionSpec{
-			Group:   "kubevirt.io",
+			Group:   "v2v.kubevirt.io",
 			Version: "v1alpha1",
 			Scope:   "Namespaced",
 			Versions: []extv1beta1.CustomResourceDefinitionVersion{
@@ -654,7 +654,7 @@ func GetCSVBase(name, namespace, displayName, description, image, replaces strin
 						Description: "Represents the deployment of " + crdDisplay,
 					},
 					csvv1alpha1.CRDDescription{
-						Name:        "v2vvmwares.kubevirt.io",
+						Name:        "v2vvmwares.v2v.kubevirt.io",
 						Version:     "v1alpha1",
 						Kind:        "V2VVmware",
 						DisplayName: "V2V Vmware",


### PR DESCRIPTION
Former group: kubevirt.io

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The v2vvmware CRD has been moved from the kubevirt.io API group to the v2v.kubevirt.io.
```

