### PR TITLE
Detect Upgrade Mode

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -42,6 +42,8 @@ spec:
             Manufacturer: KubeVirt
             Product: None
         - name: MACHINETYPE
+        - name: HCO_KV_IO_VERSION
+          value: 1.1.0
         image: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
         imagePullPolicy: IfNotPresent
         name: hyperconverged-cluster-operator

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -242,6 +242,7 @@ ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
   --ims-vmware-image-name="${VMWARE_CONTAINER}" \
   --operator-namespace="${OPERATOR_NAMESPACE}" \
   --smbios="${SMBIOS}" \
+  --hco-kv-io-version="${CSV_VERSION}" \
   --operator-image="${OPERATOR_IMAGE}"
 (cd ${PROJECT_ROOT}/tools/manifest-templator/ && go clean)
 
@@ -256,6 +257,7 @@ ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
   --ims-vmware-image-name="${VMWARE_CONTAINER}" \
   --csv-version=${CSV_VERSION} \
   --replaces-csv-version=${REPLACES_CSV_VERSION} \
+  --hco-kv-io-version="${CSV_VERSION}" \
   --spec-displayname="KubeVirt HyperConverged Cluster Operator" \
   --spec-description="$(<${PROJECT_ROOT}/docs/operator_description.md)" \
   --crd-display="HyperConverged Cluster Operator" \

--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -11,7 +11,7 @@ if [ "${JOB_TYPE}" == "travis" ]; then
     go get -v github.com/onsi/ginkgo/ginkgo
     go get -v github.com/onsi/gomega
     go get -u github.com/evanphx/json-patch
-    PACKAGE_PATH="pkg/controller/hyperconverged/"
+    PACKAGE_PATH="pkg/"
     ginkgo -r -cover ${PACKAGE_PATH}
 else
     GOFLAGS= go get github.com/onsi/ginkgo/ginkgo

