### PR TITLE
Disable VMI migration upon K8s unschedulable taint

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
@@ -126,7 +126,8 @@ var _ = Describe("HyperConverged Components", func() {
 		var req *common.HcoRequest
 
 		updatableKeys := [...]string{virtconfig.SmbiosConfigKey, virtconfig.MachineTypeKey, virtconfig.SELinuxLauncherTypeKey, virtconfig.FeatureGatesKey}
-		unupdatableKeys := [...]string{virtconfig.MigrationsConfigKey, virtconfig.NetworkInterfaceKey}
+		removeKeys := [...]string{virtconfig.MigrationsConfigKey}
+		unupdatableKeys := [...]string{virtconfig.NetworkInterfaceKey}
 
 		BeforeEach(func() {
 			hco = newHco()
@@ -182,8 +183,9 @@ var _ = Describe("HyperConverged Components", func() {
 			outdatedResource.Data[virtconfig.MachineTypeKey] = "old-machinetype-value-that-we-have-to-update"
 			outdatedResource.Data[virtconfig.SELinuxLauncherTypeKey] = "old-selinuxlauncher-value-that-we-have-to-update"
 			outdatedResource.Data[virtconfig.FeatureGatesKey] = "old-featuregates-value-that-we-have-to-update"
+			// value that we should remove if configured
+			outdatedResource.Data[virtconfig.MigrationsConfigKey] = "old-migrationsconfig-value-that-we-should-remove"
 			// values we should preserve
-			outdatedResource.Data[virtconfig.MigrationsConfigKey] = "old-migrationsconfig-value-that-we-should-preserve"
 			outdatedResource.Data[virtconfig.NetworkInterfaceKey] = "old-defaultnetworkinterface-value-that-we-should-preserve"
 
 			cl := initClient([]runtime.Object{hco, outdatedResource})
@@ -209,6 +211,11 @@ var _ = Describe("HyperConverged Components", func() {
 			for _, k := range unupdatableKeys {
 				Expect(foundResource.Data[k]).To(Equal(outdatedResource.Data[k]))
 				Expect(foundResource.Data[k]).To(Not(Equal(expectedResource.Data[k])))
+			}
+			for _, k := range removeKeys {
+				Expect(outdatedResource.Data).To(HaveKey(k))
+				Expect(expectedResource.Data).To(Not(HaveKey(k)))
+				Expect(foundResource.Data).To(Not(HaveKey(k)))
 			}
 		})
 


### PR DESCRIPTION
Currently, the default behaviour is to migrate the VMI when a node is
tainted with the node.kubernetes.io/unschedulable key. This behaviour is
wrong and can be un-expected from the user's perspective because the
unschedulable taint means "do not schedule new workloads on this node"
and not "evict existing workloads from this node".

kubevirt/kubevirt#4012 adds support for the
eviction API so we can properly handle node drains and specific
evictions on VMI pods.

This patch avoid setting (and explicitly removes during upgrades if
set in the past) the default node drain key so we won't migrate VMIs
when we're not expected to do so.

Fixes: https://bugzilla.redhat.com/1881676

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMIs will no longer migrate when node is tainted with node.kubernetes.io/unschedulable by default. Users can now use the proper node drain API to evacuate multiple VMIs from a node.
```

