### PR TITLE
Signal unsupported mode with a TaintedConfiguration condition

### DIFF
--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -114,9 +114,17 @@ func (vs *Versions) getVersion(name string) (string, bool) {
 	return "", false
 }
 
-// ConditionReconcileComplete communicates the status of the HyperConverged resource's
-// reconcile functionality. Basically, is the Reconcile function running to completion.
-const ConditionReconcileComplete conditionsv1.ConditionType = "ReconcileComplete"
+const (
+
+	// ConditionReconcileComplete communicates the status of the HyperConverged resource's
+	// reconcile functionality. Basically, is the Reconcile function running to completion.
+	ConditionReconcileComplete conditionsv1.ConditionType = "ReconcileComplete"
+
+	// ConditionTaintedConfiguration indicates that a hidden/debug configuration
+	// has been applied to the HyperConverged resource via a specialized annotation.
+	// This condition is exposed only when its value is True, and is otherwise hidden.
+	ConditionTaintedConfiguration conditionsv1.ConditionType = "TaintedConfiguration"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/controller/common/consts.go
+++ b/pkg/controller/common/consts.go
@@ -3,4 +3,9 @@ package common
 const (
 	ReconcileCompleted        = "ReconcileCompleted"
 	ReconcileCompletedMessage = "Reconcile completed successfully"
+
+	// JSONPatch annotation names
+	JSONPatchKVAnnotationName   = "kubevirt.kubevirt.io/jsonpatch"
+	JSONPatchCDIAnnotationName  = "containerizeddataimporter.kubevirt.io/jsonpatch"
+	JSONPatchCNAOAnnotationName = "networkaddonsconfigs.kubevirt.io/jsonpatch"
 )

--- a/pkg/controller/common/hcoConditions.go
+++ b/pkg/controller/common/hcoConditions.go
@@ -13,12 +13,6 @@ var (
 		conditionsv1.ConditionDegraded,
 		conditionsv1.ConditionUpgradeable,
 	}
-
-	// These are condition types that are only visible when their value is "abnormal"
-	// (i.e., 'True' for negative-polarity conditions, and 'False' for positive-polarity conditions).
-	HcoHiddenConditionTypes = []conditionsv1.ConditionType{
-		hcov1beta1.ConditionTaintedConfiguration,
-	}
 )
 
 type HcoConditions map[conditionsv1.ConditionType]conditionsv1.Condition

--- a/pkg/controller/common/hcoConditions.go
+++ b/pkg/controller/common/hcoConditions.go
@@ -13,6 +13,12 @@ var (
 		conditionsv1.ConditionDegraded,
 		conditionsv1.ConditionUpgradeable,
 	}
+
+	// These are condition types that are only visible when their value is "abnormal"
+	// (i.e., 'True' for negative-polarity conditions, and 'False' for positive-polarity conditions).
+	HcoHiddenConditionTypes = []conditionsv1.ConditionType{
+		hcov1beta1.ConditionTaintedConfiguration,
+	}
 )
 
 type HcoConditions map[conditionsv1.ConditionType]conditionsv1.Condition

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -58,18 +58,14 @@ const (
 	taintedConfigurationMessage = "Unsupported feature was activated via an HCO annotation"
 
 	hcoVersionName = "operator"
-
-	JSONPatchKVAnnotationName   = "kubevirt.kubevirt.io/jsonpatch"
-	JSONPatchCDIAnnotationName  = "containerizeddataimporter.kubevirt.io/jsonpatch"
-	JSONPatchCNAOAnnotationName = "networkaddonsconfigs.kubevirt.io/jsonpatch"
 )
 
 // Annotations used to patch operand CRs with unsupported/unofficial/hidden features.
 // The presence of any of these annotations raises the hcov1beta1.ConditionTaintedConfiguration condition.
 var JSONPatchAnnotationNames = []string{
-	JSONPatchKVAnnotationName,
-	JSONPatchCDIAnnotationName,
-	JSONPatchCNAOAnnotationName,
+	common.JSONPatchKVAnnotationName,
+	common.JSONPatchCDIAnnotationName,
+	common.JSONPatchCNAOAnnotationName,
 }
 
 // Add creates a new HyperConverged Controller and adds it to the Manager. The Manager will set fields on the Controller

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/operands"
 	"os"
@@ -1223,7 +1224,7 @@ var _ = Describe("HyperconvergedController", func() {
 			It("Raises a TaintedConfiguration condition upon detection of such configuration", func() {
 				hco := commonTestUtils.NewHco()
 				hco.ObjectMeta.Annotations = map[string]string{
-					JSONPatchKVAnnotationName: `
+					common.JSONPatchKVAnnotationName: `
 						[
 							{
 								"op": "add",

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -1217,5 +1217,84 @@ var _ = Describe("HyperconvergedController", func() {
 
 			})
 		})
+
+		Context("Detection of a tainted configuration", func() {
+
+			It("Raises a TaintedConfiguration condition upon detection of such configuration", func() {
+				hco := commonTestUtils.NewHco()
+				hco.ObjectMeta.Annotations = map[string]string{
+					JSONPatchKVAnnotationName: `
+						[
+							{
+								"op": "add",
+								"path": "/configuration/migrations",
+								"value": '{"allowPostCopy": "true"}'
+							}
+						]`,
+				}
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco})
+				r := initReconciler(cl)
+
+				// Do the reconcile
+				res, err := r.Reconcile(request)
+				Expect(err).To(BeNil())
+				Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+
+				// Get the HCO
+				foundResource := &hcov1beta1.HyperConverged{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				// Check conditions
+				Expect(foundResource.Status.Conditions).To(ContainElement(testlib.RepresentCondition(conditionsv1.Condition{
+					Type:    hcov1beta1.ConditionTaintedConfiguration,
+					Status:  corev1.ConditionTrue,
+					Reason:  taintedConfigurationReason,
+					Message: taintedConfigurationMessage,
+				})))
+			})
+
+			It("Removes the TaintedConfiguration condition upon removal of such configuration", func() {
+				hco := commonTestUtils.NewHco()
+				hco.Status.Conditions = append(hco.Status.Conditions, conditionsv1.Condition{
+					Type:    hcov1beta1.ConditionTaintedConfiguration,
+					Status:  corev1.ConditionTrue,
+					Reason:  taintedConfigurationReason,
+					Message: taintedConfigurationMessage,
+				})
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco})
+				r := initReconciler(cl)
+
+				// Do the reconcile
+				res, err := r.Reconcile(request)
+				Expect(err).To(BeNil())
+
+				// Expecting "Requeue: false" since the conditions aren't empty
+				Expect(res).Should(Equal(reconcile.Result{Requeue: false}))
+
+				// Get the HCO
+				foundResource := &hcov1beta1.HyperConverged{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				// Check conditions
+				// Check conditions
+				Expect(foundResource.Status.Conditions).To(Not(ContainElement(testlib.RepresentCondition(conditionsv1.Condition{
+					Type:    hcov1beta1.ConditionTaintedConfiguration,
+					Status:  corev1.ConditionTrue,
+					Reason:  taintedConfigurationReason,
+					Message: taintedConfigurationMessage,
+				}))))
+			})
+
+		})
 	})
 })


### PR DESCRIPTION
This PR adds a new condition, `TaintedConfiguration: True` to the HCO CR, when it's annotated with a hidden/unofficial configuration annotation.


**Release note**:
```release-note
Added a new condition to signal when HCO runs with an unsupported configuration.
```

