### PR TITLE
Align git tag for cluster-network-addons-operator

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -845,7 +845,7 @@ github.com/kubernetes-csi/csi-lib-utils v0.7.0/go.mod h1:bze+2G9+cmoHxN6+WyG1qT4
 github.com/kubernetes-csi/csi-test v2.0.0+incompatible/go.mod h1:YxJ4UiuPWIhMBkxUKY5c267DyA0uDZ/MtAimhx/2TA0=
 github.com/kubernetes-csi/external-snapshotter/v2 v2.1.1 h1:t5bmB3Y8nCaLA4aFrIpX0zjHEF/HUkJp6f5rm7BsVzM=
 github.com/kubernetes-csi/external-snapshotter/v2 v2.1.1/go.mod h1:dV5oB3U62KBdlf9ADWkMmjGd3USauqQtwIm2OZb5mqI=
-github.com/kubevirt/cluster-network-addons-operator v0.42.4 h1:lP10ws8DsXMzlH9WhJWd1fcrLXZDIeKUBXvb9EbaHDw=
+github.com/kubevirt/cluster-network-addons-operator v0.42.4 h1:JS8sA+NN7BquuIvXYrG+XaKU8quDsdhqmo58/Ke6C7U=
 github.com/kubevirt/cluster-network-addons-operator v0.42.4/go.mod h1:qtYFyYlmjk8egulFv39Sy2Bji2igdM2U2SdRxZFTMss=
 github.com/kubevirt/kubevirt-ssp-operator v1.2.1 h1:rwMm1eR0RUKvXLF4F9www1XinD3BsroB7cw84fsNbAQ=
 github.com/kubevirt/kubevirt-ssp-operator v1.2.1/go.mod h1:r8NvAzhRVvq7l8rnT5YGFXk9usDtlJ3QB2tttSXqPCc=


### PR DESCRIPTION
Align git tag for cluster-network-addons-operator

cluster-network-addons-operator got tagged again,
align go.sum

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

