### PR TITLE
network: enable KubeMacPool again

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -1003,6 +1003,7 @@ func newNetworkAddonsForCR(cr *hcov1alpha1.HyperConverged, namespace string) *ne
 			LinuxBridge: &networkaddonsv1alpha1.LinuxBridge{},
 			Ovs:         &networkaddonsv1alpha1.Ovs{},
 			NMState:     &networkaddonsv1alpha1.NMState{},
+			KubeMacPool: &networkaddonsv1alpha1.KubeMacPool{},
 		},
 	}
 }

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -1040,7 +1040,7 @@ func (r *ReconcileHyperConverged) ensureNetworkAddons(req *hcoRequest) (upgradeD
 		}
 	}
 
-	if !reflect.DeepEqual(found.Spec, networkAddons.Spec) {
+	if !reflect.DeepEqual(found.Spec, networkAddons.Spec) && !r.upgradeMode {
 		req.logger.Info("Updating existing Network Addons")
 		found.Spec = networkAddons.Spec
 		return false, r.client.Update(req.ctx, found)

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -688,6 +688,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 				Expect(foundResource.Spec.Multus).To(Equal(&networkaddonsv1alpha1.Multus{}))
 				Expect(foundResource.Spec.LinuxBridge).To(Equal(&networkaddonsv1alpha1.LinuxBridge{}))
+				Expect(foundResource.Spec.KubeMacPool).To(Equal(&networkaddonsv1alpha1.KubeMacPool{}))
 			})
 
 			It("should find if present", func() {


### PR DESCRIPTION
It should be stabilized and good to go.

Signed-off-by: Petr Horacek <phoracek@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeMacPool is part of the installation again
```

