### PR TITLE
[release-2.3] Fix CI for klog/v2

### DIFF
--- a/tests/build/Dockerfile
+++ b/tests/build/Dockerfile
@@ -30,6 +30,8 @@ RUN \
     go install ./... ) && \
     ( go get -u golang.org/x/lint/golint ) && \
     ( go get -u github.com/rmohr/go-swagger-utils/swagger-doc ) && \
+    ( go get -u -d k8s.io/klog ) && \
+    ( ln -s /go/src/k8s.io/klog /go/src/k8s.io/klog/v2 ) && \
     ( go get -u -d k8s.io/code-generator/cmd/deepcopy-gen && \
     go get -u -d k8s.io/kube-openapi/cmd/openapi-gen ) && \
     ( cd $GOPATH/src/k8s.io/code-generator/cmd/deepcopy-gen && \


### PR DESCRIPTION
klog officially released v2 on Apr 10th so
/v2 is not anymore a subdir there but the top
level directory.
Implementing an hack to temporary fix it with
a symlink until all the involved modules will
be ready for that.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

