### PR TITLE
Hide nodePlacement APIs from the UI

### DIFF
--- a/deploy/index-image/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/index-image/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -125,6 +125,16 @@ spec:
         path: version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: nodePlacement APIs are temporary hidden
+        displayName: nodePlacement APIs are temporary hidden
+        path: infra
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: nodePlacement APIs are temporary hidden
+        displayName: nodePlacement APIs are temporary hidden
+        path: workloads
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       version: v1beta1
     - description: V2V Vmware
       displayName: V2V Vmware

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:19e3a3a9636185361e30f859216b83c9fcd1c3acbfd7129bf8a6adbc468b5a2e
-    createdAt: "2020-11-07 05:10:13"
+    createdAt: "2020-11-09 12:22:35"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -123,6 +123,16 @@ spec:
       - description: HIDDEN FIELDS - operator version.
         displayName: HIDDEN FIELDS - operator version
         path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: nodePlacement APIs are temporary hidden
+        displayName: nodePlacement APIs are temporary hidden
+        path: infra
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: nodePlacement APIs are temporary hidden
+        displayName: nodePlacement APIs are temporary hidden
+        path: workloads
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       version: v1beta1

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -1115,6 +1115,26 @@ func GetCSVBase(name, namespace, displayName, description, image, replaces strin
 									"urn:alm:descriptor:com.tectonic.ui:hidden",
 								},
 							},
+							// TODO: remove this only once nodePlacement APIs are mature
+							// enough to be shown on the UI
+							{
+								DisplayName: "nodePlacement APIs are temporary hidden",
+								Description: "nodePlacement APIs are temporary hidden",
+								Path:        "infra",
+								XDescriptors: []string{
+									"urn:alm:descriptor:com.tectonic.ui:hidden",
+								},
+							},
+							// TODO: remove this only once nodePlacement APIs are mature
+							// enough to be shown on the UI
+							{
+								DisplayName: "nodePlacement APIs are temporary hidden",
+								Description: "nodePlacement APIs are temporary hidden",
+								Path:        "workloads",
+								XDescriptors: []string{
+									"urn:alm:descriptor:com.tectonic.ui:hidden",
+								},
+							},
 						},
 						StatusDescriptors: []csvv1alpha1.StatusDescriptor{},
 					},


### PR DESCRIPTION
Hide nodePlacement APIs from the UI

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Hide nodePlacement APIs from the UI
```

