### PR TITLE
Use root user when calling create-new-version

### DIFF
--- a/deploy/Dockerfile.registry.upgrade
+++ b/deploy/Dockerfile.registry.upgrade
@@ -5,6 +5,7 @@ ENV GOPATH=/go
 RUN echo "UPGRADE_VERSION: ${UPGRADE_VERSION}"
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .
+USER root
 RUN dnf install -y dep golang make findutils tar && dnf clean all -y
 RUN export UPGRADE_VERSION=${UPGRADE_VERSION} && \
     ./hack/upgrade-create-new-version.sh

--- a/deploy/Dockerfile.registry.upgrade-prev
+++ b/deploy/Dockerfile.registry.upgrade-prev
@@ -5,6 +5,7 @@ ENV GOPATH=/go
 RUN echo "UPGRADE_VERSION: ${UPGRADE_VERSION}"
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .
+USER root
 RUN dnf install -y dep golang make findutils tar && dnf clean all -y
 RUN export UPGRADE_VERSION=${UPGRADE_VERSION} && \
     export PREV=true && \


### PR DESCRIPTION
The current Dockerfile fails to create a new registry with "Operation
not permitted" when trying to deploy the nightly build

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

