### PR TITLE
Fix /registry permissions to be group writable

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -8,8 +8,8 @@ USER root
 
 # Initialize the database
 RUN ["initializer", "--manifests", "/registry/kubevirt-hyperconverged", "--output", "bundles.db"]
-
 RUN ["chown", "1001", "bundles.db"]
+RUN ["chmod", "-R", "g+rwx", "."]
 
 USER 1001
 


### PR DESCRIPTION
registry-server creates some files under /registry, so we need to make
sure it's writable

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

