### PR TITLE
Make uninstall safer and faster

### DIFF
--- a/pkg/apis/hco/v1alpha1/hyperconverged_webhook.go
+++ b/pkg/apis/hco/v1alpha1/hyperconverged_webhook.go
@@ -115,7 +115,7 @@ func (r *HyperConverged) ValidateDelete() error {
 		r.NewKubeVirt(),
 		r.NewCDI(),
 	} {
-		err := hcoutil.EnsureDeleted(ctx, cli, obj, r.Name, hcolog, true)
+		err := hcoutil.EnsureDeleted(ctx, cli, obj, r.Name, hcolog, true, false)
 		if err != nil {
 			hcolog.Error(err, "Delete validation failed", "GVK", obj.GetObjectKind().GroupVersionKind())
 			return err

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -311,6 +311,11 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 			req.Dirty = req.Dirty || fin_dropped
 		}
 	} else {
+		if !req.HCOTriggered {
+			// this is just the effect of a delete request created by HCO
+			// in the previous iteration, ignore it
+			return reconcile.Result{}, nil
+		}
 		return r.ensureHcoDeleted(req)
 	}
 

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -1,7 +1,12 @@
 package operands
 
 import (
+	"context"
 	"fmt"
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
+	"sync"
+	"time"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
@@ -10,8 +15,6 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	kubevirtv1 "kubevirt.io/client-go/api/v1"
-	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,6 +26,7 @@ const (
 	uninstallVirtErrorMsg = "The uninstall request failed on virt component: "
 	ErrHCOUninstall       = "ErrHCOUninstall"
 	uninstallHCOErrorMsg  = "The uninstall request failed on dependent components, please check their logs."
+	deleteTimeOut         = 30 * time.Second
 )
 
 type OperandHandler struct {
@@ -90,43 +94,72 @@ func (h OperandHandler) Ensure(req *common.HcoRequest) error {
 }
 
 func (h OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
-	for _, obj := range []runtime.Object{
+
+	tCtx, cancel := context.WithTimeout(req.Ctx, deleteTimeOut)
+	defer cancel()
+
+	wg := sync.WaitGroup{}
+	errorCh := make(chan error)
+	done := make(chan bool)
+
+	resources := []runtime.Object{
 		NewKubeVirt(req.Instance),
 		NewCDI(req.Instance),
 		NewNetworkAddons(req.Instance),
 		NewKubeVirtCommonTemplateBundle(req.Instance),
 		NewConsoleCLIDownload(req.Instance),
 		NewVMImportForCR(req.Instance),
-	} {
-		err := hcoutil.EnsureDeleted(req.Ctx, h.client, obj, req.Instance.Name, req.Logger, false)
-		if err != nil {
-			req.Logger.Error(err, "Failed to manually delete objects")
+	}
 
-			// TODO: ask to other components to expose something like
-			// func IsDeleteRefused(err error) bool
-			// to be able to clearly distinguish between an explicit
-			// refuse from other operator and any other kind of error that
-			// could potentially happen in the process
+	wg.Add(len(resources))
 
-			errT := ErrHCOUninstall
-			errMsg := uninstallHCOErrorMsg
-			switch obj.(type) {
-			case *kubevirtv1.KubeVirt:
-				errT = ErrVirtUninstall
-				errMsg = uninstallVirtErrorMsg + err.Error()
-			case *cdiv1beta1.CDI:
-				errT = ErrCDIUninstall
-				errMsg = uninstallCDIErrorMsg + err.Error()
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	for _, res := range resources {
+		go func(o runtime.Object, wgr *sync.WaitGroup) {
+			defer wgr.Done()
+			err := hcoutil.EnsureDeleted(tCtx, h.client, o, req.Instance.Name, req.Logger, false, true)
+			if err != nil {
+				req.Logger.Error(err, "Failed to manually delete objects")
+				errT := ErrHCOUninstall
+				errMsg := uninstallHCOErrorMsg
+				switch o.(type) {
+				case *kubevirtv1.KubeVirt:
+					errT = ErrVirtUninstall
+					errMsg = uninstallVirtErrorMsg + err.Error()
+				case *cdiv1beta1.CDI:
+					errT = ErrCDIUninstall
+					errMsg = uninstallCDIErrorMsg + err.Error()
+				}
+
+				h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, errT, errMsg)
+				errorCh <- err
+			} else {
+				if key, err := client.ObjectKeyFromObject(o); err == nil {
+					h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed %s %s", o.GetObjectKind().GroupVersionKind().Kind, key.Name))
+				}
 			}
+		}(res, &wg)
+	}
 
-			h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, errT, errMsg)
-
+	select {
+	case err := <-errorCh:
+		return err
+	case <-tCtx.Done():
+		return tCtx.Err()
+	case <-done:
+		// just in case close(done) was selected while there is an error,
+		// check the error channel again.
+		if len(errorCh) != 0 {
+			err := <-errorCh
 			return err
 		}
 
-		if key, err := client.ObjectKeyFromObject(obj); err == nil {
-			h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed %s %s", obj.GetObjectKind().GroupVersionKind().Kind, key.Name))
-		}
+		return nil
 	}
+
 	return nil
 }

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -170,7 +170,7 @@ func (wh WebhookHandler) ValidateDelete(hc *v1beta1.HyperConverged) error {
 		operands.NewKubeVirt(hc),
 		operands.NewCDI(hc),
 	} {
-		err := hcoutil.EnsureDeleted(ctx, wh.cli, obj, hc.Name, wh.logger, true)
+		err := hcoutil.EnsureDeleted(ctx, wh.cli, obj, hc.Name, wh.logger, true, false)
 		if err != nil {
 			wh.logger.Error(err, "Delete validation failed", "GVK", obj.GetObjectKind().GroupVersionKind())
 			return err


### PR DESCRIPTION
Make uninstall safer and faster

kubectl/oc delete command by defaults runs with --wait=true and so it waits for resources to be gone before returning.
This waits for finalizers.

The client-go from controller-runtime instead doesn't implement that logic that it's completely up to the caller.

Let's implement it in ComponentResourceRemoval to be sure that the deletion is safe.
Use a context with 30 second timeouts to avoid getting stuck forever in the middle of the delete.

Let's then try to delete other CRs in parallel with goroutines syncked with a wait group to make the uninstall faster.

Introduce a graceful period of 60 seconds after all the operators removed the finalizer on their CRs and before removing HCO one as a workaround for bugs on component operators.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Make uninstall safer and faster
```

