### PR TITLE
Avoid deploying NodeLabellerBundle when running with KVM_EMULATION

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -28,8 +28,8 @@ HCO_RESOURCE_NAME="kubevirt-hyperconverged"
 HCO_CRD_NAME="hyperconvergeds.hco.kubevirt.io"
 
 CI=""
-if [ "$1" == "CI" ]; then
-	echo "deploying on CI"
+if [ -n "$KUBEVIRT_PROVIDER" ]; then
+	echo "deploying on KubevirtCI ${KUBEVIRT_PROVIDER}"
 	CI="true"
 elif [ "$HOSTNAME" == "hco-e2e-aws" ] || [ "$HOSTNAME" == "e2e-aws-cnv" ]; then
 	echo "deploying on AWS CI"

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -423,22 +423,18 @@ var _ = Describe("HyperconvergedController", func() {
 					checkAvailability(foundResource, corev1.ConditionTrue)
 				*/
 
-				// TODO: temporary avoid checking conditions on KubevirtNodeLabellerBundle because it's currently
-				// broken on k8s. Revert this when we will be able to fix it
-				/*
-					origConds = expected.kvNlb.Status.Conditions
-					expected.kvNlb.Status.Conditions = expected.cdi.Status.Conditions[1:]
-					cl = expected.initClient()
-					foundResource, requeue = doReconcile(cl, expected.hco)
-					Expect(requeue).To(BeFalse())
-					checkAvailability(foundResource, corev1.ConditionFalse)
+				origConds = expected.kvNlb.Status.Conditions
+				expected.kvNlb.Status.Conditions = expected.cdi.Status.Conditions[1:]
+				cl = expected.initClient()
+				foundResource, requeue = doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeFalse())
+				checkAvailability(foundResource, corev1.ConditionFalse)
 
-					expected.kvNlb.Status.Conditions = origConds
-					cl = expected.initClient()
-					foundResource, requeue = doReconcile(cl, expected.hco)
-					Expect(requeue).To(BeFalse())
-					checkAvailability(foundResource, corev1.ConditionTrue)
-				*/
+				expected.kvNlb.Status.Conditions = origConds
+				cl = expected.initClient()
+				foundResource, requeue = doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeFalse())
+				checkAvailability(foundResource, corev1.ConditionTrue)
 
 				// TODO: temporary avoid checking conditions on KubevirtTemplateValidator because it's currently
 				// broken on k8s. Revert this when we will be able to fix it


### PR DESCRIPTION
Avoid deploying NodeLabellerBundle when running
with KVM_EMULATION because it will be completely useless

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Avoid deploying NodeLabellerBundle when running with KVM_EMULATION
```