--- a/pkg/apis/hco/v1alpha1/hyperconvarged_types_test.go
+++ b/pkg/apis/hco/v1alpha1/hyperconvarged_types_test.go
@@ -1,0 +1,250 @@
+package v1alpha1
+
+import (
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+const (
+	testName       = "aName"
+	testVersion    = "aVersion"
+	testOldVersion = "anOldVersion"
+)
+
+func TestHyperConvergedStatus_UpdateVersion_noVersions(t *testing.T) {
+	hcs := &HyperConvergedStatus{Conditions: []conditionsv1.Condition{}, RelatedObjects: []corev1.ObjectReference{}}
+
+	hcs.UpdateVersion(testName, testVersion)
+
+	if len(hcs.Versions) != 1 {
+		t.Error("Should be able to add a new version to a nil version array")
+	}
+
+	if hcs.Versions[0].Name != testName {
+		t.Errorf(`Version name should be "%s" but it's "%s"`, testName, hcs.Versions[0].Name)
+	}
+
+	if hcs.Versions[0].Version != testVersion {
+		t.Errorf(`Version should be "%s" but it's "%s"`, testVersion, hcs.Versions[0].Version)
+	}
+}
+
+func TestHyperConvergedStatus_UpdateVersion_emptyVersions(t *testing.T) {
+	hcs := &HyperConvergedStatus{
+		Conditions:     []conditionsv1.Condition{},
+		RelatedObjects: []corev1.ObjectReference{},
+		Versions:       Versions{},
+	}
+
+	hcs.UpdateVersion(testName, testVersion)
+
+	if len(hcs.Versions) != 1 {
+		t.Error("Should be able to add a new version to an empty version array")
+	}
+
+	if hcs.Versions[0].Name != testName {
+		t.Errorf(`Version name should be "%s" but it's "%s"`, testName, hcs.Versions[0].Name)
+	}
+
+	if hcs.Versions[0].Version != testVersion {
+		t.Errorf(`Version should be "%s" but it's "%s"`, testVersion, hcs.Versions[0].Version)
+	}
+}
+
+func TestHyperConvergedStatus_UpdateVersion_addNew(t *testing.T) {
+	hcs := &HyperConvergedStatus{
+		Conditions:     []conditionsv1.Condition{},
+		RelatedObjects: []corev1.ObjectReference{},
+		Versions: Versions{
+			{Name: "aaa", Version: "1.2.3"},
+			{Name: "bbb", Version: "4.5.6"},
+			{Name: "ccc", Version: "7.8.9"},
+		},
+	}
+
+	hcs.UpdateVersion(testName, testVersion)
+
+	if len(hcs.Versions) != 4 {
+		t.Errorf("Should be able to add a new version to a non-empty version array")
+	}
+
+	if hcs.Versions[3].Name != testName {
+		t.Errorf(`Version name should be ""%s"" but it's "%s"`, testName, hcs.Versions[3].Name)
+	}
+
+	if hcs.Versions[3].Version != testVersion {
+		t.Errorf(`Version should be ""%s"" but it's "%s"`, testVersion, hcs.Versions[3].Version)
+	}
+}
+
+func TestHyperConvergedStatus_UpdateVersion_updateFirst(t *testing.T) {
+	hcs := &HyperConvergedStatus{
+		Conditions:     []conditionsv1.Condition{},
+		RelatedObjects: []corev1.ObjectReference{},
+		Versions: Versions{
+			{Name: testName, Version: testOldVersion},
+			{Name: "bbb", Version: "4.5.6"},
+			{Name: "ccc", Version: "7.8.9"},
+		},
+	}
+
+	hcs.UpdateVersion(testName, testVersion)
+
+	if len(hcs.Versions) != 3 {
+		t.Errorf("Should be able to update an existing version; array length should be 3, but it's %d", len(hcs.Versions))
+	}
+
+	if hcs.Versions[0].Name != testName {
+		t.Errorf(`Version name should be "%s" but it's "%s"`, testName, hcs.Versions[0].Name)
+	}
+
+	if hcs.Versions[0].Version != testVersion {
+		t.Errorf(`Version should be "%s" but it's "%s"`, testVersion, hcs.Versions[0].Version)
+	}
+}
+
+func TestHyperConvergedStatus_UpdateVersion_updateMiddle(t *testing.T) {
+	hcs := &HyperConvergedStatus{
+		Conditions:     []conditionsv1.Condition{},
+		RelatedObjects: []corev1.ObjectReference{},
+		Versions: Versions{
+			{Name: "aaa", Version: "1.2.3"},
+			{Name: testName, Version: testOldVersion},
+			{Name: "ccc", Version: "7.8.9"},
+		},
+	}
+
+	hcs.UpdateVersion(testName, testVersion)
+
+	if len(hcs.Versions) != 3 {
+		t.Errorf("Should be able to update an existing version; array length should be 3, but it's %d", len(hcs.Versions))
+	}
+
+	if hcs.Versions[1].Name != testName {
+		t.Errorf(`Version name should be "%s" but it's "%s"`, testName, hcs.Versions[1].Name)
+	}
+
+	if hcs.Versions[1].Version != testVersion {
+		t.Errorf(`Version should be "%s" but it's "%s"`, testVersion, hcs.Versions[1].Version)
+	}
+}
+
+func TestHyperConvergedStatus_UpdateVersion_updateLast(t *testing.T) {
+	hcs := &HyperConvergedStatus{
+		Conditions:     []conditionsv1.Condition{},
+		RelatedObjects: []corev1.ObjectReference{},
+		Versions: Versions{
+			{Name: "aaa", Version: "1.2.3"},
+			{Name: "bbb", Version: "4.5.6"},
+			{Name: testName, Version: testOldVersion},
+		},
+	}
+
+	hcs.UpdateVersion(testName, testVersion)
+
+	if len(hcs.Versions) != 3 {
+		t.Errorf("Should be able to update an existing version; array length should be 3, but it's %d", len(hcs.Versions))
+	}
+
+	if hcs.Versions[2].Name != testName {
+		t.Errorf(`Version name should be "%s" but it's "%s"`, testName, hcs.Versions[2].Name)
+	}
+
+	if hcs.Versions[2].Version != testVersion {
+		t.Errorf(`Version should be "%s" but it's "%s"`, testVersion, hcs.Versions[2].Version)
+	}
+}
+
+func TestHyperConvergedStatus_GetVersion_nil(t *testing.T) {
+	hcs := &HyperConvergedStatus{Conditions: []conditionsv1.Condition{}, RelatedObjects: []corev1.ObjectReference{}}
+	ver, ok := hcs.GetVersion(testName)
+	if ok || ver != "" {
+		t.Error("Should not find the version in empty version array")
+	}
+}
+
+func TestHyperConvergedStatus_GetVersion_empty(t *testing.T) {
+	hcs := &HyperConvergedStatus{
+		Conditions:     []conditionsv1.Condition{},
+		RelatedObjects: []corev1.ObjectReference{},
+		Versions:       Versions{},
+	}
+	ver, ok := hcs.GetVersion(testName)
+	if ok || ver != "" {
+		t.Error("Should not find the version in empty version array")
+	}
+}
+
+func TestHyperConvergedStatus_GetVersion_notFound(t *testing.T) {
+	hcs := &HyperConvergedStatus{
+		Conditions:     []conditionsv1.Condition{},
+		RelatedObjects: []corev1.ObjectReference{},
+		Versions: Versions{
+			{Name: "aaa", Version: "1.2.3"},
+			{Name: "bbb", Version: "4.5.6"},
+			{Name: "ccc", Version: "7.8.9"},
+		},
+	}
+	ver, ok := hcs.GetVersion(testName)
+	if ok || ver != "" {
+		t.Error("Should not find the version; it should be missing")
+	}
+}
+
+func TestHyperConvergedStatus_GetVersion_findFirst(t *testing.T) {
+	hcs := &HyperConvergedStatus{
+		Conditions:     []conditionsv1.Condition{},
+		RelatedObjects: []corev1.ObjectReference{},
+		Versions: Versions{
+			{Name: testName, Version: testVersion},
+			{Name: "bbb", Version: "4.5.6"},
+			{Name: "ccc", Version: "7.8.9"},
+		},
+	}
+	ver, ok := hcs.GetVersion(testName)
+	if !ok {
+		t.Errorf(`version "%s"" should be found`, testName)
+	}
+	if ver != testVersion {
+		t.Errorf(`version "%s"" should be "%s"; but it's %s`, testName, testVersion, ver)
+	}
+}
+
+func TestHyperConvergedStatus_GetVersion_findMiddle(t *testing.T) {
+	hcs := &HyperConvergedStatus{
+		Conditions:     []conditionsv1.Condition{},
+		RelatedObjects: []corev1.ObjectReference{},
+		Versions: Versions{
+			{Name: "aaa", Version: "1.2.3"},
+			{Name: testName, Version: testVersion},
+			{Name: "ccc", Version: "7.8.9"},
+		},
+	}
+	ver, ok := hcs.GetVersion(testName)
+	if !ok {
+		t.Errorf(`version "%s"" should be found`, testName)
+	}
+	if ver != testVersion {
+		t.Errorf(`version "%s"" should be "%s"; but it's %s`, testName, testVersion, ver)
+	}
+}
+
+func TestHyperConvergedStatus_GetVersion_findLast(t *testing.T) {
+	hcs := &HyperConvergedStatus{
+		Conditions:     []conditionsv1.Condition{},
+		RelatedObjects: []corev1.ObjectReference{},
+		Versions: Versions{
+			{Name: "aaa", Version: "1.2.3"},
+			{Name: "bbb", Version: "4.5.6"},
+			{Name: testName, Version: testVersion},
+		},
+	}
+	ver, ok := hcs.GetVersion(testName)
+	if !ok {
+		t.Errorf(`version "%s"" should be found`, testName)
+	}
+	if ver != testVersion {
+		t.Errorf(`version "%s"" should be "%s"; but it's %s`, testName, testVersion, ver)
+	}
+}

--- a/pkg/apis/hco/v1alpha1/hyperconvarged_types_test.go
+++ b/pkg/apis/hco/v1alpha1/hyperconvarged_types_test.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	"testing"
@@ -12,239 +14,283 @@ const (
 	testOldVersion = "anOldVersion"
 )
 
-func TestHyperConvergedStatus_UpdateVersion_noVersions(t *testing.T) {
-	hcs := &HyperConvergedStatus{Conditions: []conditionsv1.Condition{}, RelatedObjects: []corev1.ObjectReference{}}
-
-	hcs.UpdateVersion(testName, testVersion)
-
-	if len(hcs.Versions) != 1 {
-		t.Error("Should be able to add a new version to a nil version array")
-	}
-
-	if hcs.Versions[0].Name != testName {
-		t.Errorf(`Version name should be "%s" but it's "%s"`, testName, hcs.Versions[0].Name)
-	}
-
-	if hcs.Versions[0].Version != testVersion {
-		t.Errorf(`Version should be "%s" but it's "%s"`, testVersion, hcs.Versions[0].Version)
-	}
+func TestHyperConvergedStatus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HyperConvergedStatus Suite")
 }
 
-func TestHyperConvergedStatus_UpdateVersion_emptyVersions(t *testing.T) {
-	hcs := &HyperConvergedStatus{
-		Conditions:     []conditionsv1.Condition{},
-		RelatedObjects: []corev1.ObjectReference{},
-		Versions:       Versions{},
-	}
+var _ = Describe("HyperconvergedTypes", func() {
+	Describe("HyperConvergedStatus.UpdateVersion", func() {
+		Context("Should be able to add a new version to a nil version array", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+			}
 
-	hcs.UpdateVersion(testName, testVersion)
+			hcs.UpdateVersion(testName, testVersion)
 
-	if len(hcs.Versions) != 1 {
-		t.Error("Should be able to add a new version to an empty version array")
-	}
+			It("Versions array should be with one element", func() {
+				Expect(len(hcs.Versions)).Should(Equal(1))
+			})
 
-	if hcs.Versions[0].Name != testName {
-		t.Errorf(`Version name should be "%s" but it's "%s"`, testName, hcs.Versions[0].Name)
-	}
+			It(`The version name should be "aName"`, func() {
+				Expect(hcs.Versions[0].Name).Should(Equal(testName))
+			})
 
-	if hcs.Versions[0].Version != testVersion {
-		t.Errorf(`Version should be "%s" but it's "%s"`, testVersion, hcs.Versions[0].Version)
-	}
-}
+			It(`The version should be "aVersion"`, func() {
+				Expect(hcs.Versions[0].Version).Should(Equal(testVersion))
+			})
+		})
 
-func TestHyperConvergedStatus_UpdateVersion_addNew(t *testing.T) {
-	hcs := &HyperConvergedStatus{
-		Conditions:     []conditionsv1.Condition{},
-		RelatedObjects: []corev1.ObjectReference{},
-		Versions: Versions{
-			{Name: "aaa", Version: "1.2.3"},
-			{Name: "bbb", Version: "4.5.6"},
-			{Name: "ccc", Version: "7.8.9"},
-		},
-	}
+		Context("Should be able to add a new version to an empty version array", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+				Versions:       Versions{},
+			}
 
-	hcs.UpdateVersion(testName, testVersion)
+			hcs.UpdateVersion(testName, testVersion)
 
-	if len(hcs.Versions) != 4 {
-		t.Errorf("Should be able to add a new version to a non-empty version array")
-	}
+			It("Versions array should be with one element", func() {
+				Expect(len(hcs.Versions)).Should(Equal(1))
+			})
 
-	if hcs.Versions[3].Name != testName {
-		t.Errorf(`Version name should be ""%s"" but it's "%s"`, testName, hcs.Versions[3].Name)
-	}
+			It(`The version name should be "aName"`, func() {
+				Expect(hcs.Versions[0].Name).Should(Equal(testName))
+			})
 
-	if hcs.Versions[3].Version != testVersion {
-		t.Errorf(`Version should be ""%s"" but it's "%s"`, testVersion, hcs.Versions[3].Version)
-	}
-}
+			It(`The version should be "aVersion"`, func() {
+				Expect(hcs.Versions[0].Version).Should(Equal(testVersion))
+			})
+		})
 
-func TestHyperConvergedStatus_UpdateVersion_updateFirst(t *testing.T) {
-	hcs := &HyperConvergedStatus{
-		Conditions:     []conditionsv1.Condition{},
-		RelatedObjects: []corev1.ObjectReference{},
-		Versions: Versions{
-			{Name: testName, Version: testOldVersion},
-			{Name: "bbb", Version: "4.5.6"},
-			{Name: "ccc", Version: "7.8.9"},
-		},
-	}
+		Context("Should be able to add a new version to an existing version array", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+				Versions:       Versions{
+					{Name: "aaa", Version: "1.2.3"},
+					{Name: "bbb", Version: "4.5.6"},
+					{Name: "ccc", Version: "7.8.9"},
+				},
+			}
 
-	hcs.UpdateVersion(testName, testVersion)
+			hcs.UpdateVersion(testName, testVersion)
 
-	if len(hcs.Versions) != 3 {
-		t.Errorf("Should be able to update an existing version; array length should be 3, but it's %d", len(hcs.Versions))
-	}
+			It("Versions array should be with four elements", func() {
+				Expect(len(hcs.Versions)).Should(Equal(4))
+			})
 
-	if hcs.Versions[0].Name != testName {
-		t.Errorf(`Version name should be "%s" but it's "%s"`, testName, hcs.Versions[0].Name)
-	}
+			It(`The version name should be "aName"`, func() {
+				Expect(hcs.Versions[3].Name).Should(Equal(testName))
+			})
 
-	if hcs.Versions[0].Version != testVersion {
-		t.Errorf(`Version should be "%s" but it's "%s"`, testVersion, hcs.Versions[0].Version)
-	}
-}
+			It(`The version should be "aVersion"`, func() {
+				Expect(hcs.Versions[3].Version).Should(Equal(testVersion))
+			})
+		})
 
