### PR TITLE
Move ensure and delete operands to the new package

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -48,7 +48,6 @@ const (
 
 	reconcileInit               = "Init"
 	reconcileInitMessage        = "Initializing HyperConverged cluster"
-	reconcileFailed             = "ReconcileFailed"
 	reconcileCompleted          = "ReconcileCompleted"
 	reconcileCompletedMessage   = "Reconcile completed successfully"
 	invalidRequestReason        = "InvalidRequest"
@@ -72,27 +71,6 @@ func Add(mgr manager.Manager, ci hcoutil.ClusterInfo) error {
 	return add(mgr, newReconciler(mgr, ci))
 }
 
-// temp map, until we move all the operands code
-var (
-	operandMap = map[string]operands.Operand{}
-)
-
-func prepareHandlerMap(clt client.Client, scheme *runtime.Scheme, isOpenshift bool) {
-	operandMap["kvc"] = &operands.KvConfigHandler{Client: clt, Scheme: scheme}
-	operandMap["kvpc"] = &operands.KvPriorityClassHandler{Client: clt, Scheme: scheme}
-	operandMap["kv"] = &operands.KubevirtHandler{Client: clt, Scheme: scheme}
-	operandMap["cdi"] = &operands.CdiHandler{Client: clt, Scheme: scheme}
-	operandMap["cna"] = &operands.CnaHandler{Client: clt, Scheme: scheme}
-	operandMap["vmimport"] = &operands.VmImportHandler{Client: clt, Scheme: scheme}
-	operandMap["IMSConfig"] = operands.IMSConfigHandler{Client: clt, Scheme: scheme}
-	if isOpenshift {
-		operandMap["kvCTB"] = operands.NewCommonTemplateBundleHandler(clt, scheme)
-		operandMap["kvNLB"] = operands.NewNodeLabellerBundleHandler(clt, scheme)
-		operandMap["kvTV"] = operands.NewTemplateValidatorHandler(clt, scheme)
-		operandMap["kvMA"] = operands.NewMetricsAggregationHandler(clt, scheme)
-	}
-}
-
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo) reconcile.Reconciler {
 
@@ -101,16 +79,14 @@ func newReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo) reconcile.Reconc
 		ownVersion = version.Version
 	}
 
-	prepareHandlerMap(mgr.GetClient(), mgr.GetScheme(), ci.IsOpenshift())
-
 	return &ReconcileHyperConverged{
 		client:             mgr.GetClient(),
 		scheme:             mgr.GetScheme(),
 		recorder:           mgr.GetEventRecorderFor(hcoutil.HyperConvergedName),
 		cliDownloadHandler: &operands.CLIDownloadHandler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()},
+		operandHandler:     operands.NewOperandHandler(mgr.GetClient(), mgr.GetScheme(), ci.IsOpenshift(), hcoutil.GetEventEmitter()),
 		upgradeMode:        false,
 		ownVersion:         ownVersion,
-		clusterInfo:        ci,
 		eventEmitter:       hcoutil.GetEventEmitter(),
 		firstLoop:          true,
 	}
@@ -174,9 +150,9 @@ type ReconcileHyperConverged struct {
 	scheme             *runtime.Scheme
 	recorder           record.EventRecorder
 	cliDownloadHandler *operands.CLIDownloadHandler
+	operandHandler     *operands.OperandHandler
 	upgradeMode        bool
 	ownVersion         string
-	clusterInfo        hcoutil.ClusterInfo
 	eventEmitter       hcoutil.EventEmitter
 	firstLoop          bool
 }
@@ -312,7 +288,7 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 
 	r.cliDownloadHandler.Ensure(req)
 
-	err = r.ensureHco(req)
+	err = r.operandHandler.Ensure(req)
 	if err != nil {
 		return reconcile.Result{}, r.updateConditions(req)
 	}
@@ -453,46 +429,6 @@ func (r *ReconcileHyperConverged) ensureHcoDeleted(req *common.HcoRequest) (reco
 
 	// Need to requeue because finalizer update does not change metadata.generation
 	return reconcile.Result{Requeue: true}, nil
-}
-
-func (r *ReconcileHyperConverged) ensureHco(req *common.HcoRequest) error {
-	for _, f := range []func(*common.HcoRequest) *operands.EnsureResult{
-		r.ensureKubeVirtPriorityClass,
-		r.ensureKubeVirtConfig,
-		r.ensureKubeVirt,
-		r.ensureCDI,
-		r.ensureNetworkAddons,
-		r.ensureKubeVirtCommonTemplateBundle,
-		r.ensureKubeVirtNodeLabellerBundle,
-		r.ensureKubeVirtTemplateValidator,
-		r.ensureKubeVirtMetricsAggregation,
-		r.ensureIMSConfig,
-		r.ensureVMImport,
-	} {
-		res := f(req)
-		if res == nil { // temporary code, to support skipping ssp operands
-			continue
-		}
-		if res.Err != nil {
-			req.ComponentUpgradeInProgress = false
-			req.Conditions.SetStatusCondition(conditionsv1.Condition{
-				Type:    hcov1beta1.ConditionReconcileComplete,
-				Status:  corev1.ConditionFalse,
-				Reason:  reconcileFailed,
-				Message: fmt.Sprintf("Error while reconciling: %v", res.Err),
-			})
-			return res.Err
-		}
-
-		if res.Created {
-			r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Created", fmt.Sprintf("Created %s %s", res.Type, res.Name))
-		} else if res.Updated {
-			r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Updated", fmt.Sprintf("Updated %s %s", res.Type, res.Name))
-		}
-
-		req.ComponentUpgradeInProgress = req.ComponentUpgradeInProgress && res.UpgradeDone
-	}
-	return nil
 }
 
 func (r *ReconcileHyperConverged) aggregateComponentConditions(req *common.HcoRequest) bool {
@@ -757,62 +693,6 @@ func (r *ReconcileHyperConverged) completeReconciliation(req *common.HcoRequest)
 		}
 	}
 	return r.updateConditions(req)
