### PR TITLE
Re-enable "should start the VMI after a certificate rotation"

### DIFF
--- a/tests/func-tests/certificates_test.go
+++ b/tests/func-tests/certificates_test.go
@@ -4,10 +4,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-
-	//	"io"
-	//	"net/http"
-	//	"os"
+	"io"
+	"net/http"
+	"os"
 	"os/exec"
 	"strconv"
 	"sync"
@@ -17,8 +16,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
-
-	//	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	v1 "kubevirt.io/client-go/api/v1"
@@ -137,95 +135,91 @@ var _ = Describe("Certificates", func() {
 	// 	Expect(newCert).ToNot(Equal(oldCert))
 	// })
 
-	// TODO: disabling it because we are not able to pass it on hco-e2e-aws test suite
-	// investigate it and re-enable ASAP!
-	/*
-		Context("with an alpine VMI provided via CDI", func() {
-			const (
-				uploadProxyService   = "cdi-uploadproxy"
-				uploadProxyPort      = 443
-				localUploadProxyPort = 18443
-				imagePath            = "/tmp/alpine.iso"
-			)
+	Context("with an alpine VMI provided via CDI", func() {
+		const (
+			uploadProxyService   = "cdi-uploadproxy"
+			uploadProxyPort      = 443
+			localUploadProxyPort = 18443
+			imagePath            = "/tmp/alpine.iso"
+		)
 
-			pvcName := "alpine-pvc"
-			pvcSize := "100Mi"
+		pvcName := "alpine-pvc"
+		pvcSize := "100Mi"
 
-			virtClient, err := kubecli.GetKubevirtClient()
-			testscore.PanicOnError(err)
+		virtClient, err := kubecli.GetKubevirtClient()
+		testscore.PanicOnError(err)
 
-			BeforeEach(func() {
-				By("Downloading alpine image")
-				// alpine 3.7.0
-				r, err := http.Get("https://storage.googleapis.com/builddeps/5a4b2588afd32e7024dd61d9558b77b03a4f3189cb4c9fc05e9e944fb780acdd")
-				Expect(err).ToNot(HaveOccurred())
-				defer r.Body.Close()
+		BeforeEach(func() {
+			By("Downloading alpine image")
+			// alpine 3.7.0
+			r, err := http.Get("https://storage.googleapis.com/builddeps/5a4b2588afd32e7024dd61d9558b77b03a4f3189cb4c9fc05e9e944fb780acdd")
+			Expect(err).ToNot(HaveOccurred())
+			defer r.Body.Close()
 
-				file, err := os.Create(imagePath)
-				Expect(err).ToNot(HaveOccurred())
-				defer file.Close()
+			file, err := os.Create(imagePath)
+			Expect(err).ToNot(HaveOccurred())
+			defer file.Close()
 
-				_, err = io.Copy(file, r.Body)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-				It("should start the VMI after a certificate rotation", func() {
-					By("Rotating the certs first")
-					Expect(RotateCeritifcates(testscore.KubeVirtInstallNamespace, testscore.ContainerizedDataImporterNamespace)).To(Succeed())
-					WaitForAllPodsToBecomeReady()
-					jobType := tests.GetJobTypeEnvVar()
-					storageClass := tests.KubeVirtStorageClassLocal
-					if jobType == "prow" {
-						storageClass = ""
-					}
-
-					By("Upload image")
-					Eventually(func() error {
-						stopChan := make(chan struct{})
-						defer close(stopChan)
-						portMapping := fmt.Sprintf("%d:%d", localUploadProxyPort, uploadProxyPort)
-						err := ForwardPortsForService(uploadProxyService, testscore.KubeVirtInstallNamespace, stopChan, []string{portMapping})
-						if err != nil {
-							return err
-						}
-
-						virtctlCmd := testscore.NewRepeatableVirtctlCommand("image-upload",
-							"--namespace", testscore.NamespaceTestDefault,
-							"--image-path", imagePath,
-							"--pvc-name", pvcName,
-							"--pvc-size", pvcSize,
-							"--uploadproxy-url", fmt.Sprintf("https://127.0.0.1:%d", localUploadProxyPort),
-							"--wait-secs", "120",
-							"--storage-class", storageClass,
-							"--insecure")
-						err = virtctlCmd()
-						if err != nil {
-							return fmt.Errorf("UploadImage Error: %+v\n", err)
-						}
-						return nil
-					}, 180*time.Second, 5*time.Second).Should(Succeed())
-
-					By("Start VM")
-					vm := NewRandomVMWithPVC(pvcName)
-					vm, err = virtClient.VirtualMachine(testscore.NamespaceTestDefault).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-					// Long timeout, since we don't know if virt-launcher is already pre-pulled
-					Eventually(func() v1.VirtualMachineInstancePhase {
-						vmi, err := virtClient.VirtualMachineInstance(testscore.NamespaceTestDefault).Get(vm.Name, &k8smetav1.GetOptions{})
-						if errors.IsNotFound(err) {
-							return ""
-						}
-						Expect(err).ToNot(HaveOccurred())
-						return vmi.Status.Phase
-					}, 20*time.Minute, 2*time.Second).Should(Equal(v1.Running))
-				})
-
-			AfterEach(func() {
-				err = os.Remove(imagePath)
-				Expect(err).ToNot(HaveOccurred())
-			})
+			_, err = io.Copy(file, r.Body)
+			Expect(err).ToNot(HaveOccurred())
 		})
-	*/
+
+		It("should start the VMI after a certificate rotation", func() {
+			By("Rotating the certs first")
+			Expect(RotateCeritifcates(testscore.KubeVirtInstallNamespace, testscore.ContainerizedDataImporterNamespace)).To(Succeed())
+			WaitForAllPodsToBecomeReady()
+			jobType := tests.GetJobTypeEnvVar()
+			storageClass := tests.KubeVirtStorageClassLocal
+			if jobType == "prow" {
+				storageClass = ""
+			}
+
+			By("Upload image")
+			Eventually(func() error {
+				stopChan := make(chan struct{})
+				defer close(stopChan)
+				portMapping := fmt.Sprintf("%d:%d", localUploadProxyPort, uploadProxyPort)
+				err := ForwardPortsForService(uploadProxyService, testscore.KubeVirtInstallNamespace, stopChan, []string{portMapping})
+				if err != nil {
+					return err
+				}
+
+				virtctlCmd := testscore.NewRepeatableVirtctlCommand("image-upload",
+					"--namespace", testscore.NamespaceTestDefault,
+					"--image-path", imagePath,
+					"--pvc-name", pvcName,
+					"--pvc-size", pvcSize,
+					"--uploadproxy-url", fmt.Sprintf("https://127.0.0.1:%d", localUploadProxyPort),
+					"--wait-secs", "120",
+					"--storage-class", storageClass,
+					"--insecure")
+				err = virtctlCmd()
+				if err != nil {
+					return fmt.Errorf("UploadImage Error: %+v\n", err)
+				}
+				return nil
+			}, 180*time.Second, 5*time.Second).Should(Succeed())
+
+			By("Start VM")
+			vm := NewRandomVMWithPVC(pvcName)
+			vm, err = virtClient.VirtualMachine(testscore.NamespaceTestDefault).Create(vm)
+			Expect(err).ToNot(HaveOccurred())
+			// Long timeout, since we don't know if virt-launcher is already pre-pulled
+			Eventually(func() v1.VirtualMachineInstancePhase {
+				vmi, err := virtClient.VirtualMachineInstance(testscore.NamespaceTestDefault).Get(vm.Name, &k8smetav1.GetOptions{})
+				if errors.IsNotFound(err) {
+					return ""
+				}
+				Expect(err).ToNot(HaveOccurred())
+				return vmi.Status.Phase
+			}, 20*time.Minute, 2*time.Second).Should(Equal(v1.Running))
+		})
+
+		AfterEach(func() {
+			err = os.Remove(imagePath)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })
 
 func RotateCeritifcates(namespace string, cdiNamespace string) error {


### PR DESCRIPTION
func test "should start the VMI after a certificate rotation"
has been temporary disabled in
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/521
to unlock CI that was constantly failing.
Let's enable it again.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

