### PR TITLE
[release-1.2] Disable VMI migration upon K8s unschedulable taint (#823)

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -794,11 +794,11 @@ func newKubeVirtConfigForCR(cr *hcov1beta1.HyperConverged, namespace string) *co
 		// only virtconfig.SmbiosConfigKey, virtconfig.MachineTypeKey, virtconfig.SELinuxLauncherTypeKey,
 		// virtconfig.FeatureGatesKey and virtconfig.UseEmulationKey are going to be manipulated
 		// and only on HCO upgrades.
+		// virtconfig.MigrationsConfigKey is going to be removed if set in the past (only during upgrades).
 		// TODO: This is going to change in the next HCO release where the whole configMap is going
 		// to be continuously reconciled
 		Data: map[string]string{
 			virtconfig.FeatureGatesKey:        "DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Sidecar,Snapshot",
-			virtconfig.MigrationsConfigKey:    `{"nodeDrainTaintKey" : "node.kubernetes.io/unschedulable"}`,
 			virtconfig.SELinuxLauncherTypeKey: "virt_launcher.process",
 			virtconfig.NetworkInterfaceKey:    kubevirtDefaultNetworkInterfaceValue,
 		},
@@ -857,23 +857,39 @@ func (r *ReconcileHyperConverged) ensureKubeVirtConfig(req *hcoRequest) *EnsureR
 		// only virtconfig.SmbiosConfigKey, virtconfig.MachineTypeKey, virtconfig.SELinuxLauncherTypeKey,
 		// virtconfig.FeatureGatesKey and virtconfig.UseEmulationKey are going to be manipulated
 		// and only on HCO upgrades.
+		// virtconfig.MigrationsConfigKey is going to be removed if set in the past (only during upgrades).
 		// TODO: This is going to change in the next HCO release where the whole configMap is going
 		// to be continuously reconciled
+		dirty := false
 		for _, k := range []string{
 			virtconfig.FeatureGatesKey,
 			virtconfig.SmbiosConfigKey,
 			virtconfig.MachineTypeKey,
 			virtconfig.SELinuxLauncherTypeKey,
 			virtconfig.UseEmulationKey,
+			virtconfig.MigrationsConfigKey,
 		} {
 			if found.Data[k] != kubevirtConfig.Data[k] {
 				req.logger.Info(fmt.Sprintf("Updating %s on existing KubeVirt config", k))
 				found.Data[k] = kubevirtConfig.Data[k]
-				err = r.client.Update(req.ctx, found)
-				if err != nil {
-					req.logger.Error(err, fmt.Sprintf("Failed updating %s on an existing kubevirt config", k))
-					return res.Error(err)
-				}
+				dirty = true
+			}
+		}
+		for _, k := range []string{
+			virtconfig.MigrationsConfigKey,
+		} {
+			_, ok := found.Data[k]
+			if ok {
+				req.logger.Info(fmt.Sprintf("Deleting %s on existing KubeVirt config", k))
+				delete(found.Data, k)
+				dirty = true
+			}
+		}
+		if dirty {
+			err = r.client.Update(req.ctx, found)
+			if err != nil {
+				req.logger.Error(err, fmt.Sprintf("Failed updating an existing kubevirt config"))
+				return res.Error(err)
 			}
 		}
 	}

--- a/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
@@ -125,7 +125,8 @@ var _ = Describe("HyperConverged Components", func() {
 		var req *hcoRequest
 
 		updatableKeys := [...]string{virtconfig.SmbiosConfigKey, virtconfig.MachineTypeKey, virtconfig.SELinuxLauncherTypeKey, virtconfig.FeatureGatesKey}
-		unupdatableKeys := [...]string{virtconfig.MigrationsConfigKey, virtconfig.NetworkInterfaceKey}
+		removeKeys := [...]string{virtconfig.MigrationsConfigKey}
+		unupdatableKeys := [...]string{virtconfig.NetworkInterfaceKey}
 
 		BeforeEach(func() {
 			hco = newHco()
@@ -181,8 +182,9 @@ var _ = Describe("HyperConverged Components", func() {
 			outdatedResource.Data[virtconfig.MachineTypeKey] = "old-machinetype-value-that-we-have-to-update"
 			outdatedResource.Data[virtconfig.SELinuxLauncherTypeKey] = "old-selinuxlauncher-value-that-we-have-to-update"
 			outdatedResource.Data[virtconfig.FeatureGatesKey] = "old-featuregates-value-that-we-have-to-update"
+			// value that we should remove if configured
+			outdatedResource.Data[virtconfig.MigrationsConfigKey] = "old-migrationsconfig-value-that-we-should-remove"
 			// values we should preserve
-			outdatedResource.Data[virtconfig.MigrationsConfigKey] = "old-migrationsconfig-value-that-we-should-preserve"
 			outdatedResource.Data[virtconfig.NetworkInterfaceKey] = "old-defaultnetworkinterface-value-that-we-should-preserve"
 
 			cl := initClient([]runtime.Object{hco, outdatedResource})
@@ -208,6 +210,11 @@ var _ = Describe("HyperConverged Components", func() {
 			for _, k := range unupdatableKeys {
 				Expect(foundResource.Data[k]).To(Equal(outdatedResource.Data[k]))
 				Expect(foundResource.Data[k]).To(Not(Equal(expectedResource.Data[k])))
+			}
+			for _, k := range removeKeys {
+				Expect(outdatedResource.Data).To(HaveKey(k))
+				Expect(expectedResource.Data).To(Not(HaveKey(k)))
+				Expect(foundResource.Data).To(Not(HaveKey(k)))
 			}
 		})
 


### PR DESCRIPTION
This is a cherry-pick of #823

Currently, the default behaviour is to migrate the VMI when a node is
tainted with the node.kubernetes.io/unschedulable key. This behaviour is
wrong and can be un-expected from the user's perspective because the
unschedulable taint means "do not schedule new workloads on this node"
and not "evict existing workloads from this node".

https://github.com/kubevirt/kubevirt/pull/4012 adds support for the
eviction API so we can properly handle node drains and specific
evictions on VMI pods.

This patch avoid setting (and explicitly removes during upgrades if
set in the past) the default node drain key so we won't migrate VMIs
when we're not expected to do so.

Fixes: https://bugzilla.redhat.com/1881676

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>
Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
VMIs will no longer migrate when node is tainted with node.kubernetes.io/unschedulable by default. Users can now use the proper node drain API to evacuate multiple VMIs from a node.
```

