### PR TITLE
Add a mutating webhook to protect hco namespace

### DIFF
--- a/deploy/index-image/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/index-image/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -2418,6 +2418,29 @@ spec:
     webhookPath: /validate-hco-kubevirt-io-v1beta1-hyperconverged
   - admissionReviewVersions:
     - v1beta1
+    - v1
+    containerPort: 4343
+    deploymentName: hco-webhook
+    failurePolicy: Fail
+    generateName: mutate-ns-hco.kubevirt.io
+    objectSelector:
+      matchLabels:
+        name: kubevirt-hyperconverged
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - DELETE
+      resources:
+      - namespaces
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 30
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-ns-hco-kubevirt-io
+  - admissionReviewVersions:
+    - v1beta1
     containerPort: 8443
     deploymentName: node-maintenance-operator
     failurePolicy: Fail

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -2418,6 +2418,29 @@ spec:
     webhookPath: /validate-hco-kubevirt-io-v1beta1-hyperconverged
   - admissionReviewVersions:
     - v1beta1
+    - v1
+    containerPort: 4343
+    deploymentName: hco-webhook
+    failurePolicy: Fail
+    generateName: mutate-ns-hco.kubevirt.io
+    objectSelector:
+      matchLabels:
+        name: kubevirt-hyperconverged
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - DELETE
+      resources:
+      - namespaces
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 30
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-ns-hco-kubevirt-io
+  - admissionReviewVersions:
+    - v1beta1
     containerPort: 8443
     deploymentName: node-maintenance-operator
     failurePolicy: Fail

--- a/hack/test_delete_ns.sh
+++ b/hack/test_delete_ns.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2020 Red Hat, Inc.
+#
+
+set -ex
+
+function test_delete_ns(){
+    if [ "${CMD}" == "oc" ]; then
+        echo "Trying to delete kubevirt-hyperconverged namespace when the hyperconverged CR is still there"
+        # this should fail with a clear error message
+        ${CMD} delete namespace kubevirt-hyperconverged 2>&1 | grep "denied the request: HyperConverged CR is still present, please remove it before deleting the containing namespace"
+
+        echo "kubevirt-hyperconverged namespace should be still there"
+        ${CMD} get namespace kubevirt-hyperconverged -o yaml
+
+    else
+        echo "Ignoring webhook on k8s where we don't have OLM based validating webhooks"
+    fi
+
+    echo "Delete the hyperconverged CR to remove the product"
+    timeout 10m ${CMD} delete hyperconverged -n kubevirt-hyperconverged kubevirt-hyperconverged
+
+    #TODO: test only, remove this!
+    echo "check if really deleted"
+    ${CMD} get hyperconverged -n kubevirt-hyperconverged kubevirt-hyperconverged -o yaml || true
+
+    # remove this when we are sure that we don't have any component CR deleted in background
+    sleep 180
+
+    echo "Finally delete kubevirt-hyperconverged namespace"
+    timeout 10m ${CMD} delete namespace kubevirt-hyperconverged
+
+    #TODO: test only, remove this!
+    echo "check remaining issues"
+    ${CMD} get namespace kubevirt-hyperconverged -o yaml || true
+}
+
+

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -41,7 +41,7 @@
 # to verify that it is updated to the new operator image from 
 # the local registry.
 
-MAX_STEPS=12
+MAX_STEPS=13
 CUR_STEP=1
 RELEASE_DELTA="${RELEASE_DELTA:-1}"
 HCO_DEPLOYMENT_NAME=hco-operator
@@ -249,5 +249,9 @@ ${CMD} get deployments -n ${HCO_NAMESPACE} -o yaml | grep image | grep -v imageP
 ${CMD} get pod $HCO_CATALOGSOURCE_POD -n ${HCO_CATALOG_NAMESPACE} -o yaml | grep image | grep -v imagePullPolicy
 
 dump_sccs_after
