### PR TITLE
Fix SonarCloud Issues

### DIFF
--- a/hack/generate_local_env.py
+++ b/hack/generate_local_env.py
@@ -12,9 +12,9 @@ def get_env(line):
     return f'{env}={environ.get(env)}'
 
 
-def get_env_file(outdir, frmt='txt'):
+def get_env_file(outdir, file_format='txt'):
     rgx = re.compile('^[^ #]+=.*$')
-    if frmt == 'env':
+    if file_format == 'env':
         sep = linesep
         ext = '.env'
     else:
@@ -23,11 +23,11 @@ def get_env_file(outdir, frmt='txt'):
 
     with open('hack/config') as infile:
         with open(f'{outdir}/envs{ext}', 'w') as out:
-            vars = [line.strip() for line in infile if rgx.match(line)]
-            vars.append('KUBECONFIG=None')
-            vars.append('WEBHOOK_MODE=false')
-            vars = map(lambda s: get_env(s), vars)
-            var_str = f"{sep.join(vars)}{sep}WATCH_NAMESPACE=kubevirt-hyperconverged{sep}OSDK_FORCE_RUN_MODE=local{sep}OPERATOR_NAMESPACE=kubevirt-hyperconverged"
+            vars_list = [line.strip() for line in infile if rgx.match(line)]
+            vars_list.append('KUBECONFIG=None')
+            vars_list.append('WEBHOOK_MODE=false')
+            vars_list = map(lambda s: get_env(s), vars_list)
+            var_str = f"{sep.join(vars_list)}{sep}WATCH_NAMESPACE=kubevirt-hyperconverged{sep}OSDK_FORCE_RUN_MODE=local{sep}OPERATOR_NAMESPACE=kubevirt-hyperconverged"
             var_str = var_str + f"{sep}WEBHOOK_CERT_DIR=./_local/certs"
             var_str = var_str + f"{sep}HCO_KV_IO_VERSION={CSV_VERSION}"
             var_str = var_str + f"{sep}KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION={KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION}"

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -293,43 +293,46 @@ func main() {
 			replaces = fmt.Sprintf("%v.v%v", operatorName, semver.MustParse(*replacesCsvVersion).String())
 		}
 
+		csvParams := &components.CSVBaseParams{
+			Name:        operatorName,
+			Namespace:   *namespace,
+			DisplayName: *specDisplayName,
+			Description: *specDescription,
+			Image:       *operatorImage,
+			Replaces:    replaces,
+			Version:     version,
+			CrdDisplay:  *crdDisplay,
+		}
+
 		// This is the basic CSV without an InstallStrategy defined
-		csvBase := components.GetCSVBase(
-			operatorName,
-			*namespace,
-			*specDisplayName,
-			*specDescription,
-			*operatorImage,
-			replaces,
-			version,
-			*crdDisplay,
-		)
+		csvBase := components.GetCSVBase(csvParams)
 		csvExtended := ClusterServiceVersionExtended{
 			TypeMeta:   csvBase.TypeMeta,
 			ObjectMeta: csvBase.ObjectMeta,
 			Spec:       ClusterServiceVersionSpecExtended{ClusterServiceVersionSpec: csvBase.Spec},
 			Status:     csvBase.Status}
 
+		params := &components.DeploymentOperatorParams{
+			Namespace:           *namespace,
+			Image:               *operatorImage,
+			WebhookImage:        *webhookImage,
+			ImagePullPolicy:     "IfNotPresent",
+			ConversionContainer: *imsConversionImage,
+			VmwareContainer:     *imsVMWareImage,
+			Smbios:              *smbios,
+			Machinetype:         *machinetype,
+			HcoKvIoVersion:      *hcoKvIoVersion,
+			KubevirtVersion:     *kubevirtVersion,
+			CdiVersion:          *cdiVersion,
+			CnaoVersion:         *cnaoVersion,
+			SspVersion:          *sspVersion,
+			NmoVersion:          *nmoVersion,
+			HppoVersion:         *hppoVersion,
+			VMImportVersion:     *vmImportVersion,
+			Env:                 envVars,
+		}
 		// This is the base deployment + rbac for the HCO CSV
-		installStrategyBase := components.GetInstallStrategyBase(
-			*namespace,
-			*operatorImage,
-			*webhookImage,
-			"IfNotPresent",
-			*imsConversionImage,
-			*imsVMWareImage,
-			*smbios,
-			*machinetype,
-			*hcoKvIoVersion,
-			*kubevirtVersion,
-			*cdiVersion,
-			*cnaoVersion,
-			*sspVersion,
-			*nmoVersion,
-			*hppoVersion,
-			*vmImportVersion,
-			envVars,
-		)
+		installStrategyBase := components.GetInstallStrategyBase(params)
 
 		overwriteDeploymentSpecLabels(installStrategyBase.DeploymentSpecs, hcoutil.AppComponentDeployment)
 

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -141,6 +141,25 @@ func main() {
 		*webhookImage = *operatorImage
 	}
 
+	params := &components.DeploymentOperatorParams{
+		Namespace:           *operatorNamespace,
+		Image:               *operatorImage,
+		ImagePullPolicy:     "IfNotPresent",
+		ConversionContainer: *imsConversionImage,
+		VmwareContainer:     *imsVMWareImage,
+		Smbios:              *smbios,
+		Machinetype:         *machinetype,
+		HcoKvIoVersion:      *hcoKvIoVersion,
+		KubevirtVersion:     *kubevirtVersion,
+		CdiVersion:          *cdiVersion,
+		CnaoVersion:         *cnaoVersion,
+		SspVersion:          *sspVersion,
+		NmoVersion:          *nmoVersion,
+		HppoVersion:         *hppoVersion,
+		VMImportVersion:     *vmImportVersion,
+		Env:                 []corev1.EnvVar{},
+	}
+
 	// these represent the bare necessities for the HCO manifests, that is,
 	// enough to deploy the HCO itself.
 	// 1 deployment
@@ -152,24 +171,7 @@ func main() {
 	// service accounts are represented as a map to prevent us from generating the
 	// same service account multiple times.
 	deployments := []appsv1.Deployment{
-		components.GetDeploymentOperator(
-			*operatorNamespace,
-			*operatorImage,
-			"IfNotPresent",
-			*imsConversionImage,
-			*imsVMWareImage,
-			*smbios,
-			*machinetype,
-			*hcoKvIoVersion,
-			*kubevirtVersion,
-			*cdiVersion,
-			*cnaoVersion,
-			*sspVersion,
-			*nmoVersion,
-			*hppoVersion,
-			*vmImportVersion,
-			[]corev1.EnvVar{},
-		),
+		components.GetDeploymentOperator(params),
 		components.GetDeploymentWebhook(
 			*operatorNamespace,
 			*webhookImage,


### PR DESCRIPTION
Fix 5 major sonarCloud issue:

1. In `hack/generate_local_env.py`: Rename this variable; it shadows a builtin.
2. In `pkg/components/components.go`; func GetDeploymentOperator: This function has 16 parameters, which is greater than the 7 authorized.
3. In `pkg/components/components.go`; func GetDeploymentSpecOperator: This function has 16 parameters, which is greater than the 7 authorized.
4. In `pkg/components/components.go`; func GetInstallStrategyBase: This function has 17 parameters, which is greater than the 7 authorized.
5. In `pkg/components/components.go`; func GetCSVBase: This function has 8 parameters, which is greater than the 7 authorized.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