-func TestHyperConvergedStatus_UpdateVersion_updateMiddle(t *testing.T) {
-	hcs := &HyperConvergedStatus{
-		Conditions:     []conditionsv1.Condition{},
-		RelatedObjects: []corev1.ObjectReference{},
-		Versions: Versions{
-			{Name: "aaa", Version: "1.2.3"},
-			{Name: testName, Version: testOldVersion},
-			{Name: "ccc", Version: "7.8.9"},
-		},
-	}
+		Context("Should be able to update a new version in an existing version array (first element)", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+				Versions:       Versions{
+					{Name: testName, Version: testOldVersion},
+					{Name: "bbb", Version: "4.5.6"},
+					{Name: "ccc", Version: "7.8.9"},
+				},
+			}
 
-	hcs.UpdateVersion(testName, testVersion)
+			hcs.UpdateVersion(testName, testVersion)
 
-	if len(hcs.Versions) != 3 {
-		t.Errorf("Should be able to update an existing version; array length should be 3, but it's %d", len(hcs.Versions))
-	}
+			It("Versions array should be with three elements", func() {
+				Expect(len(hcs.Versions)).Should(Equal(3))
+			})
 
-	if hcs.Versions[1].Name != testName {
-		t.Errorf(`Version name should be "%s" but it's "%s"`, testName, hcs.Versions[1].Name)
-	}
+			It(`The version name should be "aName"`, func() {
+				Expect(hcs.Versions[0].Name).Should(Equal(testName))
+			})
 
-	if hcs.Versions[1].Version != testVersion {
-		t.Errorf(`Version should be "%s" but it's "%s"`, testVersion, hcs.Versions[1].Version)
-	}
-}
+			It(`The version should be "aVersion"`, func() {
+				Expect(hcs.Versions[0].Version).Should(Equal(testVersion))
+			})
+		})
 
