### PR TITLE
Adapt to latest origin-operator-registry image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,9 +1,17 @@
 FROM quay.io/openshift/origin-operator-registry:latest
 
-COPY deploy/olm-catalog /registry
+WORKDIR /registry
+
+COPY deploy/olm-catalog .
+
+USER root
 
 # Initialize the database
-RUN initializer --manifests /registry/kubevirt-hyperconverged --output bundles.db
+RUN ["initializer", "--manifests", "/registry/kubevirt-hyperconverged", "--output", "bundles.db"]
+
+RUN ["chown", "1001", "bundles.db"]
+
+USER 1001
 
 # There are multiple binaries in the origin-operator-registry
 # We want the registry-server


### PR DESCRIPTION
/registry was removed from the latest origin-operator-registry image,
and the workdir was changed as well, this breaks the hco's bundle image
build.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

