### PR TITLE
CI: try to mitigate some CI issues

### DIFF
--- a/hack/dump-state.sh
+++ b/hack/dump-state.sh
@@ -65,6 +65,16 @@ done
 
 cat <<EOF
 
+======================
+ClusterServiceVersions
+======================
+EOF
+
+RunCmd "${CMD} get clusterserviceversions -n kubevirt-hyperconverged"
+RunCmd "${CMD} get clusterserviceversions -n kubevirt-hyperconverged -o yaml"
+
+cat <<EOF
+
 ============
 InstallPlans
 ============


### PR DESCRIPTION
Sometimes we get unexpected "x509 ..." errors on CI,
try to mitigate them simply waiting 5 minutes
(to let the auth components eventually recovery)
and then try again (2x).

Fetch CSV logs on error to better track this
kind of issues in the future.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

