### PR TITLE
add default for HypervStrictCheck featureGate

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -47,6 +47,7 @@ spec:
             properties:
               featureGates:
                 default:
+                  hypervStrictCheck: true
                   withHostModelCPU: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
@@ -55,6 +56,11 @@ spec:
                 properties:
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
+                    type: boolean
+                  hypervStrictCheck:
+                    default: true
+                    description: Enable HyperV strict host checking for HyperV enlightenments
+                      Defaults to true, even when HyperConvergedFeatureGates is empty
                     type: boolean
                   sriovLiveMigration:
                     description: Allow migrating a virtual machine with SRIOV interfaces.

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -47,6 +47,7 @@ spec:
             properties:
               featureGates:
                 default:
+                  hypervStrictCheck: true
                   withHostModelCPU: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
@@ -55,6 +56,11 @@ spec:
                 properties:
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
+                    type: boolean
+                  hypervStrictCheck:
+                    default: true
+                    description: Enable HyperV strict host checking for HyperV enlightenments
+                      Defaults to true, even when HyperConvergedFeatureGates is empty
                     type: boolean
                   sriovLiveMigration:
                     description: Allow migrating a virtual machine with SRIOV interfaces.

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -47,6 +47,7 @@ spec:
             properties:
               featureGates:
                 default:
+                  hypervStrictCheck: true
                   withHostModelCPU: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
