### PR TITLE
Simplify ensureKubeVirtStorageConfig

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -475,7 +475,6 @@ func (r *ReconcileHyperConverged) ensureHco(req *hcoRequest) error {
 	for _, f := range []func(*hcoRequest) (upgradeDone bool, err error){
 		r.ensureKubeVirtPriorityClass,
 		r.ensureKubeVirtConfig,
-		r.ensureKubeVirtStorageConfig,
 		r.ensureKubeVirt,
 		r.ensureCDI,
 		r.ensureNetworkAddons,
@@ -957,6 +956,11 @@ func (r *ReconcileHyperConverged) ensureCDI(req *hcoRequest) (upgradeDone bool, 
 	}
 
 	req.logger.Info("CDI already exists", "CDI.Namespace", found.Namespace, "CDI.Name", found.Name)
+
+	err = r.ensureKubeVirtStorageConfig(req)
+	if err != nil {
+		return false, err
+	}
 
 	err = r.ensureKubeVirtStorageRole(req)
 	if err != nil {
@@ -1604,10 +1608,10 @@ func (r *ReconcileHyperConverged) ensureKubeVirtStorageRoleBinding(req *hcoReque
 	return nil
 }
 
-func (r *ReconcileHyperConverged) ensureKubeVirtStorageConfig(req *hcoRequest) (upgradeDone bool, err error) {
+func (r *ReconcileHyperConverged) ensureKubeVirtStorageConfig(req *hcoRequest) error {
 	kubevirtStorageConfig := newKubeVirtStorageConfigForCR(req.instance, req.Namespace)
-	if err = controllerutil.SetControllerReference(req.instance, kubevirtStorageConfig, r.scheme); err != nil {
-		return false, err
+	if err := controllerutil.SetControllerReference(req.instance, kubevirtStorageConfig, r.scheme); err != nil {
+		return err
 	}
 
 	key, err := client.ObjectKeyFromObject(kubevirtStorageConfig)
@@ -1619,22 +1623,22 @@ func (r *ReconcileHyperConverged) ensureKubeVirtStorageConfig(req *hcoRequest) (
 	err = r.client.Get(req.ctx, key, found)
 	if err != nil && apierrors.IsNotFound(err) {
 		req.logger.Info("Creating kubevirt storage config")
-		return false, r.client.Create(req.ctx, kubevirtStorageConfig)
+		return r.client.Create(req.ctx, kubevirtStorageConfig)
 	}
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	req.logger.Info("KubeVirt storage config already exists", "KubeVirtConfig.Namespace", found.Namespace, "KubeVirtConfig.Name", found.Name)
 	// Add it to the list of RelatedObjects if found
 	objectRef, err := reference.GetReference(r.scheme, found)
 	if err != nil {
-		return false, err
+		return err
 	}
 	objectreferencesv1.SetObjectReference(&req.instance.Status.RelatedObjects, *objectRef)
 
-	return req.componentUpgradeInProgress, nil
+	return nil
 }
 
 func newKubeVirtMetricsAggregationForCR(cr *hcov1alpha1.HyperConverged, namespace string) *sspv1.KubevirtMetricsAggregation {

--- a/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
@@ -257,8 +257,7 @@ var _ = Describe("HyperConverged Components", func() {
 			expectedResource := newKubeVirtStorageConfigForCR(hco, namespace)
 			cl := initClient([]runtime.Object{})
 			r := initReconciler(cl)
-			upgradeDone, err := r.ensureKubeVirtStorageConfig(req)
-			Expect(upgradeDone).To(BeFalse())
+			err := r.ensureKubeVirtStorageConfig(req)
 			Expect(err).To(BeNil())
 
 			foundResource := &corev1.ConfigMap{}
@@ -277,8 +276,7 @@ var _ = Describe("HyperConverged Components", func() {
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := initClient([]runtime.Object{hco, expectedResource})
 			r := initReconciler(cl)
-			upgradeDone, err := r.ensureKubeVirtStorageConfig(req)
-			Expect(upgradeDone).To(BeFalse())
+			err := r.ensureKubeVirtStorageConfig(req)
 			Expect(err).To(BeNil())
 
 			// Check HCO's status


### PR DESCRIPTION
As discussed in #498, this function only has upgrade logic because it's called by reconcile.
By calling it from ensureCDI we can drop the upgrade logic.

Catch up with this signature in tests.

**Release note**:
```release-note
NONE
```

