### PR TITLE
Reduce SonarCloud Number of Warnings

### DIFF
--- a/pkg/controller/operands/quickStart.go
+++ b/pkg/controller/operands/quickStart.go
@@ -78,7 +78,7 @@ func (h qsHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*consolev1.ConsoleQuickStart).ObjectMeta
 }
 
-func (h qsHooks) reset() {}
+func (h qsHooks) reset() { /* no implementation */ }
 
 func (h qsHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
 	found, ok := exists.(*consolev1.ConsoleQuickStart)

--- a/pkg/controller/operands/vmImport.go
+++ b/pkg/controller/operands/vmImport.go
@@ -140,7 +140,7 @@ func (h imsConfigHooks) checkComponentVersion(_ runtime.Object) bool            
 func (h imsConfigHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*corev1.ConfigMap).ObjectMeta
 }
-func (h imsConfigHooks) reset() {}
+func (h imsConfigHooks) reset() { /* no implementation */ }
 
 func (h *imsConfigHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	imsConfig, ok1 := required.(*corev1.ConfigMap)

--- a/tests/func-tests/utils.go
+++ b/tests/func-tests/utils.go
@@ -2,19 +2,9 @@ package tests
 
 import (
 	"flag"
-	"fmt"
-	"os"
-	"strconv"
-	"strings"
-	"time"
-
-	"github.com/onsi/ginkgo"
-	k8sv1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/kubevirt/pkg/util/cluster"
 	"kubevirt.io/kubevirt/tests"
+	"os"
 )
 
 const (
@@ -34,79 +24,6 @@ func GetJobTypeEnvVar() string {
 
 func FlagParse() {
 	flag.Parse()
-}
-
-func ForwardPortsFromService(service *k8sv1.Service, ports []string, stop chan struct{}, readyTimeout time.Duration) error {
-	selector := labels.FormatLabels(service.Spec.Selector)
-
-	targetPorts := []string{}
-	for _, p := range ports {
-		split := strings.Split(p, ":")
-		if len(split) != 2 {
-			return fmt.Errorf("invalid port mapping for %s", p)
-		}
-		found := false
-		for _, servicePort := range service.Spec.Ports {
-			if split[1] == strconv.Itoa(int(servicePort.Port)) {
-				targetPorts = append(targetPorts, split[0]+":"+servicePort.TargetPort.String())
-				found = true
-				break
-			}
-		}
-		if found == false {
-			return fmt.Errorf("Port %s not found on service", split[1])
-		}
-	}
-	cli, err := kubecli.GetKubevirtClient()
-	if err != nil {
-		return err
-	}
-
-	pods, err := cli.CoreV1().Pods(service.Namespace).List(v1.ListOptions{
-		LabelSelector: selector,
-	})
-	if err != nil {
-		return err
-	}
-
-	var targetPod *k8sv1.Pod
-ForLoop:
-	for _, pod := range pods.Items {
-		if pod.Status.Phase != k8sv1.PodRunning {
-			continue
-		}
-		for _, conditions := range pod.Status.Conditions {
-			if conditions.Type == k8sv1.PodReady && conditions.Status == k8sv1.ConditionTrue {
-				targetPod = &pod
-				break ForLoop
-			}
-		}
-	}
-
-	if targetPod == nil {
-		return fmt.Errorf("No ready pod listening on the service.")
-	}
-
-	return tests.ForwardPorts(targetPod, targetPorts, stop, readyTimeout)
-}
-
-func IsOpenShift() bool {
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
-
-	isOpenShift, err := cluster.IsOnOpenShift(virtClient)
-	if err != nil {
-		fmt.Printf("ERROR: Can not determine cluster type %v\n", err)
-		panic(err)
-	}
-
-	return isOpenShift
-}
-
-func SkipIfNotOpenShift(message string) {
-	if !IsOpenShift() {
-		ginkgo.Skip("Not running on openshift: " + message)
-	}
 }
 
 func BeforeEach() {


### PR DESCRIPTION
1. Remove unused methods from `tests/func-tests/utils.go`
2. Add a comment for the `reset() {}` with no implementation (these methods are only to statisfy an interface).
3. Refactor func cnaHooks.updateCr() to reduce size and code branches, by splitting it to several smaller functions.
3. Refactor func kvConfigHooks.updateCr() to reduce size and code branches, by splitting it to several smaller functions.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

