### PR TITLE
Track operator versions as env variables

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
-    createdAt: "2020-04-20 10:08:57"
+    createdAt: "2020-04-23 11:43:31"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1313,6 +1313,18 @@ spec:
                     Manufacturer: KubeVirt
                     Product: None
                 - name: MACHINETYPE
+                - name: KUBEVIRT_VERSION
+                  value: v0.26.0
+                - name: CDI_VERSION
+                  value: v1.13.1
+                - name: NETWORK_ADDONS_VERSION
+                  value: 0.27.7
+                - name: SSP_VERSION
+                  value: v1.0.30
+                - name: NMO_VERSION
+                  value: v0.4.0
+                - name: HPPO_VERSION
+                  value: v0.2.8
                 image: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
                 imagePullPolicy: IfNotPresent
                 name: hyperconverged-cluster-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -42,6 +42,18 @@ spec:
             Manufacturer: KubeVirt
             Product: None
         - name: MACHINETYPE
+        - name: KUBEVIRT_VERSION
+          value: v0.26.0
+        - name: CDI_VERSION
+          value: v1.13.1
+        - name: NETWORK_ADDONS_VERSION
+          value: 0.27.7
+        - name: SSP_VERSION
+          value: v1.0.30
+        - name: NMO_VERSION
+          value: v0.4.0
+        - name: HPPO_VERSION
+          value: v0.2.8
         image: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
         imagePullPolicy: IfNotPresent
         name: hyperconverged-cluster-operator

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -242,6 +242,12 @@ ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
   --ims-vmware-image-name="${VMWARE_CONTAINER}" \
   --operator-namespace="${OPERATOR_NAMESPACE}" \
   --smbios="${SMBIOS}" \
+  --kubevirt-version="${KUBEVIRT_VERSION}" \
+  --cdi-version="${CDI_VERSION}" \
+  --cnao-version="${NETWORK_ADDONS_VERSION}" \
+  --ssp-version="${SSP_VERSION}" \
+  --nmo-version="${NMO_VERSION}" \
+  --hppo-version="${HPPO_VERSION}" \
   --operator-image="${OPERATOR_IMAGE}"
 (cd ${PROJECT_ROOT}/tools/manifest-templator/ && go clean)
 
@@ -261,6 +267,12 @@ ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
   --crd-display="HyperConverged Cluster Operator" \
   --smbios="${SMBIOS}" \
   --csv-overrides="$(<${csvOverrides})" \
+  --kubevirt-version="${KUBEVIRT_VERSION}" \
+  --cdi-version="${CDI_VERSION}" \
+  --cnao-version="${NETWORK_ADDONS_VERSION}" \
+  --ssp-version="${SSP_VERSION}" \
+  --nmo-version="${NMO_VERSION}" \
+  --hppo-version="${HPPO_VERSION}" \
   --operator-image-name="${OPERATOR_IMAGE}" > "${CSV_DIR}/${OPERATOR_NAME}.v${CSV_VERSION}.${CSV_EXT}"
 (cd ${PROJECT_ROOT}/tools/csv-merger/ && go clean)
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -39,9 +39,20 @@ type StrategyDetailsDeployment struct {
 	ClusterPermissions []StrategyDeploymentPermissions `json:"clusterPermissions,omitempty"`
 }
 
-const hcoName = "hyperconverged-cluster-operator"
+const (
+	hcoName             = "hyperconverged-cluster-operator"
+	kubevirtVersionEnvV = "KUBEVIRT_VERSION"
+	cdiVersionEnvV      = "CDI_VERSION"
+	cnaoVersionEnvV     = "NETWORK_ADDONS_VERSION"
+	sspVersionEnvV      = "SSP_VERSION"
+	nmoVersionEnvV      = "NMO_VERSION"
+	hppoVersionEnvV     = "HPPO_VERSION"
+)
 
-func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype string) appsv1.Deployment {
+func GetDeployment(
+	namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype string,
+	kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion string,
+) appsv1.Deployment {
 	return appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -53,11 +64,17 @@ func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwar
 				"name": hcoName,
 			},
 		},
-		Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype),
+		Spec: GetDeploymentSpec(
+			namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype,
+			kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion,
+		),
 	}
 }
 
