### PR TITLE
Reconcile certificate configuration for KubeVirt

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -154,13 +154,13 @@ spec:
                 description: certConfig holds the rotation policy for internal, self-signed certificates
                 properties:
                   caOverlapInterval:
-                    description: CAOverlapInterval the duration of CA Certificates at CABundle if not set it will default to CARotateInterval
+                    description: CAOverlapInterval defines the duration of CA Certificates at CABundle
                     type: string
                   caRotateInterval:
-                    description: CARotateInterval configurated duration for CA and certificate
+                    description: CARotateInterval defines the duration for CA and certificate
                     type: string
                   certRotateInterval:
-                    description: CertRotateInterval configurated duration for of service certificate the the webhook configuration is referencing different services all of them will share the same duration
+                    description: CertRotateInterval defines the duration of service certificate
                     type: string
                 type: object
               infra:

--- a/deploy/index-image/kubevirt-hyperconverged/1.3.0/hco00.crd.yaml
+++ b/deploy/index-image/kubevirt-hyperconverged/1.3.0/hco00.crd.yaml
@@ -154,13 +154,13 @@ spec:
                 description: certConfig holds the rotation policy for internal, self-signed certificates
                 properties:
                   caOverlapInterval:
-                    description: CAOverlapInterval the duration of CA Certificates at CABundle if not set it will default to CARotateInterval
+                    description: CAOverlapInterval defines the duration of CA Certificates at CABundle
                     type: string
                   caRotateInterval:
-                    description: CARotateInterval configurated duration for CA and certificate
+                    description: CARotateInterval defines the duration for CA and certificate
                     type: string
                   certRotateInterval:
-                    description: CertRotateInterval configurated duration for of service certificate the the webhook configuration is referencing different services all of them will share the same duration
+                    description: CertRotateInterval defines the duration of service certificate
                     type: string
                 type: object
               infra:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/hco00.crd.yaml
@@ -154,13 +154,13 @@ spec:
                 description: certConfig holds the rotation policy for internal, self-signed certificates
                 properties:
                   caOverlapInterval:
-                    description: CAOverlapInterval the duration of CA Certificates at CABundle if not set it will default to CARotateInterval
+                    description: CAOverlapInterval defines the duration of CA Certificates at CABundle
                     type: string
                   caRotateInterval:
-                    description: CARotateInterval configurated duration for CA and certificate
+                    description: CARotateInterval defines the duration for CA and certificate
                     type: string
                   certRotateInterval:
-                    description: CertRotateInterval configurated duration for of service certificate the the webhook configuration is referencing different services all of them will share the same duration
+                    description: CertRotateInterval defines the duration of service certificate
                     type: string
                 type: object
               infra:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.3.0/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:5eda2aecdc670c171489f16438e9c8af72c101463af0d06943a70af76dfbc32d
