### PR TITLE
Add Operator Descriptors to properly render node placement on UI

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:95c8c3e9002ebe55254b9371757a98a3d29991ba83e3edfe405a9174c596365a
-    createdAt: "2020-10-06 15:26:30"
+    createdAt: "2020-10-06 17:32:02"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -88,6 +88,42 @@ spec:
       displayName: HyperConverged Cluster Operator Deployment
       kind: HyperConverged
       name: hyperconvergeds.hco.kubevirt.io
+      specDescriptors:
+      - description: nodeAffinity describes node affinity scheduling rules for the infra pods.
+        displayName: Infra components node affinity
+        path: infra.nodePlacement.affinity.nodeAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
+      - description: podAffinity describes pod affinity scheduling rules for the infra pods.
+        displayName: Infra components pod affinity
+        path: infra.nodePlacement.affinity.podAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAffinity
+      - description: podAntiAffinity describes pod anti affinity scheduling rules for the infra pods.
+        displayName: Infra components pod anti-affinity
+        path: infra.nodePlacement.affinity.podAntiAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
+      - description: nodeAffinity describes node affinity scheduling rules for the workloads pods.
+        displayName: Workloads components node affinity
+        path: workloads.nodePlacement.affinity.nodeAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
+      - description: podAffinity describes pod affinity scheduling rules for the workloads pods.
+        displayName: Workloads components pod affinity
+        path: workloads.nodePlacement.affinity.podAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAffinity
+      - description: podAntiAffinity describes pod anti affinity scheduling rules for the workloads pods.
+        displayName: Workloads components pod anti-affinity
+        path: workloads.nodePlacement.affinity.podAntiAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
+      - description: HIDDEN FIELDS - operator version.
+        displayName: HIDDEN FIELDS - operator version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       version: v1beta1
     - description: V2V Vmware
       displayName: V2V Vmware

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -878,6 +878,67 @@ func GetCSVBase(name, namespace, displayName, description, image, replaces strin
 						Kind:        "HyperConverged",
 						DisplayName: crdDisplay + " Deployment",
 						Description: "Represents the deployment of " + crdDisplay,
+						// TODO: move this to annotations on hyperconverged_types.go once kubebuilder
+						// properly supports SpecDescriptors as the operator-sdk already does
+						SpecDescriptors: []csvv1alpha1.SpecDescriptor{
+							{
+								DisplayName: "Infra components node affinity",
+								Description: "nodeAffinity describes node affinity scheduling rules for the infra pods.",
+								Path:        "infra.nodePlacement.affinity.nodeAffinity",
+								XDescriptors: []string{
+									"urn:alm:descriptor:com.tectonic.ui:nodeAffinity",
+								},
+							},
+							{
+								DisplayName: "Infra components pod affinity",
+								Description: "podAffinity describes pod affinity scheduling rules for the infra pods.",
+								Path:        "infra.nodePlacement.affinity.podAffinity",
+								XDescriptors: []string{
+									"urn:alm:descriptor:com.tectonic.ui:podAffinity",
+								},
+							},
+							{
+								DisplayName: "Infra components pod anti-affinity",
+								Description: "podAntiAffinity describes pod anti affinity scheduling rules for the infra pods.",
+								Path:        "infra.nodePlacement.affinity.podAntiAffinity",
+								XDescriptors: []string{
+									"urn:alm:descriptor:com.tectonic.ui:podAntiAffinity",
+								},
+							},
+							{
+								DisplayName: "Workloads components node affinity",
+								Description: "nodeAffinity describes node affinity scheduling rules for the workloads pods.",
+								Path:        "workloads.nodePlacement.affinity.nodeAffinity",
+								XDescriptors: []string{
+									"urn:alm:descriptor:com.tectonic.ui:nodeAffinity",
+								},
+							},
+							{
+								DisplayName: "Workloads components pod affinity",
+								Description: "podAffinity describes pod affinity scheduling rules for the workloads pods.",
+								Path:        "workloads.nodePlacement.affinity.podAffinity",
+								XDescriptors: []string{
+									"urn:alm:descriptor:com.tectonic.ui:podAffinity",
+								},
+							},
+							{
+								DisplayName: "Workloads components pod anti-affinity",
+								Description: "podAntiAffinity describes pod anti affinity scheduling rules for the workloads pods.",
+								Path:        "workloads.nodePlacement.affinity.podAntiAffinity",
+								XDescriptors: []string{
+									"urn:alm:descriptor:com.tectonic.ui:podAntiAffinity",
+								},
+							},
+							{
+								DisplayName: "HIDDEN FIELDS - operator version",
+								Description: "HIDDEN FIELDS - operator version.",
+								Path:        "version",
+								XDescriptors: []string{
+									"urn:alm:descriptor:com.tectonic.ui:hidden",
+								},
+							},
+						},
+						StatusDescriptors: []csvv1alpha1.StatusDescriptor{},
 					},
 					// TODO: remove once oVirt and VMware providers are removed from HCO
 					{


### PR DESCRIPTION
Following
https://github.com/openshift/console/tree/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors ,
let's add Operator Descriptors to get node placement APIs
pretty rendered on UI form.

Kubebuilder still doens't directly supports them with its
annotations as the oeprator-sdk does, so let's add them
to the CRD Templates stanza in the ClusterServiceVersion.

Use the same mechanism to hide spec.version from the create
form.

Fixes: https://bugzilla.redhat.com/1885535

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Add Operator Descriptors to properly render node placement on UI
```

