### PR TITLE
Delete ConsoleQuickStart on HyperConverged deletion

### DIFF
--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -44,4 +44,4 @@ sleep 60
 KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/test_quick_start.sh
 
 # Check the webhook, to see if it allow deleteing of the HyperConverged CR
-${KUBECTL_BINARY} delete hco -n kubevirt-hyperconverged kubevirt-hyperconverged
+./hack/retry.sh 10 30 "${KUBECTL_BINARY} delete hco -n kubevirt-hyperconverged kubevirt-hyperconverged"

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -231,7 +231,7 @@ Msg "verify the hyperconverged-cluster deployment is using the new image"
 
 set -x
 SEARCH_PHRASE="${OPENSHIFT_BUILD_NAMESPACE}/stable"
-./hack/retry.sh 30 30 "${CMD} get -n ${HCO_NAMESPACE} deployment ${HCO_DEPLOYMENT_NAME} -o jsonpath=\"{ .spec.template.spec.containers[0].image }\" | grep ${SEARCH_PHRASE}"
+./hack/retry.sh 60 30 "${CMD} get -n ${HCO_NAMESPACE} deployment ${HCO_DEPLOYMENT_NAME} -o jsonpath=\"{ .spec.template.spec.containers[0].image }\" | grep ${SEARCH_PHRASE}"
 
 Msg "wait that cluster is operational after upgrade"
 timeout 20m bash -c 'export CMD="${CMD}";exec ./hack/check-state.sh'

--- a/pkg/controller/commonTestUtils/testUtils.go
+++ b/pkg/controller/commonTestUtils/testUtils.go
@@ -98,8 +98,14 @@ func NewHyperConvergedConfig() *sdkapi.NodePlacement {
 	}
 }
 
+var testScheme *runtime.Scheme
+
 func GetScheme() *runtime.Scheme {
-	s := scheme.Scheme
+	if testScheme != nil {
+		return testScheme
+	}
+
+	testScheme = scheme.Scheme
 
 	for _, f := range []func(*runtime.Scheme) error{
 		apis.AddToScheme,
@@ -111,8 +117,8 @@ func GetScheme() *runtime.Scheme {
 		monitoringv1.AddToScheme,
 		extv1.AddToScheme,
 	} {
-		Expect(f(s)).To(BeNil())
+		Expect(f(testScheme)).To(BeNil())
 	}
 
-	return s
+	return testScheme
 }

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -223,7 +223,7 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 		// reload eventEmitter. The client should now find all the required resources
 		r.eventEmitter.UpdateClient(req.Ctx, r.client, req.Logger)
 
-		r.operandHandler.FirstUseInitiation(r.scheme, hcoutil.GetClusterInfo().IsOpenshift())
+		r.operandHandler.FirstUseInitiation(r.scheme, hcoutil.GetClusterInfo().IsOpenshift(), req.Instance)
 	}
 
 	res, err := r.doReconcile(req)

