### PR TITLE
Modify nightly-bundle tests assets

### DIFF
--- a/deploy/nightly-bundle/Dockerfile
+++ b/deploy/nightly-bundle/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos:centos8.1.1911
+
+COPY deploy/nightly-bundle/deploy.sh /deploy.sh
+COPY deploy/nightly-bundle/create_docker_config.sh /create_docker_config.sh
+COPY deploy/nightly-bundle/kubevirt-testing-infra.yaml /kubevirt-testing-infra.yaml
+COPY deploy/nightly-bundle/kubevirt-tests-pod-spec-override.json.in /kubevirt-tests-pod-spec-override.json.in
+
+RUN yum install -y jq sed
+RUN chmod +x /deploy.sh /create_docker_config.sh

--- a/deploy/nightly-bundle/create_docker_config.sh
+++ b/deploy/nightly-bundle/create_docker_config.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+function main() {
+    local registry="${1:?}"
+    local username="${2:?}"
+    local password="${3:?}"
+
+    local dockerconfig_patch original_pull_secret patched_pull_secret
+    local encoded_pull_secret auth
+
+    auth="$(create_auth_entry "$username" "$password")"
+    dockerconfig_patch="$(create_dockerconfig "$auth" "$registry")"
+    original_pull_secret="$(get_original_pull_secret)"
+    patched_pull_secret="$(
+        patch_pull_secret "$original_pull_secret" "$dockerconfig_patch"
+    )"
+    pull_secret_b64="$(b64_encode "$patched_pull_secret")"
+    apply_pull_secret_patch "$pull_secret_b64"
+}
+
+function create_auth_entry() {
+    local username="${1:?}"
+    local password="${2:?}"
+
+    echo -n "${username}:${password}" | base64 -w 0
+}
+
+function create_dockerconfig() {
+    local auth="${1:?}"
+    local registry="${2:?}"
+
+    echo -n "{\"auths\":{\"${registry}\":{\"auth\":\"${auth}\",\"email\":\"\"}}}"
+}
+
+function apply_pull_secret_patch() {
+    local encoded_pull_secret="${1:?}"
+
+    oc patch secret/pull-secret -n openshift-config --type merge --patch \
+	"{\"data\":{\".dockerconfigjson\":\"${encoded_pull_secret}\"}}"
+}
+
+function b64_encode() {
+    local data="${1:?}"
+
+    echo -n "$data" | base64 -w 0
+}
+
+function patch_pull_secret() {
+    local orig="${1:?}"
+    local patch="${2:?}"
+
+    local data
+    data="$(jq -c ".auths" <<<"$patch")"
+    jq -c ".auths += $data" <<<"$orig"
+}
+
+function generate_dockerconfig_patch() {
+    local org="${1:?}"
+    local username="${2:?}"
+    local password="${3:?}"
+
+    cat << EOF
+{
+    "${org}": {
+        "username": "${username}",
+        "password": "${password}"
+    }
+}
+EOF
+}
+
+function get_original_pull_secret() {
+    oc get secret/pull-secret -n openshift-config -o json | \
+        jq '.data.".dockerconfigjson"' | tr -d '"' | base64 -d
+}
+
+main "$@"

--- a/deploy/nightly-bundle/kubevirt-test-pod.yaml
+++ b/deploy/nightly-bundle/kubevirt-test-pod.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bundle-tester
+  labels:
+    app: cnv-testing
+  namespace: openshift-cnv
+spec:
+  containers:
+    - name: test-runner
+      image: @OPERATOR_IMAGE_URL@
+      command:
+        - /bin/kubevirt.test
+        - --installed-namespace=openshift-cnv
+        - --cdi-namespace=openshift-cnv
+        - --config=/etc/config/test-config.json
+        - --ginkgo.seed=0
+      volumeMounts:
+        - name: test-config
+          mountPath: /etc/config
+  securityContext:
+    privileged: true
+  serviceAccountName: kubevirt-testing
+  volumes:
+    - name: test-config
+      configMap:
+        name: kubevirt-test-config

