### PR TITLE
Cache operad CRs

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -15,8 +15,6 @@ for namespace in ${namespaces[@]}; do
     fi
 done
 
-
-
 # Launch all of the CRDs.
 kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/cluster-network-addons00.crd.yaml
 kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/containerized-data-importer00.crd.yaml
@@ -25,9 +23,6 @@ kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-clus
 kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/hostpath-provisioner00.crd.yaml
 kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/node-maintenance00.crd.yaml
 kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/scheduling-scale-performance00.crd.yaml
-kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/scheduling-scale-performance01.crd.yaml
-kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/scheduling-scale-performance02.crd.yaml
-kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/scheduling-scale-performance03.crd.yaml
 kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/vm-import-operator00.crd.yaml
 kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/hco01.crd.yaml
 kubectl apply  -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/hco02.crd.yaml

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -200,6 +200,8 @@ func (r *ReconcileHyperConverged) Reconcile(request reconcile.Request) (reconcil
 		pRequest = reconcile.Request{
 			NamespacedName: hco,
 		}
+	} else {
+		r.operandHandler.Reset()
 	}
 
 	req := common.NewHcoRequest(pRequest, log, r.upgradeMode, hcoTriggered)

--- a/pkg/controller/operands/cdi_test.go
+++ b/pkg/controller/operands/cdi_test.go
@@ -590,6 +590,55 @@ var _ = Describe("CDI Operand", func() {
 				Expect(cdi.Spec.CloneStrategyOverride).To(BeNil())
 			})
 		})
+
+		Context("Cache", func() {
+			cl := commonTestUtils.InitClient([]runtime.Object{})
+			handler := newCdiHandler(cl, commonTestUtils.GetScheme())
+
+			It("should start with empty cache", func() {
+				Expect(handler.hooks.(*cdiHooks).cache).To(BeNil())
+			})
+
+			It("should update the cache when reading full CR", func() {
+				cr, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cr).ToNot(BeNil())
+				Expect(handler.hooks.(*cdiHooks).cache).ToNot(BeNil())
+
+				By("compare pointers to make sure cache is working", func() {
+					Expect(handler.hooks.(*cdiHooks).cache == cr).Should(BeTrue())
+
+					cdi1, err := handler.hooks.getFullCr(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(cdi1).ToNot(BeNil())
+					Expect(cr == cdi1).Should(BeTrue())
+				})
+			})
+
+			It("should remove the cache on reset", func() {
+				handler.hooks.(*cdiHooks).reset()
+				Expect(handler.hooks.(*cdiHooks).cache).To(BeNil())
+			})
+
+			It("check that reset actually cause creating of a new cached instance", func() {
+				crI, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(crI).ToNot(BeNil())
+				Expect(handler.hooks.(*cdiHooks).cache).ToNot(BeNil())
+
+				handler.hooks.(*cdiHooks).reset()
+				Expect(handler.hooks.(*cdiHooks).cache).To(BeNil())
+
+				crII, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(crII).ToNot(BeNil())
+				Expect(handler.hooks.(*cdiHooks).cache).ToNot(BeNil())
+
+				Expect(crI == crII).To(BeFalse())
+				Expect(handler.hooks.(*cdiHooks).cache == crI).To(BeFalse())
+				Expect(handler.hooks.(*cdiHooks).cache == crII).To(BeTrue())
+			})
+		})
 	})
 
 	Context("KubeVirt Storage Config", func() {

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -55,6 +55,7 @@ func (h metricsServiceHooks) checkComponentVersion(_ runtime.Object) bool       
 func (h metricsServiceHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*corev1.Service).ObjectMeta
 }
+func (h metricsServiceHooks) reset() {}
 
 func (h *metricsServiceHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	service, ok1 := required.(*corev1.Service)
@@ -142,6 +143,7 @@ func (h metricsServiceMonitorHooks) checkComponentVersion(_ runtime.Object) bool
 func (h metricsServiceMonitorHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*monitoringv1.ServiceMonitor).ObjectMeta
 }
+func (h metricsServiceMonitorHooks) reset() {}
 
 func (h *metricsServiceMonitorHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	monitor, ok1 := required.(*monitoringv1.ServiceMonitor)
@@ -214,6 +216,7 @@ func (h prometheusRuleHooks) checkComponentVersion(_ runtime.Object) bool       
 func (h prometheusRuleHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*monitoringv1.PrometheusRule).ObjectMeta
 }
+func (h prometheusRuleHooks) reset() {}
 
 func (h *prometheusRuleHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	rule, ok1 := required.(*monitoringv1.PrometheusRule)

--- a/pkg/controller/operands/networkAddons_test.go
+++ b/pkg/controller/operands/networkAddons_test.go
@@ -549,6 +549,57 @@ var _ = Describe("CNA Operand", func() {
 				Expect(cna.Spec.ImagePullPolicy).To(BeEmpty())
 			})
 		})
