### PR TITLE
Add Prometheus metric for out-of-band modifications to secondary resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,6 @@ require (
 	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca
 	github.com/operator-framework/api v0.3.13
 	github.com/operator-framework/operator-lib v0.2.0
-	github.com/prometheus/client_golang v1.7.1
-	github.com/prometheus/client_model v0.2.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5
 	google.golang.org/genproto v0.0.0-20200701001935-0939c5918c31 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,8 @@ require (
 	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca
 	github.com/operator-framework/api v0.3.13
 	github.com/operator-framework/operator-lib v0.2.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5
 	google.golang.org/genproto v0.0.0-20200701001935-0939c5918c31 // indirect

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -378,7 +378,7 @@ var _ = Describe("HyperconvergedController", func() {
 				hco := commonTestUtils.NewHco()
 				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
 				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
-				existingResource := hco.NewKubeVirt()
+				existingResource := operands.NewKubeVirt(hco, namespace)
 
 				// now, modify KV's node placement
 				seconds3 := int64(3)
@@ -436,7 +436,7 @@ var _ = Describe("HyperconvergedController", func() {
 				hco := commonTestUtils.NewHco()
 				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
 				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
-				existingResource := hco.NewKubeVirt()
+				existingResource := operands.NewKubeVirt(hco, namespace)
 
 				// now, modify KV's node placement
 				seconds3 := int64(3)

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/operands"
-	"os"
-	"time"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/metrics"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -370,6 +372,116 @@ var _ = Describe("HyperconvergedController", func() {
 					Reason:  reconcileCompleted,
 					Message: reconcileCompletedMessage,
 				})))
+			})
+
+			It("should increment counter when out-of-band change overwritten", func() {
+				hco := commonTestUtils.NewHco()
+				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
+				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
+				existingResource := hco.NewKubeVirt()
+
+				// now, modify KV's node placement
+				seconds3 := int64(3)
+				existingResource.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: &seconds3,
+				})
+				existingResource.Spec.Workloads.NodePlacement.Tolerations = append(hco.Spec.Workloads.NodePlacement.Tolerations, corev1.Toleration{
+					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: &seconds3,
+				})
+
+				existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"] = "BADvalue1"
+				existingResource.Spec.Workloads.NodePlacement.NodeSelector["key2"] = "BADvalue2"
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+				r := initReconciler(cl)
+
+				// mock a reconciliation triggered by a change in secondary CR
+				ph, err := getSecondaryCRPlaceholder()
+				Expect(err).To(BeNil())
+				rq := request
+				rq.NamespacedName = ph
+
+				counterValueBefore, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(existingResource.Name)
+				Expect(err).To(BeNil())
+
+				// Do the reconcile
+				res, err := r.Reconcile(rq)
+				Expect(err).To(BeNil())
+				Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+
+				foundResource := &kubevirtv1.KubeVirt{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				Expect(existingResource.Spec.Infra.NodePlacement.Tolerations).To(HaveLen(3))
+				Expect(existingResource.Spec.Workloads.NodePlacement.Tolerations).To(HaveLen(3))
+				Expect(existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("BADvalue1"))
+				Expect(existingResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("BADvalue2"))
+
+				Expect(foundResource.Spec.Infra.NodePlacement.Tolerations).To(HaveLen(2))
+				Expect(foundResource.Spec.Workloads.NodePlacement.Tolerations).To(HaveLen(2))
+				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("value1"))
+				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("value2"))
+
+				counterValueAfter, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(foundResource.Name)
+				Expect(err).To(BeNil())
+				Expect(counterValueAfter).To(Equal(counterValueBefore + 1))
+
+			})
+
+			It("should not increment counter when CR was changed by HCO", func() {
+				hco := commonTestUtils.NewHco()
+				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
+				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewHyperConvergedConfig()}
+				existingResource := hco.NewKubeVirt()
+
+				// now, modify KV's node placement
+				seconds3 := int64(3)
+				existingResource.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: &seconds3,
+				})
+				existingResource.Spec.Workloads.NodePlacement.Tolerations = append(hco.Spec.Workloads.NodePlacement.Tolerations, corev1.Toleration{
+					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: &seconds3,
+				})
+
+				existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"] = "BADvalue1"
+				existingResource.Spec.Workloads.NodePlacement.NodeSelector["key2"] = "BADvalue2"
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+				r := initReconciler(cl)
+
+				counterValueBefore, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(existingResource.Name)
+				Expect(err).To(BeNil())
+
+				// Do the reconcile triggered by HCO
+				res, err := r.Reconcile(request)
+				Expect(err).To(BeNil())
+				Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+
+				foundResource := &kubevirtv1.KubeVirt{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				Expect(existingResource.Spec.Infra.NodePlacement.Tolerations).To(HaveLen(3))
+				Expect(existingResource.Spec.Workloads.NodePlacement.Tolerations).To(HaveLen(3))
+				Expect(existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("BADvalue1"))
+				Expect(existingResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("BADvalue2"))
+
+				Expect(foundResource.Spec.Infra.NodePlacement.Tolerations).To(HaveLen(2))
+				Expect(foundResource.Spec.Workloads.NodePlacement.Tolerations).To(HaveLen(2))
+				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("value1"))
+				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("value2"))
+
+				counterValueAfter, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(foundResource.Name)
+				Expect(err).To(BeNil())
+				Expect(counterValueAfter).To(Equal(counterValueBefore))
+
 			})
 
 			It(`should be not available when components with missing "Available" condition`, func() {

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -5,6 +5,7 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/metrics"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -78,7 +79,7 @@ func (h OperandHandler) Ensure(req *common.HcoRequest) error {
 				h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Updated", fmt.Sprintf("Updated %s %s", res.Type, res.Name))
 			} else {
 				h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, "Overwritten", fmt.Sprintf("Overwritten %s %s", res.Type, res.Name))
-				// TODO: raise an alert, count them with a CR specific metric and so on...
+				metrics.HcoMetrics.IncOverwrittenModifications(res.Name)
 			}
 		}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,27 +6,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-var (
-	// Number of out-of-band modifications overwritten by HCO
-	overwrittenModifications = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "hyperconverged_cluster_operator_out_of_band_modifications",
-			Help: "Count of out-of-band modifications overwritten by HCO",
-		},
-		[]string{"component_name"},
-	)
-
-	// HcoMetrics wrapper for all hco metrics
-	HcoMetrics = hcoMetrics{overwrittenModifications}
-)
+// HcoMetrics wrapper for all hco metrics
+var HcoMetrics = hcoMetrics{prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "hyperconverged_cluster_operator_out_of_band_modifications",
+		Help: "Count of out-of-band modifications overwritten by HCO",
+	},
+	[]string{"component_name"},
+)}
 
 // hcoMetrics holds all HCO metrics
 type hcoMetrics struct {
+	// overwrittenModifications counts out-of-band modifications overwritten by HCO
 	overwrittenModifications *prometheus.CounterVec
 }
 
 func init() {
-	metrics.Registry.MustRegister(overwrittenModifications)
+	HcoMetrics.init()
+}
+
+func (hm *hcoMetrics) init() {
+	metrics.Registry.MustRegister(hm.overwrittenModifications)
 }
 
 // IncOverwrittenModifications increments counter by 1

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// Number of out-of-band modifications overwritten by HCO
+	overwrittenModifications = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "hyperconverged_cluster_operator_out_of_band_modifications",
+			Help: "Count of out-of-band modifications overwritten by HCO",
+		},
+		[]string{"component_name"},
+	)
+
+	// HcoMetrics wrapper for all hco metrics
+	HcoMetrics = hcoMetrics{overwrittenModifications}
+)
+
+// hcoMetrics holds all HCO metrics
+type hcoMetrics struct {
+	overwrittenModifications *prometheus.CounterVec
+}
+
+func init() {
+	metrics.Registry.MustRegister(overwrittenModifications)
+}
+
+// IncOverwrittenModifications increments counter by 1
+func (hm *hcoMetrics) IncOverwrittenModifications(componentName string) {
+	hm.overwrittenModifications.With(prometheus.Labels{"component_name": componentName}).Inc()
+}
+
+// GetOverwrittenModificationsCount returns current value of counter. If error is not nil then value is undefined
+func (hm *hcoMetrics) GetOverwrittenModificationsCount(componentName string) (float64, error) {
+	var m = &dto.Metric{}
+	err := hm.overwrittenModifications.With(prometheus.Labels{"component_name": componentName}).Write(m)
+	return m.Counter.GetValue(), err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -177,10 +177,12 @@ github.com/pborman/uuid
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.7.1
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.2.0
+## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.10.0
 github.com/prometheus/common/expfmt


### PR DESCRIPTION
This PR adds metric counter for modifications to secondary resources that was not initiated by primary resource and thus overwritten.
More metrics expected to be added later to the hcoMetrics struct.

Signed-off-by: Andrey Odarenko andreyo@il.ibm.com

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

