### PR TITLE
Fix an OLM Doc URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ curl https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operato
 
 ## Developer Workflow
 If you want to make changes to the HCO, here's how you can test your changes
-through [OLM](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/install/install.md#installing-olm).
+through [OLM](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md#installing-olm).
 
 Build the HCO container using the Makefile recipes `make container-build` and
 `make container-push` with vars `IMAGE_REGISTRY`, `OPERATOR_IMAGE`, and `IMAGE_TAG`


### PR DESCRIPTION
The URL for Installing OLM in the README file was outdated.
This was pointed out issue #717 by @sradco .

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix an OLM Doc URL in README
```

