### PR TITLE
Fix ValidateUpdate on the validating webhook

### DIFF
--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
@@ -120,8 +120,8 @@ func (r *HyperConverged) ValidateUpdate(old runtime.Object) error {
 
 		opts := &client.UpdateOptions{DryRun: []string{metav1.DryRunAll}}
 		for _, obj := range []runtime.Object{
-			&kubevirtv1.KubeVirt{},
-			&cdiv1beta1.CDI{},
+			r.NewKubeVirt(),
+			r.NewCDI(),
 		} {
 			if err := r.UpdateOperatorCr(ctx, obj, opts); err != nil {
 				return err


### PR DESCRIPTION
Fix ValidateUpdate on the validating webhook

Fix ValidateUpdate on the validating webhook
properling looking up for existing objects
correctly initializing their names.

Fixes: https://bugzilla.redhat.com/1884138

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Fix ValidateUpdate on the validating webhook
```

