### PR TITLE
Fix bug 1839837 were HCO updates fails duo to previous update.

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -166,15 +166,16 @@ type ReconcileHyperConverged struct {
 	ownVersion  string
 }
 
+// hcoRequest - gather data for a specific request
 type hcoRequest struct {
-	reconcile.Request
-	logger                     logr.Logger
-	conditions                 hcoConditions
-	ctx                        context.Context
-	instance                   *hcov1alpha1.HyperConverged
-	componentUpgradeInProgress bool
-	dirty                      bool
-	statusDirty                bool
+	reconcile.Request                                      // inheritance of operator request
+	logger                     logr.Logger                 // request logger
+	conditions                 hcoConditions               // in-memory conditions
+	ctx                        context.Context             // context of this request, to be use for any other call
+	instance                   *hcov1alpha1.HyperConverged // the current state of the CR, as read from K8s
+	componentUpgradeInProgress bool                        // if in upgrade mode, accumulate the component upgrade status
+	dirty                      bool                        // is something was changed in the CR
+	statusDirty                bool                        // is something was changed in the CR's Status
 }
 
 // Reconcile reads that state of the cluster for a HyperConverged object and makes changes based on the state read
@@ -207,14 +208,14 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 
 	/*
 			From K8s API reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/
-		    ================================================================================================================
-			Replace: Replacing a resource object will update the resource by replacing the existing spec with the provided
-			one. For read-then-write operations this is safe because an optimistic lock failure will occur if the resource
-			was	modified between the read and write.
+		    ============================================================================================================
+			Replace: Replacing a resource object will update the resource by replacing the existing spec with the
+			provided one. For read-then-write operations this is safe because an optimistic lock failure will occur if
+			the resource was modified between the read and write.
 
-			**Note: The ResourceStatus will be ignored by the system and will not be updated. To update the status, one must
-			invoke the specific status update operation.**
-			================================================================================================================
+			**Note: The ResourceStatus will be ignored by the system and will not be updated. To update the status, one
+			must invoke the specific status update operation.**
+			============================================================================================================
 
 			So we need to update both the CR and the CR Status.
 	*/

--- a/pkg/controller/hyperconverged/testClient_test.go
+++ b/pkg/controller/hyperconverged/testClient_test.go
@@ -1,0 +1,118 @@
+package hyperconverged
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type hcoTestClient struct {
+	client      client.Client
+	sw          *hcoTestStatusWriter
+	readErrors  testErrors
+	writeErrors testErrors
+}
+
+func (c *hcoTestClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	if ok, err := c.readErrors.getNextError(); ok {
+		return err
+	}
+	return c.client.Get(ctx, key, obj)
+}
+
+func (c *hcoTestClient) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	if ok, err := c.writeErrors.getNextError(); ok {
+		return err
+	}
+	return c.client.List(ctx, list, opts...)
+}
+
+func (c *hcoTestClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	if ok, err := c.writeErrors.getNextError(); ok {
+		return err
+	}
+	return c.client.Create(ctx, obj, opts...)
+}
+
+func (c *hcoTestClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	if ok, err := c.writeErrors.getNextError(); ok {
+		return err
+	}
+	return c.client.Delete(ctx, obj, opts...)
+}
+
+func (c *hcoTestClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	if ok, err := c.writeErrors.getNextError(); ok {
+		return err
+	}
+	return c.client.Update(ctx, obj, opts...)
+}
+
+func (c *hcoTestClient) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if ok, err := c.writeErrors.getNextError(); ok {
+		return err
+	}
+	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *hcoTestClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+	if ok, err := c.writeErrors.getNextError(); ok {
+		return err
+	}
+	return c.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c *hcoTestClient) Status() client.StatusWriter {
+	return c.sw
+}
+
+func (c *hcoTestClient) initiateReadErrors(errs ...error) {
+	c.readErrors = errs
+}
+
+func (c *hcoTestClient) initiateWriteErrors(errs ...error) {
+	c.writeErrors = errs
+}
+
+type hcoTestStatusWriter struct {
+	client client.Client
+	errors testErrors
+}
+
+func (sw *hcoTestStatusWriter) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	if ok, err := sw.errors.getNextError(); ok {
+		return err
+	}
+	return sw.client.Update(ctx, obj, opts...)
+}
+
+func (sw *hcoTestStatusWriter) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if ok, err := sw.errors.getNextError(); ok {
+		return err
+	}
+	return sw.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (sw *hcoTestStatusWriter) initiateErrors(errs ...error) {
+	sw.errors = errs
+}
+
+type testErrors []error
+
+func (errs *testErrors) getNextError() (bool, error) {
+	if len(*errs) == 0 {
+		return false, nil
+	}
+
+	err := (*errs)[0]
+	*errs = (*errs)[1:]
+
+	return true, err
+}
+
+func initClient(clientObjects []runtime.Object) *hcoTestClient {
+	// Create a fake client to mock API calls
+	cl := fake.NewFakeClient(clientObjects...)
+	return &hcoTestClient{client: cl, sw: &hcoTestStatusWriter{client: cl}}
+}


### PR DESCRIPTION
This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1839837

The reconcile is now a wrapper to the new doReconcile method. The Reconcile wrapper is the only place HCO update the CR.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
fix bug 1839837 - Avoid errors in hco-operator log when it is trying to update its resource twice in a single reconciliation loop
https://bugzilla.redhat.com/show_bug.cgi?id=1839837
```

