### PR TITLE
[release-2.4] Add missing fields, required by OLM

### DIFF
--- a/pkg/apis/hco/v1alpha1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1alpha1/hyperconverged_types.go
@@ -26,6 +26,9 @@ type HyperConvergedSpec struct {
 
 	// LocalStorageClassName the name of the local storage class.
 	LocalStorageClassName string `json:"LocalStorageClassName,omitempty"`
+
+	// operator version
+	Version string `json:"version,omitempty"`
 }
 
 // HyperConvergedStatus defines the observed state of HyperConverged

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -201,7 +201,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).To(BeNil())
 				Expect(foundResource.Name).To(Equal(expectedResource.Name))
-				Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+				Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			})
 
@@ -320,7 +320,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).To(BeNil())
 				Expect(foundResource.Name).To(Equal(expectedResource.Name))
-				Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+				Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			})
 
@@ -388,7 +388,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).To(BeNil())
 				Expect(foundResource.Name).To(Equal(expectedResource.Name))
-				Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+				Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			})
 
@@ -537,7 +537,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).To(BeNil())
 				Expect(foundResource.Name).To(Equal(expectedResource.Name))
-				Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+				Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			})
 
@@ -686,7 +686,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).To(BeNil())
 				Expect(foundResource.Name).To(Equal(expectedResource.Name))
-				Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+				Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 				Expect(foundResource.Spec.Multus).To(Equal(&networkaddonsv1alpha1.Multus{}))
 				Expect(foundResource.Spec.LinuxBridge).To(Equal(&networkaddonsv1alpha1.LinuxBridge{}))
@@ -816,7 +816,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).To(BeNil())
 				Expect(foundResource.Name).To(Equal(expectedResource.Name))
-				Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+				Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			})
 
@@ -926,7 +926,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).To(BeNil())
 				Expect(foundResource.Name).To(Equal(expectedResource.Name))
-				Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+				Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			})
 
@@ -1061,7 +1061,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).To(BeNil())
 				Expect(foundResource.Name).To(Equal(expectedResource.Name))
-				Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+				Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			})
 
@@ -1185,7 +1185,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).To(BeNil())
 				Expect(foundResource.Name).To(Equal(expectedResource.Name))
-				Expect(foundResource.Labels).Should(HaveKeyWithValue("app", name))
+				Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
 				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			})
 
@@ -1671,8 +1671,41 @@ var _ = Describe("HyperconvergedController", func() {
 			})
 		})
 
+		Context("Validate OLM required fields", func() {
+			expected := getBasicDeployment()
+			origConds := expected.hco.Status.Conditions
+
+			BeforeEach(func() {
+				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
+				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
+				os.Setenv("OPERATOR_NAMESPACE", namespace)
+				os.Setenv(util.HcoKvIoVersionName, version.Version)
+			})
+
+			It("Should set required fields on init", func() {
+				expected.hco.Status.Conditions = nil
+
+				cl := expected.initClient()
+				foundResource, requeue := doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeTrue())
+
+				Expect(foundResource.ObjectMeta.Labels[appLabel]).Should(Equal(hcov1alpha1.HyperConvergedName))
+			})
+
+			It("Should set required fields when missing", func() {
+				expected.hco.Status.Conditions = origConds
+				// old HCO Version is set
+				cl := expected.initClient()
+				foundResource, requeue := doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeFalse())
+
+				Expect(foundResource.ObjectMeta.Labels[appLabel]).Should(Equal(hcov1alpha1.HyperConvergedName))
+			})
+		})
+
 		Context("Upgrade Mode", func() {
 			expected := getBasicDeployment()
+			origConditions := expected.hco.Status.Conditions
 			okConds := expected.hco.Status.Conditions
 
 			const (
@@ -1700,6 +1733,8 @@ var _ = Describe("HyperconvergedController", func() {
 				os.Setenv(util.VMImportEnvV, newComponentVersion)
 
 				os.Setenv(util.HcoKvIoVersionName, newVersion)
+
+				expected.hco.Status.Conditions = origConditions
 			})
 
 			It("Should update HCO Version Id in the CR on init", func() {
@@ -1721,12 +1756,15 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(ok).To(BeTrue())
 				Expect(ver).Should(Equal(newVersion))
 
+				Expect(foundResource.Spec.Version).Should(Equal(newVersion))
+
 				expected.hco.Status.Conditions = okConds
 			})
 
 			It("detect upgrade existing HCO Version", func() {
 				// old HCO Version is set
 				expected.hco.Status.UpdateVersion(hcoVersionName, oldVersion)
+				expected.hco.Spec.Version = oldVersion
 
 				// CDI is not ready
 				expected.cdi.Status.Conditions = getGenericProgressingConditions()
@@ -1741,6 +1779,8 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(ok).To(BeTrue())
 				Expect(ver).Should(Equal(oldVersion))
 
+				Expect(foundResource.Spec.Version).Should(Equal(oldVersion))
+
 				// now, complete the upgrade
 				expected.cdi.Status.Conditions = getGenericCompletedConditions()
 				cl = expected.initClient()
@@ -1752,6 +1792,7 @@ var _ = Describe("HyperconvergedController", func() {
 				ver, ok = foundResource.Status.GetVersion(hcoVersionName)
 				Expect(ok).To(BeTrue())
 				Expect(ver).Should(Equal(newVersion))
+				Expect(foundResource.Spec.Version).Should(Equal(newVersion))
 				cond := conditionsv1.FindStatusCondition(foundResource.Status.Conditions, conditionsv1.ConditionProgressing)
 				Expect(cond.Status).Should(BeEquivalentTo("False"))
 			})
@@ -1760,6 +1801,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// CDI is not ready
 				expected.cdi.Status.Conditions = getGenericProgressingConditions()
 				expected.hco.Status.Versions = nil
+				expected.hco.Spec.Version = ""
 
 				cl := expected.initClient()
 				foundResource, requeue := doReconcile(cl, expected.hco)
@@ -1771,6 +1813,7 @@ var _ = Describe("HyperconvergedController", func() {
 				fmt.Fprintln(GinkgoWriter, "foundResource.Status.Versions", foundResource.Status.Versions)
 				Expect(ok).To(BeFalse())
 				Expect(ver).Should(BeEmpty())
+				Expect(foundResource.Spec.Version).To(BeEmpty())
 
 				// now, complete the upgrade
 				expected.cdi.Status.Conditions = getGenericCompletedConditions()
@@ -1783,6 +1826,8 @@ var _ = Describe("HyperconvergedController", func() {
 				ver, ok = foundResource.Status.GetVersion(hcoVersionName)
 				Expect(ok).To(BeTrue())
 				Expect(ver).Should(Equal(newVersion))
+				Expect(foundResource.Spec.Version).Should(Equal(newVersion))
+
 				cond := conditionsv1.FindStatusCondition(foundResource.Status.Conditions, conditionsv1.ConditionProgressing)
 				Expect(cond.Status).Should(BeEquivalentTo("False"))
 			})


### PR DESCRIPTION
Fix bug [1716329](https://bugzilla.redhat.com/show_bug.cgi?id=1716329)
* Add the `status.version` field to HCO CR.
* Add the `labels['app']` field to HCO CR.

*Note*: The `status.phase` field is not required anymore.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug 1716329: https://bugzilla.redhat.com/show_bug.cgi?id=1716329
```