--- a/pkg/controller/operands/operandHandler_test.go
+++ b/pkg/controller/operands/operandHandler_test.go
@@ -1,0 +1,151 @@
+package operands
+
+import (
+	"os"
+
+	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
+	"github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	consolev1 "github.com/openshift/api/console/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
+)
+
+var _ = Describe("Test operandHandler", func() {
+	Context("Test operandHandler", func() {
+		testFileLocation := getTestFilesLocation()
+
+		_ = os.Setenv("CONVERSION_CONTAINER", "just-a-value:version")
+		_ = os.Setenv("VMWARE_CONTAINER", "just-a-value:version")
+
+		It("should create all objects are created", func() {
+			err := os.Setenv(manifestLocationVarName, testFileLocation)
+			Expect(err).ToNot(HaveOccurred())
+			hco := commonTestUtils.NewHco()
+			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+
+			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, commonTestUtils.EventEmitterMock{})
+			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
+
+			req := commonTestUtils.NewReq(hco)
+
+			err = handler.Ensure(req)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("make sure the KV object created", func() {
+				// Read back KV
+				kvList := kubevirtv1.KubeVirtList{}
+				err := cli.List(req.Ctx, &kvList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kvList).ToNot(BeNil())
+				Expect(kvList.Items).To(HaveLen(1))
+				Expect(kvList.Items[0].Name).Should(Equal("kubevirt-kubevirt-hyperconverged"))
+			})
+
+			By("make sure the CNA object created", func() {
+				// Read back KV
+				cnaList := networkaddonsv1.NetworkAddonsConfigList{}
+				err := cli.List(req.Ctx, &cnaList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cnaList).ToNot(BeNil())
+				Expect(cnaList.Items).To(HaveLen(1))
+				Expect(cnaList.Items[0].Name).Should(Equal("cluster"))
+			})
+
+			By("make sure the CDI object created", func() {
+				// Read back KV
+				cdiList := cdiv1beta1.CDIList{}
+				err := cli.List(req.Ctx, &cdiList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cdiList).ToNot(BeNil())
+				Expect(cdiList.Items).To(HaveLen(1))
+				Expect(cdiList.Items[0].Name).Should(Equal("cdi-kubevirt-hyperconverged"))
+			})
+
+			By("make sure the VM-Import object created", func() {
+				// Read back KV
+				vmImportList := v1beta1.VMImportConfigList{}
+				err := cli.List(req.Ctx, &vmImportList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmImportList).ToNot(BeNil())
+				Expect(vmImportList.Items).To(HaveLen(1))
+				Expect(vmImportList.Items[0].Name).Should(Equal("vmimport-kubevirt-hyperconverged"))
+			})
+
+			By("make sure the ConsoleQuickStart object created", func() {
+				// Read back the ConsoleQuickStart
+				qsList := consolev1.ConsoleQuickStartList{}
+				err := cli.List(req.Ctx, &qsList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(qsList).ToNot(BeNil())
+				Expect(qsList.Items).To(HaveLen(1))
+				Expect(qsList.Items[0].Name).Should(Equal("test-quick-start"))
+			})
+		})
+
+		It("make sure the all objects are deleted", func() {
+			err := os.Setenv(manifestLocationVarName, testFileLocation)
+			Expect(err).ToNot(HaveOccurred())
+			hco := commonTestUtils.NewHco()
+			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+
+			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, commonTestUtils.EventEmitterMock{})
+			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
+
+			req := commonTestUtils.NewReq(hco)
+			err = handler.Ensure(req)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = handler.EnsureDeleted(req)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("check that KV is deleted", func() {
+				// Read back KV
+				kvList := kubevirtv1.KubeVirtList{}
+				err = cli.List(req.Ctx, &kvList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kvList).ToNot(BeNil())
+				Expect(kvList.Items).To(BeEmpty())
+			})
+
+			By("make sure the CNA object deleted", func() {
+				// Read back KV
+				cnaList := networkaddonsv1.NetworkAddonsConfigList{}
+				err := cli.List(req.Ctx, &cnaList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cnaList).ToNot(BeNil())
+				Expect(cnaList.Items).To(BeEmpty())
+			})
+
+			By("make sure the CDI object deleted", func() {
+				// Read back KV
+				cdiList := cdiv1beta1.CDIList{}
+				err := cli.List(req.Ctx, &cdiList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cdiList).ToNot(BeNil())
+				Expect(cdiList.Items).To(BeEmpty())
+			})
+
+			By("make sure the VM-Import object deleted", func() {
+				// Read back KV
+				vmImportList := v1beta1.VMImportConfigList{}
+				err := cli.List(req.Ctx, &vmImportList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmImportList).ToNot(BeNil())
+				Expect(vmImportList.Items).To(BeEmpty())
+			})
+
+			By("check that ConsoleQuickStart is deleted", func() {
+				// Read back the ConsoleQuickStart
+				qsList := consolev1.ConsoleQuickStartList{}
+				err = cli.List(req.Ctx, &qsList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(qsList).ToNot(BeNil())
+				Expect(qsList.Items).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/pkg/controller/operands/operands_suite_test.go
+++ b/pkg/controller/operands/operands_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestHyperconverged(t *testing.T) {
+func TestOperators(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Operands Suite")
 }

--- a/pkg/controller/operands/quickStart.go
+++ b/pkg/controller/operands/quickStart.go
@@ -127,7 +127,7 @@ func checkCrdExists(ctx context.Context, Client client.Client, logger log.Logger
 	return true, nil
 }
 
-func getQuickStartHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme) ([]Operand, error) {
+func getQuickStartHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
 	crdExists, err := checkCrdExists(context.TODO(), Client, logger)
 	if err != nil {
 		return nil, err
@@ -168,6 +168,7 @@ func getQuickStartHandlers(logger log.Logger, Client client.Client, Scheme *runt
 			if err != nil {
 				logger.Info("Can't generate a ConsoleQuickStart object from yaml file", "file name", path)
 			} else {
+				qs.Labels = getLabels(hc)
 				handlers = append(handlers, newQuickStartHandler(Client, Scheme, qs))
 			}
 		}

--- a/pkg/controller/operands/quickStart.go
+++ b/pkg/controller/operands/quickStart.go
@@ -84,7 +84,7 @@ func (h qsHooks) updateCr(req *common.HcoRequest, Client client.Client, exists r
 		return false, false, errors.New("can't convert to ConsoleQuickStart")
 	}
 
-	if !reflect.DeepEqual(found.Spec, h.required.Spec) && !req.UpgradeMode {
+	if !reflect.DeepEqual(found.Spec, h.required.Spec) {
 		if req.HCOTriggered {
 			req.Logger.Info("Updating existing ConsoleQuickStart's Spec to new opinionated values", "name", h.required.Name)
 		} else {

--- a/pkg/controller/operands/utils_test.go
+++ b/pkg/controller/operands/utils_test.go
@@ -1,0 +1,36 @@
+package operands
+
+import (
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"path"
+	"strings"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	pkgDirectory = "pkg/controller/operands"
+	testFilesLoc = "testFiles"
+)
+
+var (
+	qsCrd = &extv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: consoleQuickStartCrdName,
+		},
+	}
+)
+
+func getTestFilesLocation() string {
+	wd, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred())
+	if strings.HasSuffix(wd, pkgDirectory) {
+		return testFilesLoc
+	}
+	return path.Join(pkgDirectory, testFilesLoc)
+}


### PR DESCRIPTION
Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upun deletion of the HyperConverged CR, remove the QuickStart objects
```

