### PR TITLE
[release-1.2] Split operator and webhook into two different pods (#893)

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -12,7 +12,7 @@ rm -rf _out/
 cp -r deploy _out/
 
 # Sed from quay.io to local registry
-sed -r -i "s|image: quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|image: registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" _out/operator.yaml
+sed -r -i 's|: quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|: registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g' _out/operator.yaml
 
 CMD="./cluster/kubectl.sh" ./hack/clean.sh
 

--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -110,6 +110,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	// TODO: remove this once we will move to OLM operator conditions
+	// Get the webhook mode
+	operatorWebhookMode, err := hcoutil.GetWebhookModeFromEnv()
+	if err != nil {
+		log.Error(err, "Failed to get operator webhook mode from the environment")
+		os.Exit(1)
+	}
+	if operatorWebhookMode {
+		log.Info("operatorWebhookMode: running only the validating webhook")
+	} else {
+		log.Info("operatorWebhookMode: running only the real operator")
+	}
+
 	if runInLocal {
 		depOperatorNs = operatorNsEnv
 	}
@@ -142,11 +155,15 @@ func main() {
 
 	ctx := context.TODO()
 
-	// Become the leader before proceeding
-	err = leader.Become(ctx, "hyperconverged-cluster-operator-lock")
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
+	// a lock is not needed in webhook mode
+	// TODO: remove this once we will move to OLM operator conditions
+	if !operatorWebhookMode {
+		// Become the leader before proceeding
+		err = leader.Become(ctx, "hyperconverged-cluster-operator-lock")
+		if err != nil {
+			log.Error(err, "")
+			os.Exit(1)
+		}
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
@@ -156,20 +173,6 @@ func main() {
 	})
 	if err != nil {
 		log.Error(err, "")
-		os.Exit(1)
-	}
-
-	ci := hcoutil.GetClusterInfo()
-	err = ci.CheckRunningInOpenshift(log, runInLocal)
-	if err != nil {
-		log.Error(err, "Cannot detect cluster type")
-	}
-
-	eventEmitter := hcoutil.GetEventEmitter()
-	// Set temporary configuration, until the regular client is ready
-	eventEmitter.Init(ctx, mgr, ci, log)
-	if err != nil {
-		log.Error(err, "failed to initiate event emitter")
 		os.Exit(1)
 	}
 
@@ -192,11 +195,30 @@ func main() {
 		}
 	}
 
-	// Setup all Controllers
-	if err := controller.AddToManager(mgr, ci); err != nil {
-		log.Error(err, "")
-		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to register component; "+err.Error())
+	// Detect OpenShift version
+	ci := hcoutil.GetClusterInfo()
+	err = ci.CheckRunningInOpenshift(log, runInLocal)
+	if err != nil {
+		log.Error(err, "Cannot detect cluster type")
 		os.Exit(1)
+	}
+
+	eventEmitter := hcoutil.GetEventEmitter()
+	// Set temporary configuration, until the regular client is ready
+	eventEmitter.Init(ctx, mgr, ci, log)
+	if err != nil {
+		log.Error(err, "failed to initiate event emitter")
+		os.Exit(1)
+	}
+
+	// TODO: remove this once we will move to OLM operator conditions
+	if !operatorWebhookMode {
+		// Setup all Controllers
+		if err := controller.AddToManager(mgr, ci); err != nil {
+			log.Error(err, "")
+			eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to register component; "+err.Error())
+			os.Exit(1)
+		}
 	}
 
 	if !runInLocal {
@@ -227,18 +249,21 @@ func main() {
 		}
 	}
 
-	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
-	// necessary to configure Prometheus to scrape metrics from this operator.
-	if err = (&hcov1beta1.HyperConverged{}).SetupWebhookWithManager(ctx, mgr); err != nil {
-		log.Error(err, "unable to create webhook", "webhook", "HyperConverged")
-		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to create webhook")
-		os.Exit(1)
-	}
-
-	err = createPriorityClass(ctx, mgr)
-	if err != nil {
-		log.Error(err, "Failed creating PriorityClass")
-		os.Exit(1)
+	// TODO: remove this once we will move to OLM operator conditions
+	if operatorWebhookMode {
+		// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
+		// necessary to configure Prometheus to scrape metrics from this operator.
+		if err = (&hcov1beta1.HyperConverged{}).SetupWebhookWithManager(ctx, mgr); err != nil {
+			log.Error(err, "unable to create webhook", "webhook", "HyperConverged")
+			eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to create webhook")
+			os.Exit(1)
+		}
+	} else {
+		err = createPriorityClass(ctx, mgr)
+		if err != nil {
+			log.Error(err, "Failed creating PriorityClass")
+			os.Exit(1)
+		}
 	}
 
 	log.Info("Starting the Cmd.")

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
@@ -7,8 +7,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional
     certified: "false"
-    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
-    createdAt: "2020-10-20 09:15:26"
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+    createdAt: "2020-10-23 09:15:17"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1683,9 +1683,11 @@ spec:
               - command:
                 - hyperconverged-cluster-operator
                 env:
+                - name: WEBHOOK_MODE
+                  value: "false"
                 - name: KVM_EMULATION
                 - name: OPERATOR_IMAGE
-                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
                 - name: OPERATOR_NAME
                   value: hyperconverged-cluster-operator
                 - name: OPERATOR_NAMESPACE
@@ -1721,9 +1723,51 @@ spec:
                   value: v0.5.2
                 - name: VM_IMPORT_VERSION
                   value: v0.2.4
-                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
                 imagePullPolicy: IfNotPresent
                 name: hyperconverged-cluster-operator
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - name: hco-webhook
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-webhook
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hyperconverged-cluster-webhook
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-operator
+                env:
+                - name: WEBHOOK_MODE
+                  value: "true"
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-webhook
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+                imagePullPolicy: IfNotPresent
+                name: hyperconverged-cluster-webhook
                 readinessProbe:
                   exec:
                     command:
@@ -2266,7 +2310,7 @@ spec:
     name: hostpath-provisioner
   - image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:074aae9b1fbc727975934e86eea31e699e4504c24e1a7aea6d0b2d69f0e07673
     name: hostpath-provisioner-operator
-  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
+  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
     name: hyperconverged-cluster-operator
   - image: quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e
     name: kubemacpool
@@ -2313,7 +2357,7 @@ spec:
     - v1beta1
     - v1
     containerPort: 4343
-    deploymentName: hco-operator
+    deploymentName: hco-webhook
     failurePolicy: Fail
     generateName: validate-hco.kubevirt.io
     rules:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,9 +20,11 @@ spec:
       - command:
         - hyperconverged-cluster-operator
         env:
+        - name: WEBHOOK_MODE
+          value: "false"
         - name: KVM_EMULATION
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
+          value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
         - name: OPERATOR_NAME
           value: hyperconverged-cluster-operator
         - name: OPERATOR_NAMESPACE
@@ -58,9 +60,57 @@ spec:
           value: v0.5.2
         - name: VM_IMPORT_VERSION
           value: v0.2.4
-        image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
+        image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
         imagePullPolicy: IfNotPresent
         name: hyperconverged-cluster-operator
+        readinessProbe:
+          exec:
+            command:
+            - stat
+            - /tmp/operator-sdk-ready
+          failureThreshold: 1
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources: {}
+      serviceAccountName: hyperconverged-cluster-operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: hyperconverged-cluster-webhook
+  name: hyperconverged-cluster-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: hyperconverged-cluster-webhook
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        name: hyperconverged-cluster-webhook
+    spec:
+      containers:
+      - command:
+        - hyperconverged-cluster-operator
+        env:
+        - name: WEBHOOK_MODE
+          value: "true"
+        - name: OPERATOR_IMAGE
+          value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+        - name: OPERATOR_NAME
+          value: hyperconverged-cluster-webhook
+        - name: OPERATOR_NAMESPACE
+          value: kubevirt-hyperconverged
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: WATCH_NAMESPACE
+        image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+        imagePullPolicy: IfNotPresent
+        name: hyperconverged-cluster-webhook
         readinessProbe:
           exec:
             command:

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -52,7 +52,7 @@ if [ -n "${IMAGE_FORMAT}" ]; then
     HCO_IMAGE=`eval echo ${IMAGE_FORMAT}`
 fi
 
-sed -i "s|image: quay.io/kubevirt/hyperconverged-cluster-operator:.*$|image: ${HCO_IMAGE}|g" _out/operator.yaml
+sed -i -r "s|: quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|: ${HCO_IMAGE}|g" _out/operator.yaml
 
 # create namespaces
 "${CMD}" create ns "${HCO_NAMESPACE}" | true

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
@@ -36,8 +36,8 @@ func (r *HyperConverged) SetupWebhookWithManager(ctx context.Context, mgr ctrl.M
 	certs := []string{filepath.Join(WebhookCertDir, WebhookCertName), filepath.Join(WebhookCertDir, WebhookKeyName)}
 	for _, fname := range certs {
 		if _, err := os.Stat(fname); err != nil {
-			hcolog.Info("CSV certificates were not found, skipping webhook initialization")
-			return nil
+			hcolog.Error(err, "CSV certificates were not found, skipping webhook initialization")
+			return err
 		}
 	}
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -32,12 +32,14 @@ import (
 )
 
 const (
-	hcoName           = "hyperconverged-cluster-operator"
-	hcoDeploymentName = "hco-operator"
-	hcoWebhookPath    = "/validate-hco-kubevirt-io-v1beta1-hyperconverged"
+	hcoName             = "hyperconverged-cluster-operator"
+	hcoNameWebhook      = "hyperconverged-cluster-webhook"
+	hcoDeploymentName   = "hco-operator"
+	hcoWhDeploymentName = "hco-webhook"
+	hcoWebhookPath      = "/validate-hco-kubevirt-io-v1beta1-hyperconverged"
 )
 
-func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion string, env []corev1.EnvVar) appsv1.Deployment {
+func GetDeploymentOperator(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion string, env []corev1.EnvVar) appsv1.Deployment {
 	return appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -49,11 +51,27 @@ func GetDeployment(namespace, image, imagePullPolicy, conversionContainer, vmwar
 				"name": hcoName,
 			},
 		},
-		Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion, env),
+		Spec: GetDeploymentSpecOperator(namespace, image, imagePullPolicy, conversionContainer, vmwareContainerString, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion, env),
 	}
 }
 
-func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion string, env []corev1.EnvVar) appsv1.DeploymentSpec {
+func GetDeploymentWebhook(namespace, image, imagePullPolicy string, env []corev1.EnvVar) appsv1.Deployment {
+	return appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hcoNameWebhook,
+			Labels: map[string]string{
+				"name": hcoNameWebhook,
+			},
+		},
+		Spec: GetDeploymentSpecWebhook(namespace, image, imagePullPolicy, env),
+	}
+}
+
+func GetDeploymentSpecOperator(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion string, env []corev1.EnvVar) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
 		Replicas: int32Ptr(1),
 		Selector: &metav1.LabelSelector{
@@ -90,6 +108,10 @@ func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, v
 							FailureThreshold:    1,
 						},
 						Env: append([]corev1.EnvVar{
+							{
+								Name:  util.OperatorWebhookModeEnv,
+								Value: "false",
+							},
 							{
 								Name:  "KVM_EMULATION",
 								Value: "",
@@ -165,6 +187,94 @@ func GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, v
 							{
 								Name:  util.VMImportEnvV,
 								Value: vmImportVersion,
+							},
+						}, env...),
+					},
+				},
+			},
+		},
+	}
+}
+
+// Currently we are abusing the pod readiness to signal to OLM that HCO is not ready
+// for an upgrade. This has a lot of side effects, one of this is the validating webhook
+// being not able to receive traffic when exposed by a pod that is not reporting ready=true.
+// This can cause a lot of side effects if not deadlocks when the system reach a status where,
+// for any possible reason, HCO pod cannot be ready and so HCO pod cannot validate any further update or
+// delete request on HCO CR.
+// A proper solution is properly use the readiness probe only to report the pod readiness and communicate
+// status to OLM via conditions once OLM will be ready for:
+// https://github.com/operator-framework/enhancements/blob/master/enhancements/operator-conditions.md
+// in the meanwhile a quick (but dirty!) solution is to expose the same hco binary on two distinct pods:
+// the first one will run only the controller and the second one (almost always ready) just the validating
+// webhook one.
+// A deeper code refactor to produce two distinct binaries is not worth now because we are going to
+// use OLM operator conditions soon.
+// TODO: remove this once we will move to OLM operator conditions
+func GetDeploymentSpecWebhook(namespace, image, imagePullPolicy string, env []corev1.EnvVar) appsv1.DeploymentSpec {
+	return appsv1.DeploymentSpec{
+		Replicas: int32Ptr(1),
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"name": hcoNameWebhook,
+			},
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"name": hcoNameWebhook,
+				},
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: hcoName,
+				Containers: []corev1.Container{
+					{
+						Name:            hcoNameWebhook,
+						Image:           image,
+						ImagePullPolicy: corev1.PullPolicy(imagePullPolicy),
+						// TODO: command being name is artifact of operator-sdk usage
+						Command: []string{hcoName},
+						ReadinessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								Exec: &corev1.ExecAction{
+									Command: []string{
+										"stat",
+										"/tmp/operator-sdk-ready",
+									},
+								},
+							},
+							InitialDelaySeconds: 5,
+							PeriodSeconds:       5,
+							FailureThreshold:    1,
+						},
+						Env: append([]corev1.EnvVar{
+							{
+								Name:  util.OperatorWebhookModeEnv,
+								Value: "true",
+							},
+							{
+								Name:  "OPERATOR_IMAGE",
+								Value: image,
+							},
+							{
+								Name:  "OPERATOR_NAME",
+								Value: hcoNameWebhook,
+							},
+							{
+								Name:  "OPERATOR_NAMESPACE",
+								Value: namespace,
+							},
+							{
+								Name: "POD_NAME",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.name",
+									},
+								},
+							},
+							{
+								Name:  "WATCH_NAMESPACE",
+								Value: "",
 							},
 						}, env...),
 					},
