### PR TITLE
Fix the bump version bot

### DIFF
--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -28,6 +28,10 @@ function main {
   update_versions
 
   echo INFO: Updating image digest list...
+  ( \
+    cd ./tools/digester && \
+    go build . \
+  )
   ./automation/digester/update_images.sh
 
   echo INFO: Executing "build-manifests.sh"...


### PR DESCRIPTION
Fix the bump version bot to build the digester application before trying to run it.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

