### PR TITLE
Add new make target 'deploy_cr' to deploy only the HCO CR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,9 @@ charts:
 local:
 	./hack/make_local.sh
 
+deploy_cr:
+	./hack/deploy_only_cr.sh
+
 .PHONY: start \
 		clean \
 		build \
@@ -160,3 +163,4 @@ local:
 		charts \
 		kubevirt-nightly-test \
 		local \
+		deploy_cr \

--- a/hack/deploy_only_cr.sh
+++ b/hack/deploy_only_cr.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+
+HCO_NAMESPACE="kubevirt-hyperconverged"
+HCO_KIND="hyperconvergeds"
+HCO_RESOURCE_NAME="kubevirt-hyperconverged"
+
+echo "KUBEVIRT_PROVIDER: $KUBEVIRT_PROVIDER"
+
+if [ -n "$KUBEVIRT_PROVIDER" ]; then
+  echo "Running on STDCI ${KUBEVIRT_PROVIDER}"
+  source ./hack/upgrade-stdci-config
+else
+  echo "Running on OpenShift CI"
+  source ./hack/upgrade-openshiftci-config
+fi
+
+function cleanup() {
+    rv=$?
+    if [ "x$rv" != "x0" ]; then
+        echo "Error during upgrade: exit status: $rv"
+        make dump-state
+        echo "*** Upgrade test failed ***"
+    fi
+    exit $rv
+}
+
+trap "cleanup" INT TERM EXIT
+
+${CMD} apply -n kubevirt-hyperconverged -f deploy/hco.cr.yaml
+
+${CMD} wait -n "${HCO_NAMESPACE}" "${HCO_KIND}" "${HCO_RESOURCE_NAME}" --for condition=Available --timeout="30m"
+${CMD} wait deployment "${HCO_DEPLOYMENT_NAME}" --for condition=Available -n "${HCO_NAMESPACE}" --timeout="30m"


### PR DESCRIPTION
Add new make target 'deploy_cr' to deploy only the HCO CR, assuming the CSV is already deployed.

This will be used in CI for tests based on index images created and deployed by CI workloads.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

