### PR TITLE
Set failurePolicy=Fail for HCO webhook

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
@@ -2209,7 +2209,7 @@ spec:
     - v1
     containerPort: 4343
     deploymentName: hco-operator
-    failurePolicy: Ignore
+    failurePolicy: Fail
     generateName: validate-hco.kubevirt.io
     rules:
     - apiGroups:
@@ -2223,6 +2223,7 @@ spec:
       resources:
       - hyperconvergeds
     sideEffects: None
+    timeoutSeconds: 30
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-hco-kubevirt-io-v1beta1-hyperconverged
   - admissionReviewVersions:

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -182,6 +182,10 @@ EOF
 
 ${CMD} wait deployment ${HCO_DEPLOYMENT_NAME} --for condition=Available -n ${HCO_NAMESPACE} --timeout="1200s"
 
+# Creating a CR immediately after HCO pod started can
+# cause a connection error "validate-hco.kubevirt.io" webhook.
+# Give it a bit of time to cirrectly start the webhook.
+sleep 30
 CSV=$( ${CMD} get csv -o name -n ${HCO_NAMESPACE})
 HCO_API_VERSION=$( ${CMD} get -n ${HCO_NAMESPACE} "${CSV}" -o jsonpath="{ .spec.customresourcedefinitions.owned[?(@.kind=='HyperConverged')].version }")
 sed -e "s|hco.kubevirt.io/v1beta1|hco.kubevirt.io/${HCO_API_VERSION}|g" deploy/hco.cr.yaml | ${CMD} apply -n kubevirt-hyperconverged -f -


### PR DESCRIPTION
Set failurePolicy=Fail for HCO webhook: refuse admitting
update/delete request if HCO webhook cannot really process them.
As a side effect of this, an user tha wants to remove
a compeltely stuck HCO, can be required to directly
remove the ValidatingWebhookConfiguration before deleting HCO CR.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Set failurePolicy=Fail for HCO webhook
```

