### PR TITLE
build-manifests: don't attach a TTY to yamllint

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -422,8 +422,8 @@ cp -f ${TEMPDIR}/*.${CRD_EXT} ${CRD_DIR}
 cp -f ${TEMPDIR}/*.${CRD_EXT} ${CSV_DIR}
 
 # Validate the yaml files
-(cd ${CRD_DIR} && docker run -it --rm -v "$(pwd)":/yaml sdesbure/yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable}}" *.yaml)
-(cd ${CSV_DIR} && docker run -it --rm -v "$(pwd)":/yaml sdesbure/yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable}}" *.yaml)
+(cd ${CRD_DIR} && docker run --rm -v "$(pwd)":/yaml sdesbure/yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable}}" *.yaml)
+(cd ${CSV_DIR} && docker run --rm -v "$(pwd)":/yaml sdesbure/yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable}}" *.yaml)
 
 # Check there are not API Groups overlap between different CNV operators
 ${PROJECT_ROOT}/tools/csv-merger/csv-merger --crds-dir=${CRD_DIR}


### PR DESCRIPTION
When running the yamllint container in an environment without a TTY,
build-manifests.sh will fail on: `the input device is not a TTY`, we
should be safe to drop the interactive/tty flags

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

