### PR TITLE
[Release 2.4] Remove old SSP CRDs (#634)

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
-	"runtime"
-
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller"
+	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -17,6 +15,8 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
+	"os"
+	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
@@ -147,6 +147,7 @@ func main() {
 		sspopv1.AddToScheme,
 		csvv1alpha1.AddToScheme,
 		vmimportv1.AddToScheme,
+		securityv1.AddToScheme,
 	} {
 		if err := f(mgr.GetScheme()); err != nil {
 			log.Error(err, "Failed to add to scheme")

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/kubevirt/vm-import-operator v0.0.3
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.10.0
+	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca
 	github.com/operator-framework/api v0.3.5
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20200321030439-57b580e57e88

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -79,7 +79,7 @@ function status(){
       ${CMD} describe pod -n ${HCO_NAMESPACE} ${PNAME} || true
       ${CMD} logs -n ${HCO_NAMESPACE} ${PNAME} --all-containers=true || true
     done
-    HCO_POD=$( ${CMD} get pods -l "name=hostpath-provisioner-operator" -o name)
+    HCO_POD=$( ${CMD} get pods -l "name=hyperconverged-cluster-operator" -o name)
     ${CMD} logs "${HCO_POD}"
 }
 

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -79,6 +79,8 @@ function status(){
       ${CMD} describe pod -n ${HCO_NAMESPACE} ${PNAME} || true
       ${CMD} logs -n ${HCO_NAMESPACE} ${PNAME} --all-containers=true || true
     done
+    HCO_POD=$( ${CMD} get pods -l "name=hostpath-provisioner-operator" -o name)
+    ${CMD} logs "${HCO_POD}"
 }
 
 trap status EXIT

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -82,6 +82,11 @@ const (
 	hcoVersionName = "operator"
 
 	appLabel = "app"
+
+	commonTemplatesBundleOldCrdName = "kubevirtcommontemplatesbundles.kubevirt.io"
+	metricsAggregationOldCrdName    = "kubevirtmetricsaggregations.kubevirt.io"
+	nodeLabellerBundlesOldCrdName   = "kubevirtnodelabellerbundles.kubevirt.io"
+	templateValidatorsOldCrdName    = "kubevirttemplatevalidators.kubevirt.io"
 )
 
 // Add creates a new HyperConverged Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -104,6 +109,13 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		recorder:    mgr.GetEventRecorderFor(hcov1alpha1.HyperConvergedName),
 		upgradeMode: false,
 		ownVersion:  ownVersion,
+		clusterInfo: hcoutil.NewClusterInfo(mgr.GetClient()),
+		shouldRemoveOldCrd: map[string]bool{
+			commonTemplatesBundleOldCrdName: true,
+			metricsAggregationOldCrdName:    true,
+			nodeLabellerBundlesOldCrdName:   true,
+			templateValidatorsOldCrdName:    true,
+		},
 	}
 }
 
@@ -161,11 +173,13 @@ var _ reconcile.Reconciler = &ReconcileHyperConverged{}
 type ReconcileHyperConverged struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client      client.Client
-	scheme      *runtime.Scheme
-	recorder    record.EventRecorder
-	upgradeMode bool
-	ownVersion  string
+	client             client.Client
+	scheme             *runtime.Scheme
+	recorder           record.EventRecorder
+	upgradeMode        bool
+	ownVersion         string
+	clusterInfo        hcoutil.ClusterInfo
+	shouldRemoveOldCrd map[string]bool
 }
 
 // hcoRequest - gather data for a specific request
