### PR TITLE
move IMSConfigForCR and CliDownload to the new operand pkg

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -3,7 +3,6 @@ package hyperconverged
 import (
 	"fmt"
 	"os"
-	"reflect"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/operands"
@@ -13,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -29,11 +27,9 @@ import (
 	sspv1 "github.com/kubevirt/kubevirt-ssp-operator/pkg/apis/kubevirt/v1"
 	vmimportv1beta1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -77,7 +73,9 @@ func Add(mgr manager.Manager, ci hcoutil.ClusterInfo) error {
 }
 
 // temp map, until we move all the operands code
-var operandMap = map[string]operands.Operand{}
+var (
+	operandMap = map[string]operands.Operand{}
+)
 
 func prepareHandlerMap(clt client.Client, scheme *runtime.Scheme, isOpenshift bool) {
 	operandMap["kvc"] = &operands.KvConfigHandler{Client: clt, Scheme: scheme}
@@ -106,14 +104,15 @@ func newReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo) reconcile.Reconc
 	prepareHandlerMap(mgr.GetClient(), mgr.GetScheme(), ci.IsOpenshift())
 
 	return &ReconcileHyperConverged{
-		client:       mgr.GetClient(),
-		scheme:       mgr.GetScheme(),
-		recorder:     mgr.GetEventRecorderFor(hcoutil.HyperConvergedName),
-		upgradeMode:  false,
-		ownVersion:   ownVersion,
-		clusterInfo:  ci,
-		eventEmitter: hcoutil.GetEventEmitter(),
-		firstLoop:    true,
+		client:             mgr.GetClient(),
+		scheme:             mgr.GetScheme(),
+		recorder:           mgr.GetEventRecorderFor(hcoutil.HyperConvergedName),
+		cliDownloadHandler: &operands.CLIDownloadHandler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()},
+		upgradeMode:        false,
+		ownVersion:         ownVersion,
+		clusterInfo:        ci,
+		eventEmitter:       hcoutil.GetEventEmitter(),
+		firstLoop:          true,
 	}
 }
 
@@ -171,14 +170,15 @@ var _ reconcile.Reconciler = &ReconcileHyperConverged{}
 type ReconcileHyperConverged struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client       client.Client
-	scheme       *runtime.Scheme
-	recorder     record.EventRecorder
-	upgradeMode  bool
-	ownVersion   string
-	clusterInfo  hcoutil.ClusterInfo
-	eventEmitter hcoutil.EventEmitter
-	firstLoop    bool
+	client             client.Client
+	scheme             *runtime.Scheme
+	recorder           record.EventRecorder
+	cliDownloadHandler *operands.CLIDownloadHandler
+	upgradeMode        bool
+	ownVersion         string
+	clusterInfo        hcoutil.ClusterInfo
+	eventEmitter       hcoutil.EventEmitter
+	firstLoop          bool
 }
 
 // Reconcile reads that state of the cluster for a HyperConverged object and makes changes based on the state read
@@ -310,7 +310,7 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 
 	req.SetUpgradeMode(r.upgradeMode)
 