-    createdAt: "2020-11-23 20:04:50"
+    createdAt: "2020-11-24 08:51:54"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -56,17 +56,14 @@ type HyperConvergedConfig struct {
 }
 
 type HyperConvergedCertConfig struct {
-	// CARotateInterval configurated duration for CA and certificate
-	CARotateInterval string `json:"caRotateInterval,omitempty"`
+	// CARotateInterval defines the duration for CA and certificate
+	CARotateInterval metav1.Duration `json:"caRotateInterval,omitempty"`
 
-	// CAOverlapInterval the duration of CA Certificates at CABundle if
-	// not set it will default to CARotateInterval
-	CAOverlapInterval string `json:"caOverlapInterval,omitempty"`
+	// CAOverlapInterval defines the duration of CA Certificates at CABundle
+	CAOverlapInterval metav1.Duration `json:"caOverlapInterval,omitempty"`
 
-	// CertRotateInterval configurated duration for of service certificate
-	// the the webhook configuration is referencing different services all
-	// of them will share the same duration
-	CertRotateInterval string `json:"certRotateInterval,omitempty"`
+	// CertRotateInterval defines the duration of service certificate
+	CertRotateInterval metav1.Duration `json:"certRotateInterval,omitempty"`
 }
 
 // HyperConvergedStatus defines the observed state of HyperConverged

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -3,6 +3,9 @@ package operands
 import (
 	"errors"
 	"fmt"
+	"os"
+	"reflect"
+
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -13,8 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"os"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -83,6 +84,16 @@ func NewKubeVirt(hc *hcov1beta1.HyperConverged, opts ...string) *kubevirtv1.Kube
 		UninstallStrategy: kubevirtv1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist,
 		Infra:             hcoConfig2KvConfig(hc.Spec.Infra),
 		Workloads:         hcoConfig2KvConfig(hc.Spec.Workloads),
+	}
+
+	if hc.Spec.CertConfig != nil {
+		spec.CertificateRotationStrategy = kubevirtv1.KubeVirtCertificateRotateStrategy{
+			SelfSigned: &kubevirtv1.KubeVirtSelfSignConfiguration{
+				CARotateInterval:   hc.Spec.CertConfig.CARotateInterval.DeepCopy(),
+				CAOverlapInterval:  hc.Spec.CertConfig.CAOverlapInterval.DeepCopy(),
+				CertRotateInterval: hc.Spec.CertConfig.CertRotateInterval.DeepCopy(),
+			},
+		}
 	}
 
 	return &kubevirtv1.KubeVirt{

--- a/pkg/controller/operands/networkAddons.go
+++ b/pkg/controller/operands/networkAddons.go
@@ -99,9 +99,9 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged, opts ...string) *networkadd
 
 	if hc.Spec.CertConfig != nil {
 		cnaoSpec.SelfSignConfiguration = &networkaddonsshared.SelfSignConfiguration{
-			CARotateInterval:   hc.Spec.CertConfig.CARotateInterval,
-			CAOverlapInterval:  hc.Spec.CertConfig.CAOverlapInterval,
-			CertRotateInterval: hc.Spec.CertConfig.CertRotateInterval,
+			CARotateInterval:   hc.Spec.CertConfig.CARotateInterval.Duration.String(),
+			CAOverlapInterval:  hc.Spec.CertConfig.CAOverlapInterval.Duration.String(),
+			CertRotateInterval: hc.Spec.CertConfig.CertRotateInterval.Duration.String(),
 		}
 	}
 