-func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype string) appsv1.DeploymentSpec {
+func GetDeploymentSpec(
+	namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype string,
+	kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion string,
+) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
 		Replicas: int32Ptr(1),
 		Selector: &metav1.LabelSelector{
@@ -137,6 +154,30 @@ func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, v
 							{
 								Name:  "MACHINETYPE",
 								Value: machinetype,
+							},
+							{
+								Name:  kubevirtVersionEnvV,
+								Value: kubevirtVersion,
+							},
+							{
+								Name:  cdiVersionEnvV,
+								Value: cdiVersion,
+							},
+							{
+								Name:  cnaoVersionEnvV,
+								Value: cnaoVersion,
+							},
+							{
+								Name:  sspVersionEnvV,
+								Value: sspVersion,
+							},
+							{
+								Name:  nmoVersionEnvV,
+								Value: nmoVersion,
+							},
+							{
+								Name:  hppoVersionEnvV,
+								Value: hppoVersion,
 							},
 						},
 					},
@@ -524,12 +565,18 @@ func GetOperatorCR() *hcov1alpha1.HyperConverged {
 }
 
 // GetInstallStrategyBase returns the basics of an HCO InstallStrategy
-func GetInstallStrategyBase(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype string) *StrategyDetailsDeployment {
+func GetInstallStrategyBase(
+	namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype string,
+	kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion string,
+) *StrategyDetailsDeployment {
 	return &StrategyDetailsDeployment{
 		DeploymentSpecs: []StrategyDeploymentSpec{
 			StrategyDeploymentSpec{
 				Name: "hco-operator",
-				Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype),
+				Spec: GetDeploymentSpec(
+					namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype,
+					kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion,
+				),
 			},
 		},
 		Permissions: []StrategyDeploymentPermissions{},

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -94,7 +94,13 @@ var (
 		"Comma separated list of all the CRDs that should be visible in OLM console")
 	relatedImagesList = flag.String("related-images-list", "",
 		"Comma separated list of all the images referred in the CSV (just the image pull URLs or eventually a set of 'image|name' collations)")
-	crdDir = flag.String("crds-dir", "", "the directory containing the CRDs for apigroup validation. The validation will be performed if and only if the value is non-empty.")
+	crdDir          = flag.String("crds-dir", "", "the directory containing the CRDs for apigroup validation. The validation will be performed if and only if the value is non-empty.")
+	kubevirtVersion = flag.String("kubevirt-version", "", "Kubevirt operator version")
+	cdiVersion      = flag.String("cdi-version", "", "CDI operator version")
+	cnaoVersion     = flag.String("cnao-version", "", "CNA operator version")
+	sspVersion      = flag.String("ssp-version", "", "SSP operator version")
+	nmoVersion      = flag.String("nmo-version", "", "NM operator version")
+	hppoVersion     = flag.String("hppo-version", "", "HPP operator version")
 )
 
 func gen_hco_crds() {
@@ -259,6 +265,12 @@ func main() {
 			*imsVMWareImage,
 			*smbios,
 			*machinetype,
+			*kubevirtVersion,
+			*cdiVersion,
+			*cnaoVersion,
+			*sspVersion,
+			*nmoVersion,
+			*hppoVersion,
 		)
 
 		for _, image := range strings.Split(*relatedImagesList, ",") {

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -52,6 +52,12 @@ var (
 	imsVMWareImage     = flag.String("ims-vmware-image-name", "", "IMS VMWare image")
 	smbios             = flag.String("smbios", "", "Custom SMBIOS string for KubeVirt ConfigMap")
 	machinetype        = flag.String("machinetype", "", "Custom MACHINETYPE string for KubeVirt ConfigMap")
+	kubevirtVersion    = flag.String("kubevirt-version", "", "Kubevirt operator version")
+	cdiVersion         = flag.String("cdi-version", "", "CDI operator version")
+	cnaoVersion        = flag.String("cnao-version", "", "CNA operator version")
+	sspVersion         = flag.String("ssp-version", "", "SSP operator version")
+	nmoVersion         = flag.String("nmo-version", "", "NM operator version")
+	hppoVersion        = flag.String("hppo-version", "", "HPP operator version")
 )
 
 // check handles errors
@@ -116,6 +122,12 @@ func main() {
 			*imsVMWareImage,
 			*smbios,
 			*machinetype,
+			*kubevirtVersion,
+			*cdiVersion,
+			*cnaoVersion,
+			*sspVersion,
+			*nmoVersion,
+			*hppoVersion,
 		),
 	}
 	serviceAccounts := map[string]v1.ServiceAccount{


### PR DESCRIPTION
Track operator versions as env variables
in HCO deployment to enable upgrade status checks
(to be addressed in afuture PR).

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Track operator versions as env variables in HCO deployment
```

