### PR TITLE
Added certificate rotation config to HCO CR

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -150,6 +150,19 @@ spec:
               bareMetalPlatform:
                 description: BareMetalPlatform indicates whether the infrastructure is baremetal.
                 type: boolean
+              certConfig:
+                description: certConfig holds the rotation policy for internal, self-signed certificates
+                properties:
+                  caOverlapInterval:
+                    description: CAOverlapInterval the duration of CA Certificates at CABundle if not set it will default to CARotateInterval
+                    type: string
+                  caRotateInterval:
+                    description: CARotateInterval configurated duration for CA and certificate
+                    type: string
+                  certRotateInterval:
+                    description: CertRotateInterval configurated duration for of service certificate the the webhook configuration is referencing different services all of them will share the same duration
+                    type: string
+                type: object
               infra:
                 description: infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs.
                 properties:

--- a/deploy/index-image/kubevirt-hyperconverged/1.3.0/hco00.crd.yaml
+++ b/deploy/index-image/kubevirt-hyperconverged/1.3.0/hco00.crd.yaml
@@ -150,6 +150,19 @@ spec:
               bareMetalPlatform:
                 description: BareMetalPlatform indicates whether the infrastructure is baremetal.
                 type: boolean
+              certConfig:
+                description: certConfig holds the rotation policy for internal, self-signed certificates
+                properties:
+                  caOverlapInterval:
+                    description: CAOverlapInterval the duration of CA Certificates at CABundle if not set it will default to CARotateInterval
+                    type: string
+                  caRotateInterval:
+                    description: CARotateInterval configurated duration for CA and certificate
+                    type: string
+                  certRotateInterval:
+                    description: CertRotateInterval configurated duration for of service certificate the the webhook configuration is referencing different services all of them will share the same duration
+                    type: string
+                type: object
               infra:
                 description: infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs.
                 properties:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/hco00.crd.yaml
@@ -150,6 +150,19 @@ spec:
               bareMetalPlatform:
                 description: BareMetalPlatform indicates whether the infrastructure is baremetal.
                 type: boolean
+              certConfig:
+                description: certConfig holds the rotation policy for internal, self-signed certificates
+                properties:
+                  caOverlapInterval:
+                    description: CAOverlapInterval the duration of CA Certificates at CABundle if not set it will default to CARotateInterval
+                    type: string
+                  caRotateInterval:
+                    description: CARotateInterval configurated duration for CA and certificate
+                    type: string
+                  certRotateInterval:
+                    description: CertRotateInterval configurated duration for of service certificate the the webhook configuration is referencing different services all of them will share the same duration
+                    type: string
+                type: object
               infra:
                 description: infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs.
                 properties:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:19e3a3a9636185361e30f859216b83c9fcd1c3acbfd7129bf8a6adbc468b5a2e
-    createdAt: "2020-11-09 16:36:46"
+    createdAt: "2020-11-10 16:17:46"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -40,6 +40,10 @@ type HyperConvergedSpec struct {
 	// +optional
 	Workloads HyperConvergedConfig `json:"workloads,omitempty"`
 
+	// certConfig holds the rotation policy for internal, self-signed certificates
+	// +optional
+	CertConfig *HyperConvergedCertConfig `json:"certConfig,omitempty"`
+
 	// operator version
 	Version string `json:"version,omitempty"`
 }
@@ -49,6 +53,20 @@ type HyperConvergedConfig struct {
 	// NodePlacement describes node scheduling configuration.
 	// +optional
 	NodePlacement *sdkapi.NodePlacement `json:"nodePlacement,omitempty"`
+}
+
+type HyperConvergedCertConfig struct {
+	// CARotateInterval configurated duration for CA and certificate
+	CARotateInterval string `json:"caRotateInterval,omitempty"`
+
+	// CAOverlapInterval the duration of CA Certificates at CABundle if
+	// not set it will default to CARotateInterval
+	CAOverlapInterval string `json:"caOverlapInterval,omitempty"`
+
+	// CertRotateInterval configurated duration for of service certificate
+	// the the webhook configuration is referencing different services all
+	// of them will share the same duration
+	CertRotateInterval string `json:"certRotateInterval,omitempty"`
 }
 
 // HyperConvergedStatus defines the observed state of HyperConverged

--- a/pkg/controller/operands/networkAddons.go
+++ b/pkg/controller/operands/networkAddons.go
@@ -2,6 +2,8 @@ package operands
 
 import (
 	"errors"
+	"reflect"
+
 	networkaddonsshared "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	networkaddonsnames "github.com/kubevirt/cluster-network-addons-operator/pkg/names"
@@ -13,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -95,6 +96,14 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged, opts ...string) *networkadd
 		cnaoSpec.PlacementConfiguration = &networkaddonsshared.PlacementConfiguration{
 			Infra:     cnaoInfra,
 			Workloads: cnaoWorkloads,
+		}
+	}
+
+	if hc.Spec.CertConfig != nil {
+		cnaoSpec.SelfSignConfiguration = &networkaddonsshared.SelfSignConfiguration{
+			CARotateInterval:   hc.Spec.CertConfig.CARotateInterval,
+			CAOverlapInterval:  hc.Spec.CertConfig.CAOverlapInterval,
+			CertRotateInterval: hc.Spec.CertConfig.CertRotateInterval,
 		}
 	}
 


### PR DESCRIPTION
Passing certificate rotation configuration (CARotateInterval,
CAOverlapInterval and CertRotateInterval) as is from `certConfig` in
HCO CR to CNAO's SelfSignConfiguration object

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

