### PR TITLE
Try to fix the covaeralls issue

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -4,6 +4,8 @@ name: Sanity Checks
 
 # Controls when the action will run.
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -35,15 +35,9 @@ jobs:
       - name: Unit tests
         run: make test
 
-      - name: Install goveralls
-        env:
-          GO111MODULE: off
-        run: go get github.com/mattn/goveralls
-
-      - name: Send coverage
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: goveralls -coverprofile=./coverprofiles/cover.coverprofile -service=github
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: coverprofiles/cover.coverprofile
 
       - name: Verify the current manifests pass validation
         run: make container-build-operator-courier

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -5,7 +5,7 @@ name: Sanity Checks
 # Controls when the action will run.
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -14,7 +14,7 @@ if [ "${JOB_TYPE}" == "travis" ]; then
     go mod vendor
     PACKAGE_PATH="pkg/"
     mkdir -p coverprofiles
-    KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1 ginkgo -r -cover -outputdir=./coverprofiles -coverprofile=cover.coverprofile ${PACKAGE_PATH}
+    KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1 ginkgo -r -covermode atomic -outputdir=./coverprofiles -coverprofile=cover.coverprofile ${PACKAGE_PATH}
 else
     test_path="tests/func-tests"
     (cd $test_path; GOFLAGS= go get github.com/onsi/ginkgo/ginkgo)


### PR DESCRIPTION
Since HCO moved to run sanity in github action, the coveralls report is wrong - relatives to
the current branch insted of to the master branch, so the coverage check does not show increasing
or decreasing.

This PR moves to use the shogo82148/actions-goveralls@v1 action in order to solve this issue.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