+
+		Context("Cache", func() {
+			cl := commonTestUtils.InitClient([]runtime.Object{})
+			handler := newCnaHandler(cl, commonTestUtils.GetScheme())
+
+			It("should start with empty cache", func() {
+				Expect(handler.hooks.(*cnaHooks).cache).To(BeNil())
+			})
+
+			It("should update the cache when reading full CR", func() {
+				cr, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cr).ToNot(BeNil())
+				Expect(handler.hooks.(*cnaHooks).cache).ToNot(BeNil())
+
+				By("compare pointers to make sure cache is working", func() {
+					Expect(handler.hooks.(*cnaHooks).cache == cr).Should(BeTrue())
+
+					crII, err := handler.hooks.getFullCr(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(crII).ToNot(BeNil())
+					Expect(cr == crII).Should(BeTrue())
+				})
+			})
+
+			It("should remove the cache on reset", func() {
+				handler.hooks.(*cnaHooks).reset()
+				Expect(handler.hooks.(*cnaHooks).cache).To(BeNil())
+			})
+
+			It("check that reset actually cause creating of a new cached instance", func() {
+				crI, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(crI).ToNot(BeNil())
+				Expect(handler.hooks.(*cnaHooks).cache).ToNot(BeNil())
+
+				handler.hooks.(*cnaHooks).reset()
+				Expect(handler.hooks.(*cnaHooks).cache).To(BeNil())
+
+				crII, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(crII).ToNot(BeNil())
+				Expect(handler.hooks.(*cnaHooks).cache).ToNot(BeNil())
+
+				Expect(crI == crII).To(BeFalse())
+				Expect(handler.hooks.(*cnaHooks).cache == crI).To(BeFalse())
+				Expect(handler.hooks.(*cnaHooks).cache == crII).To(BeTrue())
+			})
+
+		})
+
 	})
 
 	Context("hcoConfig2CnaoPlacement", func() {

--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -24,6 +24,7 @@ import (
 
 type Operand interface {
 	ensure(req *common.HcoRequest) *EnsureResult
+	reset()
 }
 
 // Handles a specific resource (a CR, a configMap and so on), to be run during reconciliation
@@ -64,6 +65,8 @@ type hcoResourceHooks interface {
 	checkComponentVersion(runtime.Object) bool
 	// cast he specific resource to *metav1.ObjectMeta
 	getObjectMeta(runtime.Object) *metav1.ObjectMeta
+	// reset handler cached, if exists
+	reset()
 }
 
 func (h *genericOperand) ensure(req *common.HcoRequest) *EnsureResult {
@@ -165,6 +168,10 @@ func (h *genericOperand) ensure(req *common.HcoRequest) *EnsureResult {
 	}
 	// For resources that are not CRs, such as priority classes or a config map, there is no new version to upgrade
 	return res.SetUpgradeDone(req.ComponentUpgradeInProgress)
+}
+
+func (h *genericOperand) reset() {
+	h.hooks.reset()
 }
 
 // handleComponentConditions - read and process a sub-component conditions.

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -201,3 +201,9 @@ func (h OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 
 	return nil
 }
+
+func (h *OperandHandler) Reset() {
+	for _, op := range h.operands {
+		op.reset()
+	}
+}

--- a/pkg/controller/operands/quickStart.go
+++ b/pkg/controller/operands/quickStart.go
@@ -78,6 +78,8 @@ func (h qsHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*consolev1.ConsoleQuickStart).ObjectMeta
 }
 
+func (h qsHooks) reset() {}
+
 func (h qsHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
 	found, ok := exists.(*consolev1.ConsoleQuickStart)
 

--- a/pkg/controller/operands/ssp.go
+++ b/pkg/controller/operands/ssp.go
@@ -113,10 +113,15 @@ func (handler *sspHandler) ensure(req *common.HcoRequest) *EnsureResult {
 	return res
 }
 
-type sspHooks struct{}
+type sspHooks struct {
+	cache *sspv1beta1.SSP
+}
 
-func (h sspHooks) getFullCr(hc *hcov1beta1.HyperConverged) (runtime.Object, error) {
-	return NewSSP(hc), nil
+func (h *sspHooks) getFullCr(hc *hcov1beta1.HyperConverged) (runtime.Object, error) {
+	if h.cache == nil {
+		h.cache = NewSSP(hc)
+	}
+	return h.cache, nil
 }
 func (h sspHooks) getEmptyCr() runtime.Object                         { return &sspv1beta1.SSP{} }
 func (h sspHooks) validate() error                                    { return nil }
@@ -130,6 +135,9 @@ func (h sspHooks) checkComponentVersion(cr runtime.Object) bool {
 }
 func (h sspHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*sspv1beta1.SSP).ObjectMeta
+}
+func (h *sspHooks) reset() {
+	h.cache = nil
 }
 
 func (h *sspHooks) updateCr(req *common.HcoRequest, client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {

--- a/pkg/controller/operands/ssp_test.go
+++ b/pkg/controller/operands/ssp_test.go
@@ -436,6 +436,55 @@ var _ = Describe("SSP Operands", func() {
 				}
 			})
 		})
+
+		Context("Cache", func() {
+			cl := commonTestUtils.InitClient([]runtime.Object{})
+			handler := newSspHandler(cl, commonTestUtils.GetScheme())
+
+			It("should start with empty cache", func() {
+				Expect(handler.hooks.(*sspHooks).cache).To(BeNil())
+			})
+
+			It("should update the cache when reading full CR", func() {
+				cr, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cr).ToNot(BeNil())
+				Expect(handler.hooks.(*sspHooks).cache).ToNot(BeNil())
+
+				By("compare pointers to make sure cache is working", func() {
+					Expect(handler.hooks.(*sspHooks).cache == cr).Should(BeTrue())
+
+					cdi1, err := handler.hooks.getFullCr(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(cdi1).ToNot(BeNil())
+					Expect(cr == cdi1).Should(BeTrue())
+				})
+			})
+
+			It("should remove the cache on reset", func() {
+				handler.hooks.(*sspHooks).reset()
+				Expect(handler.hooks.(*sspHooks).cache).To(BeNil())
+			})
+
+			It("check that reset actually cause creating of a new cached instance", func() {
+				crI, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(crI).ToNot(BeNil())
+				Expect(handler.hooks.(*sspHooks).cache).ToNot(BeNil())
+
+				handler.hooks.(*sspHooks).reset()
+				Expect(handler.hooks.(*sspHooks).cache).To(BeNil())
+
+				crII, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(crII).ToNot(BeNil())
+				Expect(handler.hooks.(*sspHooks).cache).ToNot(BeNil())
+
+				Expect(crI == crII).To(BeFalse())
+				Expect(handler.hooks.(*sspHooks).cache == crI).To(BeFalse())
+				Expect(handler.hooks.(*sspHooks).cache == crII).To(BeTrue())
+			})
+		})
 	})
 })
 

