### PR TITLE
Don't call handleComponentConditions for KubeVirtMetricsAggregation

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -1100,7 +1100,7 @@ func (r *ReconcileHyperConverged) ensureKubeVirtMetricsAggregation(instance *hco
 	}
 	objectreferencesv1.SetObjectReference(&instance.Status.RelatedObjects, *objectRef)
 
-	handleComponentConditions(r, logger, "KubevirtMetricsAggregation", found.Status.Conditions)
+	// Don't call handleComponentConditions, because KubeVirtMetricsAggregation uses non-standard conditions
 	return r.client.Status().Update(context.TODO(), instance)
 }
 


### PR DESCRIPTION
Don't call handleComponentConditions for KubeVirtMetricsAggregation, because KubeVirtMetricsAggregation uses non-standard conditions

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
NONE
```

