### PR TITLE
Deployment using kustomize on main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,6 @@ Use it to obtain an opinionated deployment of KubeVirt and its helper operators.
 
 ![](images/HCO-design.jpg)
 
-## Installing HCO Community Operator (OpenShift Only)
-The Hyperconverged Cluster Operator is published as a Community Operator in
-Operatorhub.io.  In the UI, you can search for it under the "OperatorHub"
-tab or deploy from the commandline:
-
-```bash
-$ curl https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/hco.yaml | kubectl create -f -
-```
-
 ## Installing HCO using kustomize (Openshift OLM Only)
 To install the default community HyperConverged Cluster Operator, along with its underlying components, run:
 ```bash

--- a/README.md
+++ b/README.md
@@ -27,9 +27,16 @@ $ curl https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operato
 ```
 
 ## Installing HCO using kustomize (Openshift OLM Only)
-Refer to [kustomize deployment documentation](deploy/kustomize/README.md).
+To install the default community HyperConverged Cluster Operator, along with its underlying components, run:
+```bash
+$ curl -L https://api.github.com/repos/kubevirt/hyperconverged-cluster-operator/tarball/master | \
+tar --strip-components=1 -xvzf - kubevirt-hyperconverged-cluster-operator-*/deploy/kustomize
 
-**NOTE**: `deploy/deploy_marketplace.sh` and `deploy/deploy_imageregistry.sh` will be deprecated soon.
+$ ./deploy/kustomize/deploy_kustomize.sh
+```
+The deployment is completed when HCO custom resource reports its condition as `Available`.
+
+For more explanation and advanced options for HCO deployment using kustomize, refer to [kustomize deployment documentation](deploy/kustomize/README.md).
 
 ## Installing Unreleased Bundles Using Marketplace
 The hyperconverged cluster operator will publish the lastest bundles to [quay/kubevirt-hyperconvered/hco-operatohub](https://quay.io/application/kubevirt-hyperconverged/hco-operatorhub)

--- a/deploy/kustomize/README.md
+++ b/deploy/kustomize/README.md
@@ -14,15 +14,15 @@ There are two distinct options to deliver HCO operator to OLM - Marketplace and 
 ### Marketplace
 This method is taking advantage of OperatorSource, which makes the operator available on OLM OperatorHub (implicitly creating a CatalogSource with the same name).
 To manually deliver HCO using marketplace, edit `spec.registryNamespace` of `marketplace/operator_source.yaml` to the desired value (default is "kubevirt-hyperconverged"), and run:
-```
-oc apply -k marketplace
+```bash
+$ oc apply -k marketplace
 ```
 Which will create the HCO catalog source with default configuration. After processing is complete, the package will be available in OperatorHub.
 
 #### Private Repo
 If the operator source is located in a private Quay.io registry, you should provide the OperatorSource resource with a secret, which can be extracted by:
-```
-curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '
+```bash
+$ curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '
   {
       "user": {
           "username": "'"${QUAY_USERNAME}"'",
@@ -31,15 +31,15 @@ curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/user
   }' | jq -r '.token'
 ```
 The token should be inserted in `spec.authorizationToken.secretName` of `private_repo/operator_source.patch.yaml`, then run:
-```
-oc apply -k private_repo
+```bash
+$ oc apply -k private_repo
 ```
 
 ### Image Registry
 This method is delivering the operator's bundle image via a grpc protocol from an image registry.
 To manually deliver HCO using image registry, edit `spec.image` of `image_registry/catalog_source.yaml` to the desired image bundle URL, and run:
-```
-oc apply -k image_registry
+```bash
+$ oc apply -k image_registry
 ```
 
 ### Automation
@@ -59,23 +59,23 @@ Set environment variable "MARKETPLACE_MODE" to "false".
 
 #### Examples
 ##### Deliver Content using Marketplace (appregistry)
-```
-CONTENT_ONLY=true \
+```bash
+$ CONTENT_ONLY=true \
 MARKETPLACE_MODE=true \ |
 ./deploy/kustomize/deploy_kustomize.sh
 ```
 
 ##### Deploy HCO using Image Registry with KVM Emulation enabled
-```
-MARKETPLACE_MODE=false \
+```bash
+$ MARKETPLACE_MODE=false \
 KVM_EMULATION=true \
 CONTENT_ONLY=false \ |
 ./deploy/kustomize/deploy_kustomize.sh
 ```
 
 In order to change the default HCO bundle image, use the following command prior to executing the script:
-```
-DESIRED_IMAGE=< a URL to hco bundle image>
+```bash
+$ DESIRED_IMAGE=< a URL to hco bundle image>
 sed "s/\(image: \)\(.*\)/\1${DESIRED_IMAGE}/" deploy/kustomize/image_registry/catalog_source.yaml
 ```
 
@@ -87,8 +87,8 @@ The deployment phase consists of 3 resources, located in `base` directory:
 
 In addition, a namespace must be deployed prior to the deployment of resources above. the namespace resource can be found in `namespace.yaml`.
 To deploy HCO with default settings, run:
-```
-cat <<EOF >kustomization.yaml
+```bash
+$ cat <<EOF >kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -98,13 +98,13 @@ resources:
   - namespace.yaml
 EOF
 
-oc apply -k .
+$ oc apply -k .
 ```
 
 ### KVM Emulation
 If KVM emulation is required on your environment, use the following overlay to add the Subscription resource with relevant KVM config:
-```
-oc apply -k kvm_emulation
+```bash
+$ oc apply -k kvm_emulation
 ```
 
 ### Automation
@@ -118,8 +118,8 @@ In order to make customizations to your deployment, you need to set up other env
 ### Change Deployment Namespace
 The default namespace is `kubevirt-hyperconverged`.
 In order to change that to a custom value, you should edit `namespace.yaml` and update its `metadata.name` value, and run:
-```
-cat <<EOF >kustomization.yaml
+```bash
+$ cat <<EOF >kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -130,13 +130,13 @@ resources:
   - namespace.yaml
 EOF
 
-oc apply -k .
+$ oc apply -k .
 ```
 
 ### Modify HCO Channel and Version
 Create a Subscription patch to reflect the desired version and channel.
-```
-cat > subscription.patch.yaml << EOF
+```bash
+$ cat > subscription.patch.yaml << EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -146,7 +146,7 @@ spec:
   channel: "${HCO_CHANNEL}"
 ```
 and then update the `kustomization.yaml` to include the patch:
-```
+```bash
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -159,4 +159,4 @@ patchesStrategicMerge:
 
 #### Deploy
 When customizations are ready, run `./deploy_kustomize.sh`.
-The script will prepare and submit kustomize manifests to the cluster. It will also check whenever deployment is complete (HCO CR reports Condition "Available" True), and finish successfully.
+The script will prepare and submit kustomize manifests to the cluster. It will also check whenever deployment is complete (HCO CR reports Condition "Available"=True), and finish successfully.

--- a/deploy/kustomize/namespace.yaml
+++ b/deploy/kustomize/namespace.yaml
@@ -2,6 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kubevirt-hyperconverged
-  labels:
-    openshift.io/run-level: "1"
-    openshift.io/cluster-monitoring: "true"

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -172,12 +172,12 @@ EOF
 ./hack/retry.sh 20 30 "${CMD} get subscription -n kubevirt-hyperconverged | grep -v EOF"
 ./hack/retry.sh 20 30 "${CMD} get pods -n kubevirt-hyperconverged | grep hco-operator"
 
-HCO_OPERATOR_POD=`${CMD} get pods -n kubevirt-hyperconverged | grep hco-operator  | grep Running | head -1 | awk '{ print $1 }'`
+HCO_OPERATOR_POD=`${CMD} get pods -n kubevirt-hyperconverged | grep hco-operator  | grep 'Running\|ContainerCreating' | head -1 | awk '{ print $1 }'`
 ${CMD} wait pod $HCO_OPERATOR_POD --for condition=Ready -n kubevirt-hyperconverged --timeout="1200s"
 
 ${CMD} create -f ./deploy/hco.cr.yaml -n kubevirt-hyperconverged
 
-HCO_OPERATOR_POD=`${CMD} get pods -n ${HCO_NAMESPACE} | grep hco-operator | grep Running | head -1 | awk '{ print $1 }'`
+HCO_OPERATOR_POD=`${CMD} get pods -n ${HCO_NAMESPACE} | grep hco-operator | grep 'Running\|ContainerCreating' | head -1 | awk '{ print $1 }'`
 
 ${CMD} wait -n ${HCO_NAMESPACE} ${HCO_KIND} ${HCO_RESOURCE_NAME} --for condition=Available --timeout=30m
 ${CMD} wait pod $HCO_OPERATOR_POD --for condition=Ready -n ${HCO_NAMESPACE} --timeout=30m


### PR DESCRIPTION
* Removing mentioning legacy deployment scripts `deploy_marketplace.sh` and `deploy_imageregistry.sh`
* Providing deployment command using kustomize on main HCO repo readme file.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kustomize doc on main README.
```

