### PR TITLE
Use a watch predicate to filter on generation or annotation change

### DIFF
--- a/pkg/util/predicate/predicate.go
+++ b/pkg/util/predicate/predicate.go
@@ -1,0 +1,45 @@
+package predicate
+
+import (
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var _ predicate.Predicate = GenerationOrAnnotationChangedPredicate{}
+
+var log = logf.Log.WithName("predicate")
+
+// GenerationOrAnnotationChangedPredicate implements a predicate function
+// that skips update events in which the generation hasn't been incremented,
+// nor the annotations have changed.
+//
+// The implementation is based on sigs.k8s.io/controller-runtime/pkg/predicate.GenerationChangedPredicate.
+type GenerationOrAnnotationChangedPredicate struct {
+	predicate.Funcs
+}
+
+// Update implements default UpdateEvent filter for validating generation/annotation change
+func (GenerationOrAnnotationChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.MetaOld == nil {
+		log.Error(nil, "Update event has no old metadata", "event", e)
+		return false
+	}
+	if e.ObjectOld == nil {
+		log.Error(nil, "Update event has no old runtime object to update", "event", e)
+		return false
+	}
+	if e.ObjectNew == nil {
+		log.Error(nil, "Update event has no new runtime object for update", "event", e)
+		return false
+	}
+	if e.MetaNew == nil {
+		log.Error(nil, "Update event has no new metadata", "event", e)
+		return false
+	}
+
+	return e.MetaNew.GetGeneration() != e.MetaOld.GetGeneration() ||
+		!reflect.DeepEqual(e.MetaNew.GetAnnotations(), e.MetaOld.GetAnnotations())
+}

--- a/pkg/util/predicate/predicate_suite_test.go
+++ b/pkg/util/predicate/predicate_suite_test.go
@@ -1,0 +1,13 @@
+package predicate
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPredicate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Predicate Suite")
+}

--- a/pkg/util/predicate/predicate_test.go
+++ b/pkg/util/predicate/predicate_test.go
@@ -1,0 +1,204 @@
+package predicate
+
+import (
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("Predicate", func() {
+
+	Describe("When checking a GenerationOrAnnotationChangedPredicate", func() {
+		instance := GenerationOrAnnotationChangedPredicate{}
+
+		Context("Where the old object doesn't have metadata", func() {
+			It("should return false", func() {
+				newObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "foof",
+					}}
+
+				updateEvent := event.UpdateEvent{
+					ObjectNew: newObj,
+					MetaNew:   newObj.GetObjectMeta(),
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(updateEvent)).To(BeFalse())
+			})
+		})
+
+		Context("Where the new object doesn't have metadata", func() {
+			It("should return false", func() {
+				oldObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "foof",
+					}}
+
+				updateEvent := event.UpdateEvent{
+					ObjectOld: oldObj,
+					MetaOld:   oldObj.GetObjectMeta(),
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(updateEvent)).To(BeFalse())
+			})
+		})
+
+		Context("Where both the generation and annotations haven't changed", func() {
+			It("should return false", func() {
+				oldObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Namespace:   "foof",
+						Generation:  1,
+						Annotations: map[string]string{"key": "value"},
+					}}
+				newObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Namespace:   "foof",
+						Generation:  1,
+						Annotations: map[string]string{"key": "value"},
+					}}
+
+				updateEvent := event.UpdateEvent{
+					ObjectOld: oldObj,
+					ObjectNew: newObj,
+					MetaOld:   oldObj.GetObjectMeta(),
+					MetaNew:   newObj.GetObjectMeta(),
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(updateEvent)).To(BeFalse())
+			})
+		})
+
+		Context("Where the generation hasn't changed and the annotations are empty", func() {
+			It("should return false", func() {
+				oldObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "foo",
+						Namespace:  "foof",
+						Generation: 1,
+					}}
+				newObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "foo",
+						Namespace:  "foof",
+						Generation: 1,
+					}}
+
+				updateEvent := event.UpdateEvent{
+					ObjectOld: oldObj,
+					ObjectNew: newObj,
+					MetaOld:   oldObj.GetObjectMeta(),
+					MetaNew:   newObj.GetObjectMeta(),
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(updateEvent)).To(BeFalse())
+			})
+		})
+
+		Context("Where the generation hasn't changed but an annotation has changed", func() {
+			It("should return true", func() {
+				oldObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Namespace:   "foof",
+						Generation:  1,
+						Annotations: map[string]string{"key": "old_value"},
+					}}
+				newObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Namespace:   "foof",
+						Generation:  1,
+						Annotations: map[string]string{"key": "new_value"},
+					}}
+
+				updateEvent := event.UpdateEvent{
+					ObjectOld: oldObj,
+					ObjectNew: newObj,
+					MetaOld:   oldObj.GetObjectMeta(),
+					MetaNew:   newObj.GetObjectMeta(),
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(updateEvent)).To(BeTrue())
+			})
+		})
+
+		Context("Where the annotations haven't changed but the generation has changed", func() {
+			It("should return true", func() {
+				oldObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Namespace:   "foof",
+						Generation:  1,
+						Annotations: map[string]string{"key": "value"},
+					}}
+				newObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Namespace:   "foof",
+						Generation:  2,
+						Annotations: map[string]string{"key": "value"},
+					}}
+
+				updateEvent := event.UpdateEvent{
+					ObjectOld: oldObj,
+					ObjectNew: newObj,
+					MetaOld:   oldObj.GetObjectMeta(),
+					MetaNew:   newObj.GetObjectMeta(),
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(updateEvent)).To(BeTrue())
+			})
+		})
+
+		Context("Where both the generation and annotations have changed", func() {
+			It("should return true", func() {
+				oldObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Namespace:   "foof",
+						Generation:  1,
+						Annotations: map[string]string{"key": "old_value"},
+					}}
+				newObj := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Namespace:   "foof",
+						Generation:  2,
+						Annotations: map[string]string{"key": "new_value"},
+					}}
+
+				updateEvent := event.UpdateEvent{
+					ObjectOld: oldObj,
+					ObjectNew: newObj,
+					MetaOld:   oldObj.GetObjectMeta(),
+					MetaNew:   newObj.GetObjectMeta(),
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(updateEvent)).To(BeTrue())
+			})
+		})
+	})
+})


### PR DESCRIPTION
This PR changes the watch events [Predicate](https://github.com/kubernetes-sigs/controller-runtime/blob/8d0107636985eeedeb8c3c666abda5f602aa92be/pkg/predicate/predicate.go#L30) used the HyperConvereged controller to one that admits updates to the object annotations, even when the object's spec (==> generation) hasn't changed.

Signed-off-by: Zvi Cahana <zvic@il.ibm.com>

**Release note**:
```release-note
NONE
```