@@ -246,6 +260,10 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 }
 
 func (r *ReconcileHyperConverged) doReconcile(req *hcoRequest) (reconcile.Result, error) {
+
+	if err := r.clusterInfo.CheckRunningInOpenshift(req.ctx, req.logger); err != nil {
+		return reconcile.Result{}, err
+	}
 
 	valid, err := r.validateNamespace(req)
 	if !valid {
@@ -1225,6 +1243,11 @@ func newKubeVirtCommonTemplateBundleForCR(cr *hcov1alpha1.HyperConverged, namesp
 }
 
 func (r *ReconcileHyperConverged) ensureKubeVirtCommonTemplateBundle(req *hcoRequest) (upgradeDone bool, err error) {
+
+	if !r.clusterInfo.IsOpenshift() {
+		return true, nil
+	}
+
 	kvCTB := newKubeVirtCommonTemplateBundleForCR(req.instance, OpenshiftNamespace)
 
 	key, err := client.ObjectKeyFromObject(kvCTB)
@@ -1266,13 +1289,20 @@ func (r *ReconcileHyperConverged) ensureKubeVirtCommonTemplateBundle(req *hcoReq
 	}
 	objectreferencesv1.SetObjectReference(&req.instance.Status.RelatedObjects, *objectRef)
 
-	// TODO: temporary avoid checking conditions on KubevirtCommonTemplatesBundle because it's currently
-	// broken on k8s. Revert this when we will be able to fix it
-	// handleComponentConditions(r, req, "KubevirtCommonTemplatesBundle", found.Status.Conditions)
-	// TODO: temporary avoid checking upgrade because it's not implemented in KubevirtCommonTemplatesBundle
-	//req.componentUpgradeInProgress = req.componentUpgradeInProgress && r.checkComponentVersion(???, ???)
+	isReady := handleComponentConditions(r, req, "KubevirtCommonTemplatesBundle", found.Status.Conditions)
+
+	upgradeInProgress := false
+	if isReady {
+		upgradeInProgress = r.upgradeMode && r.checkComponentVersion(hcoutil.SspVersionEnvV, found.Status.ObservedVersion)
+		if (upgradeInProgress || !r.upgradeMode) && r.shouldRemoveOldCrd[commonTemplatesBundleOldCrdName] {
+			if r.removeCrd(req, commonTemplatesBundleOldCrdName) {
+				r.shouldRemoveOldCrd[commonTemplatesBundleOldCrdName] = false
+			}
+		}
+	}
 
 	req.statusDirty = true
+	req.componentUpgradeInProgress = req.componentUpgradeInProgress && upgradeInProgress
 	return req.componentUpgradeInProgress, nil
 }
 
@@ -1293,6 +1323,10 @@ func newKubeVirtNodeLabellerBundleForCR(cr *hcov1alpha1.HyperConverged, namespac
 }
 
 func (r *ReconcileHyperConverged) ensureKubeVirtNodeLabellerBundle(req *hcoRequest) (upgradeDone bool, err error) {
+	if !r.clusterInfo.IsOpenshift() {
+		return true, nil
+	}
+
 	kvNLB := newKubeVirtNodeLabellerBundleForCR(req.instance, req.Namespace)
 	if err = controllerutil.SetControllerReference(req.instance, kvNLB, r.scheme); err != nil {
 		return false, err
@@ -1323,9 +1357,20 @@ func (r *ReconcileHyperConverged) ensureKubeVirtNodeLabellerBundle(req *hcoReque
 	}
 	objectreferencesv1.SetObjectReference(&req.instance.Status.RelatedObjects, *objectRef)
 
-	// TODO: temporary avoid checking conditions on KubevirtNodeLabellerBundle because it's currently
-	// broken on k8s. Revert this when we will be able to fix it
-	//handleComponentConditions(r, req, "KubevirtNodeLabellerBundle", found.Status.Conditions)
+	isReady := handleComponentConditions(r, req, "KubevirtNodeLabellerBundle", found.Status.Conditions)
+
+	upgradeInProgress := false
+	if isReady {
+		upgradeInProgress = r.upgradeMode && r.checkComponentVersion(hcoutil.SspVersionEnvV, found.Status.ObservedVersion)
+		if (upgradeInProgress || !r.upgradeMode) && r.shouldRemoveOldCrd[nodeLabellerBundlesOldCrdName] {
+			if r.removeCrd(req, nodeLabellerBundlesOldCrdName) {
+				r.shouldRemoveOldCrd[nodeLabellerBundlesOldCrdName] = false
+			}
+		}
+	}
+
+	req.componentUpgradeInProgress = req.componentUpgradeInProgress && upgradeInProgress
+
 	req.statusDirty = true
 	return req.componentUpgradeInProgress, nil
 }
@@ -1459,6 +1504,10 @@ func newKubeVirtTemplateValidatorForCR(cr *hcov1alpha1.HyperConverged, namespace
 }
 
 func (r *ReconcileHyperConverged) ensureKubeVirtTemplateValidator(req *hcoRequest) (upgradeDone bool, err error) {
+	if !r.clusterInfo.IsOpenshift() {
+		return true, nil
+	}
+
 	kvTV := newKubeVirtTemplateValidatorForCR(req.instance, req.Namespace)
 	if err = controllerutil.SetControllerReference(req.instance, kvTV, r.scheme); err != nil {
 		return false, err
@@ -1489,12 +1538,19 @@ func (r *ReconcileHyperConverged) ensureKubeVirtTemplateValidator(req *hcoReques
 	}
 	objectreferencesv1.SetObjectReference(&req.instance.Status.RelatedObjects, *objectRef)
 
-	// TODO: temporary avoid checking conditions on KubevirtTemplateValidator because it's currently
-	// broken on k8s. Revert this when we will be able to fix it
-	// handleComponentConditions(r, req, "KubevirtTemplateValidator", found.Status.Conditions)
-	// TODO: temporary avoid checking upgrade because it's not implemented in KubevirtTemplateValidator
-	//req.componentUpgradeInProgress = req.componentUpgradeInProgress && r.checkComponentVersion(???, ???)
+	isReady := handleComponentConditions(r, req, "KubevirtTemplateValidator", found.Status.Conditions)
 
+	upgradeInProgress := false
+	if isReady {
+		upgradeInProgress = r.upgradeMode && r.checkComponentVersion(hcoutil.SspVersionEnvV, found.Status.ObservedVersion)
+		if (upgradeInProgress || !r.upgradeMode) && r.shouldRemoveOldCrd[templateValidatorsOldCrdName] {
+			if r.removeCrd(req, templateValidatorsOldCrdName) {
+				r.shouldRemoveOldCrd[templateValidatorsOldCrdName] = false
+			}
+		}
+	}
+
+	req.componentUpgradeInProgress = req.componentUpgradeInProgress && upgradeInProgress
 	req.statusDirty = true
 	return req.componentUpgradeInProgress, nil
 }
@@ -1570,6 +1626,10 @@ func newKubeVirtMetricsAggregationForCR(cr *hcov1alpha1.HyperConverged, namespac
 }
 
 func (r *ReconcileHyperConverged) ensureKubeVirtMetricsAggregation(req *hcoRequest) (upgradeDone bool, err error) {
+	if !r.clusterInfo.IsOpenshift() {
+		return true, nil
+	}
+
 	kubevirtMetricsAggregation := newKubeVirtMetricsAggregationForCR(req.instance, req.Namespace)
 	if err = controllerutil.SetControllerReference(req.instance, kubevirtMetricsAggregation, r.scheme); err != nil {
 		return false, err
@@ -1600,11 +1660,22 @@ func (r *ReconcileHyperConverged) ensureKubeVirtMetricsAggregation(req *hcoReque
 	}
 	objectreferencesv1.SetObjectReference(&req.instance.Status.RelatedObjects, *objectRef)
 
-	// TODO: we don't call handleComponentConditions because KubeVirtMetricsAggregation uses non-standard conditions
-	// fix this when KubeVirtMetricsAggregation will be ready for this
-	// TODO check KubeVirtMetricsAggregation version for upgrade
+	isReady := handleComponentConditions(r, req, "KubeVirtMetricsAggregation", found.Status.Conditions)
+
+	upgradeInProgress := false
+	if isReady {
+		upgradeInProgress = r.upgradeMode && r.checkComponentVersion(hcoutil.SspVersionEnvV, found.Status.ObservedVersion)
+		if (upgradeInProgress || !r.upgradeMode) && r.shouldRemoveOldCrd[metricsAggregationOldCrdName] {
+			if r.removeCrd(req, metricsAggregationOldCrdName) {
+				r.shouldRemoveOldCrd[metricsAggregationOldCrdName] = false
+			}
+		}
+	}
+
+	req.componentUpgradeInProgress = req.componentUpgradeInProgress && upgradeInProgress
 
 	req.statusDirty = true
+
 	return req.componentUpgradeInProgress, nil
 }
 
@@ -1634,7 +1705,34 @@ func (r *ReconcileHyperConverged) setLabels(req *hcoRequest) {
 		req.instance.ObjectMeta.Labels[appLabel] = req.instance.Name
 		req.dirty = true
 	}
+}
 
+// return true if not found or if deletion succeeded
+func (r *ReconcileHyperConverged) removeCrd(req *hcoRequest, crdName string) bool {
+	found := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "CustomResourceDefinition",
+			"apiVersion": "apiextensions.k8s.io/v1",
+		},
+	}
+	key := client.ObjectKey{Namespace: req.Namespace, Name: crdName}
+	err := r.client.Get(req.ctx, key, found)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			req.logger.Error(err, fmt.Sprintf("failed to read the %s CRD; %s", crdName, err.Error()))
+			return false
+		}
+	} else {
+		err = r.client.Delete(req.ctx, found)
+		if err != nil {
+			req.logger.Error(err, fmt.Sprintf("failed to remove the %s CRD; %s", crdName, err.Error()))
+			return false
+		} else {
+			req.logger.Info("successfully removed CRD", "CRD Name", crdName)
+		}
+	}
+
+	return true
 }
 
 func isKVMAvailable() bool {

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os"
@@ -1351,28 +1352,25 @@ var _ = Describe("HyperconvergedController", func() {
 					Reason:  reconcileCompleted,
 					Message: reconcileCompletedMessage,
 				})))