-}
-
-func (r *ReconcileHyperConverged) ensureKubeVirtPriorityClass(req *common.HcoRequest) *operands.EnsureResult {
-	return operandMap["kvpc"].Ensure(req)
-}
-
-func (r *ReconcileHyperConverged) ensureKubeVirtConfig(req *common.HcoRequest) *operands.EnsureResult {
-	return operandMap["kvc"].Ensure(req)
-}
-
-func (r *ReconcileHyperConverged) ensureKubeVirt(req *common.HcoRequest) *operands.EnsureResult {
-	return operandMap["kv"].Ensure(req)
-}
-
-func (r *ReconcileHyperConverged) ensureCDI(req *common.HcoRequest) *operands.EnsureResult {
-	return operandMap["cdi"].Ensure(req)
-}
-
-func (r *ReconcileHyperConverged) ensureNetworkAddons(req *common.HcoRequest) *operands.EnsureResult {
-	return operandMap["cna"].Ensure(req)
-}
-
-func (r *ReconcileHyperConverged) ensureKubeVirtCommonTemplateBundle(req *common.HcoRequest) *operands.EnsureResult {
-	if h, ok := operandMap["kvCTB"]; ok {
-		return h.Ensure(req)
-	}
-	return nil
-}
-
-func (r *ReconcileHyperConverged) ensureKubeVirtNodeLabellerBundle(req *common.HcoRequest) *operands.EnsureResult {
-	if h, ok := operandMap["kvNLB"]; ok {
-		return h.Ensure(req)
-	}
-	return nil
-}
-
-func (r *ReconcileHyperConverged) ensureIMSConfig(req *common.HcoRequest) *operands.EnsureResult {
-	return operandMap["IMSConfig"].Ensure(req)
-}
-
-func (r *ReconcileHyperConverged) ensureVMImport(req *common.HcoRequest) *operands.EnsureResult {
-	return operandMap["vmimport"].Ensure(req)
-}
-
-func (r *ReconcileHyperConverged) ensureKubeVirtTemplateValidator(req *common.HcoRequest) *operands.EnsureResult {
-	if h, ok := operandMap["kvTV"]; ok {
-		return h.Ensure(req)
-	}
-	return nil
-}
-
-func (r *ReconcileHyperConverged) ensureKubeVirtMetricsAggregation(req *common.HcoRequest) *operands.EnsureResult {
-	if h, ok := operandMap["kvMA"]; ok {
-		return h.Ensure(req)
-	}
-	return nil
 }
 
 // This function is used to exit from the reconcile function, updating the conditions and returns the reconcile result

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -45,13 +45,12 @@ var (
 
 func initReconciler(client client.Client) *ReconcileHyperConverged {
 	s := commonTestUtils.GetScheme()
-	prepareHandlerMap(client, s, true)
-
+	operandHandler := operands.NewOperandHandler(client, s, true, &eventEmitterMock{})
 	// Create a ReconcileHyperConverged object with the scheme and fake client
 	return &ReconcileHyperConverged{
 		client:             client,
 		scheme:             s,
-		clusterInfo:        clusterInfoMock{},
+		operandHandler:     operandHandler,
 		eventEmitter:       &eventEmitterMock{},
 		cliDownloadHandler: &operands.CLIDownloadHandler{Client: client, Scheme: s},
 		firstLoop:          true,
@@ -223,20 +222,6 @@ func doReconcile(cl client.Client, hco *hcov1beta1.HyperConverged) (*hcov1beta1.
 	).To(BeNil())
 
 	return foundResource, res.Requeue
-}
-
-type clusterInfoMock struct{}
-
-func (clusterInfoMock) CheckRunningInOpenshift(_ client.Reader, _ context.Context, _ logr.Logger, _ bool) error {
-	return nil
-}
-
-func (clusterInfoMock) IsOpenshift() bool {
-	return true
-}
-
-func (clusterInfoMock) IsRunningLocally() bool {
-	return false
 }
 
 type eventEmitterMock struct{}

--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -16,9 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-type CdiHandler genericOperand
+type cdiHandler genericOperand
 
-func (h *CdiHandler) Ensure(req *common.HcoRequest) *EnsureResult {
+func (h *cdiHandler) Ensure(req *common.HcoRequest) *EnsureResult {
 	cdi := req.Instance.NewCDI()
 	res := NewEnsureResult(cdi)
 
@@ -98,7 +98,7 @@ func (h *CdiHandler) Ensure(req *common.HcoRequest) *EnsureResult {
 	return res.SetUpgradeDone(upgradeDone)
 }
 
-func (h *CdiHandler) ensureKubeVirtStorageRole(req *common.HcoRequest) error {
+func (h *cdiHandler) ensureKubeVirtStorageRole(req *common.HcoRequest) error {
 	kubevirtStorageRole := NewKubeVirtStorageRoleForCR(req.Instance, req.Namespace)
 	if err := controllerutil.SetControllerReference(req.Instance, kubevirtStorageRole, h.Scheme); err != nil {
 		return err
@@ -131,7 +131,7 @@ func (h *CdiHandler) ensureKubeVirtStorageRole(req *common.HcoRequest) error {
 	return nil
 }
 
-func (h *CdiHandler) ensureKubeVirtStorageRoleBinding(req *common.HcoRequest) error {
+func (h *cdiHandler) ensureKubeVirtStorageRoleBinding(req *common.HcoRequest) error {
 	kubevirtStorageRoleBinding := NewKubeVirtStorageRoleBindingForCR(req.Instance, req.Namespace)
 	if err := controllerutil.SetControllerReference(req.Instance, kubevirtStorageRoleBinding, h.Scheme); err != nil {
 		return err
@@ -164,7 +164,7 @@ func (h *CdiHandler) ensureKubeVirtStorageRoleBinding(req *common.HcoRequest) er
 	return nil
 }
 
-func (h *CdiHandler) ensureKubeVirtStorageConfig(req *common.HcoRequest) error {
+func (h *cdiHandler) ensureKubeVirtStorageConfig(req *common.HcoRequest) error {
 	kubevirtStorageConfig := NewKubeVirtStorageConfigForCR(req.Instance, req.Namespace)
 	if err := controllerutil.SetControllerReference(req.Instance, kubevirtStorageConfig, h.Scheme); err != nil {
 		return err

--- a/pkg/controller/operands/cdi_test.go
+++ b/pkg/controller/operands/cdi_test.go
@@ -33,7 +33,7 @@ var _ = Describe("CDI Operand", func() {
 		It("should create if not present", func() {
 			expectedResource := hco.NewCDI()
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := &CdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -53,7 +53,7 @@ var _ = Describe("CDI Operand", func() {
 			expectedResource := hco.NewCDI()
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := &CdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -93,7 +93,7 @@ var _ = Describe("CDI Operand", func() {
 			missingUSResource.Spec.UninstallStrategy = nil
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, missingUSResource})
-			handler := &CdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -115,7 +115,7 @@ var _ = Describe("CDI Operand", func() {
 			hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &CdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -153,7 +153,7 @@ var _ = Describe("CDI Operand", func() {
 			existingResource := hcoNodePlacement.NewCDI()
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &CdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -197,7 +197,7 @@ var _ = Describe("CDI Operand", func() {
 			hco.Spec.Workloads.NodePlacement.NodeSelector["key1"] = "something else"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &CdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -243,7 +243,7 @@ var _ = Describe("CDI Operand", func() {
 				},
 			}
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := &CdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -294,7 +294,7 @@ var _ = Describe("CDI Operand", func() {
 		It("should create if not present", func() {
 			expectedResource := NewKubeVirtStorageConfigForCR(hco, commonTestUtils.Namespace)
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := &CdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			err := handler.ensureKubeVirtStorageConfig(req)
 			Expect(err).To(BeNil())
 
@@ -313,7 +313,7 @@ var _ = Describe("CDI Operand", func() {
 			expectedResource := NewKubeVirtStorageConfigForCR(hco, commonTestUtils.Namespace)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := &CdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cdiHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			err := handler.ensureKubeVirtStorageConfig(req)
 			Expect(err).To(BeNil())
 

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -24,9 +24,9 @@ const (
 	kubevirtDefaultNetworkInterfaceValue = "masquerade"
 )
 
-type KubevirtHandler genericOperand
+type kubevirtHandler genericOperand
 
-func (kv *KubevirtHandler) Ensure(req *common.HcoRequest) *EnsureResult {
+func (kv *kubevirtHandler) Ensure(req *common.HcoRequest) *EnsureResult {
 	virt := req.Instance.NewKubeVirt()
 	res := NewEnsureResult(virt)
 	if err := controllerutil.SetControllerReference(req.Instance, virt, kv.Scheme); err != nil {
@@ -79,9 +79,9 @@ func (kv *KubevirtHandler) Ensure(req *common.HcoRequest) *EnsureResult {
 	return res.SetUpgradeDone(upgradeDone)
 }
 
-type KvConfigHandler genericOperand
+type kvConfigHandler genericOperand
 
-func (kvc *KvConfigHandler) Ensure(req *common.HcoRequest) *EnsureResult {
+func (kvc *kvConfigHandler) Ensure(req *common.HcoRequest) *EnsureResult {
 	kubevirtConfig := NewKubeVirtConfigForCR(req.Instance, req.Namespace)
 	res := NewEnsureResult(kubevirtConfig)
 	err := controllerutil.SetControllerReference(req.Instance, kubevirtConfig, kvc.Scheme)
@@ -160,9 +160,9 @@ func (kvc *KvConfigHandler) Ensure(req *common.HcoRequest) *EnsureResult {
 	return res.SetUpgradeDone(req.ComponentUpgradeInProgress)
 }
 
-type KvPriorityClassHandler genericOperand
+type kvPriorityClassHandler genericOperand
 
-func (kvpc *KvPriorityClassHandler) Ensure(req *common.HcoRequest) *EnsureResult {
+func (kvpc *kvPriorityClassHandler) Ensure(req *common.HcoRequest) *EnsureResult {
 	req.Logger.Info("Reconciling KubeVirt PriorityClass")
 	pc := req.Instance.NewKubeVirtPriorityClass()
 	res := NewEnsureResult(pc)

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -39,7 +39,7 @@ var _ = Describe("KubeVirt Operand", func() {
 		It("should create if not present", func() {
 			expectedResource := hco.NewKubeVirtPriorityClass()
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := &KvPriorityClassHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kvPriorityClassHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -56,7 +56,7 @@ var _ = Describe("KubeVirt Operand", func() {
 		It("should do nothing if already exists", func() {
 			expectedResource := hco.NewKubeVirtPriorityClass()
 			cl := commonTestUtils.InitClient([]runtime.Object{expectedResource})
-			handler := &KvPriorityClassHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kvPriorityClassHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -68,7 +68,7 @@ var _ = Describe("KubeVirt Operand", func() {
 
 		DescribeTable("should update if something changed", func(modifiedResource *schedulingv1.PriorityClass) {
 			cl := commonTestUtils.InitClient([]runtime.Object{modifiedResource})
-			handler := &KvPriorityClassHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kvPriorityClassHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -132,7 +132,7 @@ var _ = Describe("KubeVirt Operand", func() {
 		It("should create if not present", func() {
 			expectedResource := NewKubeVirtConfigForCR(req.Instance, commonTestUtils.Namespace)
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := &KvConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kvConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -153,7 +153,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			expectedResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := &KvConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kvConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -182,7 +182,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			outdatedResource.Data[virtconfig.NetworkInterfaceKey] = "old-defaultnetworkinterface-value-that-we-should-preserve"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource})
-			handler := &KvConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kvConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 
 			// force upgrade mode
 			req.UpgradeMode = true
@@ -227,7 +227,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			outdatedResource.Data[virtconfig.DefaultNetworkInterface] = "old-defaultnetworkinterface-value-that-we-should-preserve"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource})
-			handler := &KvConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kvConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 
 			// ensure that we are not in upgrade mode
 			req.UpgradeMode = false
@@ -260,7 +260,7 @@ var _ = Describe("KubeVirt Operand", func() {
 		It("should create if not present", func() {
 			expectedResource := hco.NewKubeVirt(commonTestUtils.Namespace)
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := &KubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -280,7 +280,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			expectedResource := hco.NewKubeVirt(commonTestUtils.Namespace)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := &KubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -320,7 +320,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			missingUSResource.Spec.UninstallStrategy = ""
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, missingUSResource})
-			handler := &KubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -342,7 +342,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &KubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -379,7 +379,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			existingResource := hcoNodePlacement.NewKubeVirt()
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &KubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -415,7 +415,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			hco.Spec.Workloads.NodePlacement.NodeSelector["key1"] = "something else"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &KubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -471,7 +471,7 @@ var _ = Describe("KubeVirt Operand", func() {
 				},
 			}
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := &KubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &kubevirtHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())

--- a/pkg/controller/operands/networkAddons.go
+++ b/pkg/controller/operands/networkAddons.go
@@ -12,9 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type CnaHandler genericOperand
+type cnaHandler genericOperand
 
-func (h CnaHandler) Ensure(req *common.HcoRequest) *EnsureResult {
+func (h cnaHandler) Ensure(req *common.HcoRequest) *EnsureResult {
 	networkAddons := req.Instance.NewNetworkAddons()
 
 	res := NewEnsureResult(networkAddons)

--- a/pkg/controller/operands/networkAddons_test.go
+++ b/pkg/controller/operands/networkAddons_test.go
@@ -34,7 +34,7 @@ var _ = Describe("CNA Operand", func() {
 		It("should create if not present", func() {
 			expectedResource := hco.NewNetworkAddons()
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := &CnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -57,7 +57,7 @@ var _ = Describe("CNA Operand", func() {
 			expectedResource := hco.NewNetworkAddons()
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := &CnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -95,7 +95,7 @@ var _ = Describe("CNA Operand", func() {
 			existingResource.Spec.ImagePullPolicy = corev1.PullAlways // set non-default value
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &CnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -119,7 +119,7 @@ var _ = Describe("CNA Operand", func() {
 			hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{commonTestUtils.NewHyperConvergedConfig()}
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &CnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -153,7 +153,7 @@ var _ = Describe("CNA Operand", func() {
 			existingResource := hcoNodePlacement.NewNetworkAddons()
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &CnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -187,7 +187,7 @@ var _ = Describe("CNA Operand", func() {
 			hco.Spec.Workloads.NodePlacement.NodeSelector["key1"] = "something else"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &CnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -235,7 +235,7 @@ var _ = Describe("CNA Operand", func() {
 				},
 			}
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := &CnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &cnaHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -22,21 +22,21 @@ type OperandHandler struct {
 
 func NewOperandHandler(client client.Client, scheme *runtime.Scheme, isOpenshiftCluster bool, eventEmitter hcoutil.EventEmitter) *OperandHandler {
 	operands := []Operand{
-		&KvConfigHandler{Client: client, Scheme: scheme},
-		&KvPriorityClassHandler{Client: client, Scheme: scheme},
-		&KubevirtHandler{Client: client, Scheme: scheme},
-		&CdiHandler{Client: client, Scheme: scheme},
-		&CnaHandler{Client: client, Scheme: scheme},
-		&VmImportHandler{Client: client, Scheme: scheme},
-		&IMSConfigHandler{Client: client, Scheme: scheme},
+		&kvConfigHandler{Client: client, Scheme: scheme},
+		&kvPriorityClassHandler{Client: client, Scheme: scheme},
+		&kubevirtHandler{Client: client, Scheme: scheme},
+		&cdiHandler{Client: client, Scheme: scheme},
+		&cnaHandler{Client: client, Scheme: scheme},
+		&vmImportHandler{Client: client, Scheme: scheme},
+		&imsConfigHandler{Client: client, Scheme: scheme},
 	}
 
 	if isOpenshiftCluster {
 		operands = append(operands, []Operand{
-			NewCommonTemplateBundleHandler(client, scheme),
-			NewNodeLabellerBundleHandler(client, scheme),
-			NewTemplateValidatorHandler(client, scheme),
-			NewMetricsAggregationHandler(client, scheme),
+			newCommonTemplateBundleHandler(client, scheme),
+			newNodeLabellerBundleHandler(client, scheme),
+			newTemplateValidatorHandler(client, scheme),
+			newMetricsAggregationHandler(client, scheme),
 		}...)
 	}
 

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -2,20 +2,30 @@ package operands
 
 import (
 	"fmt"
+
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	reconcileFailed = "ReconcileFailed"
+	reconcileFailed       = "ReconcileFailed"
+	ErrCDIUninstall       = "ErrCDIUninstall"
+	uninstallCDIErrorMsg  = "The uninstall request failed on CDI component: "
+	ErrVirtUninstall      = "ErrVirtUninstall"
+	uninstallVirtErrorMsg = "The uninstall request failed on virt component: "
+	ErrHCOUninstall       = "ErrHCOUninstall"
+	uninstallHCOErrorMsg  = "The uninstall request failed on dependent components, please check their logs."
 )
 
 type OperandHandler struct {
+	client       client.Client
 	operands     []Operand
 	eventEmitter hcoutil.EventEmitter
 }
@@ -41,6 +51,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, isOpenshift
 	}
 
 	return &OperandHandler{
+		client:       client,
 		operands:     operands,
 		eventEmitter: eventEmitter,
 	}
@@ -70,4 +81,46 @@ func (h OperandHandler) Ensure(req *common.HcoRequest) error {
 	}
 	return nil
 
+}
+
+func (h OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
+	for _, obj := range []runtime.Object{
+		req.Instance.NewKubeVirt(),
+		req.Instance.NewCDI(),
+		req.Instance.NewNetworkAddons(),
+		req.Instance.NewKubeVirtCommonTemplateBundle(),
+		req.Instance.NewConsoleCLIDownload(),
+		NewVMImportForCR(req.Instance),
+	} {
+		err := hcoutil.EnsureDeleted(req.Ctx, h.client, obj, req.Instance.Name, req.Logger, false)
+		if err != nil {
+			req.Logger.Error(err, "Failed to manually delete objects")
+
+			// TODO: ask to other components to expose something like
+			// func IsDeleteRefused(err error) bool
+			// to be able to clearly distinguish between an explicit
+			// refuse from other operator and any other kind of error that
+			// could potentially happen in the process
+
+			errT := ErrHCOUninstall
+			errMsg := uninstallHCOErrorMsg
+			switch obj.(type) {
+			case *kubevirtv1.KubeVirt:
+				errT = ErrVirtUninstall
+				errMsg = uninstallVirtErrorMsg + err.Error()
+			case *cdiv1beta1.CDI:
+				errT = ErrCDIUninstall
+				errMsg = uninstallCDIErrorMsg + err.Error()
+			}
+
+			h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, errT, errMsg)
+
+			return err
+		}
+
+		if key, err := client.ObjectKeyFromObject(obj); err == nil {
+			h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed %s %s", obj.GetObjectKind().GroupVersionKind().Kind, key.Name))
+		}
+	}
+	return nil
 }

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -1,0 +1,73 @@
+package operands
+
+import (
+	"fmt"
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	reconcileFailed = "ReconcileFailed"
+)
+
+type OperandHandler struct {
+	operands     []Operand
+	eventEmitter hcoutil.EventEmitter
+}
+
+func NewOperandHandler(client client.Client, scheme *runtime.Scheme, isOpenshiftCluster bool, eventEmitter hcoutil.EventEmitter) *OperandHandler {
+	operands := []Operand{
+		&KvConfigHandler{Client: client, Scheme: scheme},
+		&KvPriorityClassHandler{Client: client, Scheme: scheme},
+		&KubevirtHandler{Client: client, Scheme: scheme},
+		&CdiHandler{Client: client, Scheme: scheme},
+		&CnaHandler{Client: client, Scheme: scheme},
+		&VmImportHandler{Client: client, Scheme: scheme},
+		&IMSConfigHandler{Client: client, Scheme: scheme},
+	}
+
+	if isOpenshiftCluster {
+		operands = append(operands, []Operand{
+			NewCommonTemplateBundleHandler(client, scheme),
+			NewNodeLabellerBundleHandler(client, scheme),
+			NewTemplateValidatorHandler(client, scheme),
+			NewMetricsAggregationHandler(client, scheme),
+		}...)
+	}
+
+	return &OperandHandler{
+		operands:     operands,
+		eventEmitter: eventEmitter,
+	}
+}
+
+func (h OperandHandler) Ensure(req *common.HcoRequest) error {
+	for _, handler := range h.operands {
+		res := handler.Ensure(req)
+		if res.Err != nil {
+			req.ComponentUpgradeInProgress = false
+			req.Conditions.SetStatusCondition(conditionsv1.Condition{
+				Type:    hcov1beta1.ConditionReconcileComplete,
+				Status:  corev1.ConditionFalse,
+				Reason:  reconcileFailed,
+				Message: fmt.Sprintf("Error while reconciling: %v", res.Err),
+			})
+			return res.Err
+		}
+
+		if res.Created {
+			h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Created", fmt.Sprintf("Created %s %s", res.Type, res.Name))
+		} else if res.Updated {
+			h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Updated", fmt.Sprintf("Updated %s %s", res.Type, res.Name))
+		}
+
+		req.ComponentUpgradeInProgress = req.ComponentUpgradeInProgress && res.UpgradeDone
+	}
+	return nil
+
+}

--- a/pkg/controller/operands/ssp.go
+++ b/pkg/controller/operands/ssp.go
@@ -32,7 +32,7 @@ type sspOperand struct {
 }
 type commonTemplateBundleHandler sspOperand
 
-func NewCommonTemplateBundleHandler(clt client.Client, scheme *runtime.Scheme) Operand {
+func newCommonTemplateBundleHandler(clt client.Client, scheme *runtime.Scheme) Operand {
 	return &commonTemplateBundleHandler{
 		genericOperand:     genericOperand{Client: clt, Scheme: scheme},
 		shouldRemoveOldCrd: true,
@@ -116,7 +116,7 @@ func (h *commonTemplateBundleHandler) Ensure(req *common.HcoRequest) *EnsureResu
 
 type nodeLabellerBundleHandler sspOperand
 
-func NewNodeLabellerBundleHandler(clt client.Client, scheme *runtime.Scheme) Operand {
+func newNodeLabellerBundleHandler(clt client.Client, scheme *runtime.Scheme) Operand {
 	return &nodeLabellerBundleHandler{
 		genericOperand:     genericOperand{Client: clt, Scheme: scheme},
 		shouldRemoveOldCrd: true,
@@ -228,7 +228,7 @@ func NewKubeVirtNodeLabellerBundleForCR(cr *hcov1beta1.HyperConverged, namespace
 
 type templateValidatorHandler sspOperand
 
-func NewTemplateValidatorHandler(clt client.Client, scheme *runtime.Scheme) Operand {
+func newTemplateValidatorHandler(clt client.Client, scheme *runtime.Scheme) Operand {
 	return &templateValidatorHandler{
 		genericOperand:     genericOperand{Client: clt, Scheme: scheme},
 		shouldRemoveOldCrd: true,
@@ -335,7 +335,7 @@ func NewKubeVirtTemplateValidatorForCR(cr *hcov1beta1.HyperConverged, namespace 
 
 type metricsAggregationHandler sspOperand
 
-func NewMetricsAggregationHandler(clt client.Client, scheme *runtime.Scheme) Operand {
+func newMetricsAggregationHandler(clt client.Client, scheme *runtime.Scheme) Operand {
 	return &metricsAggregationHandler{
 		genericOperand:     genericOperand{Client: clt, Scheme: scheme},
 		shouldRemoveOldCrd: true,

--- a/pkg/controller/operands/ssp_test.go
+++ b/pkg/controller/operands/ssp_test.go
@@ -30,7 +30,7 @@ var _ = Describe("SSP Operands", func() {
 		It("should create if not present", func() {
 			expectedResource := hco.NewKubeVirtCommonTemplateBundle()
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := NewCommonTemplateBundleHandler(cl, commonTestUtils.GetScheme()).(*commonTemplateBundleHandler)
+			handler := newCommonTemplateBundleHandler(cl, commonTestUtils.GetScheme()).(*commonTemplateBundleHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -50,7 +50,7 @@ var _ = Describe("SSP Operands", func() {
 			expectedResource := hco.NewKubeVirtCommonTemplateBundle()
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := NewCommonTemplateBundleHandler(cl, commonTestUtils.GetScheme()).(*commonTemplateBundleHandler)
+			handler := newCommonTemplateBundleHandler(cl, commonTestUtils.GetScheme()).(*commonTemplateBundleHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -70,7 +70,7 @@ var _ = Describe("SSP Operands", func() {
 			existingResource.Spec.Version = "Non default value"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := NewCommonTemplateBundleHandler(cl, commonTestUtils.GetScheme()).(*commonTemplateBundleHandler)
+			handler := newCommonTemplateBundleHandler(cl, commonTestUtils.GetScheme()).(*commonTemplateBundleHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -164,7 +164,7 @@ var _ = Describe("SSP Operands", func() {
 		It("should create if not present", func() {
 			expectedResource := NewKubeVirtNodeLabellerBundleForCR(hco, commonTestUtils.Namespace)
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := NewNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
+			handler := newNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -184,7 +184,7 @@ var _ = Describe("SSP Operands", func() {
 			expectedResource := NewKubeVirtNodeLabellerBundleForCR(hco, commonTestUtils.Namespace)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := NewNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
+			handler := newNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -204,7 +204,7 @@ var _ = Describe("SSP Operands", func() {
 			existingResource.Spec.Version = "Non default value"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := NewNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
+			handler := newNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -225,7 +225,7 @@ var _ = Describe("SSP Operands", func() {
 			hco.Spec.Workloads.NodePlacement = commonTestUtils.NewHyperConvergedConfig()
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := NewNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
+			handler := newNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -257,7 +257,7 @@ var _ = Describe("SSP Operands", func() {
 			existingResource := NewKubeVirtNodeLabellerBundleForCR(hcoNodePlacement, commonTestUtils.Namespace)
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := NewNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
+			handler := newNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -290,7 +290,7 @@ var _ = Describe("SSP Operands", func() {
 			hco.Spec.Workloads.NodePlacement.NodeSelector["key1"] = "something else"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := NewNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
+			handler := newNodeLabellerBundleHandler(cl, commonTestUtils.GetScheme()).(*nodeLabellerBundleHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -416,7 +416,7 @@ var _ = Describe("SSP Operands", func() {
 		It("should create if not present", func() {
 			expectedResource := NewKubeVirtTemplateValidatorForCR(hco, commonTestUtils.Namespace)
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := NewTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
+			handler := newTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -436,7 +436,7 @@ var _ = Describe("SSP Operands", func() {
 			expectedResource := NewKubeVirtTemplateValidatorForCR(hco, commonTestUtils.Namespace)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := NewTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
+			handler := newTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -456,7 +456,7 @@ var _ = Describe("SSP Operands", func() {
 			existingResource.Spec.TemplateValidatorReplicas = 5 // set non-default value
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := NewTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
+			handler := newTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -477,7 +477,7 @@ var _ = Describe("SSP Operands", func() {
 			hco.Spec.Infra.NodePlacement = commonTestUtils.NewHyperConvergedConfig()
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := NewTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
+			handler := newTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -509,7 +509,7 @@ var _ = Describe("SSP Operands", func() {
 			existingResource := NewKubeVirtTemplateValidatorForCR(hcoNodePlacement, commonTestUtils.Namespace)
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := NewTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
+			handler := newTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -542,7 +542,7 @@ var _ = Describe("SSP Operands", func() {
 			hco.Spec.Infra.NodePlacement.NodeSelector["key1"] = "something else"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := NewTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
+			handler := newTemplateValidatorHandler(cl, commonTestUtils.GetScheme()).(*templateValidatorHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -641,7 +641,7 @@ var _ = Describe("SSP Operands", func() {
 		It("should create if not present", func() {
 			expectedResource := NewKubeVirtMetricsAggregationForCR(hco, commonTestUtils.Namespace)
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := NewMetricsAggregationHandler(cl, commonTestUtils.GetScheme()).(*metricsAggregationHandler)
+			handler := newMetricsAggregationHandler(cl, commonTestUtils.GetScheme()).(*metricsAggregationHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -661,7 +661,7 @@ var _ = Describe("SSP Operands", func() {
 			expectedResource := NewKubeVirtMetricsAggregationForCR(hco, commonTestUtils.Namespace)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := NewMetricsAggregationHandler(cl, commonTestUtils.GetScheme()).(*metricsAggregationHandler)
+			handler := newMetricsAggregationHandler(cl, commonTestUtils.GetScheme()).(*metricsAggregationHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -681,7 +681,7 @@ var _ = Describe("SSP Operands", func() {
 			existingResource.Spec.Version = "non-default value"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := NewMetricsAggregationHandler(cl, commonTestUtils.GetScheme()).(*metricsAggregationHandler)
+			handler := newMetricsAggregationHandler(cl, commonTestUtils.GetScheme()).(*metricsAggregationHandler)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())

--- a/pkg/controller/operands/vmImport.go
+++ b/pkg/controller/operands/vmImport.go
@@ -18,9 +18,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type VmImportHandler genericOperand
+type vmImportHandler genericOperand
 
-func (h VmImportHandler) Ensure(req *common.HcoRequest) *EnsureResult {
+func (h vmImportHandler) Ensure(req *common.HcoRequest) *EnsureResult {
 	vmImport := NewVMImportForCR(req.Instance)
 	res := NewEnsureResult(vmImport)
 
@@ -101,9 +101,9 @@ func NewVMImportForCR(cr *hcov1beta1.HyperConverged) *vmimportv1beta1.VMImportCo
 	}
 }
 
-type IMSConfigHandler genericOperand
+type imsConfigHandler genericOperand
 
-func (h IMSConfigHandler) Ensure(req *common.HcoRequest) *EnsureResult {
+func (h imsConfigHandler) Ensure(req *common.HcoRequest) *EnsureResult {
 	imsConfig := NewIMSConfigForCR(req.Instance, req.Namespace)
 	res := NewEnsureResult(imsConfig)
 	if os.Getenv("CONVERSION_CONTAINER") == "" {

--- a/pkg/controller/operands/vmImport_test.go
+++ b/pkg/controller/operands/vmImport_test.go
@@ -32,7 +32,7 @@ var _ = Describe("VM-Import", func() {
 		It("should create if not present", func() {
 			expectedResource := NewVMImportForCR(hco)
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := &VmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &vmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -53,7 +53,7 @@ var _ = Describe("VM-Import", func() {
 			expectedResource := NewVMImportForCR(hco)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/vmimportconfigs/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := &VmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &vmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -73,7 +73,7 @@ var _ = Describe("VM-Import", func() {
 			existingResource.Spec.ImagePullPolicy = corev1.PullAlways // set non-default value
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &VmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &vmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -95,7 +95,7 @@ var _ = Describe("VM-Import", func() {
 			hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &VmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &vmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -134,7 +134,7 @@ var _ = Describe("VM-Import", func() {
 			existingResource := NewVMImportForCR(hcoNodePlacement)
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &VmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &vmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -173,7 +173,7 @@ var _ = Describe("VM-Import", func() {
 			hco.Spec.Infra.NodePlacement.NodeSelector["key1"] = "something else"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := &VmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &vmImportHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -215,7 +215,7 @@ var _ = Describe("VM-Import", func() {
 			os.Unsetenv("VMWARE_CONTAINER")
 
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := &IMSConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &imsConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).ToNot(BeNil())
@@ -224,7 +224,7 @@ var _ = Describe("VM-Import", func() {
 		It("should create if not present", func() {
 			expectedResource := NewIMSConfigForCR(hco, commonTestUtils.Namespace)
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := &IMSConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &imsConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -244,7 +244,7 @@ var _ = Describe("VM-Import", func() {
 			expectedResource := NewIMSConfigForCR(hco, commonTestUtils.Namespace)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := &IMSConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &imsConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).To(BeNil())
@@ -283,7 +283,7 @@ var _ = Describe("VM-Import", func() {
 			}
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource})
-			handler := &IMSConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
+			handler := &imsConfigHandler{Client: cl, Scheme: commonTestUtils.GetScheme()}
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())


### PR DESCRIPTION
These are commites 8, 9 an 10 (10/10) of the reconcile refactoring (#895).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