-func TestHyperConvergedStatus_UpdateVersion_updateLast(t *testing.T) {
-	hcs := &HyperConvergedStatus{
-		Conditions:     []conditionsv1.Condition{},
-		RelatedObjects: []corev1.ObjectReference{},
-		Versions: Versions{
-			{Name: "aaa", Version: "1.2.3"},
-			{Name: "bbb", Version: "4.5.6"},
-			{Name: testName, Version: testOldVersion},
-		},
-	}
+		Context("Should be able to update a new version in an existing version array (middle element)", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+				Versions:       Versions{
+					{Name: "aaa", Version: "1.2.3"},
+					{Name: testName, Version: testOldVersion},
+					{Name: "ccc", Version: "7.8.9"},
+				},
+			}
 
-	hcs.UpdateVersion(testName, testVersion)
+			hcs.UpdateVersion(testName, testVersion)
 
-	if len(hcs.Versions) != 3 {
-		t.Errorf("Should be able to update an existing version; array length should be 3, but it's %d", len(hcs.Versions))
-	}
+			It("Versions array should be with three elements", func() {
+				Expect(len(hcs.Versions)).Should(Equal(3))
+			})
 
-	if hcs.Versions[2].Name != testName {
-		t.Errorf(`Version name should be "%s" but it's "%s"`, testName, hcs.Versions[2].Name)
-	}
+			It(`The version name should be "aName"`, func() {
+				Expect(hcs.Versions[1].Name).Should(Equal(testName))
+			})
 
-	if hcs.Versions[2].Version != testVersion {
-		t.Errorf(`Version should be "%s" but it's "%s"`, testVersion, hcs.Versions[2].Version)
-	}
-}
+			It(`The version should be "aVersion"`, func() {
+				Expect(hcs.Versions[1].Version).Should(Equal(testVersion))
+			})
+		})
 
-func TestHyperConvergedStatus_GetVersion_nil(t *testing.T) {
-	hcs := &HyperConvergedStatus{Conditions: []conditionsv1.Condition{}, RelatedObjects: []corev1.ObjectReference{}}
-	ver, ok := hcs.GetVersion(testName)
-	if ok || ver != "" {
-		t.Error("Should not find the version in empty version array")
-	}
-}
+		Context("Should be able to update a new version in an existing version array (last element)", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+				Versions:       Versions{
+					{Name: "aaa", Version: "1.2.3"},
+					{Name: "bbb", Version: "4.5.6"},
+					{Name: testName, Version: testOldVersion},
+				},
+			}
 
-func TestHyperConvergedStatus_GetVersion_empty(t *testing.T) {
-	hcs := &HyperConvergedStatus{
-		Conditions:     []conditionsv1.Condition{},
-		RelatedObjects: []corev1.ObjectReference{},
-		Versions:       Versions{},
-	}
-	ver, ok := hcs.GetVersion(testName)
-	if ok || ver != "" {
-		t.Error("Should not find the version in empty version array")
-	}
-}
+			hcs.UpdateVersion(testName, testVersion)
 
-func TestHyperConvergedStatus_GetVersion_notFound(t *testing.T) {
-	hcs := &HyperConvergedStatus{
-		Conditions:     []conditionsv1.Condition{},
-		RelatedObjects: []corev1.ObjectReference{},
-		Versions: Versions{
-			{Name: "aaa", Version: "1.2.3"},
-			{Name: "bbb", Version: "4.5.6"},
-			{Name: "ccc", Version: "7.8.9"},
-		},
-	}
-	ver, ok := hcs.GetVersion(testName)
-	if ok || ver != "" {
-		t.Error("Should not find the version; it should be missing")
-	}
-}
+			It("Versions array should be with three elements", func() {
+				Expect(len(hcs.Versions)).Should(Equal(3))
+			})
 
-func TestHyperConvergedStatus_GetVersion_findFirst(t *testing.T) {
-	hcs := &HyperConvergedStatus{
-		Conditions:     []conditionsv1.Condition{},
-		RelatedObjects: []corev1.ObjectReference{},
-		Versions: Versions{
-			{Name: testName, Version: testVersion},
-			{Name: "bbb", Version: "4.5.6"},
-			{Name: "ccc", Version: "7.8.9"},
-		},
-	}
-	ver, ok := hcs.GetVersion(testName)
-	if !ok {
-		t.Errorf(`version "%s"" should be found`, testName)
-	}
-	if ver != testVersion {
-		t.Errorf(`version "%s"" should be "%s"; but it's %s`, testName, testVersion, ver)
-	}
-}
+			It(`The version name should be "aName"`, func() {
+				Expect(hcs.Versions[2].Name).Should(Equal(testName))
+			})
 
