### PR TITLE
WIP: KubeVirt feature gates may only be modified from HC CR

### DIFF
--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -101,6 +101,8 @@ func (be BasicExpected) initClient() *commonTestUtils.HcoTestClient {
 func getBasicDeployment() *BasicExpected {
 
 	res := &BasicExpected{}
+	operandHandler := operands.NewOperandHandler(nil, nil, true, &commonTestUtils.EventEmitterMock{})
+	defaultGw := operandHandler.GetDefaultFeatureGates()
 
 	hco := &hcov1beta1.HyperConverged{
 		ObjectMeta: metav1.ObjectMeta{
@@ -122,6 +124,8 @@ func getBasicDeployment() *BasicExpected {
 			},
 		},
 	}
+
+	applyDefaultFeatureGates(hco, defaultGw)
 	res.hco = hco
 
 	res.pc = operands.NewKubeVirtPriorityClass(hco)

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -39,8 +39,9 @@ type OperandHandler struct {
 	client   client.Client
 	operands []Operand
 	// save for deletions
-	quickStartObjects []*consolev1.ConsoleQuickStart
-	eventEmitter      hcoutil.EventEmitter
+	quickStartObjects   []*consolev1.ConsoleQuickStart
+	eventEmitter        hcoutil.EventEmitter
+	defaultFeatureGates []string
 }
 
 func NewOperandHandler(client client.Client, scheme *runtime.Scheme, isOpenshiftCluster bool, eventEmitter hcoutil.EventEmitter) *OperandHandler {
@@ -64,10 +65,14 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, isOpenshift
 		}...)
 	}
 
+	defaultFgs := make([]string, 0)
+	defaultFgs = append(defaultFgs, getKvDefaultFeatureGates()...)
+
 	return &OperandHandler{
-		client:       client,
-		operands:     operands,
-		eventEmitter: eventEmitter,
+		client:              client,
+		operands:            operands,
+		eventEmitter:        eventEmitter,
+		defaultFeatureGates: defaultFgs,
 	}
 }
 
@@ -200,4 +205,8 @@ func (h OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 	}
 
 	return nil
+}
+
+func (h OperandHandler) GetDefaultFeatureGates() []string {
+	return h.defaultFeatureGates
 }


### PR DESCRIPTION
Before this PR, KubeVirt feature gates are modified by changing the feature-gate list in KubeVirt configmap. This changes were not controlled by HCO, but HCO overrode them to default list during upgrades. In #1034, the `HotplugVolumes` feature gate was added, but it can only be set/disabled/deleted by modifying the new `featureGates` list in HC CR.

This PR makes all the feature gates to behave like `HotplugVolumes`, meaning they all can only be modified in the HC CR, but they are also copied to the config map, since KubeVirt still reads the feature gates from there. But any change in the config map will be reconciled according to the list in HC CR.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt feature gates may only be modified from HC CR

The ConfigMap feature gate is read-only.
```

