### PR TITLE
[bump-bot] Fix go.mod version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A unified operator deploying and controlling [KubeVirt](https://github.com/kubev
 - [Node Maintenance](https://github.com/kubevirt/node-maintenance-operator)
 
 This operator is typically installed from the Operator Lifecycle Manager (OLM),
-and creates operator CustomResources (CRs) for its underlying operators as can be seen in the diagrom below.
+and creates operator CustomResources (CRs) for its underlying operators as can be seen in the diagram below.
 Use it to obtain an opinionated deployment of KubeVirt and its helper operators.
 
 ![](images/HCO-design.jpg)

--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -162,12 +162,25 @@ function update_go_mod() {
 
   if [ $UPDATED_COMPONENT == "KUBEVIRT" ]; then
     MODULE_PATH="kubevirt.io"
-    EXCLUSION="/containerized-data-importer/!"
+
+    EXCLUSION_LIST=(
+      "containerized-data-importer"
+      "controller-lifecycle-operator-sdk"
+      )
+    LAST=$(( ${#EXCLUSION_LIST[*]} - 1 ))
+    EXCLUSION='/'
+    for excl in "${EXCLUSION_LIST[@]}"; do
+      EXCLUSION+="(${excl})"
+      if [ "${excl}" == "${EXCLUSION_LIST[$LAST]}" ]; then
+        EXCLUSION+='/!'
+      else
+        EXCLUSION+='|'
+      fi
+    done
   else
     MODULE_PATH=$(echo ${COMPONENTS_REPOS[$UPDATED_COMPONENT]} | cut -d "/" -f 2)
   fi
-
-  sed -E -i "$EXCLUSION s/($MODULE_PATH.*)v.+/\1${UPDATED_VERSION}/" go.mod
+  sed -E -i "${EXCLUSION} s/(${MODULE_PATH}.*)v.+/\1${UPDATED_VERSION}/" go.mod
 }
 
 main


### PR DESCRIPTION
Excluding 'kubevirt.io/controller-lifecycle-operator-sdk' from being updated, which causes `go mod vendor` to fail.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

