### PR TITLE
Add recommended labels into operands&OLM workloads

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -266,6 +266,7 @@ rules:
   - watch
   - create
   - delete
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/deploy/index-image/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/index-image/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -1695,7 +1695,13 @@ spec:
           - '*'
         serviceAccountName: vm-import-operator
       deployments:
-      - name: hco-operator
+      - label:
+          app.kubernetes.io/component: deployment
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+          name: hyperconverged-cluster-operator
+        name: hco-operator
         spec:
           replicas: 1
           selector:
@@ -1706,6 +1712,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: deployment
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: hyperconverged-cluster-operator
             spec:
               containers:
@@ -1775,7 +1785,13 @@ spec:
                   periodSeconds: 5
                 resources: {}
               serviceAccountName: hyperconverged-cluster-operator
-      - name: hco-webhook
+      - label:
+          app.kubernetes.io/component: deployment
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+          name: hyperconverged-cluster-webhook
+        name: hco-webhook
         spec:
           replicas: 1
           selector:
@@ -1786,6 +1802,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: deployment
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: hyperconverged-cluster-webhook
             spec:
               containers:
@@ -1828,7 +1848,12 @@ spec:
                   periodSeconds: 5
                 resources: {}
               serviceAccountName: hyperconverged-cluster-operator
-      - name: cluster-network-addons-operator
+      - label:
+          app.kubernetes.io/component: network
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: cluster-network-addons-operator
         spec:
           replicas: 1
           selector:
@@ -1839,6 +1864,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: network
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: cluster-network-addons-operator
             spec:
               containers:
@@ -1885,7 +1914,12 @@ spec:
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: cluster-network-addons-operator
-      - name: virt-operator
+      - label:
+          app.kubernetes.io/component: compute
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: virt-operator
         spec:
           replicas: 2
           selector:
@@ -1898,6 +1932,10 @@ spec:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ""
               labels:
+                app.kubernetes.io/component: compute
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 kubevirt.io: virt-operator
                 prometheus.kubevirt.io: ""
               name: virt-operator
@@ -1972,7 +2010,12 @@ spec:
                 secret:
                   optional: true
                   secretName: kubevirt-operator-certs
-      - name: kubevirt-ssp-operator
+      - label:
+          app.kubernetes.io/component: schedule
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: kubevirt-ssp-operator
         spec:
           replicas: 1
           selector:
@@ -1982,6 +2025,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: schedule
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: kubevirt-ssp-operator
             spec:
               containers:
@@ -2011,7 +2058,12 @@ spec:
                   name: metrics
                 resources: {}
               serviceAccountName: kubevirt-ssp-operator
-      - name: cdi-operator
+      - label:
+          app.kubernetes.io/component: storage
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: cdi-operator
         spec:
           replicas: 1
           selector:
@@ -2022,6 +2074,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: storage
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: cdi-operator
                 operator.cdi.kubevirt.io: ""
             spec:
@@ -2063,7 +2119,12 @@ spec:
               tolerations:
               - key: CriticalAddonsOnly
                 operator: Exists
-      - name: node-maintenance-operator
+      - label:
+          app.kubernetes.io/component: network
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: node-maintenance-operator
         spec:
           replicas: 1
           selector:
@@ -2073,6 +2134,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: network
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: node-maintenance-operator
             spec:
               affinity:
@@ -2102,7 +2167,12 @@ spec:
               tolerations:
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
-      - name: hostpath-provisioner-operator
+      - label:
+          app.kubernetes.io/component: storage
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: hostpath-provisioner-operator
         spec:
           replicas: 1
           selector:
@@ -2113,6 +2183,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: storage
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: hostpath-provisioner-operator
                 operator.hostpath-provisioner.kubevirt.io: ""
             spec:
@@ -2137,7 +2211,12 @@ spec:
                 name: hostpath-provisioner-operator
                 resources: {}
               serviceAccountName: hostpath-provisioner-operator
-      - name: vm-import-operator
+      - label:
+          app.kubernetes.io/component: import
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: vm-import-operator
         spec:
           replicas: 1
           selector:
@@ -2148,6 +2227,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: import
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: vm-import-operator
                 operator.v2v.kubevirt.io: ""
             spec:

--- a/deploy/index-image/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/index-image/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -359,6 +359,7 @@ spec:
           - watch
           - create
           - delete
+          - update
         - apiGroups:
           - apiextensions.k8s.io
           resources:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:e7356254a1251f1fba682be77c9a90b1f840d6a84ff88492fb1e87ae30dda9da
-    createdAt: "2020-12-24 10:06:39"
+    createdAt: "2021-01-05 14:16:29"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1695,7 +1695,13 @@ spec:
           - '*'
         serviceAccountName: vm-import-operator
       deployments:
