### PR TITLE
fix the release-bumber.sh to sort versions

### DIFF
--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CONFIG_FILE="hack/config"
 
@@ -51,7 +51,7 @@ function get_current_versions {
   )
 
   for component in "${!CURRENT_VERSIONS[@]}"; do
-    CURRENT_VERSIONS[$component]=$(grep "$component"_VERSION ${CONFIG_FILE} | cut -d "=" -f 2)
+    CURRENT_VERSIONS[$component]=$(grep "$component"_VERSION ${CONFIG_FILE} | sed -r "s|${component}_VERSION=\"(.+)\"$|\1|")
     done;
 }
 
@@ -70,8 +70,8 @@ function get_updated_versions {
 
   UPDATED_VERSIONS=()
   for component in "${!COMPONENTS_REPOS[@]}"; do
-    UPDATED_VERSIONS[$component]=\"$(get_latest_release "${COMPONENTS_REPOS[$component]}")\";
-    if [ "${UPDATED_VERSIONS[$component]}" == \"\" ]; then
+    UPDATED_VERSIONS[$component]=$(get_latest_release "${COMPONENTS_REPOS[$component]}");
+    if [ -z "${UPDATED_VERSIONS[$component]}" ]; then
       echo "ERROR: Unable to get an updated version of $component, aborting..."
       exit 1
     fi
@@ -79,7 +79,8 @@ function get_updated_versions {
 }
 
 function get_latest_release() {
-  curl -s -L --silent "https://api.github.com/repos/$1/releases" | grep -m 1 '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+  RELEASES=$(curl -s -L --silent "https://api.github.com/repos/$1/releases" | jq -r '.[].tag_name')
+  semversort "${RELEASES[*]}"
 }
 
 function compare_versions() {

--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -137,10 +137,9 @@ Continuing to next component."
       continue
     else
       echo "INFO: Updating $component to ${UPDATED_VERSIONS[$component]}."
-      sed -E -i "s/(""$component""_VERSION=).*/\1${UPDATED_VERSIONS[$component]}/" ${CONFIG_FILE}
-
+      sed -E -i "s|(${component}_VERSION=).*|\1\"${UPDATED_VERSIONS[$component]}\"|" ${CONFIG_FILE}
       echo "$component" > updated_component.txt
-      echo "${UPDATED_VERSIONS[$component]}" | tr -d '"' > updated_version.txt
+      echo "${UPDATED_VERSIONS[$component]}" > updated_version.txt
       UPDATING='true'
       break
     fi


### PR DESCRIPTION
Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