--- a/pkg/controller/operands/networkAddons_test.go
+++ b/pkg/controller/operands/networkAddons_test.go
@@ -3,6 +3,7 @@ package operands
 import (
 	"context"
 	"fmt"
+	"time"
 
 	networkaddonsshared "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
@@ -15,6 +16,7 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/openshift/custom-resource-status/testlib"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/reference"
@@ -264,9 +266,9 @@ var _ = Describe("CNA Operand", func() {
 			existingResource := NewNetworkAddons(hco)
 
 			hco.Spec.CertConfig = &hcov1beta1.HyperConvergedCertConfig{
-				CARotateInterval:   "1h",
-				CAOverlapInterval:  "2h",
-				CertRotateInterval: "3h",
+				CARotateInterval:   metav1.Duration{Duration: 1 * time.Hour},
+				CAOverlapInterval:  metav1.Duration{Duration: 2 * time.Hour},
+				CertRotateInterval: metav1.Duration{Duration: 3 * time.Hour},
 			}
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
@@ -285,18 +287,18 @@ var _ = Describe("CNA Operand", func() {
 
 			Expect(existingResource.Spec.SelfSignConfiguration).To(BeNil())
 			Expect(foundResource.Spec.SelfSignConfiguration).ToNot(BeNil())
-			Expect(foundResource.Spec.SelfSignConfiguration.CARotateInterval).Should(Equal("1h"))
-			Expect(foundResource.Spec.SelfSignConfiguration.CAOverlapInterval).Should(Equal("2h"))
-			Expect(foundResource.Spec.SelfSignConfiguration.CertRotateInterval).Should(Equal("3h"))
+			Expect(foundResource.Spec.SelfSignConfiguration.CARotateInterval).Should(Equal("1h0m0s"))
+			Expect(foundResource.Spec.SelfSignConfiguration.CAOverlapInterval).Should(Equal("2h0m0s"))
+			Expect(foundResource.Spec.SelfSignConfiguration.CertRotateInterval).Should(Equal("3h0m0s"))
 			Expect(req.Conditions).To(BeEmpty())
 		})
 
 		It("should remove cert configuration if missing in HCO CR", func() {
 			hcoCertConfig := commonTestUtils.NewHco()
 			hcoCertConfig.Spec.CertConfig = &hcov1beta1.HyperConvergedCertConfig{
-				CARotateInterval:   "1h",
-				CAOverlapInterval:  "2h",
-				CertRotateInterval: "3h",
+				CARotateInterval:   metav1.Duration{Duration: 1 * time.Hour},
+				CAOverlapInterval:  metav1.Duration{Duration: 2 * time.Hour},
+				CertRotateInterval: metav1.Duration{Duration: 3 * time.Hour},
 			}
 
 			existingResource := NewNetworkAddons(hcoCertConfig)
@@ -323,15 +325,15 @@ var _ = Describe("CNA Operand", func() {
 
 		It("should modify cert configuration according to HCO CR", func() {
 			hco.Spec.CertConfig = &hcov1beta1.HyperConvergedCertConfig{
-				CARotateInterval:   "1h",
-				CAOverlapInterval:  "2h",
-				CertRotateInterval: "3h",
+				CARotateInterval:   metav1.Duration{Duration: 1 * time.Hour},
+				CAOverlapInterval:  metav1.Duration{Duration: 2 * time.Hour},
+				CertRotateInterval: metav1.Duration{Duration: 3 * time.Hour},
 			}
 			existingResource := NewNetworkAddons(hco)
 
-			hco.Spec.CertConfig.CARotateInterval = "4h"
-			hco.Spec.CertConfig.CAOverlapInterval = "5h"
-			hco.Spec.CertConfig.CertRotateInterval = "6h"
+			hco.Spec.CertConfig.CARotateInterval = metav1.Duration{Duration: 4 * time.Hour}
+			hco.Spec.CertConfig.CAOverlapInterval = metav1.Duration{Duration: 5 * time.Hour}
+			hco.Spec.CertConfig.CertRotateInterval = metav1.Duration{Duration: 6 * time.Hour}
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
 			handler := (*genericOperand)(newCnaHandler(cl, commonTestUtils.GetScheme()))
@@ -348,14 +350,14 @@ var _ = Describe("CNA Operand", func() {
 			).To(BeNil())
 
 			Expect(existingResource.Spec.SelfSignConfiguration).ToNot(BeNil())
-			Expect(existingResource.Spec.SelfSignConfiguration.CARotateInterval).Should(Equal("1h"))
-			Expect(existingResource.Spec.SelfSignConfiguration.CAOverlapInterval).Should(Equal("2h"))
-			Expect(existingResource.Spec.SelfSignConfiguration.CertRotateInterval).Should(Equal("3h"))
+			Expect(existingResource.Spec.SelfSignConfiguration.CARotateInterval).Should(Equal("1h0m0s"))
+			Expect(existingResource.Spec.SelfSignConfiguration.CAOverlapInterval).Should(Equal("2h0m0s"))
+			Expect(existingResource.Spec.SelfSignConfiguration.CertRotateInterval).Should(Equal("3h0m0s"))
 
 			Expect(foundResource.Spec.SelfSignConfiguration).ToNot(BeNil())
-			Expect(foundResource.Spec.SelfSignConfiguration.CARotateInterval).Should(Equal("4h"))
-			Expect(foundResource.Spec.SelfSignConfiguration.CAOverlapInterval).Should(Equal("5h"))
-			Expect(foundResource.Spec.SelfSignConfiguration.CertRotateInterval).Should(Equal("6h"))
+			Expect(foundResource.Spec.SelfSignConfiguration.CARotateInterval).Should(Equal("4h0m0s"))
+			Expect(foundResource.Spec.SelfSignConfiguration.CAOverlapInterval).Should(Equal("5h0m0s"))
+			Expect(foundResource.Spec.SelfSignConfiguration.CertRotateInterval).Should(Equal("6h0m0s"))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})


### PR DESCRIPTION
Using certConfig will control both KubeVirt's CertificateRotateStrategy
and CNAO's selfSignConfiguration.
Modified certConfig to use metav1.Duration.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reconcile certificate configuration for KubeVirt
```

