### PR TITLE
Add the missing `operator-version` parameter to CDI CSV generation

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
-    createdAt: "2020-05-15 14:19:18"
+    createdAt: "2020-05-24 13:48:46"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1612,6 +1612,7 @@ spec:
                 - name: DEPLOY_CLUSTER_RESOURCES
                   value: "true"
                 - name: OPERATOR_VERSION
+                  value: v1.17.0
                 - name: CONTROLLER_IMAGE
                   value: docker.io/kubevirt/cdi-controller:v1.17.0
                 - name: IMPORTER_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -259,6 +259,7 @@ spec:
         - name: DEPLOY_CLUSTER_RESOURCES
           value: "true"
         - name: OPERATOR_VERSION
+          value: v1.17.0
         - name: CONTROLLER_IMAGE
           value: docker.io/kubevirt/cdi-controller:v1.17.0
         - name: IMPORTER_IMAGE

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -148,6 +148,7 @@ function create_cdi_csv() {
     --importer-image=${containerPrefix}/cdi-importer:${tag} \
     --uploadproxy-image=${containerPrefix}/cdi-uploadproxy:${tag} \
     --uploadserver-image=${containerPrefix}/cdi-uploadserver:${tag} \
+    --operator-version=${CDI_VERSION} \
   "
   gen_csv ${operatorName} ${imagePullUrl} ${dumpCRDsArg} ${operatorArgs}
   echo "${operatorName}"


### PR DESCRIPTION
The operator version is not set in CDI, and that blocks HCO upgrade.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
```release-note
NONE
```

