### PR TITLE
Avoid deleting KubeVirt Priority Class

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -233,8 +233,13 @@ func main() {
 	}
 }
 
+// KubeVirtPriorityClass is needed by virt-operator but OLM is not able to
+// create it so we have to create it ASAP.
+// When the user deletes HCO CR virt-operator should continue running
+// so we are never supposed to delete it: because the priority class
+// is completely opaque to OLM it will remain as a leftover on the cluster
 func createPriorityClass(ctx context.Context, mgr manager.Manager) error {
-	pc := hcoutil.NewKubeVirtPriorityClass()
+	pc := hcoutil.NewKubeVirtPriorityClass(hcov1alpha1.HyperConvergedName)
 
 	key, err := client.ObjectKeyFromObject(pc)
 	if err != nil {

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -81,8 +81,6 @@ const (
 
 	hcoVersionName = "operator"
 
-	appLabel = "app"
-
 	commonTemplatesBundleOldCrdName = "kubevirtcommontemplatesbundles.kubevirt.io"
 	metricsAggregationOldCrdName    = "kubevirtmetricsaggregations.kubevirt.io"
 	nodeLabellerBundlesOldCrdName   = "kubevirtnodelabellerbundles.kubevirt.io"
@@ -412,7 +410,6 @@ func (r *ReconcileHyperConverged) ensureHcoDeleted(req *hcoRequest) (reconcile.R
 		ensureCDIDeleted,
 		ensureNetworkAddonsDeleted,
 		ensureKubeVirtCommonTemplateBundleDeleted,
-		ensureKubeVirtPriorityClassDeleted,
 	} {
 		err := f(r.client, req)
 		if err != nil {
@@ -770,7 +767,7 @@ func (r *ReconcileHyperConverged) checkComponentVersion(versionEnvName, actualVe
 
 func newKubeVirtConfigForCR(cr *hcov1alpha1.HyperConverged, namespace string) *corev1.ConfigMap {
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -859,7 +856,7 @@ func (r *ReconcileHyperConverged) ensureKubeVirtConfig(req *hcoRequest) (upgrade
 // newKubeVirtForCR returns a KubeVirt CR
 func newKubeVirtForCR(cr *hcov1alpha1.HyperConverged, namespace string) *kubevirtv1.KubeVirt {
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 	return &kubevirtv1.KubeVirt{
 		ObjectMeta: metav1.ObjectMeta{
@@ -875,7 +872,7 @@ func newKubeVirtForCR(cr *hcov1alpha1.HyperConverged, namespace string) *kubevir
 
 func (r *ReconcileHyperConverged) ensureKubeVirtPriorityClass(req *hcoRequest) (upgradeDone bool, err error) {
 	req.logger.Info("Reconciling KubeVirt PriorityClass")
-	pc := hcoutil.NewKubeVirtPriorityClass()
+	pc := hcoutil.NewKubeVirtPriorityClass(req.instance.Name)
 
 	key, err := client.ObjectKeyFromObject(pc)
 	if err != nil {
@@ -967,7 +964,7 @@ func (r *ReconcileHyperConverged) ensureKubeVirt(req *hcoRequest) (upgradeDone b
 // newCDIForCr returns a CDI CR
 func newCDIForCR(cr *hcov1alpha1.HyperConverged, namespace string) *cdiv1alpha1.CDI {
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 	uninstallStrategy := cdiv1alpha1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist
 	return &cdiv1alpha1.CDI{
@@ -1045,7 +1042,7 @@ func (r *ReconcileHyperConverged) ensureCDI(req *hcoRequest) (upgradeDone bool, 
 // newNetworkAddonsForCR returns a NetworkAddonsConfig CR
 func newNetworkAddonsForCR(cr *hcov1alpha1.HyperConverged, namespace string) *networkaddonsv1alpha1.NetworkAddonsConfig {
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 	return &networkaddonsv1alpha1.NetworkAddonsConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1214,7 +1211,7 @@ func (r *ReconcileHyperConverged) componentNotAvailable(req *hcoRequest, compone
 
 func newKubeVirtCommonTemplateBundleForCR(cr *hcov1alpha1.HyperConverged, namespace string) *sspv1.KubevirtCommonTemplatesBundle {
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 	return &sspv1.KubevirtCommonTemplatesBundle{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1291,7 +1288,7 @@ func (r *ReconcileHyperConverged) ensureKubeVirtCommonTemplateBundle(req *hcoReq
 
 func newKubeVirtNodeLabellerBundleForCR(cr *hcov1alpha1.HyperConverged, namespace string) *sspv1.KubevirtNodeLabellerBundle {
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 	return &sspv1.KubevirtNodeLabellerBundle{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1360,7 +1357,7 @@ func (r *ReconcileHyperConverged) ensureKubeVirtNodeLabellerBundle(req *hcoReque
 
 func newIMSConfigForCR(cr *hcov1alpha1.HyperConverged, namespace string) *corev1.ConfigMap {
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1461,7 +1458,7 @@ func (r *ReconcileHyperConverged) ensureVMImport(req *hcoRequest) (upgradeDone b
 // newVMImportForCR returns a VM import CR
 func newVMImportForCR(cr *hcov1alpha1.HyperConverged, namespace string) *vmimportv1alpha1.VMImportConfig {
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 
 	return &vmimportv1alpha1.VMImportConfig{
@@ -1475,7 +1472,7 @@ func newVMImportForCR(cr *hcov1alpha1.HyperConverged, namespace string) *vmimpor
 
 func newKubeVirtTemplateValidatorForCR(cr *hcov1alpha1.HyperConverged, namespace string) *sspv1.KubevirtTemplateValidator {
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 	return &sspv1.KubevirtTemplateValidator{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1545,7 +1542,7 @@ func newKubeVirtStorageConfigForCR(cr *hcov1alpha1.HyperConverged, namespace str
 	}
 
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1597,7 +1594,7 @@ func (r *ReconcileHyperConverged) ensureKubeVirtStorageConfig(req *hcoRequest) (
 
 func newKubeVirtMetricsAggregationForCR(cr *hcov1alpha1.HyperConverged, namespace string) *sspv1.KubevirtMetricsAggregation {
 	labels := map[string]string{
-		appLabel: cr.Name,
+		hcoutil.AppLabel: cr.Name,
 	}
 	return &sspv1.KubevirtMetricsAggregation{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1684,8 +1681,8 @@ func (r *ReconcileHyperConverged) setLabels(req *hcoRequest) {
 	if req.instance.ObjectMeta.Labels == nil {
 		req.instance.ObjectMeta.Labels = map[string]string{}
 	}
-	if req.instance.ObjectMeta.Labels[appLabel] == "" {
-		req.instance.ObjectMeta.Labels[appLabel] = req.instance.Name
+	if req.instance.ObjectMeta.Labels[hcoutil.AppLabel] == "" {
+		req.instance.ObjectMeta.Labels[hcoutil.AppLabel] = req.instance.Name
 		req.dirty = true
 	}
 }
@@ -1792,36 +1789,13 @@ func componentResourceRemoval(o interface{}, c client.Client, req *hcoRequest) e
 	}
 
 	labels := resource.GetLabels()
-	if app, labelExists := labels[appLabel]; !labelExists || app != req.instance.Name {
+	if app, labelExists := labels[hcoutil.AppLabel]; !labelExists || app != req.instance.Name {
 		req.logger.Info("Existing resource wasn't deployed by HCO, ignoring", "Kind", resource.GetObjectKind())
 		return nil
 	}
 
 	err = c.Delete(req.ctx, resource)
 	return err
-}
-
-func ensureKubeVirtPriorityClassDeleted(c client.Client, req *hcoRequest) error {
-	pc := hcoutil.NewKubeVirtPriorityClass()
-	key, err := client.ObjectKeyFromObject(pc)
-	if err != nil {
-		req.logger.Error(err, "Failed to get object key for KubeVirt PriorityClass")
-		return err
-	}
-
-	found := &schedulingv1.PriorityClass{}
-	err = c.Get(req.ctx, key, found)
-
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			req.logger.Info("KubeVirt Priority Class resource doesn't exist, there is nothing to remove")
-			return nil
-		}
-		req.logger.Error(err, "Failed to get KubeVirt Priority Class from kubernetes")
-		return err
-	}
-
-	return componentResourceRemoval(found, c, req)
 }
 
 func ensureKubeVirtDeleted(c client.Client, req *hcoRequest) error {

--- a/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
@@ -43,7 +43,7 @@ var _ = Describe("HyperConverged Components", func() {
 		})
 
 		It("should create if not present", func() {
-			expectedResource := hcoutil.NewKubeVirtPriorityClass()
+			expectedResource := hcoutil.NewKubeVirtPriorityClass(hcov1alpha1.HyperConvergedName)
 			cl := initClient([]runtime.Object{})
 			r := initReconciler(cl)
 			upgradeDone, err := r.ensureKubeVirtPriorityClass(req)
@@ -60,7 +60,7 @@ var _ = Describe("HyperConverged Components", func() {
 		})
 
 		It("should do nothing if already exists", func() {
-			expectedResource := hcoutil.NewKubeVirtPriorityClass()
+			expectedResource := hcoutil.NewKubeVirtPriorityClass(hcov1alpha1.HyperConvergedName)
 			cl := initClient([]runtime.Object{expectedResource})
 			r := initReconciler(cl)
 			upgradeDone, err := r.ensureKubeVirtPriorityClass(req)
@@ -79,7 +79,7 @@ var _ = Describe("HyperConverged Components", func() {
 			Expect(upgradeDone).To(BeFalse())
 			Expect(err).To(BeNil())
 
-			expectedResource := hcoutil.NewKubeVirtPriorityClass()
+			expectedResource := hcoutil.NewKubeVirtPriorityClass(hcov1alpha1.HyperConvergedName)
 			key, err := client.ObjectKeyFromObject(expectedResource)
 			Expect(err).ToNot(HaveOccurred())
 			foundResource := &schedulingv1.PriorityClass{}
@@ -149,7 +149,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -268,7 +268,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -336,7 +336,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -485,7 +485,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -634,7 +634,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			Expect(foundResource.Spec.Multus).To(Equal(&networkaddonsv1alpha1.Multus{}))
 			Expect(foundResource.Spec.LinuxBridge).To(Equal(&networkaddonsv1alpha1.LinuxBridge{}))
@@ -764,7 +764,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -874,7 +874,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -1009,7 +1009,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -1133,7 +1133,7 @@ var _ = Describe("HyperConverged Components", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(appLabel, name))
+			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -28,6 +28,7 @@ import (
 
 	// networkaddonsnames "github.com/kubevirt/cluster-network-addons-operator/pkg/names"
 	hcov1alpha1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1alpha1"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
@@ -507,7 +508,7 @@ var _ = Describe("HyperconvergedController", func() {
 				foundResource, requeue := doReconcile(cl, expected.hco)
 				Expect(requeue).To(BeTrue())
 
-				Expect(foundResource.ObjectMeta.Labels[appLabel]).Should(Equal(hcov1alpha1.HyperConvergedName))
+				Expect(foundResource.ObjectMeta.Labels[hcoutil.AppLabel]).Should(Equal(hcov1alpha1.HyperConvergedName))
 			})
 
 			It("Should set required fields when missing", func() {
@@ -517,7 +518,7 @@ var _ = Describe("HyperconvergedController", func() {
 				foundResource, requeue := doReconcile(cl, expected.hco)
 				Expect(requeue).To(BeFalse())
 
-				Expect(foundResource.ObjectMeta.Labels[appLabel]).Should(Equal(hcov1alpha1.HyperConvergedName))
+				Expect(foundResource.ObjectMeta.Labels[hcoutil.AppLabel]).Should(Equal(hcov1alpha1.HyperConvergedName))
 			})
 		})
 

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -125,7 +125,7 @@ func getBasicDeployment() *basicExpected {
 	}
 	res.hco = hco
 
-	res.pc = hcoutil.NewKubeVirtPriorityClass()
+	res.pc = hcoutil.NewKubeVirtPriorityClass(hcov1alpha1.HyperConvergedName)
 	// These are all of the objects that we expect to "find" in the client because
 	// we already created them in a previous reconcile.
 	expectedKVConfig := newKubeVirtConfigForCR(hco, namespace)

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -12,4 +12,5 @@ const (
 	HppoVersionEnvV      = "HPPO_VERSION"
 	VMImportEnvV         = "VM_IMPORT_VERSION"
 	HcoValidatingWebhook = "validate-hco.kubevirt.io"
+	AppLabel             = "app"
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -99,14 +99,18 @@ func GetCSVfromPod(pod *corev1.Pod, c client.Client, logger logr.Logger) (*csvv1
 	return csv, nil
 }
 
-func NewKubeVirtPriorityClass() *schedulingv1.PriorityClass {
+func NewKubeVirtPriorityClass(crname string) *schedulingv1.PriorityClass {
+	labels := map[string]string{
+		AppLabel: crname,
+	}
 	return &schedulingv1.PriorityClass{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "scheduling.k8s.io/v1",
 			Kind:       "PriorityClass",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubevirt-cluster-critical",
+			Name:   "kubevirt-cluster-critical",
+			Labels: labels,
 		},
 		// 1 billion is the highest value we can set
 		// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
Avoid deleting KubeVirt Priority Class

KV Priority Class is needed to start virt-operator
but OLM is currently not able to create it so HCO
is trying to create it ASAP.
With #669
we are trying to create it as soon as HCO starts.
But, for the same reason, we should not trying to
delete it it when the user deletes HCO CR because
virt-operator should continue running even if HCO
CR got deleted.
In the past we were trying to delete the priority
class but we was failing on that just because we forgot
to set app label on that and componentResourceRemoval is
explictly checking for that before really deleting.

**Release note**:
```release-note
Avoid deleting KV Priority Class when the user deletes HCO CR
```

