### PR TITLE
Split operator and webhook into two different pods

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -12,7 +12,7 @@ rm -rf _out/
 cp -r deploy _out/
 
 # Sed from quay.io to local registry
-sed -r -i "s|image: quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|image: registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" _out/operator.yaml
+sed -r -i 's|: quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|: registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g' _out/operator.yaml
 
 CMD="./cluster/kubectl.sh" ./hack/clean.sh
 

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -7,8 +7,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional
     certified: "false"
-    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:95c8c3e9002ebe55254b9371757a98a3d29991ba83e3edfe405a9174c596365a
-    createdAt: "2020-10-20 05:14:01"
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:0d5d8fe37c8174d93a0de46894e49c576f1cab4e8e53f276e16db012cc4cc4a6
+    createdAt: "2020-10-22 17:05:55"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1691,9 +1691,11 @@ spec:
               - command:
                 - hyperconverged-cluster-operator
                 env:
+                - name: WEBHOOK_MODE
+                  value: "false"
                 - name: KVM_EMULATION
                 - name: OPERATOR_IMAGE
-                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:95c8c3e9002ebe55254b9371757a98a3d29991ba83e3edfe405a9174c596365a
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:0d5d8fe37c8174d93a0de46894e49c576f1cab4e8e53f276e16db012cc4cc4a6
                 - name: OPERATOR_NAME
                   value: hyperconverged-cluster-operator
                 - name: OPERATOR_NAMESPACE
@@ -1729,9 +1731,51 @@ spec:
                   value: v0.5.2
                 - name: VM_IMPORT_VERSION
                   value: v0.2.4
-                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:95c8c3e9002ebe55254b9371757a98a3d29991ba83e3edfe405a9174c596365a
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:0d5d8fe37c8174d93a0de46894e49c576f1cab4e8e53f276e16db012cc4cc4a6
                 imagePullPolicy: IfNotPresent
                 name: hyperconverged-cluster-operator
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - name: hco-webhook
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-webhook
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hyperconverged-cluster-webhook
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-operator
+                env:
+                - name: WEBHOOK_MODE
+                  value: "true"
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:0d5d8fe37c8174d93a0de46894e49c576f1cab4e8e53f276e16db012cc4cc4a6
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-webhook
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:0d5d8fe37c8174d93a0de46894e49c576f1cab4e8e53f276e16db012cc4cc4a6
+                imagePullPolicy: IfNotPresent
+                name: hyperconverged-cluster-webhook
                 readinessProbe:
                   exec:
                     command:
@@ -2274,7 +2318,7 @@ spec:
     name: hostpath-provisioner
   - image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:074aae9b1fbc727975934e86eea31e699e4504c24e1a7aea6d0b2d69f0e07673
     name: hostpath-provisioner-operator
-  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:95c8c3e9002ebe55254b9371757a98a3d29991ba83e3edfe405a9174c596365a
+  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:0d5d8fe37c8174d93a0de46894e49c576f1cab4e8e53f276e16db012cc4cc4a6
     name: hyperconverged-cluster-operator
   - image: quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e
     name: kubemacpool
@@ -2321,7 +2365,7 @@ spec:
     - v1beta1
     - v1
     containerPort: 4343
-    deploymentName: hco-operator
+    deploymentName: hco-webhook
     failurePolicy: Fail
     generateName: validate-hco.kubevirt.io
     rules:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,9 +20,11 @@ spec:
       - command:
         - hyperconverged-cluster-operator
         env:
+        - name: WEBHOOK_MODE
+          value: "false"
         - name: KVM_EMULATION
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:95c8c3e9002ebe55254b9371757a98a3d29991ba83e3edfe405a9174c596365a
+          value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:0d5d8fe37c8174d93a0de46894e49c576f1cab4e8e53f276e16db012cc4cc4a6
         - name: OPERATOR_NAME
           value: hyperconverged-cluster-operator
         - name: OPERATOR_NAMESPACE
@@ -58,9 +60,57 @@ spec:
           value: v0.5.2
         - name: VM_IMPORT_VERSION
           value: v0.2.4
