### PR TITLE
Add ENABLE_SSP option to hack/deploy.sh script

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -642,6 +642,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    name: ssp-operator
   name: ssp-operator-service
 spec:
   ports:
@@ -656,6 +658,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    name: node-maintenance-operator
   name: node-maintenance-operator-service
 spec:
   ports:

--- a/deploy/webhooks.yaml
+++ b/deploy/webhooks.yaml
@@ -9,6 +9,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hyperconverged-cluster-webhook-service-cert
+  labels:
+    name: hyperconverged-cluster-webhook
 spec:
   secretName: hyperconverged-cluster-webhook-service-cert
   dnsNames:
@@ -22,6 +24,8 @@ metadata:
   name: validate-hco.kubevirt.io
   annotations:
     cert-manager.io/inject-ca-from: kubevirt-hyperconverged/hyperconverged-cluster-webhook-service-cert
+  labels:
+    name: hyperconverged-cluster-webhook
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -57,6 +61,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: node-maintenance-operator-service-cert
+  labels:
+    name: node-maintenance-operator
 spec:
   secretName: node-maintenance-operator-service-cert
   dnsNames:
@@ -70,6 +76,8 @@ metadata:
   name: nodemaintenance-validation.kubevirt.io
   annotations:
     cert-manager.io/inject-ca-from: kubevirt-hyperconverged/node-maintenance-operator-service-cert
+  labels:
+    name: node-maintenance-operator
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -102,6 +110,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ssp-operator-service-cert
+  labels:
+    name: ssp-operator
 spec:
   secretName: ssp-operator-service-cert
   dnsNames:
@@ -115,6 +125,8 @@ metadata:
   name: vssp.kb.io
   annotations:
     cert-manager.io/inject-ca-from: kubevirt-hyperconverged/ssp-operator-service-cert
+  labels:
+    name: ssp-operator
 webhooks:
 - admissionReviewVersions:
   - v1beta1

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -129,10 +129,10 @@ fi
 "${CMD}" -n cert-manager wait deployment/cert-manager-webhook --for=condition=Available --timeout="300s"
 
 # Deploy local manifests
-"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/cluster_role.yaml
-"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/service_account.yaml
-"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/cluster_role_binding.yaml
-"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/crds/
+"${CMD}" apply $LABEL_SELECTOR_ARG -f _out/cluster_role.yaml
+"${CMD}" apply $LABEL_SELECTOR_ARG -f _out/service_account.yaml
+"${CMD}" apply $LABEL_SELECTOR_ARG -f _out/cluster_role_binding.yaml
+"${CMD}" apply $LABEL_SELECTOR_ARG -f _out/crds/
 
 sleep 20
 if [[ "$(${CMD} get crd ${HCO_CRD_NAME} -o=jsonpath='{.status.conditions[?(@.type=="NonStructuralSchema")].status}')" == "True" ]];
@@ -146,14 +146,14 @@ fi
 # when a new webhook (deployed by OLM in production) is introduced, 
 # it must be added into webhooks.yaml as well.
 echo "Creating resources for webhooks"
-"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/webhooks.yaml
+"${CMD}" apply $LABEL_SELECTOR_ARG -f _out/webhooks.yaml
 
 if [ "${CI}" != "true" ]; then
-	"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/operator.yaml
+	"${CMD}" apply $LABEL_SELECTOR_ARG -f _out/operator.yaml
 else
 	sed -E 's|^(\s*)- name: KVM_EMULATION$|\1- name: KVM_EMULATION\n\1  value: "true"|' < _out/operator.yaml > _out/operator-ci.yaml
 	cat _out/operator-ci.yaml
-	"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/operator-ci.yaml
+	"${CMD}" apply $LABEL_SELECTOR_ARG -f _out/operator-ci.yaml
 fi
 
 # Wait for the HCO to be ready
@@ -168,7 +168,7 @@ sleep 20
 # Check on ssp-operator only if it's enabled.
 OPERATORS=(
     "cdi-operator"
-    "cluster-network-addons-operator "
+    "cluster-network-addons-operator"
     "node-maintenance-operator"
     "vm-import-operator"
 )

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -28,6 +28,7 @@ HCO_NAMESPACE="kubevirt-hyperconverged"
 HCO_KIND="hyperconvergeds"
 HCO_RESOURCE_NAME="kubevirt-hyperconverged"
 HCO_CRD_NAME="hyperconvergeds.hco.kubevirt.io"
+ENABLE_SSP=${ENABLE_SSP:-false}
 
 CI=""
 if [ "$1" == "CI" ]; then
@@ -117,15 +118,21 @@ function debug(){
     exit 1
 }
 