+
+Msg "brutally delete HCO removing the namespace where it's running"
+source hack/test_delete_ns.sh
+test_delete_ns
 
 echo "upgrade-test completed successfully."

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -13,6 +13,7 @@ const (
 	HppoVersionEnvV        = "HPPO_VERSION"
 	VMImportEnvV           = "VM_IMPORT_VERSION"
 	HcoValidatingWebhook   = "validate-hco.kubevirt.io"
+	HcoMutatingWebhookNS   = "mutate-ns-hco.kubevirt.io"
 	AppLabel               = "app"
 	UndefinedNamespace     = ""
 	OpenshiftNamespace     = "openshift"
@@ -30,4 +31,7 @@ const (
 	HealthProbePort       int32 = 6060
 	ReadinessEndpointName       = "/readyz"
 	LivenessEndpointName        = "/livez"
+	HCOWebhookPath              = "/validate-hco-kubevirt-io-v1beta1-hyperconverged"
+	HCONSWebhookPath            = "/mutate-ns-hco-kubevirt-io"
+	WebhookPort                 = 4343
 )

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -10,6 +10,8 @@ import (
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	sspv1 "github.com/kubevirt/kubevirt-ssp-operator/pkg/apis/kubevirt/v1"
 	vmimportv1beta1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
@@ -25,26 +27,22 @@ const (
 )
 
 type WebhookHandler struct {
-	logger logr.Logger
-	cli    client.Client
+	logger    logr.Logger
+	cli       client.Client
+	namespace string
 }
 
-func (wh *WebhookHandler) Init(logger logr.Logger, cli client.Client) {
+func (wh *WebhookHandler) Init(logger logr.Logger, cli client.Client, namespace string) {
 	wh.logger = logger
 	wh.cli = cli
+	wh.namespace = namespace
 }
 
 func (wh WebhookHandler) ValidateCreate(hc *v1beta1.HyperConverged) error {
 	wh.logger.Info("Validating create", "name", hc.Name, "namespace:", hc.Namespace)
 
-	operatorNsEnv, err := hcoutil.GetOperatorNamespaceFromEnv()
-	if err != nil {
-		wh.logger.Error(err, "Failed to get operator namespace from the environment")
-		return err
-	}
-
-	if hc.Namespace != operatorNsEnv {
-		return fmt.Errorf("invalid namespace for v1beta1.HyperConverged - please use the %s namespace", operatorNsEnv)
+	if hc.Namespace != wh.namespace {
+		return fmt.Errorf("invalid namespace for v1beta1.HyperConverged - please use the %s namespace", wh.namespace)
 	}
 
 	return nil
@@ -180,4 +178,45 @@ func (wh WebhookHandler) ValidateDelete(hc *v1beta1.HyperConverged) error {
 	}
 
 	return nil
+}
+
+func (wh WebhookHandler) HandleMutatingNsDelete(ns *corev1.Namespace, dryRun bool) (bool, error) {
+	wh.logger.Info("validating namespace deletion", "name", ns.Name)
+
+	if ns.Name != wh.namespace {
+		wh.logger.Info("ignoring request for a different namespace")
+		return true, nil
+	}
+
+	ctx := context.TODO()
+	hco := &v1beta1.HyperConverged{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hcoutil.HyperConvergedName,
+			Namespace: wh.namespace,
+		},
+	}
+
+	// TODO: once the deletion of HCO CR is really safe during namespace deletion
+	// (foreground deletion, context timeouts...) try to automatically
+	// delete HCO CR if there.
+	// For now let's simply block the deletion if the namespace with a clear error message
+	// if HCO CR is still there
+
+	key, err := client.ObjectKeyFromObject(hco)
+	if err != nil {
+		wh.logger.Error(err, "failed to get object key for HyperConverged CR")
+		return false, err
+	}
+	found := &v1beta1.HyperConverged{}
+	err = wh.cli.Get(ctx, key, found)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			wh.logger.Info("HCO CR doesn't not exist, allow namespace deletion")
+			return true, nil
+		}
+		wh.logger.Error(err, "failed getting HyperConverged CR")
+		return false, err
+	}
+	wh.logger.Info("HCO CR still exists, forbid namespace deletion")
+	return false, nil
 }

--- a/pkg/webhooks/webhooks_test.go
+++ b/pkg/webhooks/webhooks_test.go
@@ -72,7 +72,7 @@ var _ = Describe("webhooks handler", func() {
 
 		cli := fake.NewFakeClientWithScheme(s)
 		wh := &WebhookHandler{}
-		wh.Init(logger, cli)
+		wh.Init(logger, cli, HcoValidNamespace)
 
 		It("should accept creation of a resource with a valid namespace", func() {
 			err := wh.ValidateCreate(cr)
@@ -96,7 +96,7 @@ var _ = Describe("webhooks handler", func() {
 			cli := getFakeClient(s, hco)
 			Expect(cli.Delete(ctx, operands.NewKubeVirt(hco))).To(BeNil())
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{
 				Spec: v1beta1.HyperConvergedSpec{
@@ -128,7 +128,7 @@ var _ = Describe("webhooks handler", func() {
 			c := getFakeClient(s, hco)
 			cli := errorClient{c, kvUpdateFailure}
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{}
 			hco.DeepCopyInto(newHco)
@@ -146,7 +146,7 @@ var _ = Describe("webhooks handler", func() {
 			cli := getFakeClient(s, hco)
 			Expect(cli.Delete(ctx, operands.NewCDI(hco))).To(BeNil())
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{
 				Spec: v1beta1.HyperConvergedSpec{
@@ -178,7 +178,7 @@ var _ = Describe("webhooks handler", func() {
 			c := getFakeClient(s, hco)
 			cli := errorClient{c, cdiUpdateFailure}
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{}
 			hco.DeepCopyInto(newHco)
@@ -204,7 +204,7 @@ var _ = Describe("webhooks handler", func() {
 			c := getFakeClient(s, hco)
 			cli := errorClient{c, noFailure}
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{}
 			hco.DeepCopyInto(newHco)
@@ -221,7 +221,7 @@ var _ = Describe("webhooks handler", func() {
 			cli := getFakeClient(s, hco)
 			Expect(cli.Delete(ctx, operands.NewNetworkAddons(hco))).To(BeNil())
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{
 				Spec: v1beta1.HyperConvergedSpec{
@@ -253,7 +253,7 @@ var _ = Describe("webhooks handler", func() {
 			c := getFakeClient(s, hco)
 			cli := errorClient{c, networkUpdateFailure}
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{}
 			hco.DeepCopyInto(newHco)
@@ -271,7 +271,7 @@ var _ = Describe("webhooks handler", func() {
 			cli := getFakeClient(s, hco)
 			Expect(cli.Delete(ctx, operands.NewKubeVirtCommonTemplateBundle(hco))).To(BeNil())
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{
 				Spec: v1beta1.HyperConvergedSpec{
@@ -303,7 +303,7 @@ var _ = Describe("webhooks handler", func() {
 			c := getFakeClient(s, hco)
 			cli := errorClient{c, kubevirtCommonTemplateBundleUpdateFailure}
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{}
 			hco.DeepCopyInto(newHco)
@@ -322,7 +322,7 @@ var _ = Describe("webhooks handler", func() {
 			cli := getFakeClient(s, hco)
 			Expect(cli.Delete(ctx, operands.NewKubeVirtNodeLabellerBundleForCR(hco, hco.Namespace))).To(BeNil())
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{
 				Spec: v1beta1.HyperConvergedSpec{
@@ -354,7 +354,7 @@ var _ = Describe("webhooks handler", func() {
 			c := getFakeClient(s, hco)
 			cli := errorClient{c, kubevirtNodeLabellerBundleUpdateFailure}
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{}
 			hco.DeepCopyInto(newHco)
@@ -373,7 +373,7 @@ var _ = Describe("webhooks handler", func() {
 			cli := getFakeClient(s, hco)
 			Expect(cli.Delete(ctx, operands.NewKubeVirtTemplateValidatorForCR(hco, hco.Namespace))).To(BeNil())
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{
 				Spec: v1beta1.HyperConvergedSpec{
@@ -405,7 +405,7 @@ var _ = Describe("webhooks handler", func() {
 			c := getFakeClient(s, hco)
 			cli := errorClient{c, kubevirtTemplateValidatorUpdateFailure}
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{}
 			hco.DeepCopyInto(newHco)
@@ -424,7 +424,7 @@ var _ = Describe("webhooks handler", func() {
 			cli := getFakeClient(s, hco)
 			Expect(cli.Delete(ctx, operands.NewKubeVirtMetricsAggregationForCR(hco, hco.Namespace))).To(BeNil())
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{
 				Spec: v1beta1.HyperConvergedSpec{
@@ -456,7 +456,7 @@ var _ = Describe("webhooks handler", func() {
 			c := getFakeClient(s, hco)
 			cli := errorClient{c, kubevirtMetricsAggregationUpdateFailure}
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{}
 			hco.DeepCopyInto(newHco)
@@ -474,7 +474,7 @@ var _ = Describe("webhooks handler", func() {
 			cli := getFakeClient(s, hco)
 			Expect(cli.Delete(ctx, operands.NewVMImportForCR(hco))).To(BeNil())
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{
 				Spec: v1beta1.HyperConvergedSpec{
@@ -506,7 +506,7 @@ var _ = Describe("webhooks handler", func() {
 			c := getFakeClient(s, hco)
 			cli := errorClient{c, vmImportUpdateFailure}
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{}
 			hco.DeepCopyInto(newHco)
@@ -532,7 +532,7 @@ var _ = Describe("webhooks handler", func() {
 			c := getFakeClient(s, hco)
 			cli := errorClient{c, timeoutError}
 			wh := &WebhookHandler{}
-			wh.Init(logger, cli)
+			wh.Init(logger, cli, HcoValidNamespace)
 
 			newHco := &v1beta1.HyperConverged{}
 			hco.DeepCopyInto(newHco)
@@ -545,6 +545,64 @@ var _ = Describe("webhooks handler", func() {
 		})
 
 	})
+
+	Context("Check mutating webhook for namespace deletion", func() {
+		BeforeEach(func() {
+			Expect(os.Setenv("OPERATOR_NAMESPACE", HcoValidNamespace)).To(BeNil())
+		})
+
+		cr := &v1beta1.HyperConverged{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ResourceName,
+				Namespace: HcoValidNamespace,
+			},
+			Spec: v1beta1.HyperConvergedSpec{},
+		}
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: HcoValidNamespace,
+			},
+		}
+
+		It("should allow the delete of the namespace if Hyperconverged CR doesn't exist", func() {
+			cli := fake.NewFakeClientWithScheme(s)
+			wh := &WebhookHandler{}
+			wh.Init(logger, cli, HcoValidNamespace)
+
+			allowed, err := wh.HandleMutatingNsDelete(ns, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(allowed).To(BeTrue())
+		})
+
+		It("should not allow the delete of the namespace if Hyperconverged CR exists", func() {
+			cli := fake.NewFakeClientWithScheme(s, cr)
+			wh := &WebhookHandler{}
+			wh.Init(logger, cli, HcoValidNamespace)
+
+			allowed, err := wh.HandleMutatingNsDelete(ns, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(allowed).To(BeFalse())
+		})
+
+		It("should ignore other namespaces even if Hyperconverged CR exists", func() {
+			cli := fake.NewFakeClientWithScheme(s, cr)
+			wh := &WebhookHandler{}
+			wh.Init(logger, cli, HcoValidNamespace)
+
+			other_ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ResourceInvalidNamespace,
+				},
+			}
+
+			allowed, err := wh.HandleMutatingNsDelete(other_ns, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(allowed).To(BeTrue())
+		})
+
+	})
+
 })
 
 func newHyperConvergedConfig() *sdkapi.NodePlacement {


### PR DESCRIPTION
Add a mutating webhook to protect hco namespace

Introducing a mutating admission webhooks, deployed by
the OLM, bound to the namespace where HCO is running
to protect it from uneducated deletion the can
potentially made it stuck.
The webhook scope is limited to that specific namespace
by the use of an objectSelector.

In this first step the mutating webhook is simply refusing,
with a clear error message,to admit the deletion of the
namespace if the Hyperconverged CR is still there.
A future enhancement can try to delete the Hyperconverged CR
as a side effect (that's why a mutating webhook with side effects)
and, only when it and all its descendants are correctly
and safely deleted, admit the deletion of the namespace.
This requires other ancillary work to make the deletion safe
avoiding race conditions.
So let's simply refuse to delete the namespace as a first
and safer step.

Test it in CI at the end of upgrade test lanes:
the test will try to delete the namespace when the Hyperconverged CR
is still there looking for a specific error message,
the test then will delete the hyperconverged CR and finally
successfully delete the namespace.

Fixes: https://bugzilla.redhat.com/1881874

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Add a mutating webhook to protect hco namespace
```