-        image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:95c8c3e9002ebe55254b9371757a98a3d29991ba83e3edfe405a9174c596365a
+        image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:0d5d8fe37c8174d93a0de46894e49c576f1cab4e8e53f276e16db012cc4cc4a6
         imagePullPolicy: IfNotPresent
         name: hyperconverged-cluster-operator
+        readinessProbe:
+          exec:
+            command:
+            - stat
+            - /tmp/operator-sdk-ready
+          failureThreshold: 1
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources: {}
+      serviceAccountName: hyperconverged-cluster-operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: hyperconverged-cluster-webhook
+  name: hyperconverged-cluster-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: hyperconverged-cluster-webhook
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        name: hyperconverged-cluster-webhook
+    spec:
+      containers:
+      - command:
+        - hyperconverged-cluster-operator
+        env:
+        - name: WEBHOOK_MODE
+          value: "true"
+        - name: OPERATOR_IMAGE
+          value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:0d5d8fe37c8174d93a0de46894e49c576f1cab4e8e53f276e16db012cc4cc4a6
+        - name: OPERATOR_NAME
+          value: hyperconverged-cluster-webhook
+        - name: OPERATOR_NAMESPACE
+          value: kubevirt-hyperconverged
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: WATCH_NAMESPACE
+        image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:0d5d8fe37c8174d93a0de46894e49c576f1cab4e8e53f276e16db012cc4cc4a6
+        imagePullPolicy: IfNotPresent
+        name: hyperconverged-cluster-webhook
         readinessProbe:
           exec:
             command:

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -53,7 +53,7 @@ if [ -n "${IMAGE_FORMAT}" ]; then
     HCO_IMAGE=`eval echo ${IMAGE_FORMAT}`
 fi
 
