### PR TITLE
Add a new environment variable to all KubeVirt operators.

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
@@ -8,8 +8,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional
     certified: "false"
-    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
-    createdAt: "2020-05-15 14:19:18"
+    containerImage: "quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0"
+    createdAt: "2020-05-17 11:02:32"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1484,6 +1484,8 @@ spec:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: WATCH_NAMESPACE
+                - name: HCO_KV_IO_VERSION
+                  value: 1.1.0
                 image: quay.io/kubevirt/cluster-network-addons-operator:0.36.0
                 imagePullPolicy: IfNotPresent
                 name: cluster-network-addons-operator
@@ -1532,6 +1534,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: HCO_KV_IO_VERSION
+                  value: 1.1.0
                 image: docker.io/kubevirt/virt-operator:v0.28.0
                 imagePullPolicy: IfNotPresent
                 name: virt-operator
@@ -1585,6 +1589,8 @@ spec:
                 - name: IMAGE_NAME_PREFIX
                 - name: OPERATOR_NAME
                   value: kubevirt-ssp-operator
+                - name: HCO_KV_IO_VERSION
+                  value: 1.1.0
                 image: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.30
                 imagePullPolicy: Always
                 name: kubevirt-ssp-operator
@@ -1628,6 +1634,8 @@ spec:
                   value: "1"
                 - name: PULL_POLICY
                   value: IfNotPresent
+                - name: HCO_KV_IO_VERSION
+                  value: 1.1.0
                 image: docker.io/kubevirt/cdi-operator:v1.17.0
                 imagePullPolicy: IfNotPresent
                 name: cdi-operator
@@ -1667,6 +1675,8 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: node-maintenance-operator
+                - name: HCO_KV_IO_VERSION
+                  value: 1.1.0
                 image: quay.io/kubevirt/node-maintenance-operator:v0.5.0
                 imagePullPolicy: Always
                 name: node-maintenance-operator
@@ -1705,6 +1715,8 @@ spec:
                   value: quay.io/kubevirt/hostpath-provisioner:v0.4.0
                 - name: PULL_POLICY
                   value: IfNotPresent
+                - name: HCO_KV_IO_VERSION
+                  value: 1.1.0
                 image: quay.io/kubevirt/hostpath-provisioner-operator:v0.4.2
                 imagePullPolicy: IfNotPresent
                 name: hostpath-provisioner-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -113,6 +113,8 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WATCH_NAMESPACE
+        - name: HCO_KV_IO_VERSION
+          value: 1.1.0
         image: quay.io/kubevirt/cluster-network-addons-operator:0.36.0
         imagePullPolicy: IfNotPresent
         name: cluster-network-addons-operator
@@ -167,6 +169,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
+        - name: HCO_KV_IO_VERSION
+          value: 1.1.0
         image: docker.io/kubevirt/virt-operator:v0.28.0
         imagePullPolicy: IfNotPresent
         name: virt-operator
@@ -226,6 +230,8 @@ spec:
         - name: IMAGE_NAME_PREFIX
         - name: OPERATOR_NAME
           value: kubevirt-ssp-operator
+        - name: HCO_KV_IO_VERSION
+          value: 1.1.0
         image: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.30
         imagePullPolicy: Always
         name: kubevirt-ssp-operator
@@ -275,6 +281,8 @@ spec:
           value: "1"
         - name: PULL_POLICY
           value: IfNotPresent
+        - name: HCO_KV_IO_VERSION
+          value: 1.1.0
         image: docker.io/kubevirt/cdi-operator:v1.17.0
         imagePullPolicy: IfNotPresent
         name: cdi-operator
@@ -320,6 +328,8 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: node-maintenance-operator
+        - name: HCO_KV_IO_VERSION
+          value: 1.1.0
         image: quay.io/kubevirt/node-maintenance-operator:v0.5.0
         imagePullPolicy: Always
         name: node-maintenance-operator
@@ -364,6 +374,8 @@ spec:
           value: quay.io/kubevirt/hostpath-provisioner:v0.4.0
         - name: PULL_POLICY
           value: IfNotPresent
+        - name: HCO_KV_IO_VERSION
+          value: 1.1.0
         image: quay.io/kubevirt/hostpath-provisioner-operator:v0.4.2
         imagePullPolicy: IfNotPresent
         name: hostpath-provisioner-operator

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -264,7 +264,8 @@ ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
   --spec-description="$(<${PROJECT_ROOT}/docs/operator_description.md)" \
   --crd-display="HyperConverged Cluster Operator" \
   --smbios="${SMBIOS}" \
-  --csv-overrides="$(<${csvOverrides})" \
+  --hco-kv-io-version="${CSV_VERSION}" \
+  --csv-overrides=$(<${csvOverrides}) \
   --operator-image-name="${OPERATOR_IMAGE}" > "${CSV_DIR}/${OPERATOR_NAME}.v${CSV_VERSION}.${CSV_EXT}"
 
 # Copy all CRDs into the CRD and CSV directories

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -42,10 +42,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const operatorName = "kubevirt-hyperconverged-operator"
+const (
+	operatorName = "kubevirt-hyperconverged-operator"
+	CSVMode = "CSV"
+	CRDMode = "CRDs"
+)
 
