### PR TITLE
Set the KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION env var in all Dockerfiles

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,13 +2,14 @@ FROM golang:1.15.2 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .
-RUN make build
+RUN make build-operator build-csv-merger
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 ENV OPERATOR=/usr/local/bin/hyperconverged-cluster-operator \
     CSV_MERGER=/usr/local/bin/csv-merger \
     USER_UID=1001 \
-    USER_NAME=hyperconverged-cluster-operator
+    USER_NAME=hyperconverged-cluster-operator \
+    KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
 RUN mkdir -p ${HOME} && \

--- a/build/Dockerfile.okd
+++ b/build/Dockerfile.okd
@@ -1,5 +1,7 @@
 FROM centos:7
 
+ENV KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
+
 COPY hyperconverged-cluster-operator /usr/bin/
 COPY hack/testFiles/test_quickstart.yaml quickStart/
 

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -7,7 +7,8 @@ RUN make build-webhook
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 ENV WEBHOOK=/usr/local/bin/hyperconverged-cluster-webhook \
     USER_UID=1001 \
-    USER_NAME=hyperconverged-cluster-webhook
+    USER_NAME=hyperconverged-cluster-webhook \
+    KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
 RUN mkdir -p ${HOME} && \

--- a/build/Dockerfile.wh.okd
+++ b/build/Dockerfile.wh.okd
@@ -1,5 +1,7 @@
 FROM centos:7
 
+ENV KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
+
 COPY hyperconverged-cluster-webhook /usr/bin/
 
 ENTRYPOINT /usr/bin/hyperconverged-cluster-webhook

--- a/hack/generate_local_env.py
+++ b/hack/generate_local_env.py
@@ -5,7 +5,7 @@ import re
 from os import environ, linesep
 
 CSV_VERSION = '1.4.0'
-
+KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION = 'v1'
 
 def get_env(line):
     env = line[:line.find('=')]
@@ -30,6 +30,7 @@ def get_env_file(outdir, frmt='txt'):
             var_str = f"{sep.join(vars)}{sep}WATCH_NAMESPACE=kubevirt-hyperconverged{sep}OSDK_FORCE_RUN_MODE=local{sep}OPERATOR_NAMESPACE=kubevirt-hyperconverged"
             var_str = var_str + f"{sep}WEBHOOK_CERT_DIR=./_local/certs"
             var_str = var_str + f"{sep}HCO_KV_IO_VERSION={CSV_VERSION}"
+            var_str = var_str + f"{sep}KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION={KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION}"
             var_str = var_str.replace("CONVERSION_CONTAINER_VERSION=", "CONVERSION_CONTAINER=").replace("VMWARE_CONTAINER_VERSION=", "VMWARE_CONTAINER=")
             out.write(var_str)
 


### PR DESCRIPTION
kubevirt/client-go package supports two APIs and the user (in this case, HCO) need to choose one of them.

This PR sets the KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION environment variable to "v1" in order to select the v1 API.

This envarioment variable also set on `make local`

More details are here: https://github.com/kubevirt/kubevirt/pull/4749

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION is set to "v1" in all HCO Dockerfiles.
```

