### PR TITLE
Fix issue in Quick-start

### DIFF
--- a/pkg/controller/operands/quickStart.go
+++ b/pkg/controller/operands/quickStart.go
@@ -52,7 +52,7 @@ type qsHooks struct {
 }
 
 func (h qsHooks) getFullCr(_ *hcov1beta1.HyperConverged) runtime.Object {
-	return h.required
+	return h.required.DeepCopy()
 }
 
 func (h qsHooks) getEmptyCr() runtime.Object {


### PR DESCRIPTION
Fix issue in Quick-start where after deletion and recreation of the HC CR, HCO failed to re-create the QS objects.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix issue in Quick-start where after deletion and recreation of the HC CR, HCO failed to re-create the QS objects.
```

