### PR TITLE
Build upgrade test images with fedora-33

### DIFF
--- a/deploy/Dockerfile.registry.upgrade
+++ b/deploy/Dockerfile.registry.upgrade
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:30-x86_64 AS builder
+FROM quay.io/fedora/fedora:33-x86_64 AS builder
 ARG UPGRADE_VERSION=100.0.0
 
 ENV GOPATH=/go

--- a/deploy/Dockerfile.registry.upgrade-prev
+++ b/deploy/Dockerfile.registry.upgrade-prev
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:30-x86_64 AS builder
+FROM quay.io/fedora/fedora:33-x86_64 AS builder
 ARG UPGRADE_VERSION=100.0.0
 
 ENV GOPATH=/go


### PR DESCRIPTION
Build upgrade test images with fedora-33

fedora-30 images got removed from quay.io

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

