### PR TITLE
Move webhook implementation to a new package

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/webhooks"
 	"github.com/spf13/pflag"
 	"os"
 	"runtime"
@@ -217,7 +218,8 @@ func main() {
 	if operatorWebhookMode {
 		// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
 		// necessary to configure Prometheus to scrape metrics from this operator.
-		if err = (&hcov1beta1.HyperConverged{}).SetupWebhookWithManager(ctx, mgr); err != nil {
+		hwHandler := &webhooks.WebhookHandler{}
+		if err = (&hcov1beta1.HyperConverged{}).SetupWebhookWithManager(ctx, mgr, hwHandler); err != nil {
 			log.Error(err, "unable to create webhook", "webhook", "HyperConverged")
 			eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to create webhook")
 			os.Exit(1)

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
@@ -3,16 +3,13 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-	kubevirtv1 "kubevirt.io/client-go/api/v1"
-	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
-	"os"
-	"path/filepath"
-	"reflect"
-
+	"github.com/go-logr/logr"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"os"
+	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -31,8 +28,20 @@ var (
 	cli    client.Client
 )
 
-func (r *HyperConverged) SetupWebhookWithManager(ctx context.Context, mgr ctrl.Manager) error {
+type WebhookHandlerIfs interface {
+	Init(logger logr.Logger, cli client.Client)
+	ValidateCreate(hc *HyperConverged) error
+	ValidateUpdate(requested *HyperConverged, exists *HyperConverged) error
+	ValidateDelete(hc *HyperConverged) error
+}
+
+var whHandler WebhookHandlerIfs
+
+func (r *HyperConverged) SetupWebhookWithManager(ctx context.Context, mgr ctrl.Manager, handler WebhookHandlerIfs) error {
 	// Make sure the certificates are mounted, this should be handled by the OLM
+	whHandler = handler
+	whHandler.Init(hcolog, cli)
+
 	certs := []string{filepath.Join(WebhookCertDir, WebhookCertName), filepath.Join(WebhookCertDir, WebhookKeyName)}
 	for _, fname := range certs {
 		if _, err := os.Stat(fname); err != nil {
@@ -89,94 +98,18 @@ func (r *HyperConverged) SetupWebhookWithManager(ctx context.Context, mgr ctrl.M
 var _ webhook.Validator = &HyperConverged{}
 
 func (r *HyperConverged) ValidateCreate() error {
-	hcolog.Info("Validating create", "name", r.Name, "namespace:", r.Namespace)
-
-	operatorNsEnv, err := hcoutil.GetOperatorNamespaceFromEnv()
-	if err != nil {
-		hcolog.Error(err, "Failed to get operator namespace from the environment")
-		return err
-	}
-
-	if r.Namespace != operatorNsEnv {
-		return fmt.Errorf("Invalid namespace for HyperConverged - please use the %s namespace", operatorNsEnv)
-	}
-
-	return nil
+	return whHandler.ValidateCreate(r)
 }
 
 func (r *HyperConverged) ValidateUpdate(old runtime.Object) error {
-	hcolog.Info("Validating update", "name", r.Name)
-
-	ctx := context.TODO()
-
 	oldR, ok := old.(*HyperConverged)
 	if !ok {
 		return fmt.Errorf("expect old object to be a %T instead of %T", oldR, old)
 	}
 
-	if !reflect.DeepEqual(
-		oldR.Spec,
-		r.Spec) {
-
-		opts := &client.UpdateOptions{DryRun: []string{metav1.DryRunAll}}
-		for _, obj := range []runtime.Object{
-			r.NewKubeVirt(),
-			r.NewCDI(),
-			// TODO: try to validate with all the components
-		} {
-			if err := r.UpdateOperatorCr(ctx, obj, opts); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// currently only supports KV and CDI
-func (r *HyperConverged) UpdateOperatorCr(ctx context.Context, exists runtime.Object, opts *client.UpdateOptions) error {
-	err := hcoutil.GetRuntimeObject(ctx, cli, exists, hcolog)
-	if err != nil {
-		hcolog.Error(err, "failed to get object from kubernetes", "kind", exists.GetObjectKind())
-		return err
-	}
-
-	switch exists.(type) {
-	case *kubevirtv1.KubeVirt:
-		existingKv := exists.(*kubevirtv1.KubeVirt)
-		required := r.NewKubeVirt()
-		existingKv.Spec = required.Spec
-
-	case *cdiv1beta1.CDI:
-		existingCdi := exists.(*cdiv1beta1.CDI)
-		required := r.NewCDI()
-		existingCdi.Spec = required.Spec
-	}
-
-	if err = cli.Update(ctx, exists, opts); err != nil {
-		hcolog.Error(err, "failed to dry-run update the object", "kind", exists.GetObjectKind())
-		return err
-	}
-
-	hcolog.Info("dry-run update the object passed", "kind", exists.GetObjectKind())
-	return nil
+	return whHandler.ValidateUpdate(r, oldR)
 }
 
 func (r *HyperConverged) ValidateDelete() error {
-	hcolog.Info("Validating delete", "name", r.Name, "namespace", r.Namespace)
-
-	ctx := context.TODO()
-
-	for _, obj := range []runtime.Object{
-		r.NewKubeVirt(),
-		r.NewCDI(),
-	} {
-		err := hcoutil.EnsureDeleted(ctx, cli, obj, r.Name, hcolog, true)
-		if err != nil {
-			hcolog.Error(err, "Delete validation failed", "GVK", obj.GetObjectKind().GroupVersionKind())
-			return err
-		}
-	}
-
-	return nil
+	return whHandler.ValidateDelete(r)
 }

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -1,0 +1,112 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type WebhookHandler struct {
+	logger logr.Logger
+	cli    client.Client
+}
+
+func (wh *WebhookHandler) Init(logger logr.Logger, cli client.Client) {
+	wh.logger = logger
+	wh.cli = cli
+}
+
+func (wh WebhookHandler) ValidateCreate(hc *v1beta1.HyperConverged) error {
+	wh.logger.Info("Validating create", "name", hc.Name, "namespace:", hc.Namespace)
+
+	operatorNsEnv, err := hcoutil.GetOperatorNamespaceFromEnv()
+	if err != nil {
+		wh.logger.Error(err, "Failed to get operator namespace from the environment")
+		return err
+	}
+
+	if hc.Namespace != operatorNsEnv {
+		return fmt.Errorf("Invalid namespace for v1beta1.HyperConverged - please use the %s namespace", operatorNsEnv)
+	}
+
+	return nil
+}
+
+func (wh WebhookHandler) ValidateUpdate(requested *v1beta1.HyperConverged, exists *v1beta1.HyperConverged) error {
+	wh.logger.Info("Validating update", "name", requested.Name)
+	ctx := context.TODO()
+
+	if !reflect.DeepEqual(
+		exists.Spec,
+		requested.Spec) {
+
+		opts := &client.UpdateOptions{DryRun: []string{metav1.DryRunAll}}
+		for _, obj := range []runtime.Object{
+			requested.NewKubeVirt(),
+			requested.NewCDI(),
+			// TODO: try to validate with all the components
+		} {
+			if err := wh.updateOperatorCr(ctx, requested, obj, opts); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// currently only supports KV and CDI
+func (wh WebhookHandler) updateOperatorCr(ctx context.Context, r *v1beta1.HyperConverged, exists runtime.Object, opts *client.UpdateOptions) error {
+	err := hcoutil.GetRuntimeObject(ctx, wh.cli, exists, wh.logger)
+	if err != nil {
+		wh.logger.Error(err, "failed to get object from kubernetes", "kind", exists.GetObjectKind())
+		return err
+	}
+
+	switch obj := exists.(type) {
+	case *kubevirtv1.KubeVirt:
+		existingKv := obj
+		required := r.NewKubeVirt()
+		existingKv.Spec = required.Spec
+
+	case *cdiv1beta1.CDI:
+		existingCdi := obj
+		required := r.NewCDI()
+		existingCdi.Spec = required.Spec
+	}
+
+	if err = wh.cli.Update(ctx, exists, opts); err != nil {
+		wh.logger.Error(err, "failed to dry-run update the object", "kind", exists.GetObjectKind())
+		return err
+	}
+
+	wh.logger.Info("dry-run update the object passed", "kind", exists.GetObjectKind())
+	return nil
+}
+
+func (wh WebhookHandler) ValidateDelete(hc *v1beta1.HyperConverged) error {
+	wh.logger.Info("Validating delete", "name", hc.Name, "namespace", hc.Namespace)
+
+	ctx := context.TODO()
+
+	for _, obj := range []runtime.Object{
+		hc.NewKubeVirt(),
+		hc.NewCDI(),
+	} {
+		err := hcoutil.EnsureDeleted(ctx, wh.cli, obj, hc.Name, wh.logger, true)
+		if err != nil {
+			wh.logger.Error(err, "Delete validation failed", "GVK", obj.GetObjectKind().GroupVersionKind())
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is done as a preparation to taking the new-operand-CR methods out of the `apis/hco/v1beta1` package

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

