### PR TITLE
Emit events during reconciliation

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller"
-	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -183,7 +182,6 @@ func main() {
 		csvv1alpha1.AddToScheme,
 		vmimportv1.AddToScheme,
 		admissionregistrationv1.AddToScheme,
-		securityv1.AddToScheme,
 	} {
 		if err := f(mgr.GetScheme()); err != nil {
 			log.Error(err, "Failed to add to scheme")
@@ -194,6 +192,7 @@ func main() {
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr, ci); err != nil {
 		log.Error(err, "")
+		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "unable to register component; "+err.Error())
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
HCO operator now emits events to during reconciliation; e.g. reconciliation done, upgrade detected etc. Before that, HCO only wrote to the log. Now it is possible to watch important events as K8s events, e.g. by calling 
```
kubctl describe hco kubevirt-hyperconverged
```

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