-      - name: hco-operator
+      - label:
+          app.kubernetes.io/component: deployment
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+          name: hyperconverged-cluster-operator
+        name: hco-operator
         spec:
           replicas: 1
           selector:
@@ -1706,6 +1712,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: deployment
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: hyperconverged-cluster-operator
             spec:
               containers:
@@ -1775,7 +1785,13 @@ spec:
                   periodSeconds: 5
                 resources: {}
               serviceAccountName: hyperconverged-cluster-operator
-      - name: hco-webhook
+      - label:
+          app.kubernetes.io/component: deployment
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+          name: hyperconverged-cluster-webhook
+        name: hco-webhook
         spec:
           replicas: 1
           selector:
@@ -1786,6 +1802,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: deployment
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: hyperconverged-cluster-webhook
             spec:
               containers:
@@ -1828,7 +1848,12 @@ spec:
                   periodSeconds: 5
                 resources: {}
               serviceAccountName: hyperconverged-cluster-operator
-      - name: cluster-network-addons-operator
+      - label:
+          app.kubernetes.io/component: network
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: cluster-network-addons-operator
         spec:
           replicas: 1
           selector:
@@ -1839,6 +1864,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: network
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: cluster-network-addons-operator
             spec:
               containers:
@@ -1885,7 +1914,12 @@ spec:
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: cluster-network-addons-operator
-      - name: virt-operator
+      - label:
+          app.kubernetes.io/component: compute
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: virt-operator
         spec:
           replicas: 2
           selector:
@@ -1898,6 +1932,10 @@ spec:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ""
               labels:
+                app.kubernetes.io/component: compute
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 kubevirt.io: virt-operator
                 prometheus.kubevirt.io: ""
               name: virt-operator
@@ -1972,7 +2010,12 @@ spec:
                 secret:
                   optional: true
                   secretName: kubevirt-operator-certs
-      - name: kubevirt-ssp-operator
+      - label:
+          app.kubernetes.io/component: schedule
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: kubevirt-ssp-operator
         spec:
           replicas: 1
           selector:
@@ -1982,6 +2025,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: schedule
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: kubevirt-ssp-operator
             spec:
               containers:
@@ -2011,7 +2058,12 @@ spec:
                   name: metrics
                 resources: {}
               serviceAccountName: kubevirt-ssp-operator
-      - name: cdi-operator
+      - label:
+          app.kubernetes.io/component: storage
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: cdi-operator
         spec:
           replicas: 1
           selector:
@@ -2022,6 +2074,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: storage
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: cdi-operator
                 operator.cdi.kubevirt.io: ""
             spec:
@@ -2063,7 +2119,12 @@ spec:
               tolerations:
               - key: CriticalAddonsOnly
                 operator: Exists
-      - name: node-maintenance-operator
+      - label:
+          app.kubernetes.io/component: network
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: node-maintenance-operator
         spec:
           replicas: 1
           selector:
@@ -2073,6 +2134,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: network
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: node-maintenance-operator
             spec:
               affinity:
@@ -2102,7 +2167,12 @@ spec:
               tolerations:
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
-      - name: hostpath-provisioner-operator
+      - label:
+          app.kubernetes.io/component: storage
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: hostpath-provisioner-operator
         spec:
           replicas: 1
           selector:
@@ -2113,6 +2183,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: storage
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: hostpath-provisioner-operator
                 operator.hostpath-provisioner.kubevirt.io: ""
             spec:
@@ -2137,7 +2211,12 @@ spec:
                 name: hostpath-provisioner-operator
                 resources: {}
               serviceAccountName: hostpath-provisioner-operator
-      - name: vm-import-operator
+      - label:
+          app.kubernetes.io/component: import
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: vm-import-operator
         spec:
           replicas: 1
           selector:
@@ -2148,6 +2227,10 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/component: import
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
                 name: vm-import-operator
                 operator.v2v.kubevirt.io: ""
             spec:

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:e7356254a1251f1fba682be77c9a90b1f840d6a84ff88492fb1e87ae30dda9da
-    createdAt: "2021-01-05 14:16:29"
+    createdAt: "2021-01-07 09:28:58"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -359,6 +359,7 @@ spec:
           - watch
           - create
           - delete
+          - update
         - apiGroups:
           - apiextensions.k8s.io
           resources:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3,6 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: deployment
+    app.kubernetes.io/part-of: hyperconverged-cluster
+    app.kubernetes.io/version: 1.4.0
     name: hyperconverged-cluster-operator
   name: hyperconverged-cluster-operator
 spec:
@@ -92,6 +95,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: deployment
+    app.kubernetes.io/part-of: hyperconverged-cluster
+    app.kubernetes.io/version: 1.4.0
     name: hyperconverged-cluster-webhook
   name: hyperconverged-cluster-webhook
 spec:
