### PR TITLE
Remove duplicate AddToScheme call for consolev1

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -157,7 +157,6 @@ func main() {
 		openshiftconfigv1.AddToScheme,
 		monitoringv1.AddToScheme,
 		extv1.AddToScheme,
-		consolev1.AddToScheme,
 	} {
 		if err := f(mgr.GetScheme()); err != nil {
 			log.Error(err, "Failed to add to scheme")


### PR DESCRIPTION
This is redundant and causes raises an error saying "multiple
group-version-kinds associated with type *v1.KubeVirt, refusing to guess
at one"

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

