### PR TITLE
[release-2.3] disable kubemacpool

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"encoding/json"
+
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -746,7 +747,6 @@ func newNetworkAddonsForCR(cr *hcov1alpha1.HyperConverged, namespace string) *ne
 		Spec: networkaddonsv1alpha1.NetworkAddonsConfigSpec{
 			Multus:      &networkaddonsv1alpha1.Multus{},
 			LinuxBridge: &networkaddonsv1alpha1.LinuxBridge{},
-			KubeMacPool: &networkaddonsv1alpha1.KubeMacPool{},
 			Ovs:         &networkaddonsv1alpha1.Ovs{},
 			NMState:     &networkaddonsv1alpha1.NMState{},
 		},

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -551,7 +551,6 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 				Expect(foundResource.Spec.Multus).To(Equal(&networkaddonsv1alpha1.Multus{}))
 				Expect(foundResource.Spec.LinuxBridge).To(Equal(&networkaddonsv1alpha1.LinuxBridge{}))
-				Expect(foundResource.Spec.KubeMacPool).To(Equal(&networkaddonsv1alpha1.KubeMacPool{}))
 			})
 
 			It("should find if present", func() {

--- a/tests/func-tests/certificates_test.go
+++ b/tests/func-tests/certificates_test.go
@@ -39,25 +39,6 @@ var _ = Describe("Certificates", func() {
 		close(stopChan)
 	})
 
-	It("should rotate kubemacpool certificates", func() {
-		By("getting the kubemacpool-service certificate")
-		oldCert, err := GetCertForService("kubemacpool-service", testscore.KubeVirtInstallNamespace, "443")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(oldCert).ToNot(BeEmpty())
-
-		By("invoking the rotation script")
-		Expect(RotateCeritifcates(testscore.KubeVirtInstallNamespace)).To(Succeed())
-		By("waiting for all pods to become ready again")
-		WaitForPodsToBecomeReady(testscore.KubeVirtInstallNamespace)
-
-		By("getting the ceritifcate again after doing the rotation")
-		newCert, err := GetCertForService("kubemacpool-service", testscore.KubeVirtInstallNamespace, "443")
-		Expect(newCert).ToNot(BeEmpty())
-
-		By("verifying that the ceritificate indeed changed")
-		Expect(newCert).ToNot(Equal(oldCert))
-	})
-
 	It("should rotate cdi certificates", func() {
 		By("getting the cdi-api certificate")
 		oldCDIAPICert, err := GetCertForService("cdi-api", testscore.KubeVirtInstallNamespace, "443")


### PR DESCRIPTION
KubeMacPool is not compatible with the latest version of Multus. Let's
just disable it and enable once it is up to date again.

Signed-off-by: Petr Horacek <phoracek@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeMacPool was disabled.
```

