### PR TITLE
Optionally ignore relatedImages from component operators

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:95c8c3e9002ebe55254b9371757a98a3d29991ba83e3edfe405a9174c596365a
-    createdAt: "2020-09-23 14:42:07"
+    createdAt: "2020-09-23 19:02:14"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -111,17 +111,18 @@ var (
 		"Comma separated list of all the CRDs that should be visible in OLM console")
 	relatedImagesList = flag.String("related-images-list", "",
 		"Comma separated list of all the images referred in the CSV (just the image pull URLs or eventually a set of 'image|name' collations)")
-	crdDir          = flag.String("crds-dir", "", "the directory containing the CRDs for apigroup validation. The validation will be performed if and only if the value is non-empty.")
-	hcoKvIoVersion  = flag.String("hco-kv-io-version", "", "KubeVirt version")
-	kubevirtVersion = flag.String("kubevirt-version", "", "Kubevirt operator version")
-	cdiVersion      = flag.String("cdi-version", "", "CDI operator version")
-	cnaoVersion     = flag.String("cnao-version", "", "CNA operator version")
-	sspVersion      = flag.String("ssp-version", "", "SSP operator version")
-	nmoVersion      = flag.String("nmo-version", "", "NM operator version")
-	hppoVersion     = flag.String("hppo-version", "", "HPP operator version")
-	vmImportVersion = flag.String("vm-import-version", "", "VM-Import operator version")
-	apiSources      = flag.String("api-sources", cwd+"/...", "Project sources")
-	envVars         EnvVarFlags
+	ignoreComponentsRelatedImages = flag.Bool("ignore-component-related-image", false, "Ignore relatedImages from components CSVs")
+	crdDir                        = flag.String("crds-dir", "", "the directory containing the CRDs for apigroup validation. The validation will be performed if and only if the value is non-empty.")
+	hcoKvIoVersion                = flag.String("hco-kv-io-version", "", "KubeVirt version")
+	kubevirtVersion               = flag.String("kubevirt-version", "", "Kubevirt operator version")
+	cdiVersion                    = flag.String("cdi-version", "", "CDI operator version")
+	cnaoVersion                   = flag.String("cnao-version", "", "CNA operator version")
+	sspVersion                    = flag.String("ssp-version", "", "SSP operator version")
+	nmoVersion                    = flag.String("nmo-version", "", "NM operator version")
+	hppoVersion                   = flag.String("hppo-version", "", "HPP operator version")
+	vmImportVersion               = flag.String("vm-import-version", "", "VM-Import operator version")
+	apiSources                    = flag.String("api-sources", cwd+"/...", "Project sources")
+	envVars                       EnvVarFlags
 )
 
 func gen_hco_crds() {
@@ -367,8 +368,10 @@ func main() {
 			}
 			csvExtended.Annotations["alm-examples"] = string(alm_b)
 
-			for _, image := range csvStruct.Spec.RelatedImages {
-				relatedImageSet.add(image.Ref)
+			if !*ignoreComponentsRelatedImages {
+				for _, image := range csvStruct.Spec.RelatedImages {
+					relatedImageSet.add(image.Ref)
+				}
 			}
 		}
 


### PR DESCRIPTION
Add a a flag to the csv-merger tool to optionally ignore
relatedImages from component operators generated CSV.

#fixes https://bugzilla.redhat.com/1882052

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Optionally ignore relatedImages from component operators
```

