### PR TITLE
csv: align 1.2.0 with what on release-1.2 branch

### DIFF
--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.2.0/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
@@ -7,8 +7,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional
     certified: "false"
-    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
-    createdAt: "2020-10-12 14:44:55"
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+    createdAt: "2020-10-23 09:15:17"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1683,9 +1683,11 @@ spec:
               - command:
                 - hyperconverged-cluster-operator
                 env:
+                - name: WEBHOOK_MODE
+                  value: "false"
                 - name: KVM_EMULATION
                 - name: OPERATOR_IMAGE
-                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
                 - name: OPERATOR_NAME
                   value: hyperconverged-cluster-operator
                 - name: OPERATOR_NAMESPACE
@@ -1720,10 +1722,52 @@ spec:
                 - name: HPPO_VERSION
                   value: v0.5.2
                 - name: VM_IMPORT_VERSION
-                  value: v0.2.3
-                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
+                  value: v0.2.4
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
                 imagePullPolicy: IfNotPresent
                 name: hyperconverged-cluster-operator
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - name: hco-webhook
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-webhook
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hyperconverged-cluster-webhook
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-operator
+                env:
+                - name: WEBHOOK_MODE
+                  value: "true"
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-webhook
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+                imagePullPolicy: IfNotPresent
+                name: hyperconverged-cluster-webhook
                 readinessProbe:
                   exec:
                     command:
@@ -2057,9 +2101,9 @@ spec:
                 - name: DEPLOY_CLUSTER_RESOURCES
                   value: "true"
                 - name: OPERATOR_VERSION
-                  value: v0.2.3
+                  value: v0.2.4
                 - name: CONTROLLER_IMAGE
-                  value: quay.io/kubevirt/vm-import-controller@sha256:59c3f2a65fbac003a772c1850a1d819b0ee529763bf2e199c2d3a799c44e71e4
+                  value: quay.io/kubevirt/vm-import-controller@sha256:8ee55747671cd78b02a05a4b6a18737c8241c6ad7e6456d1d4a92e52f6c10dad
                 - name: PULL_POLICY
                   value: IfNotPresent
                 - name: WATCH_NAMESPACE
@@ -2070,8 +2114,8 @@ spec:
                 - name: MONITORING_NAMESPACE
                   value: openshift-monitoring
                 - name: VIRTV2V_IMAGE
-                  value: quay.io/kubevirt/vm-import-virtv2v@sha256:f66d3167976340d9a65145ea5bc3d2e94cf0ab3855616a2641b27f1d2243624b
-                image: quay.io/kubevirt/vm-import-operator@sha256:62706b1ce8df1d4427f591f0b6a75a73560e724d8d5fc860144467ecf5be1edc
+                  value: quay.io/kubevirt/vm-import-virtv2v@sha256:fe0f897bb1af295c228ae9060a8ee510a44e14d4973cc912e1c1b2394dd26740
+                image: quay.io/kubevirt/vm-import-operator@sha256:1f90a44eb9a567c2e3ca6b50ca8643d850a2d04b7f9a82992ad7e6777f84ec30
                 imagePullPolicy: IfNotPresent
                 name: vm-import-operator
                 resources: {}
@@ -2266,7 +2310,7 @@ spec:
     name: hostpath-provisioner
   - image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:074aae9b1fbc727975934e86eea31e699e4504c24e1a7aea6d0b2d69f0e07673
     name: hostpath-provisioner-operator
-  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d015b58b0ed77fb20eab5cf5c4d530b3eebcba03fc75e571b1ec56dace9cb254
+  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
     name: hyperconverged-cluster-operator
   - image: quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e
     name: kubemacpool
@@ -2296,11 +2340,11 @@ spec:
     name: virt-launcher
   - image: docker.io/kubevirt/virt-operator@sha256:fec75f1d53426826a6e7b3e78f89730970dc3f7cfac7f44de7079247e4891492
     name: virt-operator
-  - image: quay.io/kubevirt/vm-import-controller@sha256:59c3f2a65fbac003a772c1850a1d819b0ee529763bf2e199c2d3a799c44e71e4
+  - image: quay.io/kubevirt/vm-import-controller@sha256:8ee55747671cd78b02a05a4b6a18737c8241c6ad7e6456d1d4a92e52f6c10dad
     name: vm-import-controller
-  - image: quay.io/kubevirt/vm-import-operator@sha256:62706b1ce8df1d4427f591f0b6a75a73560e724d8d5fc860144467ecf5be1edc
+  - image: quay.io/kubevirt/vm-import-operator@sha256:1f90a44eb9a567c2e3ca6b50ca8643d850a2d04b7f9a82992ad7e6777f84ec30
     name: vm-import-operator
-  - image: quay.io/kubevirt/vm-import-virtv2v@sha256:f66d3167976340d9a65145ea5bc3d2e94cf0ab3855616a2641b27f1d2243624b
+  - image: quay.io/kubevirt/vm-import-virtv2v@sha256:fe0f897bb1af295c228ae9060a8ee510a44e14d4973cc912e1c1b2394dd26740
     name: vm-import-virtv2v
   replaces: kubevirt-hyperconverged-operator.v1.1.0
   selector:
@@ -2313,7 +2357,7 @@ spec:
     - v1beta1
     - v1
     containerPort: 4343
-    deploymentName: hco-operator
+    deploymentName: hco-webhook
     failurePolicy: Fail
     generateName: validate-hco.kubevirt.io
     rules:


### PR DESCRIPTION
Align 1.2.0 with what on release-1.2 branch
after
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/896

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

