### PR TITLE
[release-2.4] Add the "all" category to HCO CRD (#617)

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -10,6 +10,8 @@ spec:
     type: date
   group: hco.kubevirt.io
   names:
+    categories:
+    - all
     kind: HyperConverged
     plural: hyperconvergeds
     shortNames:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.1.0/hco00.crd.yaml
@@ -10,6 +10,8 @@ spec:
     type: date
   group: hco.kubevirt.io
   names:
+    categories:
+    - all
     kind: HyperConverged
     plural: hyperconvergeds
     shortNames:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -485,6 +485,7 @@ func GetOperatorCRD(namespace string) *extv1beta1.CustomResourceDefinition {
 				Singular:   "hyperconverged",
 				Kind:       "HyperConverged",
 				ShortNames: []string{"hco", "hcos"},
+				Categories: []string{"all"},
 			},
 
 			AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{


### PR DESCRIPTION
Add the "all" category to HCO CRD, so hco will be listed when running
```bash
kubectl get all
```

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

