### PR TITLE
Fix ValidateUpdate on the validating webhook

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -153,6 +153,8 @@ done
 # compare initial cluster SCCs to be sure HCO deployment didn't introduce any change
 dump_sccs_after
 
+"${CMD}" patch hyperconverged -n ${HCO_NAMESPACE} ${HCO_RESOURCE_NAME} --type='json' -p='[{"op": "add", "path":"/spec/infra", "value": {"nodePlacement": {"nodeSelector": {"nodeType": "infra"}}}}, {"op": "add", "path": "/spec/workloads", "value": {"nodePlacement": {"nodeSelector": {"nodeType": "workloads"}}}}]'
+
 if [ -z "$CONTAINER_ERRORED" ]; then
     echo "SUCCESS"
     exit 0

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -41,7 +41,7 @@
 # to verify that it is updated to the new operator image from 
 # the local registry.
 
-MAX_STEPS=11
+MAX_STEPS=12
 CUR_STEP=1
 RELEASE_DELTA="${RELEASE_DELTA:-1}"
 HCO_DEPLOYMENT_NAME=hco-operator
@@ -245,4 +245,8 @@ ${CMD} get deployments -n ${HCO_NAMESPACE} -o yaml | grep image | grep -v imageP
 ${CMD} get pod $HCO_CATALOGSOURCE_POD -n ${HCO_CATALOG_NAMESPACE} -o yaml | grep image | grep -v imagePullPolicy
 
 dump_sccs_after
+
+Msg "Test node placement APIs"
+"${CMD}" patch hyperconverged -n ${HCO_NAMESPACE} ${HCO_RESOURCE_NAME} --type='json' -p='[{"op": "add", "path":"/spec/infra", "value": {"nodePlacement": {"nodeSelector": {"nodeType": "infra"}}}}, {"op": "add", "path": "/spec/workloads", "value": {"nodePlacement": {"nodeSelector": {"nodeType": "workloads"}}}}]'
+
 echo "upgrade-test completed successfully."

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
@@ -120,8 +120,8 @@ func (r *HyperConverged) ValidateUpdate(old runtime.Object) error {
 
 		opts := &client.UpdateOptions{DryRun: []string{metav1.DryRunAll}}
 		for _, obj := range []runtime.Object{
-			&kubevirtv1.KubeVirt{},
-			&cdiv1beta1.CDI{},
+			r.NewKubeVirt(),
+			r.NewCDI(),
 		} {
 			if err := r.UpdateOperatorCr(ctx, obj, opts); err != nil {
 				return err


### PR DESCRIPTION
Fix ValidateUpdate on the validating webhook

Fix ValidateUpdate on the validating webhook
properling looking up for existing objects
correctly initializing their names.

Testing it on e2e CI

**Release note**:
```release-note
NONE
```

