### PR TITLE
Wait a few seconds before checking CR status

### DIFF
--- a/deploy/deploy_imageregistry.sh
+++ b/deploy/deploy_imageregistry.sh
@@ -147,6 +147,9 @@ spec:
   BareMetalPlatform: true
 EOF
 
+    echo "Give the cluster 30 seconds to process the CR..."
+    sleep 30
+
     echo "Waiting for HCO to get fully deployed"
     oc wait -n ${TARGET_NAMESPACE} hyperconverged kubevirt-hyperconverged --for condition=Available --timeout=15m
     oc wait "$(oc get pods -n ${TARGET_NAMESPACE} -l name=hyperconverged-cluster-operator -o name)" -n "${TARGET_NAMESPACE}" --for condition=Ready --timeout=15m

--- a/deploy/deploy_marketplace.sh
+++ b/deploy/deploy_marketplace.sh
@@ -196,6 +196,9 @@ spec:
   BareMetalPlatform: true
 EOF
 
+    echo "Give the cluster 30 seconds to process the CR..."
+    sleep 30
+
     echo "Waiting for HCO to get fully deployed"
     oc wait -n ${TARGET_NAMESPACE} hyperconverged kubevirt-hyperconverged --for condition=Available --timeout=15m
     oc wait "$(oc get pods -n ${TARGET_NAMESPACE} -l name=hyperconverged-cluster-operator -o name)" -n "${TARGET_NAMESPACE}" --for condition=Ready --timeout=15m


### PR DESCRIPTION
OCP 4.5 seems more sensitive on this front,
let's try to make it more stable with a small
delay.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

