### PR TITLE
Continously reconcile all the resources created by HCO

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -1183,7 +1183,6 @@ var _ = Describe("HyperconvergedController", func() {
 				cl := expected.initClient()
 				rsc := schema.GroupResource{Group: hcoutil.APIVersionGroup, Resource: "hyperconvergeds.hco.kubevirt.io"}
 				cl.initiateWriteErrors(
-					nil,
 					apierrors.NewConflict(rsc, "hco", errors.New("test error")),
 				)
 				r := initReconciler(cl)

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -50,6 +50,7 @@ type basicExpected struct {
 	vmi                  *vmimportv1.VMImportConfig
 	kvMtAg               *sspv1.KubevirtMetricsAggregation
 	imsConfig            *corev1.ConfigMap
+	consoleCliDownload   *consolev1.ConsoleCLIDownload
 }
 
 func (be basicExpected) toArray() []runtime.Object {
@@ -69,6 +70,7 @@ func (be basicExpected) toArray() []runtime.Object {
 		be.vmi,
 		be.kvMtAg,
 		be.imsConfig,
+		be.consoleCliDownload,
 	}
 }
 
@@ -202,7 +204,13 @@ func getBasicDeployment() *basicExpected {
 	kvMtAg.Status.Conditions = getGenericCompletedConditions()
 	res.kvMtAg = kvMtAg
 
-	res.imsConfig = newIMSConfigForCR(hco, namespace)
+	expectedIMSConfig := newIMSConfigForCR(hco, namespace)
+	expectedIMSConfig.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/configmaps/%s", expectedIMSConfig.Namespace, expectedIMSConfig.Name)
+	res.imsConfig = expectedIMSConfig
+
+	expectedConsoleCliDownload := hco.NewConsoleCLIDownload()
+	expectedIMSConfig.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/consoleclidownloads/%s", expectedConsoleCliDownload.Namespace, expectedConsoleCliDownload.Name)
+	res.consoleCliDownload = expectedConsoleCliDownload
 
 	return res
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -202,24 +202,3 @@ func EnsureDeleted(ctx context.Context, c client.Client, obj runtime.Object, hco
 
 	return ComponentResourceRemoval(ctx, c, obj, hcoName, logger, dryRun)
 }
-
-// EnsureCreated creates the runtime object if it does not exist
-func EnsureCreated(ctx context.Context, c client.Client, obj runtime.Object, logger logr.Logger) error {
-	err := GetRuntimeObject(ctx, c, obj, logger)
-
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("Creating object", "kind", obj.GetObjectKind())
-			return c.Create(ctx, obj)
-		}
-
-		if meta.IsNoMatchError(err) {
-			return err
-		}
-
-		logger.Error(err, "failed getting runtime object", "kind", obj.GetObjectKind())
-		return err
-	}
-
-	return nil
-}


### PR DESCRIPTION
So far - accross all of HCO and operands - our
reconcileation loops were not covering all aspects
(i.e. also not the placement fields of DS),
but we need to improve all of operators in order to
make sure that all aspects are always reconciled.
Customizations are only possible with paused operators.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

Bug-Url: https://bugzilla.redhat.com/1862701

**Release note**:
```release-note
Continously reconcile all the resources created by HCO
```