+# In case SSP is disabled, apply with a label selector to filter out its resources.
+LABEL_SELECTOR_ARG=""
+if [ "$ENABLE_SSP" != "true" ]; do
+    LABEL_SELECTOR_ARG="-l name!=ssp-operator"
+fi
+
 # Deploy cert-manager for webhooks
 "${CMD}" apply -f _out/cert-manager.yaml
 "${CMD}" -n cert-manager wait deployment/cert-manager-webhook --for=condition=Available --timeout="300s"
 
 # Deploy local manifests
-"${CMD}" apply -f _out/cluster_role.yaml
-"${CMD}" apply -f _out/service_account.yaml
-"${CMD}" apply -f _out/cluster_role_binding.yaml
-"${CMD}" apply -f _out/crds/
+"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/cluster_role.yaml
+"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/service_account.yaml
+"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/cluster_role_binding.yaml
+"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/crds/
 
 sleep 20
 if [[ "$(${CMD} get crd ${HCO_CRD_NAME} -o=jsonpath='{.status.conditions[?(@.type=="NonStructuralSchema")].status}')" == "True" ]];
@@ -139,14 +146,14 @@ fi
 # when a new webhook (deployed by OLM in production) is introduced, 
 # it must be added into webhooks.yaml as well.
 echo "Creating resources for webhooks"
-"${CMD}" apply -f _out/webhooks.yaml
+"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/webhooks.yaml
 
 if [ "${CI}" != "true" ]; then
-	"${CMD}" apply -f _out/operator.yaml
+	"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/operator.yaml
 else
 	sed -E 's|^(\s*)- name: KVM_EMULATION$|\1- name: KVM_EMULATION\n\1  value: "true"|' < _out/operator.yaml > _out/operator-ci.yaml
 	cat _out/operator-ci.yaml
-	"${CMD}" apply -f _out/operator-ci.yaml
+	"${CMD}" apply "${LABEL_SELECTOR_ARG}" -f _out/operator-ci.yaml
 fi
 
 # Wait for the HCO to be ready
@@ -155,9 +162,22 @@ sleep 20
 "${CMD}" wait deployment/hyperconverged-cluster-operator --for=condition=Available --timeout="1080s" || CONTAINER_ERRORED+="hyperconverged-cluster-operator "
 "${CMD}" wait deployment/hyperconverged-cluster-webhook --for=condition=Available --timeout="1080s" || CONTAINER_ERRORED+="hyperconverged-cluster-webhook "
 
-# avoid checking the availability of virt-operator here because it will become available only when
-# HCO will create its priorityClass and this will happen only when wi will have HCO cr
-for op in cdi-operator cluster-network-addons-operator ssp-operator node-maintenance-operator vm-import-operator; do
+# Gather a list of operators to wait for.
+# Avoid checking the availability of virt-operator here because it will become available only when
+# HCO will create its priorityClass and this will happen only when wi will have HCO cr.
+# Check on ssp-operator only if it's enabled.
+OPERATORS=(
+    "cdi-operator"
+    "cluster-network-addons-operator "
+    "node-maintenance-operator"
+    "vm-import-operator"
+)
+
+if [ "$ENABLE_SSP" = "true" ]; do
+    OPERATORS+="ssp-operator"
+fi
+
+for op in "${OPERATORS[@]}"; do
     "${CMD}" wait deployment/"${op}" --for=condition=Available --timeout="540s" || CONTAINER_ERRORED+="${op} "
 done
 

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -120,7 +120,7 @@ function debug(){
 
 # In case SSP is disabled, apply with a label selector to filter out its resources.
 LABEL_SELECTOR_ARG=""
-if [ "$ENABLE_SSP" != "true" ]; do
+if [ "$ENABLE_SSP" != "true" ]; then
     LABEL_SELECTOR_ARG="-l name!=ssp-operator"
 fi
 
@@ -173,7 +173,7 @@ OPERATORS=(
     "vm-import-operator"
 )
 
-if [ "$ENABLE_SSP" = "true" ]; do
+if [ "$ENABLE_SSP" = "true" ]; then
     OPERATORS+="ssp-operator"
 fi
 

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -220,6 +220,9 @@ func main() {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: webhook.DeploymentName + "-service",
+						Labels: map[string]string{
+							"name": webhook.DeploymentName,
+						},
 					},
 					Spec: v1.ServiceSpec{
 						Selector: getSelectorOfWebhookDeployment(webhook.DeploymentName, csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs),


### PR DESCRIPTION
This PR adds a ENABLE_SSP environment variable option to `hack/deploy.sh` script, that allows to determine whether ssp-operator and associated resources will be deployed.

The default value is `false`, and is aimed to remove SSP deployment from plain k8s environments.
On OpenShift, this script can be run as `ENABLE_SSP=true hack/deploy.sh` to include SSP.

Note:
The SSP CRD is nevertheless deployed, also when SSP deployment is disabled - to support this we may need a bit larger change in how the CRD files are generated. I think this is harmless enough for now.

Signed-off-by: Zvi Cahana <zvic@il.ibm.com>

```release-note
Add ENABLE_SSP option to hack/deploy.sh script
```

