### PR TITLE
Dirty hack to unlock CI

### DIFF
--- a/deploy/Dockerfile.registry.kubevirt.nightly
+++ b/deploy/Dockerfile.registry.kubevirt.nightly
@@ -8,7 +8,7 @@ USER root
 RUN find /registry/kubevirt-hyperconverged/ -type f -exec sed -E -i 's|^(\s*)- name: KVM_EMULATION$|\1- name: KVM_EMULATION\n\1  value: "true"|' {} \; || :
 
 RUN echo "HCO_VERSION: ${HCO_VERSION}"
-RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; else sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:.*$|registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; fi
+RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; else sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:.*$|default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; fi
 RUN cat /registry/kubevirt-hyperconverged/kubevirt-hyperconverged.package.yaml
 
 # Initialize the database

--- a/deploy/Dockerfile.registry.upgrade
+++ b/deploy/Dockerfile.registry.upgrade
@@ -18,7 +18,7 @@ USER root
 RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then \
       sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     else \
-      sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:.*$|registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
+      sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:.*$|default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     fi
 # Initialize the database
 RUN initializer --manifests /registry/kubevirt-hyperconverged --output bundles.db

--- a/deploy/Dockerfile.registry.upgrade-prev
+++ b/deploy/Dockerfile.registry.upgrade-prev
@@ -19,7 +19,7 @@ USER root
 RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then \
       sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     else \
-      sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:.*$|registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
+      sed -i "s|quay.io/kubevirt/hyperconverged-cluster-operator:.*$|default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     fi
 # Initialize the database
 RUN initializer --manifests /registry/kubevirt-hyperconverged --output bundles.db


### PR DESCRIPTION
This is just a dirty hack to unlock CI harcoding (again) the name of the registry used by openshift-ci.
We should find the proper way to consume at bundle build time, but with this at least we can unlock CI and gain more time.

Please be aware that this is going  to fail if our jobs get migrated from build01 to build02 and so on.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