@@ -167,6 +173,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: network
+    app.kubernetes.io/part-of: hyperconverged-cluster
+    app.kubernetes.io/version: 1.4.0
     name: cluster-network-addons-operator
   name: cluster-network-addons-operator
 spec:
@@ -181,6 +190,9 @@ spec:
       annotations:
         description: cluster-network-addons-operator manages the lifecycle of different Kubernetes network components on top of Kubernetes cluster
       labels:
+        app.kubernetes.io/component: network
+        app.kubernetes.io/part-of: hyperconverged-cluster
+        app.kubernetes.io/version: 1.4.0
         name: cluster-network-addons-operator
     spec:
       containers:
@@ -232,6 +244,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: compute
+    app.kubernetes.io/part-of: hyperconverged-cluster
+    app.kubernetes.io/version: 1.4.0
     name: virt-operator
   name: virt-operator
 spec:
@@ -246,6 +261,9 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
+        app.kubernetes.io/component: compute
+        app.kubernetes.io/part-of: hyperconverged-cluster
+        app.kubernetes.io/version: 1.4.0
         kubevirt.io: virt-operator
         prometheus.kubevirt.io: ""
       name: virt-operator
@@ -325,6 +343,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: schedule
+    app.kubernetes.io/part-of: hyperconverged-cluster
+    app.kubernetes.io/version: 1.4.0
     name: kubevirt-ssp-operator
   name: kubevirt-ssp-operator
 spec:
@@ -336,6 +357,9 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: schedule
+        app.kubernetes.io/part-of: hyperconverged-cluster
+        app.kubernetes.io/version: 1.4.0
         name: kubevirt-ssp-operator
     spec:
       containers:
@@ -370,6 +394,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/part-of: hyperconverged-cluster
+    app.kubernetes.io/version: 1.4.0
     name: cdi-operator
   name: cdi-operator
 spec:
@@ -382,6 +409,9 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/part-of: hyperconverged-cluster
+        app.kubernetes.io/version: 1.4.0
         name: cdi-operator
         operator.cdi.kubevirt.io: ""
     spec:
@@ -428,6 +458,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: network
+    app.kubernetes.io/part-of: hyperconverged-cluster
+    app.kubernetes.io/version: 1.4.0
     name: node-maintenance-operator
   name: node-maintenance-operator
 spec:
@@ -439,6 +472,9 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: network
+        app.kubernetes.io/part-of: hyperconverged-cluster
+        app.kubernetes.io/version: 1.4.0
         name: node-maintenance-operator
     spec:
       affinity:
@@ -486,6 +522,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/part-of: hyperconverged-cluster
+    app.kubernetes.io/version: 1.4.0
     name: hostpath-provisioner-operator
   name: hostpath-provisioner-operator
 spec:
@@ -498,6 +537,9 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/part-of: hyperconverged-cluster
+        app.kubernetes.io/version: 1.4.0
         name: hostpath-provisioner-operator
         operator.hostpath-provisioner.kubevirt.io: ""
     spec:
@@ -527,6 +569,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: import
+    app.kubernetes.io/part-of: hyperconverged-cluster
+    app.kubernetes.io/version: 1.4.0
     name: vm-import-operator
   name: vm-import-operator
 spec:
@@ -539,6 +584,9 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: import
+        app.kubernetes.io/part-of: hyperconverged-cluster
+        app.kubernetes.io/version: 1.4.0
         name: vm-import-operator
         operator.v2v.kubevirt.io: ""
     spec:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,6 +15,9 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: deployment
+        app.kubernetes.io/part-of: hyperconverged-cluster
+        app.kubernetes.io/version: 1.4.0
         name: hyperconverged-cluster-operator
     spec:
       containers:
@@ -101,6 +104,9 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: deployment
+        app.kubernetes.io/part-of: hyperconverged-cluster
+        app.kubernetes.io/version: 1.4.0
         name: hyperconverged-cluster-webhook
     spec:
       containers:

