### PR TITLE
Change the method to detect cluster type

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -178,8 +178,14 @@ func main() {
 		}
 	}
 
+	ci := hcoutil.GetClusterInfo()
+	err = ci.CheckRunningInOpenshift(log, runInLocal)
+	if err != nil {
+		log.Error(err, "Cannot detect cluster type")
+	}
+
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr); err != nil {
+	if err := controller.AddToManager(mgr, ci); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,16 +1,17 @@
 package controller
 
 import (
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []func(manager.Manager, hcoutil.ClusterInfo) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, ci hcoutil.ClusterInfo) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(m, ci); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -172,7 +172,6 @@ type ReconcileHyperConverged struct {
 	ownVersion         string
 	clusterInfo        hcoutil.ClusterInfo
 	shouldRemoveOldCrd map[string]bool
-	runLocally         bool
 }
 
 // hcoRequest - gather data for a specific request

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -83,12 +83,12 @@ const (
 
 // Add creates a new HyperConverged Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+func Add(mgr manager.Manager, ci hcoutil.ClusterInfo) error {
+	return add(mgr, newReconciler(mgr, ci))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo) reconcile.Reconciler {
 
 	ownVersion := os.Getenv(hcoutil.HcoKvIoVersionName)
 	if ownVersion == "" {
@@ -101,7 +101,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		recorder:    mgr.GetEventRecorderFor(hcov1alpha1.HyperConvergedName),
 		upgradeMode: false,
 		ownVersion:  ownVersion,
-		clusterInfo: hcoutil.NewClusterInfo(mgr.GetClient()),
+		clusterInfo: ci,
 		shouldRemoveOldCrd: map[string]bool{
 			commonTemplatesBundleOldCrdName: true,
 			metricsAggregationOldCrdName:    true,
@@ -172,6 +172,7 @@ type ReconcileHyperConverged struct {
 	ownVersion         string
 	clusterInfo        hcoutil.ClusterInfo
 	shouldRemoveOldCrd map[string]bool
+	runLocally         bool
 }
 
 // hcoRequest - gather data for a specific request
@@ -252,10 +253,6 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 }
 
 func (r *ReconcileHyperConverged) doReconcile(req *hcoRequest) (reconcile.Result, error) {
-
-	if err := r.clusterInfo.CheckRunningInOpenshift(req.ctx, req.logger); err != nil {
-		return reconcile.Result{}, err
-	}
 
 	valid, err := r.validateNamespace(req)
 	if !valid {

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -294,10 +294,14 @@ func initReconciler(client client.Client) *ReconcileHyperConverged {
 
 type clusterInfoMock struct{}
 
-func (clusterInfoMock) CheckRunningInOpenshift(_ context.Context, _ logr.Logger) error {
+func (clusterInfoMock) CheckRunningInOpenshift(_ logr.Logger, _ bool) error {
 	return nil
 }
 
 func (clusterInfoMock) IsOpenshift() bool {
 	return true
+}
+
+func (clusterInfoMock) IsRunningLocally() bool {
+	return false
 }

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -1,50 +1,66 @@
 package util
 
 import (
-	"context"
+	"errors"
 	"github.com/go-logr/logr"
-	securityv1 "github.com/openshift/api/security/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	secv1 "github.com/openshift/api/security/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	"kubevirt.io/client-go/kubecli"
+	"os"
+	"strings"
 )
 
 type ClusterInfo interface {
-	CheckRunningInOpenshift(ctx context.Context, logger logr.Logger) error
+	CheckRunningInOpenshift(logger logr.Logger, runningLocally bool) error
 	IsOpenshift() bool
+	IsRunningLocally() bool
 }
 
 type ClusterInfoImp struct {
-	client             client.Reader
 	firstTime          bool
 	runningInOpenshift bool
+	runningLocally     bool
 }
 
-func NewClusterInfo(c client.Reader) ClusterInfo {
-	return &ClusterInfoImp{
-		client:             c,
-		firstTime:          true,
-		runningInOpenshift: false,
-	}
+var clusterInfo ClusterInfo
+
+func GetClusterInfo() ClusterInfo {
+	return clusterInfo
 }
 
-func (c *ClusterInfoImp) CheckRunningInOpenshift(ctx context.Context, logger logr.Logger) error {
+func (c *ClusterInfoImp) CheckRunningInOpenshift(logger logr.Logger, runningLocally bool) error {
+
 	if !c.firstTime {
 		return nil
 	}
 
-	scc := &securityv1.SecurityContextConstraintsList{}
+	c.runningLocally = runningLocally
 
-	err := c.client.List(ctx, scc)
-	clusterType := ""
+	virtCli, err := c.getKubevirtClient(logger, runningLocally)
 	if err != nil {
-		if meta.IsNoMatchError(err) {
-			c.runningInOpenshift = false
-			clusterType = "kubernetes"
-		} else {
-			logger.Error(err, "failed to read SecurityContextConstraints")
+		return err
+	}
+
+	c.runningInOpenshift = false
+	clusterType := "kubernetes"
+
+	_, apis, err := virtCli.DiscoveryClient().ServerGroupsAndResources()
+	if err != nil {
+		if !discovery.IsGroupDiscoveryFailedError(err) {
+			logger.Error(err, "failed to get ServerGroupsAndResources")
 			return err
+		} else if discovery.IsGroupDiscoveryFailedError(err) {
+			// In case of an error, check if security.openshift.io is the reason (unlikely).
+			// If it is, we are obviously on an openshift cluster.
+			// Otherwise we can do a positive check.
+			e := err.(*discovery.ErrGroupDiscoveryFailed)
+			if _, exists := e.Groups[secv1.GroupVersion]; exists {
+				c.runningInOpenshift = true
+				clusterType = "openshift"
+			}
 		}
-	} else {
+	} else if c.findApi(apis, "securitycontextconstraints") {
 		c.runningInOpenshift = true
 		clusterType = "openshift"
 	}
@@ -55,6 +71,62 @@ func (c *ClusterInfoImp) CheckRunningInOpenshift(ctx context.Context, logger log
 	return nil
 }
 
+func (c *ClusterInfoImp) getKubevirtClient(logger logr.Logger, runningLocally bool) (kubecli.KubevirtClient, error) {
+	var (
+		virtCli kubecli.KubevirtClient
+		err     error
+	)
+
+	kubecli.Init()
+	if runningLocally {
+		kubeconfig, ok := os.LookupEnv("KUBECONFIG")
+		if ok {
+			virtCli, err = kubecli.GetKubevirtClientFromFlags("", kubeconfig)
+			if err != nil {
+				logger.Error(err, "failed to get KubevirtClient From Flags", "kubeconfig", kubeconfig)
+				return nil, err
+			}
+		} else {
+			const errMsg = "KUBECONFIG environment variable is not defined"
+			err = errors.New(errMsg)
+			logger.Error(err, errMsg)
+			return nil, err
+		}
+	} else {
+		virtCli, err = kubecli.GetKubevirtClient()
+		if err != nil {
+			logger.Error(err, "failed to get KubevirtClient")
+			return nil, err
+		}
+	}
+	return virtCli, nil
+}
+
 func (c ClusterInfoImp) IsOpenshift() bool {
 	return c.runningInOpenshift
+}
+
+func (c ClusterInfoImp) IsRunningLocally() bool {
+	return c.runningLocally
+}
+
+func (c ClusterInfoImp) findApi(apis []*metav1.APIResourceList, resourceName string) bool {
+	for _, api := range apis {
+		if api.GroupVersion == secv1.GroupVersion.String() {
+			for _, resource := range api.APIResources {
+				if strings.ToLower(resource.Name) == resourceName {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func init() {
+	clusterInfo = &ClusterInfoImp{
+		firstTime:          true,
+		runningInOpenshift: false,
+	}
 }


### PR DESCRIPTION
Adopt kubevirt's method to detect cluster type

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