-func TestHyperConvergedStatus_GetVersion_findMiddle(t *testing.T) {
-	hcs := &HyperConvergedStatus{
-		Conditions:     []conditionsv1.Condition{},
-		RelatedObjects: []corev1.ObjectReference{},
-		Versions: Versions{
-			{Name: "aaa", Version: "1.2.3"},
-			{Name: testName, Version: testVersion},
-			{Name: "ccc", Version: "7.8.9"},
-		},
-	}
-	ver, ok := hcs.GetVersion(testName)
-	if !ok {
-		t.Errorf(`version "%s"" should be found`, testName)
-	}
-	if ver != testVersion {
-		t.Errorf(`version "%s"" should be "%s"; but it's %s`, testName, testVersion, ver)
-	}
-}
+			It(`The version should be "aVersion"`, func() {
+				Expect(hcs.Versions[2].Version).Should(Equal(testVersion))
+			})
+		})
 
-func TestHyperConvergedStatus_GetVersion_findLast(t *testing.T) {
-	hcs := &HyperConvergedStatus{
-		Conditions:     []conditionsv1.Condition{},
-		RelatedObjects: []corev1.ObjectReference{},
-		Versions: Versions{
-			{Name: "aaa", Version: "1.2.3"},
-			{Name: "bbb", Version: "4.5.6"},
-			{Name: testName, Version: testVersion},
-		},
-	}
-	ver, ok := hcs.GetVersion(testName)
-	if !ok {
-		t.Errorf(`version "%s"" should be found`, testName)
-	}
-	if ver != testVersion {
-		t.Errorf(`version "%s"" should be "%s"; but it's %s`, testName, testVersion, ver)
-	}
-}
+	})
+
+	Describe("HyperConvergedStatus.GetVersion", func() {
+		Context("should return empty response for nil array", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+			}
+
+			ver, ok := hcs.GetVersion(testName)
+
+			It("should not find the version", func() {
+				Expect(ok).To(BeFalse())
+			})
+			It("the version should be empty", func() {
+				Expect(ver).To(BeEmpty())
+			})
+		})
+
+		Context("should return empty response for empty array", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+				Versions:       Versions{},
+			}
+
+			ver, ok := hcs.GetVersion(testName)
+
+			It("should not find the version", func() {
+				Expect(ok).To(BeFalse())
+			})
+
+			It("the version should be empty", func() {
+				Expect(ver).To(BeEmpty())
+			})
+		})
+
+		Context("should return empty response if the version is not in the versions array", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+				Versions:       Versions{
+					{Name: "aaa", Version: "1.2.3"},
+					{Name: "bbb", Version: "4.5.6"},
+					{Name: "ccc", Version: "7.8.9"},
+				},
+			}
+
+			ver, ok := hcs.GetVersion(testName)
+
+			It("should not find the version", func() {
+				Expect(ok).To(BeFalse())
+			})
+
+			It("the version should be empty", func() {
+				Expect(ver).To(BeEmpty())
+			})
+		})
+
+		Context("should return a valid response if the version is in the versions array (first element)", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+				Versions:       Versions{
+					{Name: testName, Version: testVersion},
+					{Name: "bbb", Version: "4.5.6"},
+					{Name: "ccc", Version: "7.8.9"},
+				},
+			}
+
+			ver, ok := hcs.GetVersion(testName)
+
+			It("should not find the version", func() {
+				Expect(ok).To(BeTrue())
+			})
+
+			It("the version should be empty", func() {
+				Expect(ver).Should(Equal(testVersion))
+			})
+		})
+
+		Context("should return a valid response if the version is in the versions array (middle element)", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+				Versions:       Versions{
+					{Name: "aaa", Version: "1.2.3"},
+					{Name: testName, Version: testVersion},
+					{Name: "ccc", Version: "7.8.9"},
+				},
+			}
+
+			ver, ok := hcs.GetVersion(testName)
+
+			It("should not find the version", func() {
+				Expect(ok).To(BeTrue())
+			})
+
+			It("the version should be empty", func() {
+				Expect(ver).Should(Equal(testVersion))
+			})
+		})
+
+		Context("should return a valid response if the version is in the versions array (last element)", func() {
+			hcs := &HyperConvergedStatus{
+				Conditions:     []conditionsv1.Condition{},
+				RelatedObjects: []corev1.ObjectReference{},
+				Versions:       Versions{
+					{Name: "aaa", Version: "1.2.3"},
+					{Name: "bbb", Version: "4.5.6"},
+					{Name: testName, Version: testVersion},
+				},
+			}
+
+			ver, ok := hcs.GetVersion(testName)
+
+			It("should not find the version", func() {
+				Expect(ok).To(BeTrue())
+			})
+
+			It("the version should be empty", func() {
+				Expect(ver).Should(Equal(testVersion))
+			})
+		})
+	})
+})

