### PR TITLE
Trigger the override-bot asynchronously

### DIFF
--- a/.github/workflows/override-bot.yaml
+++ b/.github/workflows/override-bot.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   override:
     name: Check for redundant CI lanes for override
-    if: (github.event.issue.pull_request != '') && (contains(github.event.comment.body, '/override-bot')) && (github.repository == 'kubevirt/hyperconverged-cluster-operator')
+    if: github.event.issue.pull_request != '' && github.repository == 'kubevirt/hyperconverged-cluster-operator' && github.event.comment.user.login == 'openshift-ci-robot'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code


### PR DESCRIPTION
The bot will be triggered whenever "openshift-ci-robot" will be commenting on failed openshift-ci lanes, then it will override the failed redundant lanes.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

