### PR TITLE
Track changes on SCC

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -1,10 +1,9 @@
 #!/bin/bash -xe
 
-if [[ $TARGET =~ okd-.* ]]; then
-  export KUBEVIRT_PROVIDER="okd-4.1"
+export KUBEVIRT_PROVIDER="$TARGET"
+
+if [[ $TARGET =~ okd-.* || $TARGET =~ ocp-.* ]]; then
   export KUBEVIRT_MEMORY_SIZE=6144M
-elif [[ $TARGET =~ k8s-.* ]]; then
-  export KUBEVIRT_PROVIDER="k8s-1.17"
 fi
 
 export KUBEVIRT_NUM_NODES=2
@@ -18,7 +17,7 @@ make ci-functest
 
 # Upgrade test requires OLM which is currently
 # only available with okd providers
-if [[ $TARGET =~ okd-.* ]]; then
+if [[ $TARGET =~ okd-.* || $TARGET =~ ocp-.* ]]; then
   make upgrade-test
   make ci-functest
 fi

--- a/hack/compare_scc.sh
+++ b/hack/compare_scc.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2020 Red Hat, Inc.
+#
+
+set -ex
+
+SCC_BEFORE_SUFFIX=.yaml.before
+SCC_AFTER_SUFFIX=.yaml.after
+
+function dump_sccs_before(){
+    if [ "${CMD}" == "oc" ]; then
+        mkdir -p _out/scc
+        for SCCNAME in $( ${CMD} get scc -o custom-columns=:metadata.name )
+        do
+          echo -e "\n--- SCC ${SCCNAME} ---"
+          ${CMD} get scc ${SCCNAME} -o yaml > "_out/scc/${SCCNAME}${SCC_BEFORE_SUFFIX}" || true
+        done
+    else
+        echo "Ignoring SCCs on k8s"
+    fi
+}
+
+function dump_sccs_after(){
+    if [ "${CMD}" == "oc" ]; then
+        for f in _out/scc/*${SCC_BEFORE_SUFFIX}; do
+           SCCNAME=$(basename --suffix=${SCC_BEFORE_SUFFIX} "$f")
+           echo -e "\n--- SCC ${SCCNAME} ---"
+           ${CMD} get scc ${SCCNAME} -o yaml > "_out/scc/${SCCNAME}${SCC_AFTER_SUFFIX}" || true
+           diff -I '^\s*generation:.*$' -I '^\s*resourceVersion:.*$' -I '^\s*time:.*$' "_out/scc/${SCCNAME}${SCC_BEFORE_SUFFIX}" "_out/scc/${SCCNAME}${SCC_AFTER_SUFFIX}"
+        done
+    else
+        echo "Ignoring SCCs on k8s"
+    fi
+}

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -89,7 +89,8 @@ fi
 "${CMD}" delete catalogsource hco-catalogsource-example -n ${HCO_CATALOG_NAMESPACE} | true
 "${CMD}" delete operatorgroup hco-operatorgroup -n kubevirt-hyperconverged | true
 
-
+source hack/compare_scc.sh
+dump_sccs_before
 
 ${CMD} wait deployment packageserver --for condition=Available -n openshift-operator-lifecycle-manager --timeout="1200s"
 ${CMD} wait deployment catalog-operator --for condition=Available -n openshift-operator-lifecycle-manager --timeout="1200s"
@@ -235,4 +236,5 @@ ${CMD} get pod $HCO_CATALOGSOURCE_POD -n ${HCO_CATALOG_NAMESPACE} -o yaml | grep
 Msg "wait that cluster is operational after upgrade"
 timeout 10m bash -c 'export CMD="${CMD}";exec ./hack/check-state.sh'
 
+dump_sccs_after
 echo "upgrade-test completed successfully."


### PR DESCRIPTION
Detect changes on SCCs initially present on the cluster

HCO deployment (inclusing component operators) should
not modify initial SCCs already present on the OCP/OKD
cluster.
Adding a bit of logic to the deployment scripts on CI to
enforce this.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

