### PR TITLE
Use pre-prepared list of image digests to build the CSV

### DIFF
--- a/.github/workflows/digester_bot.yml
+++ b/.github/workflows/digester_bot.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Run
         run: ./automation/digester/update_images.sh
 
+      - name: Regenerage CSV
+        run: |
+          if ! git diff --quiet --exit-code; then
+          ./hack/build-manifests.sh
+          git add a.txt
+          fi
+
       - uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.HCO_BOT_TOKEN }}

--- a/.github/workflows/digester_bot.yml
+++ b/.github/workflows/digester_bot.yml
@@ -1,10 +1,10 @@
-name: Auto-Bump Component's Versions
+name: Auto-Update Image Digests
 on:
   schedule:
-    - cron:  '0 4 * * *'
+    - cron:  '0 4/4 * * *'
 jobs:
   build:
-    name: HCO Release Bump Job
+    name: HCO Update Image Digests Job
     if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')
     runs-on: ubuntu-latest
     steps:
@@ -25,11 +25,11 @@ jobs:
               dep ensure
           fi
 
-      - name: Build
+      - name: Build the degister app
         working-directory: tools/digester
         run: go build -v .
 
-      - name: Run
+      - name: Run the degister app to update the digests
         run: |
           ./automation/digester/update_images.sh
           if ! git diff --quiet --exit-code; then
@@ -52,7 +52,7 @@ jobs:
           title: "Update Image Digests"
           body: |
             Update Image Digests
-            Executed by HCO Release-Bumper Bot.
+            Executed by HCO Update Image Digest Bot.
             ```release-note
             Update Image Digests
             ```

--- a/.github/workflows/digester_bot.yml
+++ b/.github/workflows/digester_bot.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Get dependencies
         working-directory: tools/digester
         run: |
-          cd tools/
           go get -v -t -d ./...
           if [ -f Gopkg.toml ]; then
               curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
@@ -31,16 +30,18 @@ jobs:
         run: go build -v .
 
       - name: Run
-        run: ./automation/digester/update_images.sh
-
-      - name: Regenerage CSV
         run: |
+          ./automation/digester/update_images.sh
           if ! git diff --quiet --exit-code; then
-          ./hack/build-manifests.sh
-          git add a.txt
+            echo "CHANGED=true" >> $GITHUB_ENV
           fi
 
+      - name: Regenerage CSV
+        if: ${{ env.CHANGED }}
+        run: ./hack/build-manifests.sh
+
       - uses: peter-evans/create-pull-request@v3
+        if: ${{ env.CHANGED }}
         with:
           token: ${{ secrets.HCO_BOT_TOKEN }}
           commit-message: |

--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -11,24 +11,38 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: master
+
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.15' # The Go version to download (if necessary) and use.
+
       - name: Check for new releases and update
-        run: ./automation/release-bumper/release-bumper.sh
-      - name: Set "UPDATED_COMPONENT" environment variable
         run: |
-          echo 'UPDATED_COMPONENT<<EOF' >> $GITHUB_ENV
-          cat updated_component.txt >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - name: Set "UPDATED_VERSION" environment variable
-        run: |
-          echo 'UPDATED_VERSION<<EOF' >> $GITHUB_ENV
-          cat updated_version.txt >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          ./automation/release-bumper/release-bumper.sh
+          if [[ -f updated_component.txt ]]; then
+            echo 'UPDATED_COMPONENT<<EOF' >> $GITHUB_ENV
+            cat updated_component.txt >> $GITHUB_ENV
+            echo 'EOF' >> $GITHUB_ENV
+            UPDATED_COMPONENT_EXISTS=true
+          fi
+
+          if [[ -f updated_version.txt ]]; then
+            echo 'UPDATED_VERSION<<EOF' >> $GITHUB_ENV
+            cat updated_version.txt >> $GITHUB_ENV
+            echo 'EOF' >> $GITHUB_ENV
+            UPDATED_VERSION_EXISTS=true
+          fi
+
+          if [[ -n ${UPDATED_COMPONENT_EXISTS} && -n ${UPDATED_VERSION_EXISTS} ]]; then
+            echo "CHANGED=true" >> $GITHUB_ENV
+          fi
+
       - name: Remove temporary files
+        if: ${{ env.CHANGED }}
         run: rm -f updated_component.txt updated_version.txt
+
       - uses: peter-evans/create-pull-request@v3
+        if: ${{ env.CHANGED }}
         with:
           token: ${{ secrets.HCO_BOT_TOKEN }}
           commit-message: |

--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -27,6 +27,9 @@ function main {
 
   update_versions
 
+  echo INFO: Updating image digest list...
+  ./automation/digester/update_images.sh
+
   echo INFO: Executing "build-manifests.sh"...
   ./hack/build-manifests.sh
 

--- a/deploy/index-image/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/index-image/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -2077,7 +2077,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: node-maintenance-operator
-                image: quay.io/kubevirt/node-maintenance-operator:v0.7.0
+                image: quay.io/kubevirt/node-maintenance-operator@sha256:71bb8de714dc0de0616050d66405ccb58841930fc1562a61399e1b964a0b678a
                 imagePullPolicy: Always
                 name: node-maintenance-operator
                 resources: {}
@@ -2364,6 +2364,8 @@ spec:
     name: macvtap-cni
   - image: nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba
     name: multus
+  - image: quay.io/kubevirt/node-maintenance-operator@sha256:71bb8de714dc0de0616050d66405ccb58841930fc1562a61399e1b964a0b678a
+    name: node-maintenance-operator
   - image: quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620
     name: ovs-cni-marker
   - image: quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:d30b96dca17e99c9c12c83609629fb886bbd99255e2ee020ffc598c476ccdfb2
-    createdAt: "2020-11-16 20:48:25"
+    createdAt: "2020-11-19 07:39:59"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -2077,7 +2077,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: node-maintenance-operator
-                image: quay.io/kubevirt/node-maintenance-operator:v0.7.0
+                image: quay.io/kubevirt/node-maintenance-operator@sha256:71bb8de714dc0de0616050d66405ccb58841930fc1562a61399e1b964a0b678a
                 imagePullPolicy: Always
                 name: node-maintenance-operator
                 resources: {}
@@ -2364,6 +2364,8 @@ spec:
     name: macvtap-cni
   - image: nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba
     name: multus
+  - image: quay.io/kubevirt/node-maintenance-operator@sha256:71bb8de714dc0de0616050d66405ccb58841930fc1562a61399e1b964a0b678a
+    name: node-maintenance-operator
   - image: quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620
     name: ovs-cni-marker
   - image: quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -435,7 +435,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: node-maintenance-operator
-        image: quay.io/kubevirt/node-maintenance-operator:v0.7.0
+        image: quay.io/kubevirt/node-maintenance-operator@sha256:71bb8de714dc0de0616050d66405ccb58841930fc1562a61399e1b964a0b678a
         imagePullPolicy: Always
         name: node-maintenance-operator
         resources: {}


### PR DESCRIPTION
Use a pre-prepared image digest file to build the CSV. The file is checked and if needed, updated daily, or when an operand release version is changed.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

