### PR TITLE
fixing updating go.mod for modules using pseudo-version instead of semver

### DIFF
--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -130,7 +130,7 @@ function update_go_mod() {
     MODULE_PATH=$(echo ${COMPONENTS_REPOS[$UPDATED_COMPONENT]} | cut -d "/" -f 2)
   fi
 
-  sed -E -i "$EXCLUSION s/($MODULE_PATH.*)v[0-9\.]+/\1${UPDATED_VERSION}/" go.mod
+  sed -E -i "$EXCLUSION s/($MODULE_PATH.*)v.+/\1${UPDATED_VERSION}/" go.mod
 }
 
 main


### PR DESCRIPTION
The current bot is failing to update go.mod for CNAO because it does not use semver.
However, specifying the CNAO release in semver can resolve the correct version and automatically replace the value with go peuso-version.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