@@ -714,7 +824,11 @@ func GetInstallStrategyBase(namespace, image, imagePullPolicy, conversionContain
 		DeploymentSpecs: []csvv1alpha1.StrategyDeploymentSpec{
 			csvv1alpha1.StrategyDeploymentSpec{
 				Name: hcoDeploymentName,
-				Spec: GetDeploymentSpec(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion, env),
+				Spec: GetDeploymentSpecOperator(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion, env),
+			},
+			csvv1alpha1.StrategyDeploymentSpec{
+				Name: hcoWhDeploymentName,
+				Spec: GetDeploymentSpecWebhook(namespace, image, imagePullPolicy, env),
 			},
 		},
 		Permissions: []csvv1alpha1.StrategyDeploymentPermissions{},
@@ -760,7 +874,7 @@ func GetCSVBase(name, namespace, displayName, description, image, replaces strin
 	validating_webhook := csvv1alpha1.WebhookDescription{
 		GenerateName:            util.HcoValidatingWebhook,
 		Type:                    csvv1alpha1.ValidatingAdmissionWebhook,
-		DeploymentName:          hcoDeploymentName,
+		DeploymentName:          hcoWhDeploymentName,
 		ContainerPort:           4343,
 		AdmissionReviewVersions: []string{"v1beta1", "v1"},
 		SideEffects:             &sideEffect,

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -2,24 +2,25 @@ package util
 
 // HCO common constants
 const (
-	OperatorNamespaceEnv = "OPERATOR_NAMESPACE"
-	HcoKvIoVersionName   = "HCO_KV_IO_VERSION"
-	KubevirtVersionEnvV  = "KUBEVIRT_VERSION"
-	CdiVersionEnvV       = "CDI_VERSION"
-	CnaoVersionEnvV      = "NETWORK_ADDONS_VERSION"
-	SspVersionEnvV       = "SSP_VERSION"
-	NmoVersionEnvV       = "NMO_VERSION"
-	HppoVersionEnvV      = "HPPO_VERSION"
-	VMImportEnvV         = "VM_IMPORT_VERSION"
-	HcoValidatingWebhook = "validate-hco.kubevirt.io"
-	AppLabel             = "app"
-	UndefinedNamespace   = ""
-	OpenshiftNamespace   = "openshift"
-	APIVersionAlpha      = "v1alpha1"
-	APIVersionBeta       = "v1beta1"
-	CurrentAPIVersion    = APIVersionBeta
-	APIVersionGroup      = "hco.kubevirt.io"
-	APIVersion           = APIVersionGroup + "/" + APIVersionBeta
+	OperatorNamespaceEnv   = "OPERATOR_NAMESPACE"
+	OperatorWebhookModeEnv = "WEBHOOK_MODE"
+	HcoKvIoVersionName     = "HCO_KV_IO_VERSION"
+	KubevirtVersionEnvV    = "KUBEVIRT_VERSION"
+	CdiVersionEnvV         = "CDI_VERSION"
+	CnaoVersionEnvV        = "NETWORK_ADDONS_VERSION"
+	SspVersionEnvV         = "SSP_VERSION"
+	NmoVersionEnvV         = "NMO_VERSION"
+	HppoVersionEnvV        = "HPPO_VERSION"
+	VMImportEnvV           = "VM_IMPORT_VERSION"
+	HcoValidatingWebhook   = "validate-hco.kubevirt.io"
+	AppLabel               = "app"
+	UndefinedNamespace     = ""
+	OpenshiftNamespace     = "openshift"
+	APIVersionAlpha        = "v1alpha1"
+	APIVersionBeta         = "v1beta1"
+	CurrentAPIVersion      = APIVersionBeta
+	APIVersionGroup        = "hco.kubevirt.io"
+	APIVersion             = APIVersionGroup + "/" + APIVersionBeta
 	// HyperConvergedName is the name of the HyperConverged resource that will be reconciled
 	HyperConvergedName = "kubevirt-hyperconverged"
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -31,6 +31,20 @@ func GetOperatorNamespaceFromEnv() (string, error) {
 	return "", fmt.Errorf("%s unset or empty in environment", OperatorNamespaceEnv)
 }
 
+func GetWebhookModeFromEnv() (bool, error) {
+	if whmodestring, ok := os.LookupEnv(OperatorWebhookModeEnv); ok {
+		if whmodestring == "true" {
+			return true, nil
+		} else if whmodestring == "false" {
+			return false, nil
+		} else {
+			return false, fmt.Errorf("%s unexpected value in environment", OperatorWebhookModeEnv)
+		}
+	}
+
+	return false, fmt.Errorf("%s unset or empty in environment", OperatorWebhookModeEnv)
+}
+
 func GetPod(ctx context.Context, c client.Reader, logger logr.Logger, ci ClusterInfo) (*corev1.Pod, error) {
 	operatorNs, err := k8sutil.GetOperatorNamespace()
 	if err != nil {

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -123,7 +123,7 @@ func main() {
 	// service accounts are represented as a map to prevent us from generating the
 	// same service account multiple times.
 	deployments := []appsv1.Deployment{
-		components.GetDeployment(
+		components.GetDeploymentOperator(
 			*operatorNamespace,
 			*operatorImage,
 			"IfNotPresent",
@@ -139,6 +139,12 @@ func main() {
 			*nmoVersion,
 			*hppoVersion,
 			*vmImportVersion,
+			[]corev1.EnvVar{},
+		),
+		components.GetDeploymentWebhook(
+			*operatorNamespace,
+			*operatorImage,
+			"IfNotPresent",
 			[]corev1.EnvVar{},
 		),
 	}


### PR DESCRIPTION
Currently we are abusing the pod readiness to signal
to OLM that HCO is not ready for an upgrade.
This has a lot of side effects, one of this is the
validating webhook being not able to receive traffic
when exposed by a pod that is not reporting ready=true.
This can cause a lot of side effects if not deadlocks
when the system reach a status where, for any possible
reason, HCO pod cannot be ready and so HCO pod cannot
validate any further update or delete request on HCO CR.
A proper solution is properly use the readiness probe
only to report the pod readiness and communicate
status to OLM via conditions once OLM will be ready for:
https://github.com/operator-framework/enhancements/blob/master/enhancements/operator-conditions.md
in the meanwhile a quick (but dirty!) solution is to
expose the same hco binary on two distinct pods:
the first one will run only the controller and
the second one (almost always ready) just the validating
webhook one.
A deeper code refactor to produce two distinct binaries
is not worth now because we are going to use OLM operator
conditions soon.

Fixes: https://bugzilla.redhat.com/1889401

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
split operator and webhook into two different pods
```

