### PR TITLE
Excludes CDI.Spec.Config from HCO Reconciliation Loop.

### DIFF
--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -124,6 +124,7 @@ func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) *cdiv1beta1.CDI {
 
 	spec := cdiv1beta1.CDISpec{
 		UninstallStrategy: &uninstallStrategy,
+		Config:            &cdiv1beta1.CDIConfigSpec{FeatureGates: []string{"HonorWaitForFirstConsumer"}},
 	}
 
 	if hc.Spec.Infra.NodePlacement != nil {

--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -69,6 +69,8 @@ func (h *cdiHooks) updateCr(req *common.HcoRequest, Client client.Client, exists
 		found.Spec.Config.DeepCopyInto(cdi.Spec.Config)
 	}
 
+	setDefaultFeatureGates(&cdi.Spec)
+
 	if !reflect.DeepEqual(found.Spec, cdi.Spec) {
 		overwritten := false
 		if req.HCOTriggered {
@@ -85,6 +87,22 @@ func (h *cdiHooks) updateCr(req *common.HcoRequest, Client client.Client, exists
 		return true, overwritten, nil
 	}
 	return false, false, nil
+}
+
+func setDefaultFeatureGates(spec *cdiv1beta1.CDISpec) {
+	featureGate := "HonorWaitForFirstConsumer"
+
+	if spec.Config == nil {
+		spec.Config = &cdiv1beta1.CDIConfigSpec{}
+	} else {
+		for _, value := range spec.Config.FeatureGates {
+			if value == featureGate {
+				return
+			}
+		}
+	}
+
+	spec.Config.FeatureGates = append(spec.Config.FeatureGates, featureGate)
 }
 
 func (h *cdiHooks) postFound(req *common.HcoRequest, exists runtime.Object) error {

--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -62,6 +62,13 @@ func (h *cdiHooks) updateCr(req *common.HcoRequest, Client client.Client, exists
 	if !ok1 || !ok2 {
 		return false, false, errors.New("can't convert to CDI")
 	}
+
+	// HCO reconciles the CR for CDI excluding the `spec.CDIConfig`,
+	if found.Spec.Config != nil {
+		cdi.Spec.Config = &cdiv1beta1.CDIConfigSpec{}
+		found.Spec.Config.DeepCopyInto(cdi.Spec.Config)
+	}
+
 	if !reflect.DeepEqual(found.Spec, cdi.Spec) {
 		overwritten := false
 		if req.HCOTriggered {

--- a/pkg/controller/operands/cdi_test.go
+++ b/pkg/controller/operands/cdi_test.go
@@ -52,8 +52,6 @@ var _ = Describe("CDI Operand", func() {
 		It("should find if present", func() {
 			expectedResource := NewCDI(hco)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
-			expectedResource.Spec.Config = &cdiv1beta1.CDIConfigSpec{FeatureGates: []string{"HonorWaitForFirstConsumer"}}
-
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
 			handler := (*genericOperand)(newCdiHandler(cl, commonTestUtils.GetScheme()))
 			res := handler.ensure(req)
@@ -320,6 +318,7 @@ var _ = Describe("CDI Operand", func() {
 		It("should add HonorWaitForFirstConsumer featuregate if Spec.Config if empty", func() {
 			expectedResource := NewCDI(hco)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
+			expectedResource.Spec.Config = nil
 
 			// mock a reconciliation triggered by a change in CDI CR
 			req.HCOTriggered = false
@@ -345,7 +344,6 @@ var _ = Describe("CDI Operand", func() {
 		It("should handle conditions", func() {
 			expectedResource := NewCDI(hco)
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
-			expectedResource.Spec.Config = &cdiv1beta1.CDIConfigSpec{FeatureGates: []string{"HonorWaitForFirstConsumer"}}
 			expectedResource.Status.Conditions = []conditionsv1.Condition{
 				conditionsv1.Condition{
 					Type:    conditionsv1.ConditionAvailable,


### PR DESCRIPTION
CDIConfig is part of the CDI CR. Users can access it to change configuration fields in the CDI CR and the HCO reconciliation loop will not revert/override the external changes in CDI.Spec.Config.

As an exception to this rule HCO will always add the feature gate HonorWaitForFirstConsumer to CDI.Spec.Config.FeatureGates.

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CDI feature gate HonorWaitForFirstConsumer is always enabled.
```

