### PR TITLE
Release Bumper Bot - Based on GitHub Actions.

### DIFF
--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -1,7 +1,7 @@
 name: Auto-Bump Component's Versions
 on:
   schedule:
-    - cron:  '0 16 * * *'
+    - cron:  '0 11 * * *'
 jobs:
   build:
     name: HCO Release Bump Job
@@ -25,7 +25,7 @@ jobs:
           commit-message: |
             Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}
 
-            Signed-off-by: hco_release_bot <hco_release_bot@redhat.com>
+            Signed-off-by: hco_bump_bot <hco_bump_bot@redhat.com>
           committer: GitHub <noreply@github.com>
           title: "Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}"
           body: |

--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -1,0 +1,41 @@
+name: Auto-Bump Component's Versions
+on:
+  schedule:
+    - cron:  '0 16 * * *'
+jobs:
+  build:
+    name: HCO Release Bump Job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Check for new releases and update
+        run: |
+          ./automation/release-bumper/release-bumper.sh
+      - name: Set "UPDATED_COMPONENT" environment variable
+        run: echo "::set-env name=UPDATED_COMPONENT::$(cat updated_component.txt)";
+      - name: Set "UPDATED_VERSION" environment variable
+        run: echo "::set-env name=UPDATED_VERSION::$(cat updated_version.txt)";
+      - name: Remove temporary files
+        run: rm -f updated_component.txt updated_version.txt
+      - uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}
+
+            Signed-off-by: hco_release_bot <hco_release_bot@redhat.com>
+          committer: GitHub <noreply@github.com>
+          title: "Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}"
+          body: |
+            Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}
+            Excecuted by HCO Release-Bumper Bot.
+            ```release-note
+            Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}
+            ```
+          assignees: orenc1
+          reviewers: tiraboschi,orenc1
+          team-reviewers: owners, maintainers
+          draft: false
+          branch: bump_${{ env.UPDATED_COMPONENT }}_${{ env.UPDATED_VERSION }}

--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+CONFIG_FILE="hack/config"
+
+function main {
+  declare -A CURRENT_VERSIONS
+  declare -A UPDATED_VERSIONS
+  declare SHOULD_UPDATED
+
+  echo "Getting Components current versions..."
+  get_current_versions
+
+  echo "Getting Components updated versions..."
+  get_updated_versions
+
+  echo "Comparing Versions..."
+  compare_versions
+
+  if [ ${#SHOULD_UPDATED[@]} == 0 ]; then
+    echo "All components are already in latest version.";
+    exit 0;
+  fi
+
+  update_versions
+
+  echo Executing "build-manifests.sh"...
+  ./hack/build-manifests.sh
+
+  echo Executing "go mod vendor"
+  go mod vendor
+
+  echo Executing "go mod tidy"
+  go mod tidy
+}
+
+function get_current_versions {
+  CURRENT_VERSIONS=(
+    ["KUBEVIRT"]=""
+    ["CDI"]=""
+    ["NETWORK_ADDONS"]=""
+    ["SSP"]=""
+    ["NMO"]=""
+    ["HPPO"]=""
+    ["HPP"]=""
+#    ["CONVERSION_CONTAINER"]=""
+#    ["VMWARE_CONTAINER"]=""
+  )
+
+  for component in "${!CURRENT_VERSIONS[@]}"; do
+    CURRENT_VERSIONS[$component]=$(grep "$component"_VERSION ${CONFIG_FILE} | cut -d "=" -f 2)
+    done;
+}
+
+function get_updated_versions {
+  declare -A COMPONENTS_REPOS=(
+    ["KUBEVIRT"]="kubevirt/kubevirt"
+    ["CDI"]="kubevirt/containerized-data-importer"
+    ["NETWORK_ADDONS"]="kubevirt/cluster-network-addons-operator"
+    ["SSP"]="MarSik/kubevirt-ssp-operator"
+    ["NMO"]="kubevirt/node-maintenance-operator"
+    ["HPPO"]="kubevirt/hostpath-provisioner-operator"
+    ["HPP"]="kubevirt/hostpath-provisioner"
+#    ["CONVERSION_CONTAINER"]=""
+#    ["VMWARE_CONTAINER"]=""
+  )
+
+  UPDATED_VERSIONS=()
+  for component in "${!COMPONENTS_REPOS[@]}"; do
+    UPDATED_VERSIONS[$component]=\"$(get_latest_release "${COMPONENTS_REPOS[$component]}")\";
+    if [ -z "${UPDATED_VERSIONS[$component]}" ]; then
+      echo "Unable to get an updated version of $component, aborting..."
+      exit 1
+    fi
+    done;
+}
+
+function get_latest_release() {
+  curl -s -L --silent "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+function compare_versions() {
+  for component in "${!UPDATED_VERSIONS[@]}"; do
+    if [ ! "${UPDATED_VERSIONS[$component]}" == "${CURRENT_VERSIONS[$component]}" ]; then
+      echo "$component" is outdated. current: "${CURRENT_VERSIONS[$component]}", updated: "${UPDATED_VERSIONS[$component]}"
+      SHOULD_UPDATED+=( "$component" )
+    fi;
+  done;
+}
+
+function update_versions() {
+  for component in "${SHOULD_UPDATED[@]}"; do
+    echo INFO: Checking update for "$component";
+
+    # Check if pull request for that component and version already exists
+    search_pattern=$(echo "$component.*${UPDATED_VERSIONS[$component]}" | tr -d '"')
+    if curl -s -L  https://api.github.com/repos/kubevirt/hyperconverged-cluster-operator/pulls | jq .[].title | \
+    grep -q "$search_pattern"; then
+      echo "An existing pull request of bumping $component to version ${UPDATED_VERSIONS[$component]} has been found.\
+Continuing to next component."
+      continue
+    else
+      echo "Updating $component to ${UPDATED_VERSIONS[$component]}."
+      sed -E -i "s/(""$component""_VERSION=).*/\1${UPDATED_VERSIONS[$component]}/" ${CONFIG_FILE}
+
+      echo "$component" > updated_component.txt
+      echo "${UPDATED_VERSIONS[$component]}" | tr -d '"' > updated_version.txt
+      break
+    fi
+  done;
+}
+
+main


### PR DESCRIPTION
This is a workflow, implemented with GitHub Actions, which automates the process of bumping HCO-dependent components when new release is available.
The bot is running daily and can update one component at a time.


```release-note
Automatic versions bumping process.
```

