### PR TITLE
Using hco-bot user instead of default github-actions user, syncing OWNERS

### DIFF
--- a/.github/workflows/rebase-bot.yml
+++ b/.github/workflows/rebase-bot.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Build Manifests and Rebase
         run: ./automation/rebase-bot/rebase-bot.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HCO_BOT_TOKEN }}

--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -21,7 +21,7 @@ jobs:
         run: rm -f updated_component.txt updated_version.txt
       - uses: peter-evans/create-pull-request@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.HCO_BOT_TOKEN }}
           commit-message: |
             Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}
 
@@ -34,7 +34,7 @@ jobs:
             ```release-note
             Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}
             ```
-          assignees: tiraboschi,orenc1
-          reviewers: tiraboschi,orenc1
+          assignees: tiraboschi,orenc1,nunnatsa
+          reviewers: tiraboschi,orenc1,nunnatsa
           team-reviewers: owners, maintainers
           branch: bump_${{ env.UPDATED_COMPONENT }}_${{ env.UPDATED_VERSION }}

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,18 +2,14 @@
 
 aliases:
   approvers:
-      - djzager
       - nunnatsa
       - orenc1
-      - rthallisey
-      - rwsu
       - tiraboschi
       - yuvalturg
+      - sradco
   code-reviewers:
-      - djzager
       - nunnatsa
       - orenc1
-      - rthallisey
-      - rwsu
       - tiraboschi
       - yuvalturg
+      - sradco

--- a/automation/override-bot/override-bot.py
+++ b/automation/override-bot/override-bot.py
@@ -66,7 +66,7 @@ class PullRequest:
             provider = splitted[-1]
             test_name = '-'.join(splitted[:-1])
             state = status['state']
-            overridden = True if status['description'] and 'Overridden' in status['description'] else False
+            overridden = status['description'] and 'Overridden' in status['description']
             testObj = self.get_test_obj(test_name)
             if not testObj:
                 testObj = CI_Test(test_name, [])
@@ -105,7 +105,7 @@ class PullRequest:
             comment = comment[:-2] # removing comma at the end
             plural = 's' if len(override[1]) > 1 else ''
             comment += f' lane{plural} succeeded.\n'
-            comment += f'/override {override[0].name}'
+            comment += f'/override {override[0].name}\n'
 
         print (f'comment for PR #{self.number} is:\n{comment}')
         gh_pr.create_issue_comment(comment)


### PR DESCRIPTION
Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

