### PR TITLE
Preperations for splitting the webhook to a new image

### DIFF
--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -30,9 +30,9 @@ function main {
   update_versions
 
   echo INFO: Updating image digest list...
-  ( \
-    cd ./tools/digester && \
-    go build . \
+  (
+    cd ./tools/digester
+    go build .
   )
   ./automation/digester/update_images.sh
 

--- a/build/Dockerfile.wh.okd
+++ b/build/Dockerfile.wh.okd
@@ -1,0 +1,5 @@
+FROM centos:7
+
+COPY hyperconverged-cluster-webhook /usr/bin/
+
+ENTRYPOINT /usr/bin/hyperconverged-cluster-webhook

--- a/deploy/Dockerfile.registry.kubevirt.nightly
+++ b/deploy/Dockerfile.registry.kubevirt.nightly
@@ -18,7 +18,13 @@ ARG CI_REGISTRY=registry.svc.ci.openshift.org
 # ARG CI_REGISTRY=registry.build01.ci.openshift.org
 
 RUN echo "HCO_VERSION: ${HCO_VERSION}"
-RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; else sed -i -r "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml; fi
+RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then \
+      sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml \
+      sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-webhook(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-webhook:latest|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml \
+    else \
+      sed -i -r "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml \
+      sed -i -r "s|quay.io/kubevirt/hyperconverged-cluster-webhook(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-webhook|g" /registry/kubevirt-hyperconverged/${HCO_VERSION}/kubevirt-hyperconverged-operator.v${HCO_VERSION}.clusterserviceversion.yaml \
+    fi
 RUN cat /registry/kubevirt-hyperconverged/kubevirt-hyperconverged.package.yaml
 
 # Initialize the database

--- a/deploy/Dockerfile.registry.upgrade
+++ b/deploy/Dockerfile.registry.upgrade
@@ -28,8 +28,10 @@ ARG CI_REGISTRY=registry.build01.ci.openshift.org
 
 RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then \
       sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
+      sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-webhook(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-webhook:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     else \
       sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
+      sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-webhook(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-webhook|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     fi
 # Initialize the database
 RUN initializer --manifests /registry/kubevirt-hyperconverged --output bundles.db

--- a/deploy/Dockerfile.registry.upgrade-prev
+++ b/deploy/Dockerfile.registry.upgrade-prev
@@ -29,8 +29,10 @@ ARG CI_REGISTRY=registry.build01.ci.openshift.org
 
 RUN if [ -n "$KUBEVIRT_PROVIDER" ]; then \
       sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-operator:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
+      sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-webhook(@sha256)?:.*$|registry:5000/kubevirt/hyperconverged-cluster-webhook:latest|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     else \
       sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-operator(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-operator|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
+      sed -r -i "s|quay.io/kubevirt/hyperconverged-cluster-webhook(@sha256)?:.*$|${CI_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:hyperconverged-cluster-webhook|g" /registry/kubevirt-hyperconverged/${UPGRADE_VERSION}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}.clusterserviceversion.yaml; \
     fi
 # Initialize the database
 RUN initializer --manifests /registry/kubevirt-hyperconverged --output bundles.db

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -30,6 +30,19 @@ trap 'catch $? $LINENO' ERR TERM INT
 # Lastly, we take give the component CSVs to the csv-merger that combines all
 # of the manifests into a single, unified, ClusterServiceVersion.
 
+function get_image_digest() {
+  if [[ ! -f ./tools/digester/digester ]]; then
+    (
+      cd ./tools/digester
+      go build .
+    )
+  fi
+
+  local image
+  image=$(./tools/digester/digester -image "$1")
+  echo "${image}"
+}
+
 PROJECT_ROOT="$(readlink -e $(dirname "${BASH_SOURCE[0]}")/../)"
 source "${PROJECT_ROOT}"/hack/config
 source "${PROJECT_ROOT}"/deploy/images.env
@@ -284,6 +297,22 @@ for csv in "${csvs[@]}"; do
   grep -E "^ *image: [a-zA-Z0-9/\.:@\-]+$" ${csv}
 done
 
+if [[ -n ${OPERATOR_IMAGE} ]]; then
+  TEMP_IMAGE_NAME=$(get_image_digest "${OPERATOR_IMAGE}")
+  DIGEST_LIST="${DIGEST_LIST/${HCO_OPERATOR_IMAGE}/${TEMP_IMAGE_NAME}}"
+  HCO_OPERATOR_IMAGE=${TEMP_IMAGE_NAME}
+fi
+
+if [[ -n ${WEBHOOK_IMAGE} ]]; then
+  TEMP_IMAGE_NAME=$(get_image_digest "${WEBHOOK_IMAGE}")
+  if [[ -n ${HCO_WEBHOOK_IMAGE} ]]; then
+    DIGEST_LIST="${DIGEST_LIST/${HCO_WEBHOOK_IMAGE}/${TEMP_IMAGE_NAME}}"
+  else
+    DIGEST_LIST="${DIGEST_LIST},${TEMP_IMAGE_NAME}"
+  fi
+  HCO_WEBHOOK_IMAGE=${TEMP_IMAGE_NAME}
+fi
+
 if [[ -z ${HCO_WEBHOOK_IMAGE} ]]; then
   HCO_WEBHOOK_IMAGE="${HCO_OPERATOR_IMAGE}"
 fi
@@ -367,5 +396,5 @@ cp -r "${CSV_DIR}" "${INDEX_IMAGE_DIR:?}/kubevirt-hyperconverged/"
 cp "${OLM_DIR}/bundle.Dockerfile" "${INDEX_IMAGE_DIR:?}/"
 
 INDEX_IMAGE_CSV="${INDEX_IMAGE_DIR}/kubevirt-hyperconverged/${CSV_VERSION}/kubevirt-hyperconverged-operator.v${CSV_VERSION}.${CSV_EXT}"
-sed -r -i "s|createdAt: \".*\$|createdAt: \"2020-10-23 08:58:25\"|; s|quay.io/kubevirt/hyperconverged-cluster-operator.*$|+IMAGE_TO_REPLACE+|" ${INDEX_IMAGE_CSV}
+sed -r -i "s|createdAt: \".*\$|createdAt: \"2020-10-23 08:58:25\"|; s|quay.io/kubevirt/hyperconverged-cluster-operator.*$|+IMAGE_TO_REPLACE+|; s|quay.io/kubevirt/hyperconverged-cluster-webhook.*$|+WEBHOOK_IMAGE_TO_REPLACE+|" ${INDEX_IMAGE_CSV}
 

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -284,6 +284,10 @@ for csv in "${csvs[@]}"; do
   grep -E "^ *image: [a-zA-Z0-9/\.:@\-]+$" ${csv}
 done
 
+if [[ -z ${HCO_WEBHOOK_IMAGE} ]]; then
+  HCO_WEBHOOK_IMAGE="${HCO_OPERATOR_IMAGE}"
+fi
+
 # Build and write deploy dir
 (cd ${PROJECT_ROOT}/tools/manifest-templator/ && go build)
 ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
@@ -307,7 +311,8 @@ ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
   --nmo-version="${NMO_VERSION}" \
   --hppo-version="${HPPO_VERSION}" \
   --vm-import-version="${VM_IMPORT_VERSION}" \
-  --operator-image="${HCO_OPERATOR_IMAGE}"
+  --operator-image="${HCO_OPERATOR_IMAGE}" \
+  --webhook-image="${HCO_WEBHOOK_IMAGE}"
 (cd ${PROJECT_ROOT}/tools/manifest-templator/ && go clean)
 
 # Build and merge CSVs
@@ -337,7 +342,8 @@ ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
   --hppo-version="${HPPO_VERSION}" \
   --vm-import-version="${VM_IMPORT_VERSION}" \
   --related-images-list="${DIGEST_LIST}" \
-  --operator-image-name="${HCO_OPERATOR_IMAGE}" > "${CSV_DIR}/${OPERATOR_NAME}.v${CSV_VERSION}.${CSV_EXT}"
+  --operator-image-name="${HCO_OPERATOR_IMAGE}" \
+  --webhook-image-name="${HCO_WEBHOOK_IMAGE}" > "${CSV_DIR}/${OPERATOR_NAME}.v${CSV_VERSION}.${CSV_EXT}"
 
 # Copy all CRDs into the CRD and CSV directories
 rm -f ${CRD_DIR}/*


### PR DESCRIPTION
* New Dockerfile for CI
* digester: allow getting diget for a single image using the new `-image` flag and the requested image name.
* in `build-manifests.sh`, allow override the HCO operator and webhook images

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