@@ -55,6 +56,11 @@ spec:
                 properties:
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
+                    type: boolean
+                  hypervStrictCheck:
+                    default: true
+                    description: Enable HyperV strict host checking for HyperV enlightenments
+                      Defaults to true, even when HyperConvergedFeatureGates is empty
                     type: boolean
                   sriovLiveMigration:
                     description: Allow migrating a virtual machine with SRIOV interfaces.

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -135,6 +135,13 @@ Additional information: [LibvirtXMLCPUModel](https://wiki.openstack.org/wiki/Lib
 
 **note**: This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here
 
+### hypervStrictCheck Feature Gate
+Set the `hypervStrictCheck` feature gate in order to enable [HyperV enlightenments](https://kubevirt.io/user-guide/#/creation/guest-operating-system-information?id=hyperv-optimizations) for Kubevirt.
+
+**Default: `true`**
+
+To override the default, specify the featureGate in the HCO configuration.
+
 ### Feature Gates Example
 
 ```yaml

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -40,7 +40,7 @@ type HyperConvergedSpec struct {
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
 	// +optional
 	// +TODO: Always keep the default FeatureGates in sync with the default field values in HyperConvergedFeatureGates //NOSONAR
-	// +kubebuilder:default={withHostModelCPU: true, withHostPassthroughCPU: false}
+	// +kubebuilder:default={withHostModelCPU: true, withHostPassthroughCPU: false, hypervStrictCheck: true}
 	FeatureGates *HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
 	// operator version
@@ -58,6 +58,7 @@ type HyperConvergedConfig struct {
 // by default yet.
 // +optional
 // +k8s:openapi-gen=true
+// +kubebuilder:default={}
 type HyperConvergedFeatureGates struct {
 	// Allow migrating a virtual machine with SRIOV interfaces.
 	// When enabled virt-launcher pods of virtual machines with SRIOV
@@ -80,6 +81,12 @@ type HyperConvergedFeatureGates struct {
 	// +optional
 	// +kubebuilder:default=true
 	WithHostModelCPU *bool `json:"withHostModelCPU,omitempty"`
+
+	// Enable HyperV strict host checking for HyperV enlightenments
+	// Defaults to true, even when HyperConvergedFeatureGates is empty
+	// +optional
+	// +kubebuilder:default=true
+	HypervStrictCheck *bool `json:"hypervStrictCheck,omitempty"`
 }
 
 func (fgs *HyperConvergedFeatureGates) IsHotplugVolumesEnabled() bool {
@@ -96,6 +103,10 @@ func (fgs *HyperConvergedFeatureGates) IsWithHostPassthroughCPUEnabled() bool {
 
 func (fgs *HyperConvergedFeatureGates) IsWithHostModelCPUEnabled() bool {
 	return (fgs != nil) && (fgs.WithHostModelCPU != nil) && (*fgs.WithHostModelCPU)
+}
+
+func (fgs *HyperConvergedFeatureGates) IsHypervStrictCheckEnabled() bool {
+	return (fgs != nil) && (fgs.HypervStrictCheck != nil) && (*fgs.HypervStrictCheck)
 }
 
 // HyperConvergedStatus defines the observed state of HyperConverged

--- a/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
@@ -1,13 +1,14 @@
 package v1beta1
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
-	"testing"
 )
 
 const (
@@ -410,6 +411,34 @@ var _ = Describe("HyperconvergedTypes", func() {
 					WithHostModelCPU: &enabled,
 				}
 				Expect(fgs.IsWithHostModelCPUEnabled()).To(BeTrue())
+			})
+		})
+
+		Context("Test IsHypervStrictCheckEnabled", func() {
+			It("Should return false if HyperConvergedFeatureGates is nil", func() {
+				var fgs *HyperConvergedFeatureGates = nil
+				Expect(fgs.IsHypervStrictCheckEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsHypervStrictCheckEnabled does not exist", func() {
+				fgs := &HyperConvergedFeatureGates{}
+				Expect(fgs.IsHypervStrictCheckEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsHypervStrictCheckEnabled is false", func() {
+				disabled := false
+				fgs := &HyperConvergedFeatureGates{
+					HypervStrictCheck: &disabled,
+				}
+				Expect(fgs.IsHypervStrictCheckEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsHypervStrictCheckEnabled is true", func() {
+				enabled := true
+				fgs := &HyperConvergedFeatureGates{
+					HypervStrictCheck: &enabled,
+				}
+				Expect(fgs.IsHypervStrictCheckEnabled()).To(BeTrue())
 			})
 		})
 	})

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -295,38 +295,37 @@ func (h *kvConfigHooks) addEnabledFeatureGates(req *common.HcoRequest, foundFgSp
 
 func filterOutDisabledFeatureGates(req *common.HcoRequest, foundFgSplit []string, resultFg []string) (bool, []string) {
 	fgChanged := false
+	featureGateChecks := getFeatureGateChecks(req.Instance.Spec.FeatureGates)
 	for _, fg := range foundFgSplit {
-		// Remove if not in HC CR
-		switch fg {
-		case HotplugVolumesGate:
-			if !req.Instance.Spec.FeatureGates.IsHotplugVolumesEnabled() {
-				fgChanged = true
-				continue
-			}
-		case kvWithHostPassthroughCPU:
-			if !req.Instance.Spec.FeatureGates.IsWithHostPassthroughCPUEnabled() {
-				fgChanged = true
-				continue
-			}
-		case kvWithHostModelCPU:
-			if !req.Instance.Spec.FeatureGates.IsWithHostModelCPUEnabled() {
-				fgChanged = true
-				continue
-			}
-		case SRIOVLiveMigrationGate:
-			if !req.Instance.Spec.FeatureGates.IsSRIOVLiveMigrationEnabled() {
-				fgChanged = true
-				continue
-			}
-		case kvHypervStrictCheck:
-			if !req.Instance.Spec.FeatureGates.IsHypervStrictCheckEnabled() {
-				fgChanged = true
-				continue
-			}
+		if isFeatureGateMissingFrom(featureGateChecks, fg) {
+			fgChanged = true
+			continue
 		}
 		resultFg = append(resultFg, fg)
 	}
 	return fgChanged, resultFg
+}
+
+func isFeatureGateMissingFrom(checks featureGateChecks, featureGate string) bool {
+	if check, isKnown := checks[featureGate]; isKnown {
+		return !check()
+	}
+	return true
+}
+
+type featureGateChecks map[string]func() bool
+
+func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) featureGateChecks {
+	if featureGates == nil {
+		return nil
+	}
+	return map[string]func() bool{
+		HotplugVolumesGate:       featureGates.IsHotplugVolumesEnabled,
+		kvWithHostPassthroughCPU: featureGates.IsWithHostPassthroughCPUEnabled,
+		kvWithHostModelCPU:       featureGates.IsWithHostModelCPUEnabled,
+		SRIOVLiveMigrationGate:   featureGates.IsSRIOVLiveMigrationEnabled,
+		kvHypervStrictCheck:      featureGates.IsHypervStrictCheckEnabled,
+	}
 }
 
 func (h *kvConfigHooks) forceDefaultKeys(req *common.HcoRequest, found *corev1.ConfigMap, kubevirtConfig *corev1.ConfigMap) bool {
@@ -512,30 +511,11 @@ func NewKubeVirtConfigForCR(cr *hcov1beta1.HyperConverged, namespace string) *co
 
 // get list of feature gates from a specific operand list
 func getKvFeatureGateList(fgs *hcov1beta1.HyperConvergedFeatureGates) []string {
-	if fgs == nil {
-		return nil
-	}
-
 	res := make([]string, 0, 3)
-
-	if fgs.IsHotplugVolumesEnabled() {
-		res = append(res, HotplugVolumesGate)
-	}
-
-	if fgs.IsWithHostPassthroughCPUEnabled() {
-		res = append(res, kvWithHostPassthroughCPU)
-	}
-
-	if fgs.IsWithHostModelCPUEnabled() {
-		res = append(res, kvWithHostModelCPU)
-	}
-
-	if fgs.IsSRIOVLiveMigrationEnabled() {
-		res = append(res, SRIOVLiveMigrationGate)
-	}
-
-	if fgs.IsHypervStrictCheckEnabled() {
-		res = append(res, kvHypervStrictCheck)
+	for gate, check := range getFeatureGateChecks(fgs) {
+		if check() {
+			res = append(res, gate)
+		}
 	}
 
 	return res

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -310,15 +310,12 @@ func isFeatureGateMissingFrom(checks featureGateChecks, featureGate string) bool
 	if check, isKnown := checks[featureGate]; isKnown {
 		return !check()
 	}
-	return true
+	return false
 }
 
 type featureGateChecks map[string]func() bool
 
 func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) featureGateChecks {
-	if featureGates == nil {
-		return nil
-	}
 	return map[string]func() bool{
 		HotplugVolumesGate:       featureGates.IsHotplugVolumesEnabled,
 		kvWithHostPassthroughCPU: featureGates.IsWithHostPassthroughCPUEnabled,
@@ -511,8 +508,9 @@ func NewKubeVirtConfigForCR(cr *hcov1beta1.HyperConverged, namespace string) *co
 
 // get list of feature gates from a specific operand list
 func getKvFeatureGateList(fgs *hcov1beta1.HyperConvergedFeatureGates) []string {
-	res := make([]string, 0, 3)
-	for gate, check := range getFeatureGateChecks(fgs) {
+	checks := getFeatureGateChecks(fgs)
+	res := make([]string, 0, len(checks))
+	for gate, check := range checks {
 		if check() {
 			res = append(res, gate)
 		}

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -45,6 +45,7 @@ const (
 	// ToDo: remove these and use KV's virtconfig constants when available
 	kvWithHostPassthroughCPU = "WithHostPassthroughCPU"
 	kvWithHostModelCPU       = "WithHostModelCPU"
+	kvHypervStrictCheck      = "HypervStrictCheck"
 )
 
 // ************  KubeVirt Handler  **************
@@ -317,6 +318,11 @@ func filterOutDisabledFeatureGates(req *common.HcoRequest, foundFgSplit []string
 				fgChanged = true
 				continue
 			}
+		case kvHypervStrictCheck:
+			if !req.Instance.Spec.FeatureGates.IsHypervStrictCheckEnabled() {
+				fgChanged = true
+				continue
+			}
 		}
 		resultFg = append(resultFg, fg)
 	}
@@ -526,6 +532,10 @@ func getKvFeatureGateList(fgs *hcov1beta1.HyperConvergedFeatureGates) []string {
 
 	if fgs.IsSRIOVLiveMigrationEnabled() {
 		res = append(res, SRIOVLiveMigrationGate)
+	}
+
+	if fgs.IsHypervStrictCheckEnabled() {
+		res = append(res, kvHypervStrictCheck)
 	}
 
 	return res

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -896,6 +896,7 @@ var _ = Describe("KubeVirt Operand", func() {
 						HotplugVolumes:         &disabled,
 						WithHostPassthroughCPU: &disabled,
 						WithHostModelCPU:       &disabled,
+						HypervStrictCheck:      &disabled,
 					}
 
 					existingResource, err := NewKubeVirt(hco)
@@ -1550,16 +1551,28 @@ var _ = Describe("KubeVirt Operand", func() {
 			Expect(fgList[0]).Should(Equal(SRIOVLiveMigrationGate))
 		})
 
+		It("Should create a slice if HypervStrictCheck gate is enabled", func() {
+			enabled := true
+			fgs := &hcov1beta1.HyperConvergedFeatureGates{
+				HypervStrictCheck: &enabled,
+			}
+			fgList := getKvFeatureGateList(fgs)
+			Expect(fgList).To(HaveLen(1))
+			Expect(fgList[0]).Should(Equal(kvHypervStrictCheck))
+		})
+
 		It("Should create a slice when all gates are enabled", func() {
 			enabled := true
 			fgs := &hcov1beta1.HyperConvergedFeatureGates{
 				HotplugVolumes:         &enabled,
 				WithHostPassthroughCPU: &enabled,
 				WithHostModelCPU:       &enabled,
+				HypervStrictCheck:      &enabled,
+				SRIOVLiveMigration:     &enabled,
 			}
 			fgList := getKvFeatureGateList(fgs)
-			Expect(fgList).To(HaveLen(3))
-			Expect(fgList).Should(ContainElements(HotplugVolumesGate, kvWithHostPassthroughCPU, kvWithHostModelCPU))
+			Expect(fgList).To(HaveLen(5))
+			Expect(fgList).Should(ContainElements(HotplugVolumesGate, kvWithHostPassthroughCPU, kvWithHostModelCPU, kvHypervStrictCheck, SRIOVLiveMigrationGate))
 		})
 
 		It("Should create a slice when part of gates are enabled", func() {
@@ -1569,11 +1582,13 @@ var _ = Describe("KubeVirt Operand", func() {
 				HotplugVolumes:         &enabled,
 				WithHostPassthroughCPU: &disabled,
 				WithHostModelCPU:       &enabled,
+				HypervStrictCheck:      &disabled,
+				SRIOVLiveMigration:     &enabled,
 			}
 			fgList := getKvFeatureGateList(fgs)
-			Expect(fgList).To(HaveLen(2))
-			Expect(fgList).Should(ContainElements(HotplugVolumesGate, kvWithHostModelCPU))
-			Expect(fgList).ShouldNot(ContainElements(kvWithHostPassthroughCPU))
+			Expect(fgList).To(HaveLen(3))
+			Expect(fgList).Should(ContainElements(HotplugVolumesGate, kvWithHostModelCPU, SRIOVLiveMigrationGate))
+			Expect(fgList).ShouldNot(ContainElements(kvWithHostPassthroughCPU, kvHypervStrictCheck))
 		})
 	})
 })


### PR DESCRIPTION
I'm not sure if this is the right way to do this. This will set the `HypervStrictCheck` FeatureGate to true if it (or any feature gates at all) are not provided.
It can be set to false by specifying it in the HCO config.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The kubevirt `HypervStrictCheck` FeatureGate will default to true.
```

/cc @ksimon1 @omeryahud 