-	r.ensureConsoleCLIDownload(req)
+	r.cliDownloadHandler.Ensure(req)
 
 	err = r.ensureHco(req)
 	if err != nil {
@@ -799,39 +799,6 @@ func (r *ReconcileHyperConverged) ensureIMSConfig(req *common.HcoRequest) *opera
 
 func (r *ReconcileHyperConverged) ensureVMImport(req *common.HcoRequest) *operands.EnsureResult {
 	return operandMap["vmimport"].Ensure(req)
-}
-
-func (r *ReconcileHyperConverged) ensureConsoleCLIDownload(req *common.HcoRequest) error {
-	ccd := req.Instance.NewConsoleCLIDownload()
-
-	found := req.Instance.NewConsoleCLIDownload()
-	err := hcoutil.EnsureCreated(req.Ctx, r.client, found, req.Logger)
-	if err != nil {
-		if meta.IsNoMatchError(err) {
-			req.Logger.Info("ConsoleCLIDownload was not found, skipping")
-		}
-		return err
-	}
-
-	// Make sure we hold the right link spec
-	if reflect.DeepEqual(found.Spec, ccd.Spec) {
-		objectRef, err := reference.GetReference(r.scheme, found)
-		if err != nil {
-			req.Logger.Error(err, "failed getting object reference for ConsoleCLIDownload")
-			return err
-		}
-		objectreferencesv1.SetObjectReference(&req.Instance.Status.RelatedObjects, *objectRef)
-		return nil
-	}
-
-	ccd.Spec.DeepCopyInto(&found.Spec)
-
-	err = r.client.Update(req.Ctx, found)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (r *ReconcileHyperConverged) ensureKubeVirtTemplateValidator(req *common.HcoRequest) *operands.EnsureResult {

--- a/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_components_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	consolev1 "github.com/openshift/api/console/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -25,118 +24,6 @@ import (
 )
 
 var _ = Describe("HyperConverged Components", func() {
-
-	Context("Manage IMS Config", func() {
-
-		var hco *hcov1beta1.HyperConverged
-		var req *common.HcoRequest
-
-		BeforeEach(func() {
-			os.Setenv("CONVERSION_CONTAINER", "new-conversion-container-value")
-			os.Setenv("VMWARE_CONTAINER", "new-vmware-container-value")
-			hco = commonTestUtils.NewHco()
-			req = commonTestUtils.NewReq(hco)
-		})
-
-		It("should error if environment vars not specified", func() {
-			os.Unsetenv("CONVERSION_CONTAINER")
-			os.Unsetenv("VMWARE_CONTAINER")
-
-			cl := commonTestUtils.InitClient([]runtime.Object{})
-			r := initReconciler(cl)
-			res := r.ensureIMSConfig(req)
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Err).ToNot(BeNil())
-		})
-
-		It("should create if not present", func() {
-			expectedResource := newIMSConfigForCR(hco, namespace)
-			cl := commonTestUtils.InitClient([]runtime.Object{})
-			r := initReconciler(cl)
-			res := r.ensureIMSConfig(req)
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Err).To(BeNil())
-
-			foundResource := &corev1.ConfigMap{}
-			Expect(
-				cl.Get(context.TODO(),
-					types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
-					foundResource),
-			).To(BeNil())
-			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, name))
-			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
-		})
-
-		It("should find if present", func() {
-			expectedResource := newIMSConfigForCR(hco, namespace)
-			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
-			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			r := initReconciler(cl)
-			res := r.ensureIMSConfig(req)
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Err).To(BeNil())
-
-			// Check HCO's status
-			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
-			objectRef, err := reference.GetReference(r.scheme, expectedResource)
-			Expect(err).To(BeNil())
-			// ObjectReference should have been added
-			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRef))
-		})
-
-		// in an ideal world HCO should be managing the whole config map,
-		// now due to a bad design only a few values of this config map are
-		// really managed by HCO while others are managed by other entities
-		// TODO: fix this bad design splitting the config map into two distinct objects and reconcile the whole object here
-		It("should (partially!!!) reconcile according to env values", func() {
-			convk := "v2v-conversion-image"
-			vmwarek := "kubevirt-vmware-image"
-			updatableKeys := [...]string{convk, vmwarek}
-			unupdatableKeyValues := map[string]string{
-				"ext_key_1": "ext_value_1",
-				"ext_key_2": "ext_value_2",
-			}
-
-			expectedResource := newIMSConfigForCR(hco, namespace)
-			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
-			outdatedResource := newIMSConfigForCR(hco, namespace)
-			outdatedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", outdatedResource.Namespace, outdatedResource.Name)
-			// values we should update
-			outdatedResource.Data[convk] = "old-conversion-container-value-we-have-to-update"
-			outdatedResource.Data[vmwarek] = "old-vmware-container-value-we-have-to-update"
-			// add values we should not touch
-			for k, v := range unupdatableKeyValues {
-				outdatedResource.Data[k] = v
-			}
-
-			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource})
-			r := initReconciler(cl)
-
-			res := r.ensureIMSConfig(req)
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Updated).To(BeTrue())
-			Expect(res.Err).To(BeNil())
-
-			foundResource := &corev1.ConfigMap{}
-			Expect(
-				cl.Get(context.TODO(),
-					types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
-					foundResource),
-			).To(BeNil())
-
-			for _, k := range updatableKeys {
-				Expect(foundResource.Data[k]).To(Not(Equal(outdatedResource.Data[k])))
-				Expect(foundResource.Data[k]).To(Equal(expectedResource.Data[k]))
-			}
-
-			for k, v := range unupdatableKeyValues {
-				Expect(foundResource.Data).To(HaveKeyWithValue(k, v))
-			}
-
-		})
-
-	})
 
 	Context("ConsoleCLIDownload", func() {
 

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -195,7 +195,7 @@ func getBasicDeployment() *BasicExpected {
 	kvMtAg.Status.Conditions = getGenericCompletedConditions()
 	res.kvMtAg = kvMtAg
 
-	res.imsConfig = newIMSConfigForCR(hco, namespace)
+	res.imsConfig = operands.NewIMSConfigForCR(hco, namespace)
 	res.imsConfig.Data["v2v-conversion-image"] = commonTestUtils.Conversion_image
 	res.imsConfig.Data["kubevirt-vmware-image"] = commonTestUtils.Vmware_image
 

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -49,11 +49,12 @@ func initReconciler(client client.Client) *ReconcileHyperConverged {
 
 	// Create a ReconcileHyperConverged object with the scheme and fake client
 	return &ReconcileHyperConverged{
-		client:       client,
-		scheme:       s,
-		clusterInfo:  clusterInfoMock{},
-		eventEmitter: &eventEmitterMock{},
-		firstLoop:    true,
+		client:             client,
+		scheme:             s,
+		clusterInfo:        clusterInfoMock{},
+		eventEmitter:       &eventEmitterMock{},
+		cliDownloadHandler: &operands.CLIDownloadHandler{Client: client, Scheme: s},
+		firstLoop:          true,
 	}
 }
 

--- a/pkg/controller/operands/cliDownload.go
+++ b/pkg/controller/operands/cliDownload.go
@@ -1,0 +1,45 @@
+package operands
+
+import (
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/reference"
+	"reflect"
+)
+
+type CLIDownloadHandler genericOperand
+
+func (h CLIDownloadHandler) Ensure(req *common.HcoRequest) error {
+	ccd := req.Instance.NewConsoleCLIDownload()
+
+	found := req.Instance.NewConsoleCLIDownload()
+	err := hcoutil.EnsureCreated(req.Ctx, h.Client, found, req.Logger)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			req.Logger.Info("ConsoleCLIDownload was not found, skipping")
+		}
+		return err
+	}
+
+	// Make sure we hold the right link spec
+	if reflect.DeepEqual(found.Spec, ccd.Spec) {
+		objectRef, err := reference.GetReference(h.Scheme, found)
+		if err != nil {
+			req.Logger.Error(err, "failed getting object reference for ConsoleCLIDownload")
+			return err
+		}
+		objectreferencesv1.SetObjectReference(&req.Instance.Status.RelatedObjects, *objectRef)
+		return nil
+	}
+
+	ccd.Spec.DeepCopyInto(&found.Spec)
+
+	err = h.Client.Update(req.Ctx, found)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
These are commites 6 and 7 (7/10) of the reconcile refactoring (#895).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

