### PR TITLE
Add Two New Feature Gates

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -156,6 +156,12 @@ spec:
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean
+                  withHostModelCPU:
+                    description: Support migration for VMs with host-model CPU mode
+                    type: boolean
+                  withHostPassthroughCPU:
+                    description: Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here
+                    type: boolean
                 type: object
               infra:
                 description: infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs.

--- a/deploy/index-image/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/index-image/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -156,6 +156,12 @@ spec:
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean
+                  withHostModelCPU:
+                    description: Support migration for VMs with host-model CPU mode
+                    type: boolean
+                  withHostPassthroughCPU:
+                    description: Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here
+                    type: boolean
                 type: object
               infra:
                 description: infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs.

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -156,6 +156,12 @@ spec:
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean
+                  withHostModelCPU:
+                    description: Support migration for VMs with host-model CPU mode
+                    type: boolean
+                  withHostPassthroughCPU:
+                    description: Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here
+                    type: boolean
                 type: object
               infra:
                 description: infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs.

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -123,6 +123,18 @@ disables the feature.
 ### hotplugVolumes Feature Gate
 Set the `hotplugVolumes` feature gate in order to allow attaching a data volume to a running VMI.
 
+### withHostModelCPU Feature Gate
+Set the `withHostModelCPU`  feature gate in order to enable support migration for VMs with host-model CPU mode
+
+Additional information: [LibvirtXMLCPUModel](https://wiki.openstack.org/wiki/LibvirtXMLCPUModel)
+
+### withHostPassthroughCPU Feature Gate
+Set the `withHostPassthroughCPU`  feature gate in order to allow migrating a virtual machine with CPU host-passthrough mode. 
+
+Additional information: [LibvirtXMLCPUModel](https://wiki.openstack.org/wiki/LibvirtXMLCPUModel)
+
+**note**: This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here
+
 ### Feature Gates Example
 
 ```yaml
@@ -135,4 +147,6 @@ spec:
   workloads: {}
   featureGates:
     hotplugVolumes: true
+    withHostModelCPU: true
+    withHostPassthroughCPU: true
 ```

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -63,10 +63,27 @@ type HyperConvergedFeatureGates struct {
 	// Allow attaching a data volume to a running VMI
 	// +optional
 	HotplugVolumes *bool `json:"hotplugVolumes,omitempty"`
+
+	// Allow migrating a virtual machine with CPU host-passthrough mode. This should be
+	// enabled only when the Cluster is homogeneous from CPU HW perspective doc here
+	// +optional
+	WithHostPassthroughCPU *bool `json:"withHostPassthroughCPU,omitempty"`
+
+	// Support migration for VMs with host-model CPU mode
+	// +optional
+	WithHostModelCPU *bool `json:"withHostModelCPU,omitempty"`
 }
 
 func (fgs *HyperConvergedFeatureGates) IsHotplugVolumesEnabled() bool {
 	return (fgs != nil) && (fgs.HotplugVolumes != nil) && (*fgs.HotplugVolumes)
+}
+
+func (fgs *HyperConvergedFeatureGates) IsWithHostPassthroughCPUEnabled() bool {
+	return (fgs != nil) && (fgs.WithHostPassthroughCPU != nil) && (*fgs.WithHostPassthroughCPU)
+}
+
+func (fgs *HyperConvergedFeatureGates) IsWithHostModelCPUEnabled() bool {
+	return (fgs != nil) && (fgs.WithHostModelCPU != nil) && (*fgs.WithHostModelCPU)
 }
 
 // HyperConvergedStatus defines the observed state of HyperConverged

--- a/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
@@ -326,5 +326,61 @@ var _ = Describe("HyperconvergedTypes", func() {
 				Expect(fgs.IsHotplugVolumesEnabled()).To(BeTrue())
 			})
 		})
