### PR TITLE
Use OPERATOR_NAME/OPERATOR_NAMESPACE envvars in build-manifests.sh

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -55,8 +55,8 @@ DEFAULT_CSV_GENERATOR="/usr/bin/csv-generator"
 
 INDEX_IMAGE_DIR=${DEPLOY_DIR}/index-image
 
-OPERATOR_NAME="${NAME:-kubevirt-hyperconverged-operator}"
-OPERATOR_NAMESPACE="${NAMESPACE:-kubevirt-hyperconverged}"
+OPERATOR_NAME="${OPERATOR_NAME:-kubevirt-hyperconverged-operator}"
+OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-kubevirt-hyperconverged}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
 
 # Important extensions


### PR DESCRIPTION
Modify `build-manifests.sh` to use the `OPERATOR_NAME` and `OPERATOR_NAMESPACE` environment variables to override these values, instead of `NAME` and `NAMESPACE`. (`NAME` is used in WSL to point at the Windows host, so causing errors when running this script).

Signed-off-by: Zvi Cahana <zvic@il.ibm.com>

```release-note
NONE
```

