### PR TITLE
kustomize: validate resources properly

### DIFF
--- a/deploy/kustomize/base/hco_cr.yaml
+++ b/deploy/kustomize/base/hco_cr.yaml
@@ -4,4 +4,4 @@ metadata:
   name: kubevirt-hyperconverged
   namespace: kubevirt-hyperconverged
 spec:
-  BareMetalPlatform: true
+  bareMetalPlatform: true

--- a/deploy/kustomize/image_registry/catalog_source.yaml
+++ b/deploy/kustomize/image_registry/catalog_source.yaml
@@ -3,7 +3,6 @@ kind: CatalogSource
 metadata:
   name: kubevirt-hyperconverged
   namespace: openshift-marketplace
-  imagePullPolicy: Always
 spec:
   sourceType: grpc
   image: quay.io/kubevirt/hco-container-registry:latest


### PR DESCRIPTION
Specifying BareMetalPlatform and imagePullPolicy in the HCO CR and the
CatalogSource cause kustomize to fail with a ValidationError (unknown
field)

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

