### PR TITLE
Workaround for OLM caused restart loop

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
-    createdAt: "2020-09-09 15:23:44"
+    createdAt: "2020-09-09 16:13:12"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1585,7 +1585,7 @@ spec:
                     - stat
                     - /tmp/operator-sdk-ready
                   failureThreshold: 1
-                  initialDelaySeconds: 5
+                  initialDelaySeconds: 180
                   periodSeconds: 5
                 resources: {}
               serviceAccountName: hyperconverged-cluster-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -67,7 +67,7 @@ spec:
             - stat
             - /tmp/operator-sdk-ready
           failureThreshold: 1
-          initialDelaySeconds: 5
+          initialDelaySeconds: 180
           periodSeconds: 5
         resources: {}
       serviceAccountName: hyperconverged-cluster-operator


### PR DESCRIPTION
Raise initialDelaySeconds value on the readiness probe
as a temporary workaroud for https://bugzilla.redhat.com/1868712
that causes a restart loop on operators with OLM based
OLM admission webhooks.

This is just a temporary workaround until OLM will properly supports
operator conditions as documented in:
https://github.com/operator-framework/enhancements/blob/master/enhancements/operator-conditions.md

Currently the only communication channel with OLM is the readiness
probe on the operator pod but this is overloaded by different
meanings and so HCO is also using it to signal the status of components operators:
an HyperConverged Cluster can take up to 10-15 minutes
to be ready and during this time HCO pod reports ready=false
and this is translated to the phase of the CSV object.
Now, as for https://bugzilla.redhat.com/1868712 ,
OLM tries to reinstall a CSV with phase != Success and this will
cause OLM to generate new certs for the admission validating
webhooks defined in the CSV but this will cause the deployment
associated to that webhooks to be updated with a new olmcahash
annotation causing a restart of that pods.
In the case of HCO pod, after each restart,
HCO will adopt components CRs created in the past and,
if at least one of the components operators is still
not ready/available/..., HCO will report again ready = false
entering a restart loop.

Setting a really high InitialDelaySeconds value
is just an horrible workaround to get restarted less frequently
during the initial deployment of the HyperConverged Cluster.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Raise initialDelaySeconds on the pod readiness probe as a workaround for https://bugzilla.redhat.com/1868712
```

