### PR TITLE
Add missing fields, required by OLM

### DIFF
--- a/pkg/apis/hco/v1alpha1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1alpha1/hyperconverged_types.go
@@ -26,6 +26,9 @@ type HyperConvergedSpec struct {
 
 	// LocalStorageClassName the name of the local storage class.
 	LocalStorageClassName string `json:"LocalStorageClassName,omitempty"`
+
+	// operator version
+	Version string `json:"version,omitempty"`
 }
 
 // HyperConvergedStatus defines the observed state of HyperConverged

--- a/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
@@ -146,7 +146,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -265,7 +265,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -333,7 +333,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -482,7 +482,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -631,7 +631,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			Expect(foundResource.Spec.Multus).To(Equal(&networkaddonsv1alpha1.Multus{}))
 			Expect(foundResource.Spec.LinuxBridge).To(Equal(&networkaddonsv1alpha1.LinuxBridge{}))
@@ -761,7 +761,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -871,7 +871,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -1006,7 +1006,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -1130,7 +1130,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 


### PR DESCRIPTION
Fix bug [1716329](https://bugzilla.redhat.com/show_bug.cgi?id=1716329)
* Add the `status.version` field to HCO CR.
* Add the `labels['app']` field to HCO CR.

*Note*: The `status.phase` field is not required anymore.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug 1716329: https://bugzilla.redhat.com/show_bug.cgi?id=1716329
```