-const CSVMode = "CSV"
-const CRDMode = "CRDs"
 
 var validOutputModes = []string{CSVMode, CRDMode}
 
@@ -296,6 +298,8 @@ func main() {
 				}
 
 				strategySpec := csvStruct.Spec.InstallStrategy.StrategySpec
+
+				util.AddEnvAcrossContainers(strategySpec, hcoKvIoVersionName, *hcoKvIoVersion)
 
 				installStrategyBase.DeploymentSpecs = append(installStrategyBase.DeploymentSpecs, strategySpec.DeploymentSpecs...)
 				installStrategyBase.ClusterPermissions = append(installStrategyBase.ClusterPermissions, strategySpec.ClusterPermissions...)

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	hcoUtils "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"io/ioutil"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"log"
@@ -44,10 +45,9 @@ import (
 
 const (
 	operatorName = "kubevirt-hyperconverged-operator"
-	CSVMode = "CSV"
-	CRDMode = "CRDs"
+	CSVMode      = "CSV"
+	CRDMode      = "CRDs"
 )
-
 
 var validOutputModes = []string{CSVMode, CRDMode}
 
@@ -299,7 +299,7 @@ func main() {
 
 				strategySpec := csvStruct.Spec.InstallStrategy.StrategySpec
 
-				util.AddEnvAcrossContainers(strategySpec, hcoKvIoVersionName, *hcoKvIoVersion)
+				util.AddEnvAcrossContainersOf(&strategySpec, hcoUtils.HcoKvIoVersionName, *hcoKvIoVersion)
 
 				installStrategyBase.DeploymentSpecs = append(installStrategyBase.DeploymentSpecs, strategySpec.DeploymentSpecs...)
 				installStrategyBase.ClusterPermissions = append(installStrategyBase.ClusterPermissions, strategySpec.ClusterPermissions...)

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
+	hcoUtils "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"github.com/kubevirt/hyperconverged-cluster-operator/tools/util"
 
 	csvv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -280,7 +281,7 @@ func main() {
 				})
 			}
 
-			util.AddEnvAcrossContainers(strategySpec, hcoKvIoVersionName, *hcoKvIoVersion)
+			util.AddEnvAcrossContainers(&strategySpec, hcoUtils.HcoKvIoVersionName, *hcoKvIoVersion)
 		}
 	}
 

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -279,6 +279,8 @@ func main() {
 					},
 				})
 			}
+
+			util.AddEnvAcrossContainers(strategySpec, hcoKvIoVersionName, *hcoKvIoVersion)
 		}
 	}
 

--- a/tools/util/envVarUtils.go
+++ b/tools/util/envVarUtils.go
@@ -1,11 +1,21 @@
 package util
 
 import (
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
+	ofv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	csvv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func AddEnvAcrossContainers(installStrategy *components.StrategyDetailsDeployment, varName, varValue string) {
+func AddEnvAcrossContainers(installStrategy *csvv1alpha1.StrategyDetailsDeployment, varName, varValue string) {
+	for _, depSpec := range installStrategy.DeploymentSpecs {
+		for index, container := range depSpec.Spec.Template.Spec.Containers {
+			UpdateEnvVar(&container, varName, varValue)
+			depSpec.Spec.Template.Spec.Containers[index] = container
+		}
+	}
+}
+
+func AddEnvAcrossContainersOf(installStrategy *ofv1alpha1.StrategyDetailsDeployment, varName, varValue string) {
 	for _, depSpec := range installStrategy.DeploymentSpecs {
 		for index, container := range depSpec.Spec.Template.Spec.Containers {
 			UpdateEnvVar(&container, varName, varValue)
@@ -28,4 +38,3 @@ func UpdateEnvVar(container *corev1.Container, varName, varValue string) {
 
 	container.Env = append(container.Env, corev1.EnvVar{Name: varName, Value: varValue})
 }
-

--- a/tools/util/envVarUtils.go
+++ b/tools/util/envVarUtils.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func AddEnvAcrossContainers(installStrategy *components.StrategyDetailsDeployment, varName, varValue string) {
+	for _, depSpec := range installStrategy.DeploymentSpecs {
+		for index, container := range depSpec.Spec.Template.Spec.Containers {
+			UpdateEnvVar(&container, varName, varValue)
+			depSpec.Spec.Template.Spec.Containers[index] = container
+		}
+	}
+}
+
+func UpdateEnvVar(container *corev1.Container, varName, varValue string) {
+	if container.Env == nil {
+		container.Env = make([]corev1.EnvVar, 0, 1)
+	} else {
+		for _, env := range container.Env {
+			if env.Name == varName {
+				env.Value = varValue
+				return
+			}
+		}
+	}
+
+	container.Env = append(container.Env, corev1.EnvVar{Name: varName, Value: varValue})
+}
+


### PR DESCRIPTION
Add a new environment variable, `HCO_KV_IO_VERSION`, to all KubeVirt operator containers, in oerder to support upgrade status report from HCO.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
```release-note
Add a new environment variable `HCO_KV_IO_VERSION` to all KubeVirt operator containers with a common KubeVirt version.
```

