### PR TITLE
Use a fully qualified finalizer name

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -43,7 +43,8 @@ var (
 const (
 	// We cannot set owner reference of cluster-wide resources to namespaced HyperConverged object. Therefore,
 	// use finalizers to manage the cleanup.
-	FinalizerName = "hyperconvergeds.hco.kubevirt.io"
+	FinalizerName = "kubevirt.io/hyperconverged"
+	badFinalizerName = "hyperconvergeds.hco.kubevirt.io"
 
 	// OpenshiftNamespace is for resources that belong in the openshift namespace
 
@@ -300,6 +301,10 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 		// Add the finalizer if it's not there
 		if !contains(req.Instance.ObjectMeta.Finalizers, FinalizerName) {
 			req.Instance.ObjectMeta.Finalizers = append(req.Instance.ObjectMeta.Finalizers, FinalizerName)
+			req.Dirty = true
+		}
+		if contains(req.Instance.ObjectMeta.Finalizers, badFinalizerName) {
+			req.Instance.ObjectMeta.Finalizers = drop(req.Instance.ObjectMeta.Finalizers, badFinalizerName)
 			req.Dirty = true
 		}
 	} else {

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -43,7 +43,7 @@ var (
 const (
 	// We cannot set owner reference of cluster-wide resources to namespaced HyperConverged object. Therefore,
 	// use finalizers to manage the cleanup.
-	FinalizerName = "kubevirt.io/hyperconverged"
+	FinalizerName    = "kubevirt.io/hyperconverged"
 	badFinalizerName = "hyperconvergeds.hco.kubevirt.io"
 
 	// OpenshiftNamespace is for resources that belong in the openshift namespace

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -611,6 +611,46 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.ObjectMeta.Finalizers).To(BeNil())
 
 			})
+
+			It(`should set a finalizer on HCO CR`, func() {
+				expected := getBasicDeployment()
+				cl := expected.initClient()
+				r := initReconciler(cl)
+				res, err := r.Reconcile(request)
+				Expect(err).To(BeNil())
+				Expect(res).Should(Equal(reconcile.Result{}))
+
+				foundResource := &hcov1beta1.HyperConverged{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				Expect(foundResource.Status.RelatedObjects).ToNot(BeNil())
+				Expect(foundResource.ObjectMeta.Finalizers).Should(Equal([]string{FinalizerName}))
+			})
+
+			It(`should replace a finalizer with a bad name if there`, func() {
+				expected := getBasicDeployment()
+				expected.hco.ObjectMeta.Finalizers = []string{badFinalizerName}
+				cl := expected.initClient()
+				r := initReconciler(cl)
+				res, err := r.Reconcile(request)
+				Expect(err).To(BeNil())
+				Expect(res).Should(Equal(reconcile.Result{}))
+
+				foundResource := &hcov1beta1.HyperConverged{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				Expect(foundResource.Status.RelatedObjects).ToNot(BeNil())
+				Expect(foundResource.ObjectMeta.Finalizers).Should(Equal([]string{FinalizerName}))
+			})
+
 		})
 
 		Context("Validate OLM required fields", func() {


### PR DESCRIPTION
In the past we used "hyperconvergeds.hco.kubevirt.io"
as the name of HCO finalizer but it fails on some resources.

Using a fully qualified name like "kubevirt.io/hyperconverged"
and removing the old one if there.

Example:
```
[stirabos@crc ~]$ oc patch serviceaccounts -n kubevirt-hyperconverged hyperconverged-cluster-operator --type json -p '[{ "op": "add", "path": "/metadata/finalizers", "value": ["hyperconvergeds.hco.kubevirt.io"] }]'
The ServiceAccount "hyperconverged-cluster-operator" is invalid: metadata.finalizers[0]: Invalid value: "hyperconvergeds.hco.kubevirt.io": name is neither a standard finalizer name nor is it fully qualified
[stirabos@crc ~]$ oc patch serviceaccounts -n kubevirt-hyperconverged hyperconverged-cluster-operator --type json -p '[{ "op": "add", "path": "/metadata/finalizers", "value": ["kubevirt.io/hyperconverged"] }]'
serviceaccount/hyperconverged-cluster-operator patched
```

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Use a fully qualified finalizer name
```

