### PR TITLE
Reconcile IMS ConfigMap

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -1467,6 +1467,16 @@ func (r *ReconcileHyperConverged) ensureIMSConfig(req *hcoRequest) *EnsureResult
 	}
 	objectreferencesv1.SetObjectReference(&req.instance.Status.RelatedObjects, *objectRef)
 
+	if !reflect.DeepEqual(found.Data, imsConfig.Data) {
+		found.Data = imsConfig.Data
+		req.logger.Info("Updating existing IMS Configmap to its default value")
+		err = r.client.Update(req.ctx, found)
+		if err != nil {
+			return res.Error(err)
+		}
+		return res.SetUpdated()
+	}
+
 	return res.SetUpgradeDone(req.componentUpgradeInProgress)
 }
 

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -46,8 +46,8 @@ var _ = Describe("HyperconvergedController", func() {
 		Context("HCO Lifecycle", func() {
 
 			BeforeEach(func() {
-				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
-				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
+				os.Setenv("CONVERSION_CONTAINER", conversion_image)
+				os.Setenv("VMWARE_CONTAINER", vmware_image)
 				os.Setenv("OPERATOR_NAMESPACE", namespace)
 			})
 
@@ -503,8 +503,8 @@ var _ = Describe("HyperconvergedController", func() {
 			origConds := expected.hco.Status.Conditions
 
 			BeforeEach(func() {
-				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
-				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
+				os.Setenv("CONVERSION_CONTAINER", conversion_image)
+				os.Setenv("VMWARE_CONTAINER", vmware_image)
 				os.Setenv("OPERATOR_NAMESPACE", namespace)
 				os.Setenv(hcoutil.HcoKvIoVersionName, version.Version)
 			})
@@ -543,8 +543,8 @@ var _ = Describe("HyperconvergedController", func() {
 			)
 
 			BeforeEach(func() {
-				os.Setenv("CONVERSION_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-v2v-conversion:v2.0.0")
-				os.Setenv("VMWARE_CONTAINER", "registry.redhat.io/container-native-virtualization/kubevirt-vmware:v2.0.0}")
+				os.Setenv("CONVERSION_CONTAINER", conversion_image)
+				os.Setenv("VMWARE_CONTAINER", vmware_image)
 				os.Setenv("OPERATOR_NAMESPACE", namespace)
 
 				expected.kv.Status.ObservedKubeVirtVersion = newComponentVersion

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -86,6 +86,8 @@ var (
 			Namespace: namespace,
 		},
 	}
+	conversion_image = "quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0"
+	vmware_image     = "quay.io/kubevirt/kubevirt-vmware:v2.0.0"
 )
 
 func newHco() *hcov1beta1.HyperConverged {
@@ -205,6 +207,8 @@ func getBasicDeployment() *basicExpected {
 	res.kvMtAg = kvMtAg
 
 	res.imsConfig = newIMSConfigForCR(hco, namespace)
+	res.imsConfig.Data["v2v-conversion-image"] = conversion_image
+	res.imsConfig.Data["kubevirt-vmware-image"] = vmware_image
 
 	return res
 }


### PR DESCRIPTION
IMS ConfigMap should be reconciled to HCO opinionated values.

Fixes: https://bugzilla.redhat.com/1879993

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Reconcile IMS ConfigMap
```

