### PR TITLE
Update sed path in deploy_kustomize.sh

### DIFF
--- a/deploy/kustomize/deploy_kustomize.sh
+++ b/deploy/kustomize/deploy_kustomize.sh
@@ -21,8 +21,8 @@ main() {
   sed -i "s/- kubevirt-hyperconverged/- $TARGET_NAMESPACE/" $SCRIPT_DIR/base/operator_group.yaml
 
   # setting appropriate version and channel in the subscription manifest
-  sed -ri "s|(startingCSV.+v)[0-9].+|\1${HCO_VERSION}|" deploy/kustomize/base/subscription.yaml
-  sed -ri "s|(channel: ).+|\1\"${HCO_CHANNEL}\"|" deploy/kustomize/base/subscription.yaml
+  sed -ri "s|(startingCSV.+v)[0-9].+|\1${HCO_VERSION}|" $SCRIPT_DIR/base/subscription.yaml
+  sed -ri "s|(channel: ).+|\1\"${HCO_CHANNEL}\"|" $SCRIPT_DIR/base/subscription.yaml
 
   TMPDIR=$(mktemp -d)
   cp -r $SCRIPT_DIR/* $TMPDIR


### PR DESCRIPTION
PR #711 added to sed calls. Both are relative to the base
of the git directory. The calls fail when the deploy_kustomize.sh
script is ran from the kustomize directory.

Updated sed calls to use the $SCRIPT_DIR parameter

Signed-off-by: Keith Schincke <keith.schincke@gmail.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

