### PR TITLE
Upgrade tests from arbitrary older releases

### DIFF
--- a/hack/upgrade-create-new-version.sh
+++ b/hack/upgrade-create-new-version.sh
@@ -18,7 +18,7 @@ set -ex
 
 DEPLOY_DIR="./deploy"
 PACKAGE_DIR="${DEPLOY_DIR}/olm-catalog/kubevirt-hyperconverged"
-LATEST_VERSION=$(ls -d ${PACKAGE_DIR}/*/ | sort -r | head -1 | cut -d '/' -f 5)
+LATEST_VERSION=$(ls -d ${PACKAGE_DIR}/*/ | sort -rV | head -1 | cut -d '/' -f 5)
 
 OPERATOR_NAME="kubevirt-hyperconverged-operator"
 LATEST_CSV_DIR="${PACKAGE_DIR}/${LATEST_VERSION}"

--- a/hack/upgrade-openshiftci-config
+++ b/hack/upgrade-openshiftci-config
@@ -3,7 +3,7 @@
 HCO_OPERATOR_IMAGE=`eval echo ${IMAGE_FORMAT}`
 CI_IMAGE_URL_PREFIX=$(echo $HCO_OPERATOR_IMAGE | cut -d ":" -f 1)
 echo "CI_IMAGE_URL_PREFIX: $CI_IMAGE_URL_PREFIX"
-REGISTRY_IMAGE="quay.io/kubevirt/hco-container-registry:latest" # TODO: handle a complex upgrade matrix
+REGISTRY_IMAGE="quay.io/kubevirt/hco-container-registry:latest"
 REGISTRY_IMAGE_UPGRADE="${CI_IMAGE_URL_PREFIX}:hco-registry-upgrade"
 REGISTRY_IMAGE_URL_PREFIX=$CI_IMAGE_URL_PREFIX
 HCO_CATALOG_NAMESPACE="openshift-marketplace"

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -43,6 +43,7 @@
 
 MAX_STEPS=8
 CUR_STEP=1
+RELEASE_DELTA="${RELEASE_DELTA:-1}"
 
 function Msg {
     { set +x; } 2>/dev/null
@@ -107,6 +108,9 @@ Msg "create catalogsource and subscription to install HCO"
 HCO_NAMESPACE="kubevirt-hyperconverged"
 HCO_KIND="hyperconvergeds"
 HCO_RESOURCE_NAME="kubevirt-hyperconverged"
+PACKAGE_DIR="./deploy/olm-catalog/kubevirt-hyperconverged"
+INITIAL_CHANNEL=$(ls -d ${PACKAGE_DIR}/*/ | sort -rV | awk "NR==$((RELEASE_DELTA+1))" | cut -d '/' -f 5)
+echo "INITIAL_CHANNEL: $INITIAL_CHANNEL"
 
 ${CMD} create ns ${HCO_NAMESPACE} | true
 ${CMD} get pods -n ${HCO_NAMESPACE}
@@ -129,6 +133,7 @@ metadata:
   name: hco-catalogsource-example
   namespace: ${HCO_CATALOG_NAMESPACE}
 spec:
+  channel: ${INITIAL_CHANNEL}
   sourceType: grpc
   image: ${REGISTRY_IMAGE}
   displayName: KubeVirt HyperConverged


### PR DESCRIPTION
Improve the upgrade test script to be able to start
from an arbitrary older release.

Use current - 1 as the default (sorting them with sort -rV).
We can use this to add more upgrade test lanes in the future.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Upgrade tests from arbitrary older releases
```

