### PR TITLE
Change alert name

### DIFF
--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -25,7 +25,7 @@ const (
 	operatorNameEnv      = "OPERATOR_NAME"
 	metricsSuffix        = "-operator-metrics"
 	alertRuleGroup       = "kubevirt.hyperconverged.rules"
-	outOfBandUpdateAlert = "Kubevirt_hyperconverged_out-of-band_CR_modification_detected"
+	outOfBandUpdateAlert = "KubevirtHyperconvergedClusterOperatorCRModification"
 )
 
 type metricsServiceHandler genericOperand


### PR DESCRIPTION
Change alert name to be aligned with Kubevirt alerts

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

