### PR TITLE
Fix Critical SonarCloud Issues

### DIFF
--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -21,6 +21,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const (
+	cdiRoleName = "hco.kubevirt.io:config-reader"
+)
+
 type cdiHandler genericOperand
 
 func newCdiHandler(Client client.Client, Scheme *runtime.Scheme) *cdiHandler {
@@ -240,7 +244,7 @@ func (h *cdiHooks) ensureKubeVirtStorageRoleBinding(req *common.HcoRequest) erro
 func NewKubeVirtStorageRoleForCR(cr *hcov1beta1.HyperConverged, namespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hco.kubevirt.io:config-reader",
+			Name:      cdiRoleName,
 			Labels:    getLabels(cr, hcoutil.AppComponentStorage),
 			Namespace: namespace,
 		},
@@ -258,14 +262,14 @@ func NewKubeVirtStorageRoleForCR(cr *hcov1beta1.HyperConverged, namespace string
 func NewKubeVirtStorageRoleBindingForCR(cr *hcov1beta1.HyperConverged, namespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hco.kubevirt.io:config-reader",
+			Name:      cdiRoleName,
 			Labels:    getLabels(cr, hcoutil.AppComponentStorage),
 			Namespace: namespace,
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
-			Name:     "hco.kubevirt.io:config-reader",
+			Name:     cdiRoleName,
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -305,7 +309,7 @@ func (h storageConfigHooks) checkComponentVersion(_ runtime.Object) bool        
 func (h storageConfigHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*corev1.ConfigMap).ObjectMeta
 }
-func (h storageConfigHooks) reset() {}
+func (h storageConfigHooks) reset() { /* no implementation */ }
 func (h *storageConfigHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	storageConfig, ok1 := required.(*corev1.ConfigMap)
 	found, ok2 := exists.(*corev1.ConfigMap)

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -55,7 +55,7 @@ func (h metricsServiceHooks) checkComponentVersion(_ runtime.Object) bool       
 func (h metricsServiceHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*corev1.Service).ObjectMeta
 }
-func (h metricsServiceHooks) reset() {}
+func (h metricsServiceHooks) reset( /* No implementation */ ) {}
 
 func (h *metricsServiceHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	service, ok1 := required.(*corev1.Service)
@@ -143,7 +143,7 @@ func (h metricsServiceMonitorHooks) checkComponentVersion(_ runtime.Object) bool
 func (h metricsServiceMonitorHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*monitoringv1.ServiceMonitor).ObjectMeta
 }
-func (h metricsServiceMonitorHooks) reset() {}
+func (h metricsServiceMonitorHooks) reset( /* No implementation */ ) {}
 
 func (h *metricsServiceMonitorHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	monitor, ok1 := required.(*monitoringv1.ServiceMonitor)
@@ -216,7 +216,7 @@ func (h prometheusRuleHooks) checkComponentVersion(_ runtime.Object) bool       
 func (h prometheusRuleHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*monitoringv1.PrometheusRule).ObjectMeta
 }
-func (h prometheusRuleHooks) reset() {}
+func (h prometheusRuleHooks) reset( /* No implementation */ ) {}
 
 func (h *prometheusRuleHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	rule, ok1 := required.(*monitoringv1.PrometheusRule)


### PR DESCRIPTION
Fix some critical sonarCloud issues:

1. In `cmd/hyperconverged-cluster-operator/main.go`: Refactor this method to reduce its Cognitive Complexity from 22 to the 15 allowed.
2. In `cmd/hyperconverged-cluster-webhook/main.go`: Refactor this method to reduce its Cognitive Complexity from 21 to the 15 allowed.
3. In `pkg/apis/hco/v1beta1/hyperconverged_webhook.go`; SetupWebhookWithManager: Refactor this method to reduce its Cognitive Complexity from 16 to the 15 allowed.
4. In `pkg/controller/operands/cdi.go` Define a constant instead of duplicating this literal "hco.kubevirt.io:config-reader" 3 times.
5. In `pkg/controller/operands/cdi.go`; reset(): Add a nested comment explaining why this function is empty or complete the implementation.
6. In `pkg/controller/operands/monitoring.go`: Add a nested comment explaining why this function is empty or complete the implementation X three times

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