--- a/hack/check_labels.sh
+++ b/hack/check_labels.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2020 Red Hat, Inc.
+#
+
+
+set -euo pipefail
+
+KUBECTL_BINARY="${KUBECTL_BINARY:-"kubectl"}"
+HCO_NAMESPACE="${HCO_NAMESPACE:-"kubevirt-hyperconverged"}"
+HCO_RESOURCE_NAME="${HCO_RESOURCE_NAME:-"kubevirt-hyperconverged"}"
+
+function check_label_value() {
+  local labels_as_json="$1"
+  local key="$2"
+  local expected="$3"
+
+  found="$(echo "$labels_as_json" |jq '."'$key'"' |tr -d '"')"
+  if [[ "$found" != "$expected" ]]; then
+    echo "Value for label $key is not correct! Expected:'$expected' Found:'$found'"
+    exit 1
+  fi
+}
+
+
+function check_label_has_value() {
+  local labels_as_json="$1"
+  local key="$2"
+
+  found="$(echo "$labels_as_json" |jq '."'$key'"' |tr -d '"')"
+  if [[ "$found" == "null" ]]; then
+    echo "Label $key does not exist!"
+    exit 1
+  fi
+}
+
+function check_labels(){
+  local labels_as_json="$1"
+  check_label_value "$labels_as_json" "app" "kubevirt-hyperconverged"
+  check_label_value "$labels_as_json" "app.kubernetes.io/part-of" "hyperconverged-cluster"
+  check_label_value "$labels_as_json" "app.kubernetes.io/managed-by" "hco-operator"
+
+  check_label_has_value "$labels_as_json" "app.kubernetes.io/component"
+  check_label_has_value "$labels_as_json" "app.kubernetes.io/version"
+}
+
+echo "Fetching related objects..."
+related_obj_json="$(${KUBECTL_BINARY} get  hco "${HCO_RESOURCE_NAME}" -n "${HCO_NAMESPACE}" -o jsonpath='{.status .relatedObjects}')"
+
+echo "Putting related objects into array..."
+related_obj_array=()
+while IFS='' read -r line; do related_obj_array+=("$line"); done < <(echo "$related_obj_json" |jq '.[] | .kind + "," + .name + "," + .namespace' |tr -d '"')
+
+for obj in "${related_obj_array[@]}"
+do
+  type="$(echo "$obj" |cut -d',' -f1)"
+  name="$(echo "$obj" |cut -d',' -f2)"
+  namespace="$(echo "$obj" |cut -d',' -f3)"
+
+  namespace_flag=""
+  if [[ "$namespace" != "" ]]; then
+    namespace_flag="-n $namespace"
+  fi
+
+  echo "Checking labels of $type/$name"
+  labels_of_ojb="$(${KUBECTL_BINARY} get "$type" "$name" $namespace_flag -o json |jq .metadata.labels)"
+  check_labels "$labels_of_ojb"
+done
+

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -43,5 +43,7 @@ sleep 60
 
 KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/test_quick_start.sh
 
+./hack/retry.sh 10 30 "KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_labels.sh"
+
 # Check the webhook, to see if it allow deleteing of the HyperConverged CR
 ./hack/retry.sh 10 30 "${KUBECTL_BINARY} delete hco -n kubevirt-hyperconverged kubevirt-hyperconverged"

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -282,6 +282,10 @@ Msg "Check that OVS is deployed or not deployed according to deployOVS annotatio
 ./hack/retry.sh 40 15 "CMD=${CMD} PREVIOUS_OVS_ANNOTATION=${PREVIOUS_OVS_ANNOTATION}\
  PREVIOUS_OVS_STATE=${PREVIOUS_OVS_STATE} ./hack/check_upgrade_ovs.sh"
 
+Msg "Check that managed objects has correct labels"
+./hack/retry.sh 10 30 "KUBECTL_BINARY=${CMD} ./hack/check_labels.sh"
+
+
 Msg "Brutally delete HCO removing the namespace where it's running"
 source hack/test_delete_ns.sh
 test_delete_ns

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -547,6 +547,7 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 				"watch",
 				"create",
 				"delete",
+				"update",
 			},
 		},
 		{

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -57,7 +57,7 @@ func GetDeploymentOperator(namespace, image, imagePullPolicy, conversionContaine
 	}
 }
 
-func GetDeploymentWebhook(namespace, image, imagePullPolicy string, env []corev1.EnvVar) appsv1.Deployment {
+func GetDeploymentWebhook(namespace, image, imagePullPolicy, hcoKvIoVersion string, env []corev1.EnvVar) appsv1.Deployment {
 	deploy := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -69,7 +69,7 @@ func GetDeploymentWebhook(namespace, image, imagePullPolicy string, env []corev1
 				"name": hcoNameWebhook,
 			},
 		},
-		Spec: GetDeploymentSpecWebhook(namespace, image, imagePullPolicy, env),
+		Spec: GetDeploymentSpecWebhook(namespace, image, imagePullPolicy, hcoKvIoVersion, env),
 	}
 
 	InjectVolumesForWebHookCerts(&deploy)
@@ -115,9 +115,7 @@ func GetDeploymentSpecOperator(namespace, image, imagePullPolicy, conversionCont
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					"name": hcoName,
-				},
+				Labels: getLabels(hcoName, hcoKvIoVersion),
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: hcoName,
@@ -252,6 +250,15 @@ func GetDeploymentSpecOperator(namespace, image, imagePullPolicy, conversionCont
 	}
 }
 
