### PR TITLE
Temporarily enable debug logs for OLM

### DIFF
--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -92,6 +92,9 @@ function cleanup() {
 trap "cleanup" INT TERM EXIT
 
 Msg "Enable debug logging for OLM"
+
+"${CMD}" patch clusterversion version --type json -patch '[{"op": "add", "path": "/spec/overrides", "value": { "kind": "Deployment", "group": "apps/v1", "name": "olm-operator", "namespace": "openshift-operator-lifecycle-manager", "unmanaged": true }}]'
+sleep 10s
 "${CMD}" patch deployment olm-operator -n openshift-operator-lifecycle-manager --type json --patch '[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--debug"}]'
 sleep 30s # Let it soak in
 

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -93,7 +93,17 @@ trap "cleanup" INT TERM EXIT
 
 Msg "Enable debug logging for OLM"
 
-"${CMD}" patch clusterversion version --type json -patch '[{"op": "add", "path": "/spec/overrides", "value": { "kind": "Deployment", "group": "apps/v1", "name": "olm-operator", "namespace": "openshift-operator-lifecycle-manager", "unmanaged": true }}]'
+"${CMD}" patch clusterversion version --type json --patch "$(cat << 'EOM'
+- op: add
+  path: /spec/overrides
+  value:
+  - kind: Deployment
+    group: apps/v1
+    name: olm-operator
+    namespace: openshift-operator-lifecycle-manager
+    unmanaged: true
+EOM
+)"
 sleep 10s
 "${CMD}" patch deployment olm-operator -n openshift-operator-lifecycle-manager --type json --patch '[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--debug"}]'
 sleep 30s # Let it soak in

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -41,7 +41,7 @@
 # to verify that it is updated to the new operator image from 
 # the local registry.
 
-MAX_STEPS=14
+MAX_STEPS=15
 CUR_STEP=1
 RELEASE_DELTA="${RELEASE_DELTA:-1}"
 HCO_DEPLOYMENT_NAME=hco-operator
@@ -91,6 +91,9 @@ function cleanup() {
 
 trap "cleanup" INT TERM EXIT
 
+Msg "Enable debug logging for OLM"
+"${CMD}" patch deployment olm-operator -n openshift-operator-lifecycle-manager --type json --patch '[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--debug"}]'
+sleep 30s # Let it soak in
 
 Msg "Clean cluster"
 


### PR DESCRIPTION
This PR enables OLM debug logging in upgrade test.
The goal is to assist in debugging CI test failures which might be related to OLM.

**This PR shouldn't be merged.**

Signed-off-by: Zvi Cahana <zvic@il.ibm.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

