### PR TITLE
fixing a missing key on a log statement

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -756,7 +756,7 @@ func (r *ReconcileHyperConverged) ensureKubeVirtPriorityClass(instance *hcov1alp
 
 	// at this point we found the object in the cache and we check if something was changed
 	if pc.Name == found.Name && pc.Value == found.Value && pc.Description == found.Description {
-		req.logger.Info("KubeVirt PriorityClass already exists", pc.Name)
+		req.logger.Info("KubeVirt PriorityClass already exists", "PriorityClass.Name", pc.Name)
 		objectRef, err := reference.GetReference(scheme.Scheme, found)
 		if err != nil {
 			req.logger.Error(err, "failed getting object reference for found object")


### PR DESCRIPTION
currently the operator fails logging with
```
{"level":"dpanic","ts":1589805982.9115388,"logger":"controller_hyperconverged","msg":"odd number of arguments passed as key-value pairs for logging","Request.Namespace":"kubevirt-hyperconverged","Request.Name":"kubevirt-hyperconverged","ignored key":"kubevirt-cluster-critical","stacktrace":"github.com/go-logr/zapr.handleFields\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:106\ngithub.com/go-logr/zapr.(*infoLogger).Info\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:70\ngithub.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/hyperconverged.(*ReconcileHyperConverged).ensureKubeVirtPriorityClass\n\t/go/src/github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/hyperconverged/hyperconverged_controller.go:589\ngithub.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/hyperconverged.(*ReconcileHyperConverged).Reconcile\n\t/go/src/github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/hyperconverged/hyperconverged_controller.go:338\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.16.4/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.16.4/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.16.4/pkg/util/wait/wait.go:88"}
```
when it finds an existing KubeVirt PriorityClass.

Fixing it adding the missing key to the log statement

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