-				// TODO: temporary ignoring KubevirtTemplateValidator conditions
-				/*
-					// Why Template validator? Because it is the last to be checked, so the last missing overwrites everything
-					Expect(foundResource.Status.Conditions).To(ContainElement(testlib.RepresentCondition(conditionsv1.Condition{
-						Type:    conditionsv1.ConditionAvailable,
-						Status:  corev1.ConditionFalse,
-						Reason:  "KubevirtTemplateValidatorConditions",
-						Message: "KubevirtTemplateValidator resource has no conditions",
-					})))
-					Expect(foundResource.Status.Conditions).To(ContainElement(testlib.RepresentCondition(conditionsv1.Condition{
-						Type:    conditionsv1.ConditionProgressing,
-						Status:  corev1.ConditionTrue,
-						Reason:  "KubevirtTemplateValidatorConditions",
-						Message: "KubevirtTemplateValidator resource has no conditions",
-					})))
-					Expect(foundResource.Status.Conditions).To(ContainElement(testlib.RepresentCondition(conditionsv1.Condition{
-						Type:    conditionsv1.ConditionUpgradeable,
-						Status:  corev1.ConditionFalse,
-						Reason:  "KubevirtTemplateValidatorConditions",
-						Message: "KubevirtTemplateValidator resource has no conditions",
-					})))
-				*/
+				// Why Template validator? Because it is the last to be checked, so the last missing overwrites everything
+				Expect(foundResource.Status.Conditions).To(ContainElement(testlib.RepresentCondition(conditionsv1.Condition{
+					Type:    conditionsv1.ConditionAvailable,
+					Status:  corev1.ConditionFalse,
+					Reason:  "KubevirtTemplateValidatorConditions",
+					Message: "KubevirtTemplateValidator resource has no conditions",
+				})))
+				Expect(foundResource.Status.Conditions).To(ContainElement(testlib.RepresentCondition(conditionsv1.Condition{
+					Type:    conditionsv1.ConditionProgressing,
+					Status:  corev1.ConditionTrue,
+					Reason:  "KubevirtTemplateValidatorConditions",
+					Message: "KubevirtTemplateValidator resource has no conditions",
+				})))
+				Expect(foundResource.Status.Conditions).To(ContainElement(testlib.RepresentCondition(conditionsv1.Condition{
+					Type:    conditionsv1.ConditionUpgradeable,
+					Status:  corev1.ConditionFalse,
+					Reason:  "KubevirtTemplateValidatorConditions",
+					Message: "KubevirtTemplateValidator resource has no conditions",
+				})))
 			})
 
 			It("should complete when components are finished", func() {
@@ -1549,56 +1547,44 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(requeue).To(BeFalse())
 				checkAvailability(foundResource, corev1.ConditionTrue)
 
-				// TODO: temporary avoid checking conditions on KubevirtCommonTemplatesBundle because it's currently
-				// broken on k8s. Revert this when we will be able to fix it
-				/*
-					origConds = expected.kvCtb.Status.Conditions
-					expected.kvCtb.Status.Conditions = expected.cdi.Status.Conditions[1:]
-					cl = expected.initClient()
-					foundResource, requeue = doReconcile(cl, expected.hco)
-					Expect(requeue).To(BeFalse())
-					checkAvailability(foundResource, corev1.ConditionFalse)
+				origConds = expected.kvCtb.Status.Conditions
+				expected.kvCtb.Status.Conditions = expected.cdi.Status.Conditions[1:]
+				cl = expected.initClient()
+				foundResource, requeue = doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeFalse())
+				checkAvailability(foundResource, corev1.ConditionFalse)
 
-					expected.kvCtb.Status.Conditions = origConds
-					cl = expected.initClient()
-					foundResource, requeue = doReconcile(cl, expected.hco)
-					Expect(requeue).To(BeFalse())
-					checkAvailability(foundResource, corev1.ConditionTrue)
-				*/
+				expected.kvCtb.Status.Conditions = origConds
+				cl = expected.initClient()
+				foundResource, requeue = doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeFalse())
+				checkAvailability(foundResource, corev1.ConditionTrue)
 
-				// TODO: temporary avoid checking conditions on KubevirtNodeLabellerBundle because it's currently
-				// broken on k8s. Revert this when we will be able to fix it
-				/*
-					origConds = expected.kvNlb.Status.Conditions
-					expected.kvNlb.Status.Conditions = expected.cdi.Status.Conditions[1:]
-					cl = expected.initClient()
-					foundResource, requeue = doReconcile(cl, expected.hco)
-					Expect(requeue).To(BeFalse())
-					checkAvailability(foundResource, corev1.ConditionFalse)
+				origConds = expected.kvNlb.Status.Conditions
+				expected.kvNlb.Status.Conditions = expected.cdi.Status.Conditions[1:]
+				cl = expected.initClient()
+				foundResource, requeue = doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeFalse())
+				checkAvailability(foundResource, corev1.ConditionFalse)
 
-					expected.kvNlb.Status.Conditions = origConds
-					cl = expected.initClient()
-					foundResource, requeue = doReconcile(cl, expected.hco)
-					Expect(requeue).To(BeFalse())
-					checkAvailability(foundResource, corev1.ConditionTrue)
-				*/
+				expected.kvNlb.Status.Conditions = origConds
+				cl = expected.initClient()
+				foundResource, requeue = doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeFalse())
+				checkAvailability(foundResource, corev1.ConditionTrue)
 
