### PR TITLE
add new defaults to kubevirt-config

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -434,6 +434,8 @@ func newKubeVirtConfigForCR(cr *hcov1alpha1.HyperConverged, namespace string) *c
 			"feature-gates":       "DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Sidecar",
 			"migrations":          `{"nodeDrainTaintKey" : "node.kubernetes.io/unschedulable"}`,
 			"selinuxLauncherType": "spc_t",
+			"obsolete-cpus":       "486, pentium, pentium2, pentium3, pentiumpro, coreduo, n270, core2duo, Conroe, athlon, phenom",
+			"min-cpu":             "Penryn",
 		},
 	}
 	val, ok := os.LookupEnv("SMBIOS")


### PR DESCRIPTION
This PR adds default min-cpu and obsolete-cpus variables. They are 
used by node-labeller in kubevirt

This PR has to be merged after https://github.com/kubevirt/kubevirt/pull/3355.

//cc @tiraboschi 
Signed-off-by: Karel Simon <ksimon@redhat.com>

**Release note**:

```release-note
added default min-cpu and obsolete-cpus variables into kubevirt-config
```

