### PR TITLE
Validate Upgrade of the HCO CR's Workloads

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
-    createdAt: "2020-09-21 14:07:38"
+    createdAt: "2020-09-23 09:19:30"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -2273,6 +2273,7 @@ spec:
       operations:
       - CREATE
       - DELETE
+      - UPDATE
       resources:
       - hyperconvergeds
     sideEffects: None

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
-    createdAt: "2020-09-23 09:19:30"
+    createdAt: "2020-09-22 15:07:05"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook_test.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook_test.go
@@ -240,6 +240,7 @@ func newHyperConvergedConfig() *sdkapi.NodePlacement {
 }
 
 type fakeFailure int
+
 const (
 	noFailure fakeFailure = iota
 	kvUpdateFailure

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook_test.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook_test.go
@@ -1,11 +1,22 @@
 package v1beta1
 
 import (
+	"context"
+	"errors"
+	sdkapi "github.com/kubevirt/controller-lifecycle-operator-sdk/pkg/sdk/api"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -41,4 +52,181 @@ var _ = Describe("Hyperconverged Webhooks", func() {
 
 		// TODO: add tests for update validation with existing workload
 	})
+
+	Context("validate update webhook", func() {
+		s := scheme.Scheme
+		for _, f := range []func(*runtime.Scheme) error{
+			AddToScheme,
+			cdiv1beta1.AddToScheme,
+			kubevirtv1.AddToScheme,
+		} {
+			Expect(f(s)).To(BeNil())
+		}
+
+		It("should return error if KV CR is missing", func() {
+			hco := &HyperConverged{}
+			// replace the real client with a mock
+			cli = fake.NewFakeClientWithScheme(s, hco, hco.NewCDI())
+
+			newHco := &HyperConverged{
+				Spec: HyperConvergedSpec{
+					Infra: HyperConvergedConfig{
+						NodePlacement: newHyperConvergedConfig(),
+					},
+					Workloads: HyperConvergedConfig{
+						NodePlacement: newHyperConvergedConfig(),
+					},
+				},
+			}
+
+			err := newHco.ValidateUpdate(hco)
+			Expect(err).NotTo(BeNil())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("should return error if dry-run update of KV CR returns error", func() {
+			hco := &HyperConverged{
+				Spec: HyperConvergedSpec{
+					Infra: HyperConvergedConfig{
+						NodePlacement: newHyperConvergedConfig(),
+					},
+					Workloads: HyperConvergedConfig{
+						NodePlacement: newHyperConvergedConfig(),
+					},
+				},
+			}
+			// replace the real client with a mock
+			c := fake.NewFakeClientWithScheme(s, hco, hco.NewKubeVirt(), hco.NewCDI())
+			cli = errorClient{c, KvError}
+
+			newHco := &HyperConverged{}
+			hco.DeepCopyInto(newHco)
+			// change something in workloads to trigger dry-run update
+			newHco.Spec.Workloads.NodePlacement.NodeSelector["a change"] = "Something else"
+
+			err := newHco.ValidateUpdate(hco)
+			Expect(err).NotTo(BeNil())
+			Expect(err).Should(Equal(KvError))
+		})
+
+		It("should return error if CDI CR is missing", func() {
+			hco := &HyperConverged{}
+			// replace the real client with a mock
+			cli = fake.NewFakeClientWithScheme(s, hco, hco.NewKubeVirt())
+
+			newHco := &HyperConverged{
+				Spec: HyperConvergedSpec{
+					Infra: HyperConvergedConfig{
+						NodePlacement: newHyperConvergedConfig(),
+					},
+					Workloads: HyperConvergedConfig{
+						NodePlacement: newHyperConvergedConfig(),
+					},
+				},
+			}
+
+			err := newHco.ValidateUpdate(hco)
+			Expect(err).NotTo(BeNil())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("should return error if dry-run update of CDI CR returns error", func() {
+			hco := &HyperConverged{
+				Spec: HyperConvergedSpec{
+					Infra: HyperConvergedConfig{
+						NodePlacement: newHyperConvergedConfig(),
+					},
+					Workloads: HyperConvergedConfig{
+						NodePlacement: newHyperConvergedConfig(),
+					},
+				},
+			}
+			// replace the real client with a mock
+			c := fake.NewFakeClientWithScheme(s, hco, hco.NewKubeVirt(), hco.NewCDI())
+			cli = errorClient{c, CdiError}
+
+			newHco := &HyperConverged{}
+			hco.DeepCopyInto(newHco)
+			// change something in workloads to trigger dry-run update
+			newHco.Spec.Workloads.NodePlacement.NodeSelector["a change"] = "Something else"
+
+			err := newHco.ValidateUpdate(hco)
+			Expect(err).NotTo(BeNil())
+			Expect(err).Should(Equal(CdiError))
+		})
+
+		It("should not return error if no different in Spec.Workloads", func() {
+			hco := &HyperConverged{
+				Spec: HyperConvergedSpec{
+					Infra: HyperConvergedConfig{
+						NodePlacement: newHyperConvergedConfig(),
+					},
+					Workloads: HyperConvergedConfig{
+						NodePlacement: newHyperConvergedConfig(),
+					},
+				},
+			}
+
+			// replace the real client with a mock
+			cli = fake.NewFakeClientWithScheme(s, hco)
+
+			newHco := &HyperConverged{}
+			hco.DeepCopyInto(newHco)
+			// Change only infra, but leave workloads as is
+			newHco.Spec.Infra.NodePlacement.NodeSelector["a change"] = "Something else"
+
+			// should new return error, even when there are no CDI and KV
+			err := newHco.ValidateUpdate(hco)
+			Expect(err).To(BeNil())
+		})
+	})
 })
+
+func newHyperConvergedConfig() *sdkapi.NodePlacement {
+	seconds1, seconds2 := int64(1), int64(2)
+	return &sdkapi.NodePlacement{
+		NodeSelector: map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		},
+		Affinity: &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{Key: "key1", Operator: "operator1", Values: []string{"value11, value12"}},
+								{Key: "key2", Operator: "operator2", Values: []string{"value21, value22"}},
+							},
+							MatchFields: []corev1.NodeSelectorRequirement{
+								{Key: "key1", Operator: "operator1", Values: []string{"value11, value12"}},
+								{Key: "key2", Operator: "operator2", Values: []string{"value21, value22"}},
+							},
+						},
+					},
+				},
+			},
+		},
+		Tolerations: []corev1.Toleration{
+			{Key: "key1", Operator: "operator1", Value: "value1", Effect: "effect1", TolerationSeconds: &seconds1},
+			{Key: "key2", Operator: "operator2", Value: "value2", Effect: "effect2", TolerationSeconds: &seconds2},
+		},
+	}
+}
+
+type errorClient struct {
+	client.Client
+	err error
+}
+
+var (
+	KvError = errors.New("fake KubeVirt error")
+	CdiError = errors.New("fake CDI error")
+)
+
+func (ec errorClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	if ec.err != nil {
+		return ec.err
+	}
+	return ec.Client.Update(ctx, obj, opts...)
+}

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -771,6 +771,7 @@ func GetCSVBase(name, namespace, displayName, description, image, replaces strin
 				Operations: []admissionregistrationv1.OperationType{
 					admissionregistrationv1.Create,
 					admissionregistrationv1.Delete,
+					admissionregistrationv1.Update,
 				},
 				Rule: admissionregistrationv1.Rule{
 					APIGroups:   []string{util.APIVersionGroup},


### PR DESCRIPTION
Add a check to the webhook, to make sure that the workloads change is acceptable by KubeVirt and CDI operators, by running dry run update of of their CRs.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Validate Upgrade of the HCO CR's Workloads
```

