### PR TITLE
Override-bot: add missing \n to split multiple commands

### DIFF
--- a/automation/override-bot/override-bot.py
+++ b/automation/override-bot/override-bot.py
@@ -105,7 +105,7 @@ class PullRequest:
             comment = comment[:-2] # removing comma at the end
             plural = 's' if len(override[1]) > 1 else ''
             comment += f' lane{plural} succeeded.\n'
-            comment += f'/override {override[0].name}'
+            comment += f'/override {override[0].name}\n'
 
         print (f'comment for PR #{self.number} is:\n{comment}')
         gh_pr.create_issue_comment(comment)

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
-    createdAt: "2020-09-18 05:11:21"
+    createdAt: "2020-09-22 06:52:28"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,


### PR DESCRIPTION
Override-bot: add missing \n to split multiple commands

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