-				// TODO: temporary avoid checking conditions on KubevirtTemplateValidator because it's currently
-				// broken on k8s. Revert this when we will be able to fix it
-				/*
-					origConds = expected.kvTv.Status.Conditions
-					expected.kvTv.Status.Conditions = expected.cdi.Status.Conditions[1:]
-					cl = expected.initClient()
-					foundResource, requeue = doReconcile(cl, expected.hco)
-					Expect(requeue).To(BeFalse())
-					checkAvailability(foundResource, corev1.ConditionFalse)
+				origConds = expected.kvTv.Status.Conditions
+				expected.kvTv.Status.Conditions = expected.cdi.Status.Conditions[1:]
+				cl = expected.initClient()
+				foundResource, requeue = doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeFalse())
+				checkAvailability(foundResource, corev1.ConditionFalse)
 
-					expected.kvTv.Status.Conditions = origConds
-					cl = expected.initClient()
-					foundResource, requeue = doReconcile(cl, expected.hco)
-					Expect(requeue).To(BeFalse())
-					checkAvailability(foundResource, corev1.ConditionTrue)
-				*/
+				expected.kvTv.Status.Conditions = origConds
+				cl = expected.initClient()
+				foundResource, requeue = doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeFalse())
+				checkAvailability(foundResource, corev1.ConditionTrue)
 			})
 
 			It(`should delete HCO`, func() {
@@ -1706,6 +1692,12 @@ var _ = Describe("HyperconvergedController", func() {
 
 				expected.vmi.Status.ObservedVersion = newComponentVersion
 				os.Setenv(util.VMImportEnvV, newComponentVersion)
+
+				os.Setenv(util.SspVersionEnvV, newComponentVersion)
+				expected.kvCtb.Status.ObservedVersion = newComponentVersion
+				expected.kvNlb.Status.ObservedVersion = newComponentVersion
+				expected.kvTv.Status.ObservedVersion = newComponentVersion
+				expected.kvMtAg.Status.ObservedVersion = newComponentVersion
 
 				os.Setenv(util.HcoKvIoVersionName, newVersion)
 
@@ -2541,5 +2533,15 @@ func initReconciler(client client.Client) *ReconcileHyperConverged {
 	}
 
 	// Create a ReconcileHyperConverged object with the scheme and fake client
-	return &ReconcileHyperConverged{client: client, scheme: s}
+	return &ReconcileHyperConverged{client: client, scheme: s, clusterInfo: &clusterInfoMock{}}
+}
+
+type clusterInfoMock struct{}
+
+func (clusterInfoMock) CheckRunningInOpenshift(_ context.Context, _ logr.Logger) error {
+	return nil
+}
+
+func (clusterInfoMock) IsOpenshift() bool {
+	return true
 }

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	securityv1 "github.com/openshift/api/security/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ClusterInfo interface {
+	CheckRunningInOpenshift(ctx context.Context, logger logr.Logger) error
+	IsOpenshift() bool
+}
+
+type ClusterInfoImp struct {
+	client             client.Reader
+	firstTime          bool
+	runningInOpenshift bool
+}
+
+func NewClusterInfo(c client.Reader) ClusterInfo {
+	return &ClusterInfoImp{
+		client:             c,
+		firstTime:          true,
+		runningInOpenshift: false,
+	}
+}
+
+func (c *ClusterInfoImp) CheckRunningInOpenshift(ctx context.Context, logger logr.Logger) error {
+	if !c.firstTime {
+		return nil
+	}
+
+	scc := &securityv1.SecurityContextConstraintsList{}
+
+	err := c.client.List(ctx, scc)
+	clusterType := ""
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			c.runningInOpenshift = false
+			clusterType = "kubernetes"
+		} else {
+			logger.Error(err, "failed to read SecurityContextConstraints")
+			return err
+		}
+	} else {
+		c.runningInOpenshift = true
+		clusterType = "openshift"
+	}
+
+	logger.Info("Cluster type = " + clusterType)
+	c.firstTime = false
+
+	return nil
+}
+
+func (c ClusterInfoImp) IsOpenshift() bool {
+	return c.runningInOpenshift
+}


### PR DESCRIPTION
* Check SSP conditions and versions, but only if running in an openshift cluster
* Remove the old SSP CRDs on completion of upgrade or upon successful deployment

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Check SSP conditions and versions, but only if running in an openshift cluster.
Remove the old SSP CRDs on completion of upgrade or upon successful deployment
```

