### PR TITLE
[Release 2.4] fix BZ 1856447

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -715,6 +715,9 @@ func (r *ReconcileHyperConverged) aggregateComponentConditions(req *hcoRequest) 
 
 func (r *ReconcileHyperConverged) completeReconciliation(req *hcoRequest) error {
 	allComponentsAreUp := r.aggregateComponentConditions(req)
+
+	hcoReady := false
+
 	if allComponentsAreUp {
 		req.logger.Info("No component operator reported negatively")
 
@@ -732,22 +735,9 @@ func (r *ReconcileHyperConverged) completeReconciliation(req *hcoRequest) error 
 			req.logger.Info(fmt.Sprintf("Successfuly upgraded to version %s", r.ownVersion))
 		}
 
-		// If no operator whose conditions we are watching reports an error, then it is safe
-		// to set readiness.
-		r := ready.NewFileReady()
-		err := r.Set()
-		if err != nil {
-			req.logger.Error(err, "Failed to mark operator ready")
-			return err
-		}
-	} else if cond, conditionFound := req.conditions[conditionsv1.ConditionUpgradeable]; conditionFound && cond.Status == corev1.ConditionFalse {
-		// If for any reason we marked ourselves !upgradeable...then unset readiness
-		r := ready.NewFileReady()
-		err := r.Unset()
-		if err != nil {
-			req.logger.Error(err, "Failed to mark operator unready")
-			return err
-		}
+		// If not in upgrade mode, then we're ready, because all the operators reported positive conditions.
+		// if upgrade was done successfully, r.upgradeMode is already false here.
+		hcoReady = !r.upgradeMode
 	}
 
 	if r.upgradeMode {
@@ -758,6 +748,24 @@ func (r *ReconcileHyperConverged) completeReconciliation(req *hcoRequest) error 
 			Reason:  "HCOUpgrading",
 			Message: "HCO is now upgrading to version " + r.ownVersion,
 		})
+	}
+
+	fr := ready.NewFileReady()
+	if hcoReady {
+		// If no operator whose conditions we are watching reports an error, then it is safe
+		// to set readiness.
+		err := fr.Set()
+		if err != nil {
+			req.logger.Error(err, "Failed to mark operator ready")
+			return err
+		}
+	} else {
+		// If for any reason we marked ourselves !upgradeable...then unset readiness
+		err := fr.Unset()
+		if err != nil {
+			req.logger.Error(err, "Failed to mark operator unready")
+			return err
+		}
 	}
 
 	return r.updateConditions(req)

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/go-logr/logr"
+	"github.com/operator-framework/operator-sdk/pkg/ready"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os"
@@ -1824,8 +1825,32 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cond.Reason).Should(Equal("HCOUpgrading"))
 				Expect(cond.Message).Should(Equal("HCO is now upgrading to version " + newVersion))
 
-				// now, complete the upgrade
+				hcoReady, err := checkHcoReady()
+				Expect(err).To(BeNil())
+				Expect(hcoReady).To(BeFalse())
+
+				// check that the upgrade is not done if the not all the versions are match.
+				// Conditions are valid
 				expected.cdi.Status.Conditions = getGenericCompletedConditions()
+				cl = expected.initClient()
+				foundResource, requeue = doReconcile(cl, expected.hco)
+				Expect(requeue).To(BeFalse())
+				checkAvailability(foundResource, corev1.ConditionTrue)
+
+				// check that the image Id is set, now, when upgrade is completed
+				ver, ok = foundResource.Status.GetVersion(hcoVersionName)
+				Expect(ok).To(BeTrue())
+				Expect(ver).Should(Equal(oldVersion))
+				cond = conditionsv1.FindStatusCondition(foundResource.Status.Conditions, conditionsv1.ConditionProgressing)
+				Expect(cond.Status).Should(BeEquivalentTo("True"))
+				Expect(cond.Reason).Should(Equal("HCOUpgrading"))
+				Expect(cond.Message).Should(Equal("HCO is now upgrading to version " + newVersion))
+
+				hcoReady, err = checkHcoReady()
+				Expect(err).To(BeNil())
+				Expect(hcoReady).To(BeFalse())
+
+				// now, complete the upgrade
 				expected.kv.Status.ObservedKubeVirtVersion = newComponentVersion
 				cl = expected.initClient()
 				foundResource, requeue = doReconcile(cl, expected.hco)
@@ -1840,6 +1865,10 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cond.Status).Should(BeEquivalentTo("False"))
 				Expect(cond.Reason).Should(Equal(reconcileCompleted))
 				Expect(cond.Message).Should(Equal(reconcileCompletedMessage))
+
+				hcoReady, err = checkHcoReady()
+				Expect(err).To(BeNil())
+				Expect(hcoReady).To(BeTrue())
 			})
 
 			It("don't complete upgrade if CDI version is not match to the CDI version env ver", func() {
@@ -1858,6 +1887,10 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(requeue).To(BeFalse())
 				checkAvailability(foundResource, corev1.ConditionFalse)
 
+				hcoReady, err := checkHcoReady()
+				Expect(err).To(BeNil())
+				Expect(hcoReady).To(BeFalse())
+
 				// check that the image Id is not set, because upgrade is not completed
 				ver, ok := foundResource.Status.GetVersion(hcoVersionName)
 				Expect(ok).To(BeTrue())
@@ -1866,6 +1899,10 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cond.Status).Should(BeEquivalentTo("True"))
 				Expect(cond.Reason).Should(Equal("HCOUpgrading"))
 				Expect(cond.Message).Should(Equal("HCO is now upgrading to version " + newVersion))
+
+				hcoReady, err = checkHcoReady()
+				Expect(err).To(BeNil())
+				Expect(hcoReady).To(BeFalse())
 
 				// now, complete the upgrade
 				expected.cdi.Status.Conditions = getGenericCompletedConditions()
@@ -1883,6 +1920,11 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cond.Status).Should(BeEquivalentTo("False"))
 				Expect(cond.Reason).Should(Equal(reconcileCompleted))
 				Expect(cond.Message).Should(Equal(reconcileCompletedMessage))
+
+				hcoReady, err = checkHcoReady()
+				Expect(err).To(BeNil())
+				Expect(hcoReady).To(BeTrue())
+
 			})
 
 			It("don't complete upgrade if CNA version is not match to the CNA version env ver", func() {
@@ -2544,4 +2586,16 @@ func (clusterInfoMock) CheckRunningInOpenshift(_ context.Context, _ logr.Logger)
 
 func (clusterInfoMock) IsOpenshift() bool {
 	return true
+}
+
+func checkHcoReady() (bool, error) {
+	_, err := os.Stat(ready.FileName)
+
+	if err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, err
 }

--- a/tools/operator-courier/Dockerfile
+++ b/tools/operator-courier/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/python-36
 
-RUN pip3 install operator-courier
+RUN pip3 install --upgrade operator-courier==2.1.7
 COPY deploy/olm-catalog/kubevirt-hyperconverged /manifests
 
 RUN operator-courier verify --ui_validate_io /manifests


### PR DESCRIPTION
Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix BZ 1856447
```

/hold
Wait for acks

This fix changes the behavior related to "ready" status and the conditions, and it is now more accurate:
Ready status will be set if all the operators are reporting valid conditions and HCO is not in upgrade mode.
During upgrade, Progressing condition is "True" until the upgrade is done.