### PR TITLE
Adding CSV Annotation for HCO CR deployment during installation

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:95c8c3e9002ebe55254b9371757a98a3d29991ba83e3edfe405a9174c596365a
-    createdAt: "2020-10-12 16:34:46"
+    createdAt: "2020-10-14 16:45:10"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -74,6 +74,7 @@ metadata:
 
       KubeVirt is distributed under the
       [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+    operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{"BareMetalPlatform":false}}'
     operatorframework.io/suggested-namespace: kubevirt-hyperconverged
     operators.operatorframework.io/internal-objects: '["v2vvmwares.v2v.kubevirt.io","ovirtproviders.v2v.kubevirt.io","networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","kubevirtcommontemplatesbundles.ssp.kubevirt.io","kubevirtmetricsaggregations.ssp.kubevirt.io","kubevirtnodelabellerbundles.ssp.kubevirt.io","kubevirttemplatevalidators.ssp.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.nodemaintenance.kubevirt.io","vmimportconfigs.v2v.kubevirt.io"]'
     repository: https://github.com/kubevirt/hyperconverged-cluster-operator

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -3,10 +3,8 @@ package components
 import (
 	"encoding/json"
 	"fmt"
-
 	"golang.org/x/tools/go/packages"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"time"
 
 	"sigs.k8s.io/controller-tools/pkg/loader"
@@ -729,7 +727,7 @@ func GetInstallStrategyBase(namespace, image, imagePullPolicy, conversionContain
 
 // GetCSVBase returns a base HCO CSV without an InstallStrategy
 func GetCSVBase(name, namespace, displayName, description, image, replaces string, version semver.Version, crdDisplay string) *csvv1alpha1.ClusterServiceVersion {
-	almExamples, _ := json.Marshal([]interface{}{
+	almExamples, _ := json.Marshal(
 		map[string]interface{}{
 			"apiVersion": "hco.kubevirt.io/v1beta1",
 			"kind":       "HyperConverged",
@@ -740,8 +738,7 @@ func GetCSVBase(name, namespace, displayName, description, image, replaces strin
 			"spec": map[string]interface{}{
 				"BareMetalPlatform": false,
 			},
-		},
-	})
+		})
 
 	sideEffect := admissionregistrationv1.SideEffectClassNone
 	// Explicitly fail on unvalidated (for any reason) requests:
@@ -801,7 +798,8 @@ func GetCSVBase(name, namespace, displayName, description, image, replaces strin
 				"description":    description,
 				"repository":     "https://github.com/kubevirt/hyperconverged-cluster-operator",
 				"support":        "false",
-				"operatorframework.io/suggested-namespace": namespace,
+				"operatorframework.io/suggested-namespace":     namespace,
+				"operatorframework.io/initialization-resource": string(almExamples),
 			},
 		},
 		Spec: csvv1alpha1.ClusterServiceVersionSpec{

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -345,11 +345,15 @@ func main() {
 					},
 				)
 			}
-
 			csv_base_alm_string := csvExtended.Annotations["alm-examples"]
 			csv_struct_alm_string := csvStruct.Annotations["alm-examples"]
 			var base_almcrs []interface{}
 			var struct_almcrs []interface{}
+
+			if !strings.HasPrefix(csv_base_alm_string, "[") {
+				csv_base_alm_string = "[" + csv_base_alm_string + "]"
+			}
+
 			if err = json.Unmarshal([]byte(csv_base_alm_string), &base_almcrs); err != nil {
 				panic(err)
 			}

--- a/tools/util/marshaller.go
+++ b/tools/util/marshaller.go
@@ -25,6 +25,7 @@ package util
 import (
 	"encoding/json"
 	"io"
+	"regexp"
 	"strings"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -107,8 +108,8 @@ func MarshallObject(obj interface{}, writer io.Writer) error {
 
 	// fix templates by removing unneeded single quotes...
 	s := string(yamlBytes)
-	s = strings.Replace(s, "'{{", "{{", -1)
-	s = strings.Replace(s, "}}'", "}}", -1)
+	re := regexp.MustCompile(`'({{.*?}})'`)
+	s = re.ReplaceAllString(s, "$1")
 
 	// fix double quoted strings by removing unneeded single quotes...
 	s = strings.Replace(s, " '\"", " \"", -1)


### PR DESCRIPTION
Utilizing OLM feature of creating the operand's CR as a part of the installation process through OpertorHub.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add initialization-resource annotation to CSV
```

