### PR TITLE
[release-4.4] disable kubemacpool

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"encoding/json"
+
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -670,7 +671,6 @@ func newNetworkAddonsForCR(cr *hcov1alpha1.HyperConverged, namespace string) *ne
 		Spec: networkaddonsv1alpha1.NetworkAddonsConfigSpec{
 			Multus:      &networkaddonsv1alpha1.Multus{},
 			LinuxBridge: &networkaddonsv1alpha1.LinuxBridge{},
-			KubeMacPool: &networkaddonsv1alpha1.KubeMacPool{},
 			Ovs:         &networkaddonsv1alpha1.Ovs{},
 			NMState:     &networkaddonsv1alpha1.NMState{},
 		},


### PR DESCRIPTION
KubeMacPool is not compatible with the latest version of Multus. Let's
just disable it and enable once it is up to date again.

Signed-off-by: Petr Horacek <phoracek@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeMacPool was disabled.
```