--- a/pkg/controller/operands/vmImport.go
+++ b/pkg/controller/operands/vmImport.go
@@ -34,10 +34,15 @@ func newVmImportHandler(Client client.Client, Scheme *runtime.Scheme) *vmImportH
 	}
 }
 
-type vmImportHooks struct{}
+type vmImportHooks struct {
+	cache *vmimportv1beta1.VMImportConfig
+}
 
-func (h vmImportHooks) getFullCr(hc *hcov1beta1.HyperConverged) (runtime.Object, error) {
-	return NewVMImportForCR(hc), nil
+func (h *vmImportHooks) getFullCr(hc *hcov1beta1.HyperConverged) (runtime.Object, error) {
+	if h.cache == nil {
+		h.cache = NewVMImportForCR(hc)
+	}
+	return h.cache, nil
 }
 func (h vmImportHooks) getEmptyCr() runtime.Object                             { return &vmimportv1beta1.VMImportConfig{} }
 func (h vmImportHooks) validate() error                                        { return nil }
@@ -51,6 +56,9 @@ func (h vmImportHooks) checkComponentVersion(cr runtime.Object) bool {
 }
 func (h vmImportHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*vmimportv1beta1.VMImportConfig).ObjectMeta
+}
+func (h *vmImportHooks) reset() {
+	h.cache = nil
 }
 
 func (h *vmImportHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
@@ -132,6 +140,8 @@ func (h imsConfigHooks) checkComponentVersion(_ runtime.Object) bool            
 func (h imsConfigHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*corev1.ConfigMap).ObjectMeta
 }
