### PR TITLE
Make the default binding mechanism to  be Masquerade

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
@@ -124,7 +124,7 @@ var _ = Describe("HyperConverged Components", func() {
 		var req *hcoRequest
 
 		updatableKeys := [...]string{virtconfig.SmbiosConfigKey, virtconfig.MachineTypeKey, virtconfig.SELinuxLauncherTypeKey}
-		unupdatableKeys := [...]string{virtconfig.FeatureGatesKey, virtconfig.MigrationsConfigKey}
+		unupdatableKeys := [...]string{virtconfig.FeatureGatesKey, virtconfig.MigrationsConfigKey, virtconfig.NetworkInterfaceKey}
 
 		BeforeEach(func() {
 			hco = newHco()
@@ -182,6 +182,7 @@ var _ = Describe("HyperConverged Components", func() {
 			// values we should preserve
 			outdatedResource.Data[virtconfig.FeatureGatesKey] = "old-featuregates-value-that-we-should-preserve"
 			outdatedResource.Data[virtconfig.MigrationsConfigKey] = "old-migrationsconfig-value-that-we-should-preserve"
+			outdatedResource.Data[virtconfig.NetworkInterfaceKey] = "old-defaultnetworkinterface-value-that-we-should-preserve"
 
 			cl := initClient([]runtime.Object{hco, outdatedResource})
 			r := initReconciler(cl)
@@ -221,6 +222,7 @@ var _ = Describe("HyperConverged Components", func() {
 			// values we should preserve
 			outdatedResource.Data[virtconfig.FeatureGatesKey] = "old-featuregates-value-that-we-should-preserve"
 			outdatedResource.Data[virtconfig.MigrationsConfigKey] = "old-migrationsconfig-value-that-we-should-preserve"
+			outdatedResource.Data[virtconfig.DefaultNetworkInterface] = "old-defaultnetworkinterface-value-that-we-should-preserve"
 
 			cl := initClient([]runtime.Object{hco, outdatedResource})
 			r := initReconciler(cl)


### PR DESCRIPTION
Make the default binding mechanism to be `masquerade`

Since HCO's focus are legacy workloads where live migration is a common practice,
It is required to encourage  the use of `masquerade` binding over bridge.
However, the `bridge` binding is still available and it is even the default,
which sometimes makes the usage confusing for users.
That's why we would like `masquerade` to be our default binding mechanism.

This PR injects `masquerade` value to the default network interface field in kubevirt configMap.
Then this value will be used when installing kubevirt, thus making masquerade as the
default binding mechanism.

another thing changed in this PR is to make the controller to
to vendor the configMap keys and not hardcode them.
Signed-off-by: alonSadan <asadan@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose kubevirt default network interface in HCO-CR, give it a value of `masquerade` and pass it to kubevirt configMap 
```

