### PR TITLE
csv-merger: support passing environment variables

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -37,7 +37,7 @@ const (
 	hcoWebhookPath    = "/validate-hco-kubevirt-io-v1beta1-hyperconverged"
 )
 
-func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion string) appsv1.Deployment {
+func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion string, env []corev1.EnvVar) appsv1.Deployment {
 	return appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -49,11 +49,11 @@ func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwar
 				"name": hcoName,
 			},
 		},
-		Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion),
+		Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion, env),
 	}
 }
 
-func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion string) appsv1.DeploymentSpec {
+func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion string, env []corev1.EnvVar) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
 		Replicas: int32Ptr(1),
 		Selector: &metav1.LabelSelector{
@@ -89,7 +89,7 @@ func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, v
 							PeriodSeconds:       5,
 							FailureThreshold:    1,
 						},
-						Env: []corev1.EnvVar{
+						Env: append([]corev1.EnvVar{
 							{
 								Name:  "KVM_EMULATION",
 								Value: "",
@@ -166,7 +166,7 @@ func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, v
 								Name:  util.VMImportEnvV,
 								Value: vmImportVersion,
 							},
-						},
+						}, env...),
 					},
 				},
 			},
@@ -709,12 +709,12 @@ func GetOperatorCR() *hcov1beta1.HyperConverged {
 }
 
 // GetInstallStrategyBase returns the basics of an HCO InstallStrategy
-func GetInstallStrategyBase(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion string) *csvv1alpha1.StrategyDetailsDeployment {
+func GetInstallStrategyBase(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion string, env []corev1.EnvVar) *csvv1alpha1.StrategyDetailsDeployment {
 	return &csvv1alpha1.StrategyDetailsDeployment{
 		DeploymentSpecs: []csvv1alpha1.StrategyDeploymentSpec{
 			csvv1alpha1.StrategyDeploymentSpec{
 				Name: hcoDeploymentName,
-				Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion),
+				Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion, env),
 			},
 		},
 		Permissions: []csvv1alpha1.StrategyDeploymentPermissions{},

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/tools/util"
 
 	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -107,6 +108,7 @@ var (
 	hppoVersion     = flag.String("hppo-version", "", "HPP operator version")
 	vmImportVersion = flag.String("vm-import-version", "", "VM-Import operator version")
 	apiSources      = flag.String("api-sources", cwd+"/...", "Project sources")
+	envVars         = flag.String("env-vars", "", "Comma separated list of key=value environment variables")
 )
 
 func gen_hco_crds() {
@@ -136,6 +138,23 @@ func stringInSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+func getEnvVarList(s string) []corev1.EnvVar {
+	var envVars []corev1.EnvVar
+
+	if len(s) == 0 {
+		return envVars
+	}
+
+	for _, kvPair := range strings.Split(s, ",") {
+		kv := strings.Split(kvPair, "=")
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  kv[0],
+			Value: kv[1],
+		})
+	}
+	return envVars
 }
 
 func validateNoApiOverlap(crdDir string) bool {
@@ -282,6 +301,7 @@ func main() {
 			*nmoVersion,
 			*hppoVersion,
 			*vmImportVersion,
+			getEnvVarList(*envVars),
 		)
 
 		for _, image := range strings.Split(*relatedImagesList, ",") {

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -31,6 +31,7 @@ import (
 
 	csvv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,6 +139,7 @@ func main() {
 			*nmoVersion,
 			*hppoVersion,
 			*vmImportVersion,
+			[]corev1.EnvVar{},
 		),
 	}
 	serviceAccounts := map[string]v1.ServiceAccount{


### PR DESCRIPTION
When generating the CSV, we would like to have the option to pass in
extra environment variables for the HCO deployment.
This patch introduces the --env-vars flag that accepts a comma separated
list of key=value pairs.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
csv-merger: support passing environment variables
```