+func (h imsConfigHooks) reset() {}
+
 func (h *imsConfigHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	imsConfig, ok1 := required.(*corev1.ConfigMap)
 	found, ok2 := exists.(*corev1.ConfigMap)

--- a/pkg/controller/operands/vmImport_test.go
+++ b/pkg/controller/operands/vmImport_test.go
@@ -253,6 +253,54 @@ var _ = Describe("VM-Import", func() {
 			Expect(req.Conditions).To(BeEmpty())
 		})
 
+		Context("Cache", func() {
+			cl := commonTestUtils.InitClient([]runtime.Object{})
+			handler := newVmImportHandler(cl, commonTestUtils.GetScheme())
+
+			It("should start with empty cache", func() {
+				Expect(handler.hooks.(*vmImportHooks).cache).To(BeNil())
+			})
+
+			It("should update the cache when reading full CR", func() {
+				cr, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cr).ToNot(BeNil())
+				Expect(handler.hooks.(*vmImportHooks).cache).ToNot(BeNil())
+
+				By("compare pointers to make sure cache is working", func() {
+					Expect(handler.hooks.(*vmImportHooks).cache == cr).Should(BeTrue())
+
+					cdi1, err := handler.hooks.getFullCr(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(cdi1).ToNot(BeNil())
+					Expect(cr == cdi1).Should(BeTrue())
+				})
+			})
+
+			It("should remove the cache on reset", func() {
+				handler.hooks.(*vmImportHooks).reset()
+				Expect(handler.hooks.(*vmImportHooks).cache).To(BeNil())
+			})
+
+			It("check that reset actually cause creating of a new cached instance", func() {
+				crI, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(crI).ToNot(BeNil())
+				Expect(handler.hooks.(*vmImportHooks).cache).ToNot(BeNil())
+
+				handler.hooks.(*vmImportHooks).reset()
+				Expect(handler.hooks.(*vmImportHooks).cache).To(BeNil())
+
+				crII, err := handler.hooks.getFullCr(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(crII).ToNot(BeNil())
+				Expect(handler.hooks.(*vmImportHooks).cache).ToNot(BeNil())
+
+				Expect(crI == crII).To(BeFalse())
+				Expect(handler.hooks.(*vmImportHooks).cache == crI).To(BeFalse())
+				Expect(handler.hooks.(*vmImportHooks).cache == crII).To(BeTrue())
+			})
+		})
 	})
 
 	Context("Manage IMS Config", func() {


### PR DESCRIPTION
Creating a CR became a bit complex and time consuming. Since CRs creation are only function of the HC CR, there is no p[oint to recreate them if the HC CR was not changed.

This PR caches the operand CRs and reuse them. CRs are only re-generated if the HC itself changed.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