+func getLabels(name, hcoKvIoVersion string) map[string]string {
+	return map[string]string{
+		"name":                    name,
+		hcoutil.AppLabelVersion:   hcoKvIoVersion,
+		hcoutil.AppLabelPartOf:    hcoutil.HyperConvergedCluster,
+		hcoutil.AppLabelComponent: hcoutil.AppComponentDeployment,
+	}
+}
+
 // Currently we are abusing the pod readiness to signal to OLM that HCO is not ready
 // for an upgrade. This has a lot of side effects, one of this is the validating webhook
 // being not able to receive traffic when exposed by a pod that is not reporting ready=true.
@@ -267,7 +274,7 @@ func GetDeploymentSpecOperator(namespace, image, imagePullPolicy, conversionCont
 // A deeper code refactor to produce two distinct binaries is not worth now because we are going to
 // use OLM operator conditions soon.
 // TODO: remove this once we will move to OLM operator conditions
-func GetDeploymentSpecWebhook(namespace, image, imagePullPolicy string, env []corev1.EnvVar) appsv1.DeploymentSpec {
+func GetDeploymentSpecWebhook(namespace, image, imagePullPolicy, hcoKvIoVersion string, env []corev1.EnvVar) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
 		Replicas: int32Ptr(1),
 		Selector: &metav1.LabelSelector{
@@ -280,9 +287,7 @@ func GetDeploymentSpecWebhook(namespace, image, imagePullPolicy string, env []co
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					"name": hcoNameWebhook,
-				},
+				Labels: getLabels(hcoNameWebhook, hcoKvIoVersion),
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: hcoName,
@@ -929,12 +934,14 @@ func GetInstallStrategyBase(namespace, image, webhookImage, imagePullPolicy, con
 	return &csvv1alpha1.StrategyDetailsDeployment{
 		DeploymentSpecs: []csvv1alpha1.StrategyDeploymentSpec{
 			csvv1alpha1.StrategyDeploymentSpec{
-				Name: hcoDeploymentName,
-				Spec: GetDeploymentSpecOperator(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion, env),
+				Name:  hcoDeploymentName,
+				Spec:  GetDeploymentSpecOperator(namespace, image, imagePullPolicy, conversionContainer, vmwareContainer, smbios, machinetype, hcoKvIoVersion, kubevirtVersion, cdiVersion, cnaoVersion, sspVersion, nmoVersion, hppoVersion, vmImportVersion, env),
+				Label: getLabels(hcoName, hcoKvIoVersion),
 			},
 			csvv1alpha1.StrategyDeploymentSpec{
-				Name: hcoWhDeploymentName,
-				Spec: GetDeploymentSpecWebhook(namespace, webhookImage, imagePullPolicy, env),
+				Name:  hcoWhDeploymentName,
+				Spec:  GetDeploymentSpecWebhook(namespace, webhookImage, imagePullPolicy, hcoKvIoVersion, env),
+				Label: getLabels(hcoNameWebhook, hcoKvIoVersion),
 			},
 		},
 		Permissions: []csvv1alpha1.StrategyDeploymentPermissions{},

--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -2,8 +2,11 @@ package operands
 
 import (
 	"errors"
+	"reflect"
+
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
@@ -14,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/reference"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -71,7 +73,8 @@ func (h *cdiHooks) updateCr(req *common.HcoRequest, Client client.Client, exists
 
 	setDefaultFeatureGates(&cdi.Spec)
 
-	if !reflect.DeepEqual(found.Spec, cdi.Spec) {
+	if !reflect.DeepEqual(found.Spec, cdi.Spec) ||
+		!reflect.DeepEqual(found.Labels, cdi.Labels) {
 		overwritten := false
 		if req.HCOTriggered {
 			req.Logger.Info("Updating existing CDI's Spec to new opinionated values")
@@ -79,6 +82,7 @@ func (h *cdiHooks) updateCr(req *common.HcoRequest, Client client.Client, exists
 			req.Logger.Info("Reconciling an externally updated CDI's Spec to its opinionated values")
 			overwritten = true
 		}
+		util.DeepCopyLabels(&cdi.ObjectMeta, &found.ObjectMeta)
 		cdi.Spec.DeepCopyInto(&found.Spec)
 		err := Client.Update(req.Ctx, found)
 		if err != nil {
@@ -137,7 +141,7 @@ func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) *cdiv1beta1.CDI {
 	return &cdiv1beta1.CDI{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cdi-" + hc.Name,
-			Labels:    getLabels(hc),
+			Labels:    getLabels(hc, hcoutil.AppComponentStorage),
 			Namespace: getNamespace(hcoutil.UndefinedNamespace, opts),
 		},
 		Spec: spec,
@@ -211,13 +215,10 @@ func (h *cdiHooks) ensureKubeVirtStorageRoleBinding(req *common.HcoRequest) erro
 }
 
 func NewKubeVirtStorageRoleForCR(cr *hcov1beta1.HyperConverged, namespace string) *rbacv1.Role {
-	labels := map[string]string{
-		"app": cr.Name,
-	}
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "hco.kubevirt.io:config-reader",
-			Labels:    labels,
+			Labels:    getLabels(cr, hcoutil.AppComponentStorage),
 			Namespace: namespace,
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -232,13 +233,10 @@ func NewKubeVirtStorageRoleForCR(cr *hcov1beta1.HyperConverged, namespace string
 }
 
 func NewKubeVirtStorageRoleBindingForCR(cr *hcov1beta1.HyperConverged, namespace string) *rbacv1.RoleBinding {
-	labels := map[string]string{
-		"app": cr.Name,
-	}
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "hco.kubevirt.io:config-reader",
-			Labels:    labels,
+			Labels:    getLabels(cr, hcoutil.AppComponentStorage),
 			Namespace: namespace,
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -300,6 +298,12 @@ func (h *storageConfigHooks) updateCr(req *common.HcoRequest, Client client.Clie
 			needsUpdate = true
 		}
 	}
+
+	if !reflect.DeepEqual(found.Labels, storageConfig.Labels) {
+		util.DeepCopyLabels(&storageConfig.ObjectMeta, &found.ObjectMeta)
+		needsUpdate = true
+	}
+
 	if needsUpdate {
 		req.Logger.Info("Updating existing KubeVirt Storage Configmap to its default values")
 		err := Client.Update(req.Ctx, found)
@@ -320,13 +324,10 @@ func NewKubeVirtStorageConfigForCR(cr *hcov1beta1.HyperConverged, namespace stri
 
 	ocsRBD := "ocs-storagecluster-ceph-rbd"
 
-	labels := map[string]string{
-		hcoutil.AppLabel: cr.Name,
-	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubevirt-storage-class-defaults",
-			Labels:    labels,
+			Labels:    getLabels(cr, hcoutil.AppComponentStorage),
 			Namespace: namespace,
 		},
 		Data: map[string]string{

--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -170,6 +170,12 @@ func (h *cdiHooks) ensureKubeVirtStorageRole(req *common.HcoRequest) error {
 		return err
 	}
 
+	if !reflect.DeepEqual(found.Labels, kubevirtStorageRole.Labels) {
+		req.Logger.Info("Updating KubeVirt storage role for labels")
+		util.DeepCopyLabels(&kubevirtStorageRole.ObjectMeta, &found.ObjectMeta)
+		return h.Client.Update(req.Ctx, found)
+	}
+
 	req.Logger.Info("KubeVirt storage role already exists", "KubeVirtConfig.Namespace", found.Namespace, "KubeVirtConfig.Name", found.Name)
 	// Add it to the list of RelatedObjects if found
 	objectRef, err := reference.GetReference(h.Scheme, found)
@@ -201,6 +207,12 @@ func (h *cdiHooks) ensureKubeVirtStorageRoleBinding(req *common.HcoRequest) erro
 
 	if err != nil {
 		return err
+	}
+
+	if !reflect.DeepEqual(found.Labels, kubevirtStorageRoleBinding.Labels) {
+		req.Logger.Info("Updating KubeVirt storage rolebinding for labels")
+		util.DeepCopyLabels(&kubevirtStorageRoleBinding.ObjectMeta, &found.ObjectMeta)
+		return h.Client.Update(req.Ctx, found)
 	}
 
 	req.Logger.Info("KubeVirt storage rolebinding already exists", "KubeVirtConfig.Namespace", found.Namespace, "KubeVirtConfig.Name", found.Name)

--- a/pkg/controller/operands/cliDownload.go
+++ b/pkg/controller/operands/cliDownload.go
@@ -7,6 +7,7 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	consolev1 "github.com/openshift/api/console/v1"
 	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
@@ -37,11 +38,14 @@ func (h CLIDownloadHandler) Ensure(req *common.HcoRequest) error {
 			return err
 		}
 		objectreferencesv1.SetObjectReference(&req.Instance.Status.RelatedObjects, *objectRef)
-		return nil
+
+		if reflect.DeepEqual(found.Labels, ccd.Labels) {
+			return nil
+		}
 	}
 
 	ccd.Spec.DeepCopyInto(&found.Spec)
-
+	util.DeepCopyLabels(&ccd.ObjectMeta, &found.ObjectMeta)
 	err = h.Client.Update(req.Ctx, found)
 	if err != nil {
 		return err

--- a/pkg/controller/operands/cliDownload.go
+++ b/pkg/controller/operands/cliDownload.go
@@ -2,6 +2,9 @@ package operands
 
 import (
 	"fmt"
+	"os"
+	"reflect"
+
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -10,8 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/reference"
-	"os"
-	"reflect"
 )
 
 type CLIDownloadHandler genericOperand
@@ -65,7 +66,7 @@ func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLID
 	return &consolev1.ConsoleCLIDownload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "virtctl-clidownloads-" + hc.Name,
-			Labels: getLabels(hc),
+			Labels: getLabels(hc, hcoutil.AppComponentCompute),
 		},
 
 		Spec: consolev1.ConsoleCLIDownloadSpec{

--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -2,8 +2,9 @@ package operands
 
 import (
 	"fmt"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"os"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
@@ -263,7 +264,7 @@ func getNamespace(defaultNamespace string, opts []string) string {
 	return defaultNamespace
 }
 
-func getLabels(hc *hcov1beta1.HyperConverged) map[string]string {
+func getLabels(hc *hcov1beta1.HyperConverged, component hcoutil.AppComponent) map[string]string {
 	hcoName := hcov1beta1.HyperConvergedName
 
 	if hc.Name != "" {
@@ -271,6 +272,10 @@ func getLabels(hc *hcov1beta1.HyperConverged) map[string]string {
 	}
 
 	return map[string]string{
-		hcoutil.AppLabel: hcoName,
+		hcoutil.AppLabel:          hcoName,
+		hcoutil.AppLabelManagedBy: hcoutil.OperatorName,
+		hcoutil.AppLabelVersion:   hcoutil.GetHcoKvIoVersion(),
+		hcoutil.AppLabelPartOf:    hcoutil.HyperConvergedCluster,
+		hcoutil.AppLabelComponent: string(component),
 	}
 }

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -25,6 +25,18 @@ const (
 	CurrentAPIVersion      = APIVersionBeta
 	APIVersionGroup        = "hco.kubevirt.io"
 	APIVersion             = APIVersionGroup + "/" + APIVersionBeta
+	// Recommended labels by Kubernetes. See
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+	AppLabelPrefix    = "app.kubernetes.io"
+	AppLabelVersion   = AppLabelPrefix + "/version"
+	AppLabelManagedBy = AppLabelPrefix + "/managed-by"
+	AppLabelPartOf    = AppLabelPrefix + "/part-of"
+	AppLabelComponent = AppLabelPrefix + "/component"
+	// Operator name for managed-by label
+	OperatorName = "hco-operator"
+	// Value for "part-of" label
+	HyperConvergedCluster = "hyperconverged-cluster"
+
 	// HyperConvergedName is the name of the HyperConverged resource that will be reconciled
 	HyperConvergedName          = "kubevirt-hyperconverged"
 	MetricsHost                 = "0.0.0.0"
@@ -37,4 +49,16 @@ const (
 	HCOWebhookPath              = "/validate-hco-kubevirt-io-v1beta1-hyperconverged"
 	HCONSWebhookPath            = "/mutate-ns-hco-kubevirt-io"
 	WebhookPort                 = 4343
+)
+
+type AppComponent string
+
+const (
+	AppComponentCompute    AppComponent = "compute"
+	AppComponentStorage                 = "storage"
+	AppComponentImport                  = "import"
+	AppComponentNetwork                 = "network"
+	AppComponentMonitoring              = "monitoring"
+	AppComponentSchedule                = "schedule"
+	AppComponentDeployment              = "deployment"
 )

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -1,6 +1,8 @@
 package util
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 func DeepCopyLabels(src, tgt *metav1.ObjectMeta) {
 	if src.Labels == nil {

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -1,0 +1,14 @@
+package util
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+func DeepCopyLabels(src, tgt *metav1.ObjectMeta) {
+	if src.Labels == nil {
+		return
+	}
+
+	tgt.Labels = make(map[string]string, len(src.Labels))
+	for key, val := range src.Labels {
+		tgt.Labels[key] = val
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -326,3 +326,12 @@ func ContainsString(s []string, word string) bool {
 	}
 	return false
 }
+
+var hcoKvIoVersion string
+
+func GetHcoKvIoVersion() string {
+	if hcoKvIoVersion == "" {
+		hcoKvIoVersion = os.Getenv(HcoKvIoVersionName)
+	}
+	return hcoKvIoVersion
+}

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"flag"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"os"
 	"path"
 	"sort"
@@ -105,14 +106,35 @@ func main() {
 	defer v2voVirtCrd.Close()
 
 	// the CSVs we expect to handle
-	csvs := []string{
-		*cnaCsv,
-		*virtCsv,
-		*sspCsv,
-		*cdiCsv,
-		*nmoCsv,
-		*hppCsv,
-		*vmImportCsv,
+	componentsWithCsvs := []util.CsvWithComponent{
+		{
+			Csv:       *cnaCsv,
+			Component: hcoutil.AppComponentNetwork,
+		},
+		{
+			Csv:       *virtCsv,
+			Component: hcoutil.AppComponentCompute,
+		},
+		{
+			Csv:       *sspCsv,
+			Component: hcoutil.AppComponentSchedule,
+		},
+		{
+			Csv:       *cdiCsv,
+			Component: hcoutil.AppComponentStorage,
+		},
+		{
+			Csv:       *nmoCsv,
+			Component: hcoutil.AppComponentNetwork,
+		},
+		{
+			Csv:       *hppCsv,
+			Component: hcoutil.AppComponentStorage,
+		},
+		{
+			Csv:       *vmImportCsv,
+			Component: hcoutil.AppComponentImport,
+		},
 	}
 
 	if webhookImage == nil || *webhookImage == "" {
@@ -156,6 +178,10 @@ func main() {
 			[]corev1.EnvVar{},
 		),
 	}
+	// hco-operator and hco-webhook
+	for i, _ := range deployments {
+		overwriteDeploymentLabels(&deployments[i], hcoutil.AppComponentDeployment)
+	}
 
 	services := []v1.Service{
 		components.GetServiceWebhook(
@@ -175,9 +201,9 @@ func main() {
 		components.GetClusterRoleBinding(*operatorNamespace),
 	}
 
-	for _, csvStr := range csvs {
-		if csvStr != "" {
-			csvBytes := []byte(csvStr)
+	for _, csvStr := range componentsWithCsvs {
+		if csvStr.Csv != "" {
+			csvBytes := []byte(csvStr.Csv)
 
 			csvStruct := &csvv1alpha1.ClusterServiceVersion{}
 
@@ -232,6 +258,7 @@ func main() {
 					Spec: deploymentSpec.Spec,
 				}
 				injectWebhookMounts(csvStruct.Spec.WebhookDefinitions, &deploy)
+				overwriteDeploymentLabels(&deploy, csvStr.Component)
 				deployments = append(deployments, deploy)
 			}
 
@@ -397,4 +424,22 @@ func injectWebhookMounts(webhookDefs []csvv1alpha1.WebhookDescription, deploy *a
 			components.InjectVolumesForWebHookCerts(deploy)
 		}
 	}
+}
+
+func overwriteDeploymentLabels(deploy *appsv1.Deployment, component hcoutil.AppComponent) {
+	if deploy.Labels == nil {
+		deploy.Labels = make(map[string]string)
+	}
+	if deploy.Spec.Template.Labels == nil {
+		deploy.Spec.Template.Labels = make(map[string]string)
+	}
+	overwriteWithStandardLabels(deploy.Spec.Template.Labels, *hcoKvIoVersion, component)
+	overwriteWithStandardLabels(deploy.Labels, *hcoKvIoVersion, component)
+}
+
+func overwriteWithStandardLabels(labels map[string]string, version string, component hcoutil.AppComponent) {
+	// managed-by label is not set here since we don't know who is going to deploy the generated yaml files
+	labels[hcoutil.AppLabelVersion] = version
+	labels[hcoutil.AppLabelPartOf] = hcoutil.HyperConvergedCluster
+	labels[hcoutil.AppLabelComponent] = string(component)
 }

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -152,6 +152,7 @@ func main() {
 			*operatorNamespace,
 			*webhookImage,
 			"IfNotPresent",
+			*hcoKvIoVersion,
 			[]corev1.EnvVar{},
 		),
 	}

--- a/tools/util/csv_with_component.go
+++ b/tools/util/csv_with_component.go
@@ -1,0 +1,8 @@
+package util
+
+import hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+
+type CsvWithComponent struct {
+	Csv       string
+	Component hcoutil.AppComponent
+}


### PR DESCRIPTION
With this PR, we are adding recommended labels[1] into all operands we manage with hco-operator.

````
app.kubernetes.io/managed-by=hco-operator
app.kubernetes.io/version=<version-of-hco-operator>
app.kubernetes.io/component=<component-of-operand-like-compute-or-storage>
app.kubernetes.io/part-of=hyperconverged-cluster
````

We are keeping this as it is in order to not break any existing mechanism.
```
app=kubevirt-hyperconverged
```

***OLM PART***
This PR adds the labels into the workloads we deploy with OLM as well.  See the changes in
- deploy/index-image/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
- deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml

***operator.yaml***
This PR adds the labels into the workloads we deploy with operator.yaml. Since we don't know who is going to deploy with this file, we didn't use "managed-by" label in this manifest file. 

***Testing***

- Unit tests in hyperconverged_controller_test.go and e2e tests in check_labels.sh: checks all objects under .status.relatedObjects of HCO and verifies that all of them have these labels.



**Release note**:
```release-note
Adds some of the recommended labels* into workloads

* https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ 
```

1. https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/