### PR TITLE
Follow again openshift-ci internal registry

### DIFF
--- a/deploy/Dockerfile.registry.kubevirt.nightly
+++ b/deploy/Dockerfile.registry.kubevirt.nightly
@@ -15,7 +15,7 @@ RUN find /registry/kubevirt-hyperconverged/ -type f -exec sed -E -i 's|^(\s*)- n
 # OCP 4.5:
 ARG CI_REGISTRY=registry.svc.ci.openshift.org
 # OCP 4.6:
-# ARG CI_REGISTRY=default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
+# ARG CI_REGISTRY=registry.build01.ci.openshift.org
 
 RUN echo "HCO_VERSION: ${HCO_VERSION}"
 RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; else sed -i -r "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; fi

--- a/deploy/Dockerfile.registry.upgrade
+++ b/deploy/Dockerfile.registry.upgrade
@@ -23,7 +23,7 @@ USER root
 # OCP 4.5:
 # ARG CI_REGISTRY=registry.svc.ci.openshift.org
 # OCP 4.6:
-ARG CI_REGISTRY=default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
+ARG CI_REGISTRY=registry.build01.ci.openshift.org
 
 RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then \
       sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \

--- a/deploy/Dockerfile.registry.upgrade-prev
+++ b/deploy/Dockerfile.registry.upgrade-prev
@@ -24,7 +24,7 @@ USER root
 # OCP 4.5:
 # ARG CI_REGISTRY=registry.svc.ci.openshift.org
 # OCP 4.6:
-ARG CI_REGISTRY=default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
+ARG CI_REGISTRY=registry.build01.ci.openshift.org
 
 RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then \
       sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \


### PR DESCRIPTION
The address of openshift-ci internal registry changed again:
default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
=> registry.build01.ci.openshift.org

Following it.
This is going to end only when we will be able to consume
openshift-ci built index images also for upgrade tests.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