--- a/pkg/apis/hco/v1alpha1/hyperconvarged_types_test.go
+++ b/pkg/apis/hco/v1alpha1/hyperconvarged_types_test.go
@@ -68,7 +68,7 @@ var _ = Describe("HyperconvergedTypes", func() {
 			hcs := &HyperConvergedStatus{
 				Conditions:     []conditionsv1.Condition{},
 				RelatedObjects: []corev1.ObjectReference{},
-				Versions:       Versions{
+				Versions: Versions{
 					{Name: "aaa", Version: "1.2.3"},
 					{Name: "bbb", Version: "4.5.6"},
 					{Name: "ccc", Version: "7.8.9"},
@@ -94,7 +94,7 @@ var _ = Describe("HyperconvergedTypes", func() {
 			hcs := &HyperConvergedStatus{
 				Conditions:     []conditionsv1.Condition{},
 				RelatedObjects: []corev1.ObjectReference{},
-				Versions:       Versions{
+				Versions: Versions{
 					{Name: testName, Version: testOldVersion},
 					{Name: "bbb", Version: "4.5.6"},
 					{Name: "ccc", Version: "7.8.9"},
@@ -120,7 +120,7 @@ var _ = Describe("HyperconvergedTypes", func() {
 			hcs := &HyperConvergedStatus{
 				Conditions:     []conditionsv1.Condition{},
 				RelatedObjects: []corev1.ObjectReference{},
-				Versions:       Versions{
+				Versions: Versions{
 					{Name: "aaa", Version: "1.2.3"},
 					{Name: testName, Version: testOldVersion},
 					{Name: "ccc", Version: "7.8.9"},
@@ -146,7 +146,7 @@ var _ = Describe("HyperconvergedTypes", func() {
 			hcs := &HyperConvergedStatus{
 				Conditions:     []conditionsv1.Condition{},
 				RelatedObjects: []corev1.ObjectReference{},
-				Versions:       Versions{
+				Versions: Versions{
 					{Name: "aaa", Version: "1.2.3"},
 					{Name: "bbb", Version: "4.5.6"},
 					{Name: testName, Version: testOldVersion},
@@ -209,7 +209,7 @@ var _ = Describe("HyperconvergedTypes", func() {
 			hcs := &HyperConvergedStatus{
 				Conditions:     []conditionsv1.Condition{},
 				RelatedObjects: []corev1.ObjectReference{},
-				Versions:       Versions{
+				Versions: Versions{
 					{Name: "aaa", Version: "1.2.3"},
 					{Name: "bbb", Version: "4.5.6"},
 					{Name: "ccc", Version: "7.8.9"},
@@ -231,7 +231,7 @@ var _ = Describe("HyperconvergedTypes", func() {
 			hcs := &HyperConvergedStatus{
 				Conditions:     []conditionsv1.Condition{},
 				RelatedObjects: []corev1.ObjectReference{},
-				Versions:       Versions{
+				Versions: Versions{
 					{Name: testName, Version: testVersion},
 					{Name: "bbb", Version: "4.5.6"},
 					{Name: "ccc", Version: "7.8.9"},
@@ -253,7 +253,7 @@ var _ = Describe("HyperconvergedTypes", func() {
 			hcs := &HyperConvergedStatus{
 				Conditions:     []conditionsv1.Condition{},
 				RelatedObjects: []corev1.ObjectReference{},
-				Versions:       Versions{
+				Versions: Versions{
 					{Name: "aaa", Version: "1.2.3"},
 					{Name: testName, Version: testVersion},
 					{Name: "ccc", Version: "7.8.9"},
@@ -275,7 +275,7 @@ var _ = Describe("HyperconvergedTypes", func() {
 			hcs := &HyperConvergedStatus{
 				Conditions:     []conditionsv1.Condition{},
 				RelatedObjects: []corev1.ObjectReference{},
-				Versions:       Versions{
+				Versions: Versions{
 					{Name: "aaa", Version: "1.2.3"},
 					{Name: "bbb", Version: "4.5.6"},
 					{Name: testName, Version: testVersion},

--- a/pkg/apis/hco/v1alpha1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1alpha1/hyperconverged_types.go
@@ -42,6 +42,50 @@ type HyperConvergedStatus struct {
 	// been created AND found in the cluster.
 	// +optional
 	RelatedObjects []corev1.ObjectReference `json:"relatedObjects,omitempty"`
+
+	// Versions is a list of HCO component versions, as name/version pairs. The version with a name of "operator"
+	// is the HCO version itself, as described here:
+	// https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version
+	// +optional
+	Versions Versions `json:"versions,omitempty"`
+}
+
+func (hcs *HyperConvergedStatus) UpdateVersion(name, version string) {
+	hcs.Versions.updateVersion(name, version)
+}
+
+func (hcs *HyperConvergedStatus) GetVersion(name string) (string, bool) {
+	return hcs.Versions.getVersion(name)
+}
+
+type Version struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+func newVersion(name, version string) Version {
+	return Version{Name: name, Version: version}
+}
+
+type Versions []Version
+
+func (vs *Versions) updateVersion(name, version string) {
+	for i, v := range *vs {
+		if v.Name == name {
+			(*vs)[i].Version = version
+			return
+		}
+	}
+	*vs = append(*vs, newVersion(name, version))
+}
+
+func (vs *Versions) getVersion(name string) (string, bool) {
+	for _, v := range *vs {
+		if v.Name == name {
+			return v.Version, true
+		}
+	}
+	return "", false
 }
 
 // ConditionReconcileComplete communicates the status of the HyperConverged resource's

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -3,6 +3,7 @@ package components
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"time"
 
 	"github.com/blang/semver"
@@ -41,7 +42,7 @@ type StrategyDetailsDeployment struct {
 
 const hcoName = "hyperconverged-cluster-operator"
 
-func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype string) appsv1.Deployment {
+func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype, hcoKvIoVersion string) appsv1.Deployment {
 	return appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -53,11 +54,11 @@ func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwar
 				"name": hcoName,
 			},
 		},
-		Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype),
+		Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype, hcoKvIoVersion),
 	}
 }
 
-func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype string) appsv1.DeploymentSpec {
+func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion string) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
 		Replicas: int32Ptr(1),
 		Selector: &metav1.LabelSelector{
@@ -137,6 +138,10 @@ func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, v
 							{
 								Name:  "MACHINETYPE",
 								Value: machinetype,
+							},
+							{
+								Name:  util.HcoKvIoVersionName,
+								Value: hcoKvIoVersion,
 							},
 						},
 					},
@@ -539,12 +544,12 @@ func GetOperatorCR() *hcov1alpha1.HyperConverged {
 }
 
 // GetInstallStrategyBase returns the basics of an HCO InstallStrategy
-func GetInstallStrategyBase(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype string) *StrategyDetailsDeployment {
+func GetInstallStrategyBase(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion string) *StrategyDetailsDeployment {
 	return &StrategyDetailsDeployment{
 		DeploymentSpecs: []StrategyDeploymentSpec{
 			StrategyDeploymentSpec{
 				Name: "hco-operator",
-				Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype),
+				Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion),
 			},
 		},
 		Permissions: []StrategyDeploymentPermissions{},

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -319,7 +319,7 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 
 	if !r.upgradeMode && !init && knownHcoVersion != r.ownVersion {
 		r.upgradeMode = true
-		reqLogger.Info(fmt.Sprintf("Upgating from version %s to version %s", knownHcoVersion, r.ownVersion))
+		reqLogger.Info(fmt.Sprintf("Start upgrating from version %s to version %s", knownHcoVersion, r.ownVersion))
 	}
 
 	for _, f := range []func(*hcov1alpha1.HyperConverged, logr.Logger, reconcile.Request) error{

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -395,7 +395,7 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 		if r.upgradeMode { // update the new image only when upgrade is completed
 			instance.Status.UpdateVersion(hcoVersionName, r.ownVersion)
 			r.upgradeMode = false
-			reqLogger.Info(fmt.Sprintf("Successfuly upgraded to version %s"), r.ownVersion)
+			reqLogger.Info(fmt.Sprintf("Successfuly upgraded to version %s", r.ownVersion))
 		}
 
 		// If no operator whose conditions we are watching reports an error, then it is safe

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -235,7 +235,7 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 			Message: reconcileInitMessage,
 		})
 
-		err = r.client.Update(context.TODO(), instance)
+		err = r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
 			reqLogger.Error(err, "Failed to add conditions to status")
 			return reconcile.Result{}, err
@@ -418,7 +418,7 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 			}
 		}
 	}
-	return reconcile.Result{}, r.client.Update(context.TODO(), instance)
+	return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
 }
 
 func (r *ReconcileHyperConverged) updateImageId(instance *hcov1alpha1.HyperConverged, ownImage string) {
@@ -426,6 +426,7 @@ func (r *ReconcileHyperConverged) updateImageId(instance *hcov1alpha1.HyperConve
 		instance.ObjectMeta.Annotations = map[string]string{}
 	}
 	instance.ObjectMeta.Annotations[operatorImageCr] = ownImage
+	r.client.Update(context.TODO(), instance)
 }
 
 func (r *ReconcileHyperConverged) emitEvent(instance *hcov1alpha1.HyperConverged, logger logr.Logger, kind string, errT string, errMsg string) error {

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -1734,7 +1734,6 @@ var _ = Describe("HyperconvergedController", func() {
 				os.Setenv(operatorImageEnv, NEW_IMAGE)
 
 				// no image Id in CR
-				//delete(expected.hco.ObjectMeta.Annotations, operatorImageCr)
 				expected.hco.ObjectMeta.Annotations = nil
 				// CDI is not ready
 				expected.cdi.Status.Conditions = getGenericProgressingConditions()

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -1604,11 +1604,15 @@ var _ = Describe("HyperconvergedController", func() {
 					origConds = expected.kvCtb.Status.Conditions
 					expected.kvCtb.Status.Conditions = expected.cdi.Status.Conditions[1:]
 					cl = expected.initClient()
-					checkAvailability(expected.hco, cl, false, corev1.ConditionFalse)
+					foundResource, requeue = doReconcile(cl, expected.hco)
+					Expect(requeue).To(BeFalse())
+					checkAvailability(foundResource, corev1.ConditionFalse)
 
 					expected.kvCtb.Status.Conditions = origConds
 					cl = expected.initClient()
-					checkAvailability(expected.hco, cl, false, corev1.ConditionTrue)
+					foundResource, requeue = doReconcile(cl, expected.hco)
+					Expect(requeue).To(BeFalse())
+					checkAvailability(foundResource, corev1.ConditionTrue)
 				*/
 
 				// TODO: temporary avoid checking conditions on KubevirtNodeLabellerBundle because it's currently
@@ -1617,11 +1621,15 @@ var _ = Describe("HyperconvergedController", func() {
 					origConds = expected.kvNlb.Status.Conditions
 					expected.kvNlb.Status.Conditions = expected.cdi.Status.Conditions[1:]
 					cl = expected.initClient()
-					checkAvailability(expected.hco, cl, false, corev1.ConditionFalse)
+					foundResource, requeue = doReconcile(cl, expected.hco)
+					Expect(requeue).To(BeFalse())
+					checkAvailability(foundResource, corev1.ConditionFalse)
 
 					expected.kvNlb.Status.Conditions = origConds
 					cl = expected.initClient()
-					checkAvailability(expected.hco, cl, false, corev1.ConditionTrue)
+					foundResource, requeue = doReconcile(cl, expected.hco)
+					Expect(requeue).To(BeFalse())
+					checkAvailability(foundResource, corev1.ConditionTrue)
 				*/
 
 				// TODO: temporary avoid checking conditions on KubevirtTemplateValidator because it's currently
@@ -1630,11 +1638,15 @@ var _ = Describe("HyperconvergedController", func() {
 					origConds = expected.kvTv.Status.Conditions
 					expected.kvTv.Status.Conditions = expected.cdi.Status.Conditions[1:]
 					cl = expected.initClient()
-					checkAvailability(expected.hco, cl, false, corev1.ConditionFalse)
+					foundResource, requeue = doReconcile(cl, expected.hco)
+					Expect(requeue).To(BeFalse())
+					checkAvailability(foundResource, corev1.ConditionFalse)
 
 					expected.kvTv.Status.Conditions = origConds
 					cl = expected.initClient()
-					checkAvailability(expected.hco, cl, false, corev1.ConditionTrue)
+					foundResource, requeue = doReconcile(cl, expected.hco)
+					Expect(requeue).To(BeFalse())
+					checkAvailability(foundResource, corev1.ConditionTrue)
 				*/
 			})
 

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"github.com/kubevirt/hyperconverged-cluster-operator/version"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"os"
 	"time"
 

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -1674,8 +1674,8 @@ var _ = Describe("HyperconvergedController", func() {
 			okConds := expected.hco.Status.Conditions
 
 			const (
-				OLD_IMAGE = "quay.io/kubuvirt/hyperconverged-cluster-operator:v2.3.0"
-				NEW_IMAGE = "quay.io/kubuvirt/hyperconverged-cluster-operator:v2.4.0"
+				OldImage = "quay.io/kubuvirt/hyperconverged-cluster-operator:v1.0.0"
+				NewImage = "quay.io/kubuvirt/hyperconverged-cluster-operator:v1.1.0"
 			)
 
 			BeforeEach(func() {
@@ -1685,7 +1685,7 @@ var _ = Describe("HyperconvergedController", func() {
 			})
 
 			It("Should update the image Id in the CR on init", func() {
-				os.Setenv(operatorImageEnv, OLD_IMAGE)
+				os.Setenv(operatorImageEnv, OldImage)
 
 				expected.hco.Status.Conditions = nil
 
@@ -1697,19 +1697,19 @@ var _ = Describe("HyperconvergedController", func() {
 						break
 					}
 				}
-				Expect(foundResource.Annotations[operatorImageCr]).Should(Equal(OLD_IMAGE))
+				Expect(foundResource.Annotations[operatorImageCr]).Should(Equal(OldImage))
 
 				expected.hco.Status.Conditions = okConds
 			})
 
 			It("detect upgrade where with image Id", func() {
-				os.Setenv(operatorImageEnv, NEW_IMAGE)
+				os.Setenv(operatorImageEnv, NewImage)
 
 				// old image Id is set
 				if expected.hco.ObjectMeta.Annotations == nil {
 					expected.hco.ObjectMeta.Annotations = map[string]string{}
 				}
-				expected.hco.ObjectMeta.Annotations[operatorImageCr] = OLD_IMAGE
+				expected.hco.ObjectMeta.Annotations[operatorImageCr] = OldImage
 
 				// CDI is not ready
 				expected.cdi.Status.Conditions = getGenericProgressingConditions()
@@ -1718,7 +1718,7 @@ var _ = Describe("HyperconvergedController", func() {
 				foundResource := checkAvailability(expected.hco, cl, false, corev1.ConditionFalse)
 
 				// check that the image Id is not set, because upgrade is not completed
-				Expect(foundResource.ObjectMeta.Annotations[operatorImageCr]).Should(Equal(OLD_IMAGE))
+				Expect(foundResource.ObjectMeta.Annotations[operatorImageCr]).Should(Equal(OldImage))
 
 				// now, complete the upgrade
 				expected.cdi.Status.Conditions = getGenericCompletedConditions()
@@ -1726,12 +1726,12 @@ var _ = Describe("HyperconvergedController", func() {
 				foundResource = checkAvailability(expected.hco, cl, false, corev1.ConditionTrue)
 
 				// check that the image Id is set, now, when upgrade is completed
-				Expect(foundResource.ObjectMeta.Annotations[operatorImageCr]).Should(Equal(NEW_IMAGE))
+				Expect(foundResource.ObjectMeta.Annotations[operatorImageCr]).Should(Equal(NewImage))
 
 			})
 
 			It("detect upgrade where w/o image Id", func() {
-				os.Setenv(operatorImageEnv, NEW_IMAGE)
+				os.Setenv(operatorImageEnv, NewImage)
 
 				// no image Id in CR
 				expected.hco.ObjectMeta.Annotations = nil
@@ -1750,7 +1750,7 @@ var _ = Describe("HyperconvergedController", func() {
 				foundResource = checkAvailability(expected.hco, cl, false, corev1.ConditionTrue)
 
 				// check that the image Id is set, now, when upgrade is completed
-				Expect(foundResource.ObjectMeta.Annotations[operatorImageCr]).Should(Equal(NEW_IMAGE))
+				Expect(foundResource.ObjectMeta.Annotations[operatorImageCr]).Should(Equal(NewImage))
 
 			})
 

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -1,0 +1,7 @@
+package util
+
+// HCO common constants
+const (
+	OperatorNamespaceEnv = "OPERATOR_NAMESPACE"
+	HcoKvIoVersionName   = "HCO_KV_IO_VERSION"
+)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -16,8 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const OperatorNamespaceEnv = "OPERATOR_NAMESPACE"
-
 func GetOperatorNamespaceFromEnv() (string, error) {
 	if namespace, ok := os.LookupEnv(OperatorNamespaceEnv); ok {
 		return namespace, nil

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -94,7 +94,8 @@ var (
 		"Comma separated list of all the CRDs that should be visible in OLM console")
 	relatedImagesList = flag.String("related-images-list", "",
 		"Comma separated list of all the images referred in the CSV (just the image pull URLs or eventually a set of 'image|name' collations)")
-	crdDir = flag.String("crds-dir", "", "the directory containing the CRDs for apigroup validation. The validation will be performed if and only if the value is non-empty.")
+	crdDir         = flag.String("crds-dir", "", "the directory containing the CRDs for apigroup validation. The validation will be performed if and only if the value is non-empty.")
+	hcoKvIoVersion = flag.String("hco-kv-io-version", "", "KubeVirt version")
 )
 
 func gen_hco_crds() {
@@ -259,6 +260,7 @@ func main() {
 			*imsVMWareImage,
 			*smbios,
 			*machinetype,
+			*hcoKvIoVersion,
 		)
 
 		for _, image := range strings.Split(*relatedImagesList, ",") {

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -52,6 +52,7 @@ var (
 	imsVMWareImage     = flag.String("ims-vmware-image-name", "", "IMS VMWare image")
 	smbios             = flag.String("smbios", "", "Custom SMBIOS string for KubeVirt ConfigMap")
 	machinetype        = flag.String("machinetype", "", "Custom MACHINETYPE string for KubeVirt ConfigMap")
+	hcoKvIoVersion     = flag.String("hco-kv-io-version", "", "KubeVirt version")
 )
 
 // check handles errors
@@ -116,6 +117,7 @@ func main() {
 			*imsVMWareImage,
 			*smbios,
 			*machinetype,
+			*hcoKvIoVersion,
 		),
 	}
 	serviceAccounts := map[string]v1.ServiceAccount{


### PR DESCRIPTION
HCO now find out if it in upgrade mode. This is a preparation for the next phase, where HCO will notify the end-user about doing upgrade and completing it.

On init, HCO add the image Id to the CR's annotations.
On non-init reconciliation, HCO checks if ts image Id match to the image Id in the CR; if not, or if there is no image Id in the CR, HCO is in upgrade mode.
On upgrade mode, when processing is completed and HCO become available, HCO updates the image Id in the CR to the new image Id, and exits upgrade mode.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
NONE
```