-sed -i "s|image: quay.io/kubevirt/hyperconverged-cluster-operator:.*$|image: ${HCO_IMAGE}|g" _out/operator.yaml
+sed -i -r "s|: quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|: ${HCO_IMAGE}|g" _out/operator.yaml
 
 if [[ -n ${HCO_CONFIGURATION_HOOK} ]]; then
   ${HCO_CONFIGURATION_HOOK}

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
@@ -36,8 +36,8 @@ func (r *HyperConverged) SetupWebhookWithManager(ctx context.Context, mgr ctrl.M
 	certs := []string{filepath.Join(WebhookCertDir, WebhookCertName), filepath.Join(WebhookCertDir, WebhookKeyName)}
 	for _, fname := range certs {
 		if _, err := os.Stat(fname); err != nil {
-			hcolog.Info("CSV certificates were not found, skipping webhook initialization")
-			return nil
+			hcolog.Error(err, "CSV certificates were not found, skipping webhook initialization")
+			return err
 		}
 	}
 

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -6,6 +6,7 @@ import (
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	secv1 "github.com/openshift/api/security/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -47,8 +48,8 @@ func (c *ClusterInfoImp) CheckRunningInOpenshift(creader client.Reader, ctx cont
 
 	err = creader.Get(ctx, key, clusterVersion)
 
-	if err != nil && apierrors.IsNotFound(err) {
-		if apierrors.IsNotFound(err) {
+	if err != nil {
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
 			// Not on OpenShift
 			isOpenShift = false
 		} else {

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -2,24 +2,25 @@ package util
 
 // HCO common constants
 const (
-	OperatorNamespaceEnv = "OPERATOR_NAMESPACE"
-	HcoKvIoVersionName   = "HCO_KV_IO_VERSION"
-	KubevirtVersionEnvV  = "KUBEVIRT_VERSION"
-	CdiVersionEnvV       = "CDI_VERSION"
-	CnaoVersionEnvV      = "NETWORK_ADDONS_VERSION"
-	SspVersionEnvV       = "SSP_VERSION"
-	NmoVersionEnvV       = "NMO_VERSION"
-	HppoVersionEnvV      = "HPPO_VERSION"
-	VMImportEnvV         = "VM_IMPORT_VERSION"
-	HcoValidatingWebhook = "validate-hco.kubevirt.io"
-	AppLabel             = "app"
-	UndefinedNamespace   = ""
-	OpenshiftNamespace   = "openshift"
-	APIVersionAlpha      = "v1alpha1"
-	APIVersionBeta       = "v1beta1"
-	CurrentAPIVersion    = APIVersionBeta
-	APIVersionGroup      = "hco.kubevirt.io"
-	APIVersion           = APIVersionGroup + "/" + APIVersionBeta
+	OperatorNamespaceEnv   = "OPERATOR_NAMESPACE"
+	OperatorWebhookModeEnv = "WEBHOOK_MODE"
+	HcoKvIoVersionName     = "HCO_KV_IO_VERSION"
+	KubevirtVersionEnvV    = "KUBEVIRT_VERSION"
+	CdiVersionEnvV         = "CDI_VERSION"
+	CnaoVersionEnvV        = "NETWORK_ADDONS_VERSION"
+	SspVersionEnvV         = "SSP_VERSION"
+	NmoVersionEnvV         = "NMO_VERSION"
+	HppoVersionEnvV        = "HPPO_VERSION"
+	VMImportEnvV           = "VM_IMPORT_VERSION"
+	HcoValidatingWebhook   = "validate-hco.kubevirt.io"
+	AppLabel               = "app"
+	UndefinedNamespace     = ""
+	OpenshiftNamespace     = "openshift"
+	APIVersionAlpha        = "v1alpha1"
+	APIVersionBeta         = "v1beta1"
+	CurrentAPIVersion      = APIVersionBeta
+	APIVersionGroup        = "hco.kubevirt.io"
+	APIVersion             = APIVersionGroup + "/" + APIVersionBeta
 	// HyperConvergedName is the name of the HyperConverged resource that will be reconciled
 	HyperConvergedName = "kubevirt-hyperconverged"
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -30,6 +30,20 @@ func GetOperatorNamespaceFromEnv() (string, error) {
 	return "", fmt.Errorf("%s unset or empty in environment", OperatorNamespaceEnv)
 }
 
+func GetWebhookModeFromEnv() (bool, error) {
+	if whmodestring, ok := os.LookupEnv(OperatorWebhookModeEnv); ok {
+		if whmodestring == "true" {
+			return true, nil
+		} else if whmodestring == "false" {
+			return false, nil
+		} else {
+			return false, fmt.Errorf("%s unexpected value in environment", OperatorWebhookModeEnv)
+		}
+	}
+
+	return false, fmt.Errorf("%s unset or empty in environment", OperatorWebhookModeEnv)
+}
+
 func GetPod(ctx context.Context, c client.Reader, logger logr.Logger, ci ClusterInfo) (*corev1.Pod, error) {
 	operatorNs, err := k8sutil.GetOperatorNamespace()
 	if err != nil {

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -123,7 +123,7 @@ func main() {
 	// service accounts are represented as a map to prevent us from generating the
 	// same service account multiple times.
 	deployments := []appsv1.Deployment{
-		components.GetDeployment(
+		components.GetDeploymentOperator(
 			*operatorNamespace,
 			*operatorImage,
 			"IfNotPresent",
@@ -139,6 +139,12 @@ func main() {
 			*nmoVersion,
 			*hppoVersion,
 			*vmImportVersion,
+			[]corev1.EnvVar{},
+		),
+		components.GetDeploymentWebhook(
+			*operatorNamespace,
+			*operatorImage,
+			"IfNotPresent",
 			[]corev1.EnvVar{},
 		),
 	}


### PR DESCRIPTION
Split operator and webhook into two different pods

Currently we are abusing the pod readiness to signal
to OLM that HCO is not ready for an upgrade.
This has a lot of side effects, one of this is the
validating webhook being not able to receive traffic
when exposed by a pod that is not reporting ready=true.
This can cause a lot of side effects if not deadlocks
when the system reach a status where, for any possible
reason, HCO pod cannot be ready and so HCO pod cannot
validate any further update or delete request on HCO CR.
A proper solution is properly use the readiness probe
only to report the pod readiness and communicate
status to OLM via conditions once OLM will be ready for:
https://github.com/operator-framework/enhancements/blob/master/enhancements/operator-conditions.md
in the meanwhile a quick (but dirty!) solution is to
expose the same hco binary on two distinct pods:
the first one will run only the controller and
the second one (almost always ready) just the validating
webhook one.
A deeper code refactor to produce two distinct binaries
is not worth now because we are going to use OLM operator
conditions soon.

Fixes: https://bugzilla.redhat.com/1889401

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
split operator and webhook into two different pods
```

