### PR TITLE
[release-2.4] Create a PriorityClass for KubeVirt on startup (#669)

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -873,26 +873,9 @@ func newKubeVirtForCR(cr *hcov1alpha1.HyperConverged, namespace string) *kubevir
 	}
 }
 
-func newKubeVirtPriorityClass() *schedulingv1.PriorityClass {
-	return &schedulingv1.PriorityClass{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "scheduling.k8s.io/v1",
-			Kind:       "PriorityClass",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubevirt-cluster-critical",
-		},
-		// 1 billion is the highest value we can set
-		// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-		Value:         1000000000,
-		GlobalDefault: false,
-		Description:   "This priority class should be used for KubeVirt core components only.",
-	}
-}
-
 func (r *ReconcileHyperConverged) ensureKubeVirtPriorityClass(req *hcoRequest) (upgradeDone bool, err error) {
 	req.logger.Info("Reconciling KubeVirt PriorityClass")
-	pc := newKubeVirtPriorityClass()
+	pc := hcoutil.NewKubeVirtPriorityClass()
 
 	key, err := client.ObjectKeyFromObject(pc)
 	if err != nil {
@@ -1819,7 +1802,7 @@ func componentResourceRemoval(o interface{}, c client.Client, req *hcoRequest) e
 }
 
 func ensureKubeVirtPriorityClassDeleted(c client.Client, req *hcoRequest) error {
-	pc := newKubeVirtPriorityClass()
+	pc := hcoutil.NewKubeVirtPriorityClass()
 	key, err := client.ObjectKeyFromObject(pc)
 	if err != nil {
 		req.logger.Error(err, "Failed to get object key for KubeVirt PriorityClass")

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -96,7 +96,7 @@ var _ = Describe("HyperconvergedController", func() {
 			})
 
 			It("should create if not present", func() {
-				expectedResource := newKubeVirtPriorityClass()
+				expectedResource := util.NewKubeVirtPriorityClass()
 				cl := initClient([]runtime.Object{})
 				r := initReconciler(cl)
 				upgradeDone, err := r.ensureKubeVirtPriorityClass(req)
@@ -113,7 +113,7 @@ var _ = Describe("HyperconvergedController", func() {
 			})
 
 			It("should do nothing if already exists", func() {
-				expectedResource := newKubeVirtPriorityClass()
+				expectedResource := util.NewKubeVirtPriorityClass()
 				cl := initClient([]runtime.Object{expectedResource})
 				r := initReconciler(cl)
 				upgradeDone, err := r.ensureKubeVirtPriorityClass(req)
@@ -132,7 +132,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(upgradeDone).To(BeFalse())
 				Expect(err).To(BeNil())
 
-				expectedResource := newKubeVirtPriorityClass()
+				expectedResource := util.NewKubeVirtPriorityClass()
 				key, err := client.ObjectKeyFromObject(expectedResource)
 				Expect(err).ToNot(HaveOccurred())
 				foundResource := &schedulingv1.PriorityClass{}
@@ -2380,7 +2380,7 @@ func getBasicDeployment() *basicExpected {
 	}
 	res.hco = hco
 
-	res.pc = newKubeVirtPriorityClass()
+	res.pc = util.NewKubeVirtPriorityClass()
 	// These are all of the objects that we expect to "find" in the client because
 	// we already created them in a previous reconcile.
 	expectedKVConfig := newKubeVirtConfigForCR(hco, namespace)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -5,14 +5,16 @@ import (
 	"fmt"
 
 	"errors"
+	"os"
+
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	csvv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -95,4 +97,21 @@ func GetCSVfromPod(pod *corev1.Pod, c client.Client, logger logr.Logger) (*csvv1
 	}
 
 	return csv, nil
+}
+
+func NewKubeVirtPriorityClass() *schedulingv1.PriorityClass {
+	return &schedulingv1.PriorityClass{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "scheduling.k8s.io/v1",
+			Kind:       "PriorityClass",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubevirt-cluster-critical",
+		},
+		// 1 billion is the highest value we can set
+		// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+		Value:         1000000000,
+		GlobalDefault: false,
+		Description:   "This priority class should be used for KubeVirt core components only.",
+	}
 }


### PR DESCRIPTION
Until now, the PriorityClass for KubeVirt was created during
reconciliation (after creating the CR for the HCO).  This caused the
virt-operator to exit with a FailedCreate status, and the CSV to stay in
a Failed status.
This patch creates the PriorityClass when the HCO starts, allowing the
virt-operator to be installed properly and the CSV's status to change to
Succeeded.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Create KubeVirt's PriorityClass when HCO starts (BZ#1851856)
```

