### PR TITLE
readme: update OperatorGroup in developer workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ kind: OperatorGroup
 metadata:
   name: hco-operatorgroup
   namespace: kubevirt-hyperconverged
+spec:
+  targetNamespaces:
+  - "kubevirt-hyperconverged"
 EOF
 ```
 


### PR DESCRIPTION
Add the missing spec.targetNamespaces to OperatorGroup snippet

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
```release-note
NONE
```

