### PR TITLE
Fix BZ 1856447

### DIFF
--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -3,6 +3,7 @@ package hyperconverged
 import (
 	"context"
 	"fmt"
+	"github.com/operator-framework/operator-sdk/pkg/ready"
 	"os"
 
 	sspopv1 "github.com/MarSik/kubevirt-ssp-operator/pkg/apis"
@@ -304,4 +305,16 @@ func (clusterInfoMock) IsOpenshift() bool {
 
 func (clusterInfoMock) IsRunningLocally() bool {
 	return false
+}
+
+func checkHcoReady() (bool, error) {
+	_, err := os.Stat(ready.FileName)
+
+	if err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, err
 }

--- a/tools/operator-courier/Dockerfile
+++ b/tools/operator-courier/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/python-36
 
-RUN pip3 install operator-courier
+RUN pip3 install --upgrade operator-courier==2.1.7
 COPY deploy/olm-catalog/kubevirt-hyperconverged /manifests
 
 RUN operator-courier verify --ui_validate_io /manifests


### PR DESCRIPTION
Fix error that if all the components are running, but not all of them are with the latest version, HCO reports "ready" but it should not.

This fix make sure that HCO only set ready for successful upgrade, when all the operators are with the right version

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug 1856447
```

