### PR TITLE
[CI] Fix the address of openshift-ci internal registry for 4.6

### DIFF
--- a/deploy/Dockerfile.registry.kubevirt.nightly
+++ b/deploy/Dockerfile.registry.kubevirt.nightly
@@ -7,8 +7,18 @@ USER root
 # enable KVM_EMULATION for CI, needed by kubevirt-node-labeller on AWS
 RUN find /registry/kubevirt-hyperconverged/ -type f -exec sed -E -i 's|^(\s*)- name: KVM_EMULATION$|\1- name: KVM_EMULATION\n\1  value: "true"|' {} \; || :
 
+# TODO: openshift-ci is currently configured to use two different
+# addresses for its internal registry depending from the OCP version:
+# please adapt this value according to that.
+# This is going to be solved only once we will move to openshift-ci generated
+# index images also for the upgrade tests.
+# OCP 4.5:
+ARG CI_REGISTRY=registry.svc.ci.openshift.org
+# OCP 4.6:
+# ARG CI_REGISTRY=default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
+
 RUN echo "HCO_VERSION: ${HCO_VERSION}"
-RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; else sed -i -r "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; fi
+RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; else sed -i -r "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; fi
 RUN cat /registry/kubevirt-hyperconverged/kubevirt-hyperconverged.package.yaml
 
 # Initialize the database

--- a/deploy/Dockerfile.registry.upgrade
+++ b/deploy/Dockerfile.registry.upgrade
@@ -15,10 +15,20 @@ ARG UPGRADE_VERSION=100.0.0
 COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/deploy/olm-catalog /registry
 USER root
 
+# TODO: openshift-ci is currently configured to use two different
+# addresses for its internal registry depending from the OCP version:
+# please adapt this value according to that.
+# This is going to be solved only once we will move to openshift-ci generated
+# index images also for the upgrade tests.
+# OCP 4.5:
+# ARG CI_REGISTRY=registry.svc.ci.openshift.org
+# OCP 4.6:
+ARG CI_REGISTRY=default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
+
 RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then \
       sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     else \
-      sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
+      sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     fi
 # Initialize the database
 RUN initializer --manifests /registry/kubevirt-hyperconverged --output bundles.db

--- a/deploy/Dockerfile.registry.upgrade-prev
+++ b/deploy/Dockerfile.registry.upgrade-prev
@@ -16,10 +16,20 @@ ARG UPGRADE_VERSION=100.0.0
 COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/deploy/olm-catalog /registry
 USER root
 
+# TODO: openshift-ci is currently configured to use two different
+# addresses for its internal registry depending from the OCP version:
+# please adapt this value according to that.
+# This is going to be solved only once we will move to openshift-ci generated
+# index images also for the upgrade tests.
+# OCP 4.5:
+# ARG CI_REGISTRY=registry.svc.ci.openshift.org
+# OCP 4.6:
+ARG CI_REGISTRY=default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
+
 RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then \
       sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     else \
-      sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
+      sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     fi
 # Initialize the database
 RUN initializer --manifests /registry/kubevirt-hyperconverged --output bundles.db


### PR DESCRIPTION
[CI] Fix the address of openshift-ci internal registry for 4.6

openshift-ci is currently configured to use two different
addresses for its internal registry depending from the OCP version:
- OCP 4.5: registry.svc.ci.openshift.org
- OCP 4.6: default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com

Fix the upgrade test lanes for OCP 4.6 now that we
are running again on OCP 4.6.

This is going to be solved only once we will move to openshift-ci generated
index images also for the upgrade tests.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

