### PR TITLE
Create a PriorityClass for KubeVirt on startup

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
@@ -31,6 +32,7 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
@@ -196,6 +198,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	err = createPriorityClass(ctx, mgr)
+	if err != nil {
+		log.Error(err, "Failed creating PriorityClass")
+		os.Exit(1)
+	}
+
 	log.Info("Starting the Cmd.")
 
 	// Start the Cmd
@@ -203,6 +211,25 @@ func main() {
 		log.Error(err, "Manager exited non-zero")
 		os.Exit(1)
 	}
+}
+
+func createPriorityClass(ctx context.Context, mgr manager.Manager) error {
+	pc := hcoutil.NewKubeVirtPriorityClass()
+
+	key, err := client.ObjectKeyFromObject(pc)
+	if err != nil {
+		log.Error(err, "Failed to get object key for KubeVirt PriorityClass")
+		return err
+	}
+
+	err = mgr.GetAPIReader().Get(ctx, key, pc)
+
+	if err != nil && apierrors.IsNotFound(err) {
+		log.Info("Creating KubeVirt PriorityClass")
+		return mgr.GetClient().Create(ctx, pc, &client.CreateOptions{})
+	}
+
+	return err
 }
 
 // serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -855,26 +855,9 @@ func newKubeVirtForCR(cr *hcov1alpha1.HyperConverged, namespace string) *kubevir
 	}
 }
 
-func newKubeVirtPriorityClass() *schedulingv1.PriorityClass {
-	return &schedulingv1.PriorityClass{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "scheduling.k8s.io/v1",
-			Kind:       "PriorityClass",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubevirt-cluster-critical",
-		},
-		// 1 billion is the highest value we can set
-		// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-		Value:         1000000000,
-		GlobalDefault: false,
-		Description:   "This priority class should be used for KubeVirt core components only.",
-	}
-}
-
 func (r *ReconcileHyperConverged) ensureKubeVirtPriorityClass(req *hcoRequest) (upgradeDone bool, err error) {
 	req.logger.Info("Reconciling KubeVirt PriorityClass")
-	pc := newKubeVirtPriorityClass()
+	pc := hcoutil.NewKubeVirtPriorityClass()
 
 	key, err := client.ObjectKeyFromObject(pc)
 	if err != nil {
@@ -1721,7 +1704,7 @@ func componentResourceRemoval(o interface{}, c client.Client, req *hcoRequest) e
 }
 
 func ensureKubeVirtPriorityClassDeleted(c client.Client, req *hcoRequest) error {
-	pc := newKubeVirtPriorityClass()
+	pc := hcoutil.NewKubeVirtPriorityClass()
 	key, err := client.ObjectKeyFromObject(pc)
 	if err != nil {
 		req.logger.Error(err, "Failed to get object key for KubeVirt PriorityClass")

--- a/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
@@ -1,9 +1,12 @@
 package hyperconverged
 
 import (
+	"os"
+
 	sspv1 "github.com/MarSik/kubevirt-ssp-operator/pkg/apis/kubevirt/v1"
 	networkaddonsv1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
 	hcov1alpha1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1alpha1"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	vmimportv1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/openshift/custom-resource-status/testlib"
@@ -15,7 +18,6 @@ import (
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
@@ -24,6 +26,7 @@ import (
 
 	"context"
 	"fmt"
+
 	"k8s.io/client-go/tools/reference"
 )
 
@@ -40,7 +43,7 @@ var _ = Describe("HyperConverged Components", func() {
 		})
 
 		It("should create if not present", func() {
-			expectedResource := newKubeVirtPriorityClass()
+			expectedResource := hcoutil.NewKubeVirtPriorityClass()
 			cl := initClient([]runtime.Object{})
 			r := initReconciler(cl)
 			upgradeDone, err := r.ensureKubeVirtPriorityClass(req)
@@ -57,7 +60,7 @@ var _ = Describe("HyperConverged Components", func() {
 		})
 
 		It("should do nothing if already exists", func() {
-			expectedResource := newKubeVirtPriorityClass()
+			expectedResource := hcoutil.NewKubeVirtPriorityClass()
 			cl := initClient([]runtime.Object{expectedResource})
 			r := initReconciler(cl)
 			upgradeDone, err := r.ensureKubeVirtPriorityClass(req)
@@ -76,7 +79,7 @@ var _ = Describe("HyperConverged Components", func() {
 			Expect(upgradeDone).To(BeFalse())
 			Expect(err).To(BeNil())
 
-			expectedResource := newKubeVirtPriorityClass()
+			expectedResource := hcoutil.NewKubeVirtPriorityClass()
 			key, err := client.ObjectKeyFromObject(expectedResource)
 			Expect(err).ToNot(HaveOccurred())
 			foundResource := &schedulingv1.PriorityClass{}

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -3,6 +3,8 @@ package hyperconverged
 import (
 	"context"
 	"fmt"
+	"os"
+
 	sspopv1 "github.com/MarSik/kubevirt-ssp-operator/pkg/apis"
 	sspv1 "github.com/MarSik/kubevirt-ssp-operator/pkg/apis/kubevirt/v1"
 	networkaddons "github.com/kubevirt/cluster-network-addons-operator/pkg/apis"
@@ -10,6 +12,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis"
 	hcov1alpha1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1alpha1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"github.com/kubevirt/hyperconverged-cluster-operator/version"
 	vmimportv1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1alpha1"
 	. "github.com/onsi/ginkgo"
@@ -23,7 +26,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	cdiv1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -122,7 +124,7 @@ func getBasicDeployment() *basicExpected {
 	}
 	res.hco = hco
 
-	res.pc = newKubeVirtPriorityClass()
+	res.pc = hcoutil.NewKubeVirtPriorityClass()
 	// These are all of the objects that we expect to "find" in the client because
 	// we already created them in a previous reconcile.
 	expectedKVConfig := newKubeVirtConfigForCR(hco, namespace)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -5,14 +5,16 @@ import (
 	"fmt"
 
 	"errors"
+	"os"
+
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	csvv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -95,4 +97,21 @@ func GetCSVfromPod(pod *corev1.Pod, c client.Client, logger logr.Logger) (*csvv1
 	}
 
 	return csv, nil
+}
+
+func NewKubeVirtPriorityClass() *schedulingv1.PriorityClass {
+	return &schedulingv1.PriorityClass{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "scheduling.k8s.io/v1",
+			Kind:       "PriorityClass",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubevirt-cluster-critical",
+		},
+		// 1 billion is the highest value we can set
+		// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+		Value:         1000000000,
+		GlobalDefault: false,
+		Description:   "This priority class should be used for KubeVirt core components only.",
+	}
 }


### PR DESCRIPTION
Until now, the PriorityClass for KubeVirt was created during
reconciliation (after creating the CR for the HCO).  This caused the
virt-operator to exit with a FailedCreate status, and the CSV to stay in
a Failed status.
This patch creates the PriorityClass when the HCO starts, allowing the
virt-operator to be installed properly and the CSV's status to change to
Succeeded.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Create KubeVirt's PriorityClass when HCO starts (BZ#1851856)
```

