### PR TITLE
Change ocp-ci tests focus

### DIFF
--- a/deploy/nightly-bundle/kubevirt-tests-pod-spec-override.json.in
+++ b/deploy/nightly-bundle/kubevirt-tests-pod-spec-override.json.in
@@ -10,7 +10,7 @@
           "--cdi-namespace=@NAMESPACE@",
           "--config=/etc/config/test-config.json",
           "--ginkgo.seed=0",
-          "--ginkgo.focus=\\[crit:high\\]",
+          "--ginkgo.focus=@GINKGO_TESTS_TO_FOCUS@",
           "--ginkgo.skip=@GINKGO_TESTS_TO_SKIP@"
         ],
         "volumeMounts": [


### PR DESCRIPTION
Initially, we wanted to run all the critical tests on ocp-ci but over
time we've seen that the tests are unstable. For now, we will reduce the
amount of tests that we run there. We will increase the tests over time.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

