### PR TITLE
Integrate API Groups overlap validation test

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -262,13 +262,15 @@ ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
   --smbios="${SMBIOS}" \
   --csv-overrides="$(<${csvOverrides})" \
   --operator-image-name="${OPERATOR_IMAGE}" > "${CSV_DIR}/${OPERATOR_NAME}.v${CSV_VERSION}.${CSV_EXT}"
-(cd ${PROJECT_ROOT}/tools/csv-merger/ && go clean)
 
 # Copy all CRDs into the CRD and CSV directories
 rm -f ${CRD_DIR}/*
 cp -f ${TEMPDIR}/*.${CRD_EXT} ${CRD_DIR}
 cp -f ${TEMPDIR}/*.${CRD_EXT} ${CSV_DIR}
 
+# Check there are not API Groups overlap between different CNV operators
+${PROJECT_ROOT}/tools/csv-merger/csv-merger --crds-dir=${CRD_DIR}
+(cd ${PROJECT_ROOT}/tools/csv-merger/ && go clean)
 
 # Intentionally removing last so failure leaves around the templates
 rm -rf ${TEMPDIR}


### PR DESCRIPTION
The test will now be performed during build, in build-manifests.sh.
Test failure results in failure of CI tests.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Integrate API Groups overlap test in build time.
```