--- a/deploy/nightly-bundle/kubevirt-testing-infra.yaml
+++ b/deploy/nightly-bundle/kubevirt-testing-infra.yaml
@@ -1,0 +1,187 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: host-path-disk-alpine
+  labels:
+    kubevirt.io: ""
+    os: "alpine"
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/hostImages/alpine
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: host-path-disk-custom
+  labels:
+    kubevirt.io: ""
+    os: "custom"
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/hostImages/custom
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cdi-http-import-server
+  namespace: openshift-cnv
+  labels:
+    kubevirt.io: "cdi-http-import-server"
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  selector:
+    kubevirt.io: cdi-http-import-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cdi-http-import-server
+  namespace: openshift-cnv
+  labels:
+    kubevirt.io: "cdi-http-import-server"
+spec:
+  selector:
+    matchLabels:
+      kubevirt.io: "cdi-http-import-server"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        kubevirt.io: cdi-http-import-server
+    spec:
+      serviceAccountName: kubevirt-testing
+      containers:
+        - name: cdi-http-import-server
+          image: kubevirt/cdi-http-import-server:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+              name: "http"
+              protocol: "TCP"
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: disks-images-provider
+  namespace: openshift-cnv
+  labels:
+    kubevirt.io: "disks-images-provider"
+spec:
+  selector:
+    matchLabels:
+      kubevirt.io: "disks-images-provider"
+  template:
+    metadata:
+      labels:
+        name: disks-images-provider
+        kubevirt.io: disks-images-provider
+      name: disks-images-provider
+    spec:
+      serviceAccountName: kubevirt-testing
+      containers:
+        - name: target
+          image: kubevirt/disks-images-provider:latest
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: images
+            mountPath: /hostImages
+          - name: local-storage
+            mountPath: /local-storage
+          securityContext:
+            privileged: true
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /ready
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      volumes:
+        - name: images
+          hostPath:
+            path: /tmp/hostImages
+            type: DirectoryOrCreate
+        - name: local-storage
+          hostPath:
+            path: /mnt/local-storage
+            type: DirectoryOrCreate
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-block-storage-cirros
+  labels:
+    kubevirt.io: ""
+    blockstorage: "cirros"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  local:
+    path: /mnt/local-storage/cirros-block-device
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - node01
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-block
+  volumeMode: Block
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-testing
+  namespace: openshift-cnv
+  labels:
+    kubevirt.io: ""
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-testing-cluster-admin
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-testing
+    namespace: openshift-cnv
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kubevirt-test-config
+  namespace: openshift-cnv
+data:
+  test-config.json: |
+    {
+     "storageClassLocal": "hostpath-provisioner",
+     "storageClassHostPath": "hostpath-provisioner",
+     "storageClassRhel": "hostpath-provisioner",
+     "storageClassWindows": "hostpath-provisioner",
+     "manageStorageClasses": false
+    }

--- a/deploy/nightly-bundle/kubevirt-tests-pod-spec-override.json.in
+++ b/deploy/nightly-bundle/kubevirt-tests-pod-spec-override.json.in
@@ -1,0 +1,37 @@
+{
+  "spec": {
+    "containers": [
+      {
+        "name": "test-runner",
+        "image": "@OPERATOR_IMAGE_URL@",
+        "command": [
+          "/bin/kubevirt.test",
+          "--installed-namespace=openshift-cnv",
+          "--cdi-namespace=openshift-cnv",
+          "--config=/etc/config/test-config.json",
+          "--ginkgo.seed=0",
+          "--ginkgo.focus=\\[crit:high\\]",
+          "--ginkgo.skip=(Slirp Networking)|(with CPU spec)|(with TX offload disabled)|(with cni flannel and ptp plugin interface)|(with ovs-cni plugin)|(test_id:1752)|(SRIOV)|(with EFI)|(Operator)|(GPU)|(test_id:3466)"
+        ],
+        "volumeMounts": [
+          {
+            "name": "kubevirt-test-config",
+            "mountPath": "/etc/config"
+          }
+        ]
+      }
+    ],
+    "securityContext": {
+      "privileged": true
+    },
+    "serviceAccountName": "kubevirt-testing",
+    "volumes": [
+      {
+        "name": "kubevirt-test-config",
+        "configMap": {
+          "name": "kubevirt-test-config"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added some scripts to patch the cluster pull secret and deploy infra
pods that are required to run kubevirt tests.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>


*This is a cherry pick of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/563

```release-note
NONE
```