+
+		Context("Test IsWithHostPassthroughCPUEnabled", func() {
+			It("Should return false if HyperConvergedFeatureGates is nil", func() {
+				var fgs *HyperConvergedFeatureGates = nil
+				Expect(fgs.IsWithHostPassthroughCPUEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if WithHostPassthroughCPU does not exist", func() {
+				fgs := &HyperConvergedFeatureGates{}
+				Expect(fgs.IsWithHostPassthroughCPUEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if WithHostPassthroughCPU is false", func() {
+				disabled := false
+				fgs := &HyperConvergedFeatureGates{
+					WithHostPassthroughCPU: &disabled,
+				}
+				Expect(fgs.IsWithHostPassthroughCPUEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if WithHostPassthroughCPU is true", func() {
+				enabled := true
+				fgs := &HyperConvergedFeatureGates{
+					WithHostPassthroughCPU: &enabled,
+				}
+				Expect(fgs.IsWithHostPassthroughCPUEnabled()).To(BeTrue())
+			})
+		})
+
+		Context("Test IsWithHostModelCPUEnabled", func() {
+			It("Should return false if HyperConvergedFeatureGates is nil", func() {
+				var fgs *HyperConvergedFeatureGates = nil
+				Expect(fgs.IsWithHostModelCPUEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if WithHostModelCPU does not exist", func() {
+				fgs := &HyperConvergedFeatureGates{}
+				Expect(fgs.IsWithHostModelCPUEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if WithHostModelCPU is false", func() {
+				disabled := false
+				fgs := &HyperConvergedFeatureGates{
+					WithHostModelCPU: &disabled,
+				}
+				Expect(fgs.IsWithHostModelCPUEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if WithHostModelCPU is true", func() {
+				enabled := true
+				fgs := &HyperConvergedFeatureGates{
+					WithHostModelCPU: &enabled,
+				}
+				Expect(fgs.IsWithHostModelCPUEnabled()).To(BeTrue())
+			})
+		})
 	})
 })

--- a/pkg/apis/hco/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.deepcopy.go
@@ -82,6 +82,16 @@ func (in *HyperConvergedFeatureGates) DeepCopyInto(out *HyperConvergedFeatureGat
 		*out = new(bool)
 		**out = **in
 	}
+	if in.WithHostPassthroughCPU != nil {
+		in, out := &in.WithHostPassthroughCPU, &out.WithHostPassthroughCPU
+		*out = new(bool)
+		**out = **in
+	}
+	if in.WithHostModelCPU != nil {
+		in, out := &in.WithHostModelCPU, &out.WithHostModelCPU
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/hco/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.openapi.go
@@ -94,6 +94,20 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedFeatureGates(ref common.Reference
 							Format:      "",
 						},
 					},
+					"withHostPassthroughCPU": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"withHostModelCPU": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Support migration for VMs with host-model CPU mode",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -25,7 +25,14 @@ const (
 )
 
 const (
+	// todo: remove this when KV configmap will be drop
 	cmFeatureGates = "DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Sidecar,Snapshot"
+)
+
+const (
+	// ToDo: remove these and use KV's virtconfig constants when available
+	kvWithHostPassthroughCPU = "WithHostPassthroughCPU"
+	kvWithHostModelCPU       = "WithHostModelCPU"
 )
 
 // ************  KubeVirt Handler  **************
@@ -247,6 +254,16 @@ func (h *kvConfigHooks) updateCr(req *common.HcoRequest, Client client.Client, e
 					fgChanged = true
 					continue
 				}
+			case kvWithHostPassthroughCPU:
+				if !req.Instance.Spec.FeatureGates.IsWithHostPassthroughCPUEnabled() {
+					fgChanged = true
+					continue
+				}
+			case kvWithHostModelCPU:
+				if !req.Instance.Spec.FeatureGates.IsWithHostModelCPUEnabled() {
+					fgChanged = true
+					continue
+				}
 			}
 			resultFg = append(resultFg, fg)
 		}
@@ -428,10 +445,18 @@ func getKvFeatureGateList(fgs *hcov1beta1.HyperConvergedFeatureGates) []string {
 		return nil
 	}
 
-	res := make([]string, 0, 1)
+	res := make([]string, 0, 3)
 
 	if fgs.IsHotplugVolumesEnabled() {
 		res = append(res, virtconfig.HotplugVolumesGate)
+	}
+
+	if fgs.IsWithHostPassthroughCPUEnabled() {
+		res = append(res, kvWithHostPassthroughCPU)
+	}
+
+	if fgs.IsWithHostModelCPUEnabled() {
+		res = append(res, kvWithHostModelCPU)
 	}
 
 	return res


### PR DESCRIPTION
This PR add support in two new feature gates:
* `withHostModelCPU`: Support migration for VMs with host-model CPU mode
* `withHostPassthroughCPU`: Allow migrating a virtual machine with CPU host-passthrough mode.

This two new feature gate may be added to the HyperConverged CR:
```yaml
apiVersion: hco.kubevirt.io/v1beta1
kind: HyperConverged
metadata:
  name: kubevirt-hyperconverged
spec:
  infra: {}
  workloads: {}
  featureGates:
    hotplugVolumes: true
    withHostPassthroughCPU: true
    withHostModelCPU: true
```

**Release note**:
```release-note
Added two new feature gates:
* `withHostModelCPU`: Support migration for VMs with host-model CPU mode
* `withHostPassthroughCPU`: Allow migrating a virtual machine with CPU host-passthrough mode.
```

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>
