### PR TITLE
Try to fix the goverall issue

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -44,7 +44,7 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI_BRANCH: master
-        run: goveralls -coverprofile=./coverprofiles/cover.coverprofile -service=github
+        run: goveralls -v -coverprofile=./coverprofiles/cover.coverprofile -service=github
 
       - name: Verify the current manifests pass validation
         run: make container-build-operator-courier

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -47,7 +47,7 @@ jobs:
           echo "GITHUB_HEAD_REF = ${GITHUB_HEAD_REF}"
           echo "GITHUB_BASE_REF = ${GITHUB_BASE_REF}"
           echo "GITHUB_REF = ${GITHUB_REF}"
-          GITHUB_REF=${GITHUB_BASE_REF} goveralls -v -coverprofile=./coverprofiles/cover.coverprofile -service=github
+          (GITHUB_REF=${GITHUB_BASE_REF} goveralls -v -coverprofile=./coverprofiles/cover.coverprofile -service=github)
 
       - name: Verify the current manifests pass validation
         run: make container-build-operator-courier

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -44,7 +44,10 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REF: master
-        run: goveralls -v -coverprofile=./coverprofiles/cover.coverprofile -service=github
+        run: |-
+          echo "GITHUB_HEAD_REF = ${GITHUB_HEAD_REF}"
+          echo "GITHUB_BASE_REF = ${GITHUB_HEAD_REF}"
+          goveralls -v -coverprofile=./coverprofiles/cover.coverprofile -service=github
 
       - name: Verify the current manifests pass validation
         run: make container-build-operator-courier

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Send coverage
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CI_BRANCH: master
+          GITHUB_REF: master
         run: goveralls -v -coverprofile=./coverprofiles/cover.coverprofile -service=github
 
       - name: Verify the current manifests pass validation

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -43,11 +43,11 @@ jobs:
       - name: Send coverage
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REF: master
         run: |-
           echo "GITHUB_HEAD_REF = ${GITHUB_HEAD_REF}"
-          echo "GITHUB_BASE_REF = ${GITHUB_HEAD_REF}"
-          goveralls -v -coverprofile=./coverprofiles/cover.coverprofile -service=github
+          echo "GITHUB_BASE_REF = ${GITHUB_BASE_REF}"
+          echo "GITHUB_REF = ${GITHUB_REF}"
+          GITHUB_REF=${GITHUB_BASE_REF} goveralls -v -coverprofile=./coverprofiles/cover.coverprofile -service=github
 
       - name: Verify the current manifests pass validation
         run: make container-build-operator-courier

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: Send coverage
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_BRANCH: master
         run: goveralls -coverprofile=./coverprofiles/cover.coverprofile -service=github
 
       - name: Verify the current manifests pass validation


### PR DESCRIPTION
Cureently, the coverage only shows the coverage for the specific PR, and does not
show increasing or decresing.

Guessing the issue is that github action uses the PR source branch instead the PR target branch, this PR tries to
handle the by setting the `CI_BRANCH` environment variable.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

