### PR TITLE
Do not execute go mod tidy

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -24,7 +24,6 @@ git clone https://github.com/kubevirt/kubevirt.git
 (cd kubevirt; git checkout "${latest_kubevirt_commit}")
 go mod edit -replace kubevirt.io/client-go=./kubevirt/staging/src/kubevirt.io/client-go
 go mod vendor
-go mod tidy
 
 # set envs
 build_date="$(date +%Y%m%d)"


### PR DESCRIPTION
Calling go mod tidy causes an inconsistent vendoring error in nightly
build.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

