### PR TITLE
Reduce number of sonarCloud warnings

### DIFF
--- a/pkg/controller/operands/ensure_result.go
+++ b/pkg/controller/operands/ensure_result.go
@@ -37,8 +37,8 @@ func (r *EnsureResult) SetUpdated() *EnsureResult {
 	return r
 }
 
-func (r *EnsureResult) SetOverwritten() *EnsureResult {
-	r.Overwritten = true
+func (r *EnsureResult) SetOverwritten(overwritten bool) *EnsureResult {
+	r.Overwritten = overwritten
 	return r
 }
 

--- a/pkg/controller/operands/ensure_result_test.go
+++ b/pkg/controller/operands/ensure_result_test.go
@@ -83,7 +83,7 @@ var _ = Describe("HyperConverged Ensure Result", func() {
 
 		It("Should set overwritten", func() {
 			er := NewEnsureResult(kv)
-			er.SetOverwritten()
+			er.SetOverwritten(true)
 			Expect(er.Name).To(BeEmpty())
 			Expect(er.UpgradeDone).To(BeFalse())
 			Expect(er.Updated).To(BeFalse())
@@ -108,7 +108,7 @@ var _ = Describe("HyperConverged Ensure Result", func() {
 			er := NewEnsureResult(kv).
 				Error(errors.New("a test error")).
 				SetUpdated().
-				SetOverwritten().
+				SetOverwritten(true).
 				SetCreated().
 				SetUpgradeDone(true).
 				SetName("a name")

--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -83,14 +83,8 @@ func (h *genericOperand) ensure(req *common.HcoRequest) *EnsureResult {
 		return res.Error(err)
 	}
 
-	ref, ok := cr.(metav1.Object)
-	if h.setControllerReference {
-		if !ok {
-			return res.Error(fmt.Errorf("can't convert %T to k8s.io/apimachinery/pkg/apis/meta/v1.Object", cr))
-		}
-		if err := controllerutil.SetControllerReference(req.Instance, ref, h.Scheme); err != nil {
-			return res.Error(err)
-		}
+	if err := h.doSetControllerReference(req, cr); err != nil {
+		return res.Error(err)
 	}
 
 	key := client.ObjectKeyFromObject(cr)
@@ -98,69 +92,102 @@ func (h *genericOperand) ensure(req *common.HcoRequest) *EnsureResult {
 	found := h.hooks.getEmptyCr()
 	err = h.Client.Get(req.Ctx, key, found)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			req.Logger.Info("Creating " + h.crType)
-			err = h.Client.Create(req.Ctx, cr)
-			if err != nil {
-				req.Logger.Error(err, "Failed to create object for "+h.crType)
-				return res.Error(err)
-			}
-			return res.SetCreated().SetName(key.Name)
-		}
-		return res.Error(err)
+		return h.createNewCr(req, err, cr, res)
 	}
 
+	return h.handleExistingCr(req, key, found, cr, res)
+}
+
+func (h *genericOperand) handleExistingCr(req *common.HcoRequest, key client.ObjectKey, found client.Object, cr client.Object, res *EnsureResult) *EnsureResult {
 	req.Logger.Info(h.crType+" already exists", h.crType+".Namespace", key.Namespace, h.crType+".Name", key.Name)
 
-	if err = h.hooks.postFound(req, found); err != nil {
+	if err := h.hooks.postFound(req, found); err != nil {
 		return res.Error(err)
 	}
 
-	if h.removeExistingOwner {
-		existingOwners := h.hooks.getObjectMeta(found).GetOwnerReferences()
-
-		if len(existingOwners) > 0 {
-			req.Logger.Info(h.crType + " has owners, removing...")
-			err = h.Client.Update(req.Ctx, found)
-			if err != nil {
-				req.Logger.Error(err, fmt.Sprintf("Failed to remove %s's previous owners", h.crType))
-			}
-		}
-
-		if err == nil {
-			// do that only once
-			h.removeExistingOwner = false
-		}
-	}
+	h.doRemoveExistingOwners(req, found)
 
 	updated, overwritten, err := h.hooks.updateCr(req, h.Client, found, cr)
 	if err != nil {
 		return res.Error(err)
 	}
+
 	if updated {
-		res.SetUpdated()
-		if overwritten {
-			res.SetOverwritten()
-		}
-		return res
+		return res.SetUpdated().SetOverwritten(overwritten)
 	}
 
-	// Add it to the list of RelatedObjects if found
-	objectRef, err := reference.GetReference(h.Scheme, found)
-	if err != nil {
+	if err = h.addCrToTheRelatedObjectList(req, err, found); err != nil {
 		return res.Error(err)
 	}
-	objectreferencesv1.SetObjectReference(&req.Instance.Status.RelatedObjects, *objectRef)
 
-	if h.isCr {
-		// Handle KubeVirt resource conditions
-		isReady := handleComponentConditions(req, h.crType, h.hooks.getConditions(found))
-
-		upgradeDone := req.UpgradeMode && isReady && h.hooks.checkComponentVersion(found)
-		return res.SetUpgradeDone(upgradeDone)
+	if h.isCr { // for operands, perform some more checks
+		return h.completeEnsureOperands(req, found, res)
 	}
 	// For resources that are not CRs, such as priority classes or a config map, there is no new version to upgrade
 	return res.SetUpgradeDone(req.ComponentUpgradeInProgress)
+}
+
+func (h *genericOperand) completeEnsureOperands(req *common.HcoRequest, found client.Object, res *EnsureResult) *EnsureResult {
+	// Handle KubeVirt resource conditions
+	isReady := handleComponentConditions(req, h.crType, h.hooks.getConditions(found))
+
+	upgradeDone := req.UpgradeMode && isReady && h.hooks.checkComponentVersion(found)
+	return res.SetUpgradeDone(upgradeDone)
+}
+
+func (h *genericOperand) addCrToTheRelatedObjectList(req *common.HcoRequest, err error, found client.Object) error {
+	// Add it to the list of RelatedObjects if found
+	objectRef, err := reference.GetReference(h.Scheme, found)
+	if err != nil {
+		return err
+	}
+
+	objectreferencesv1.SetObjectReference(&req.Instance.Status.RelatedObjects, *objectRef)
+	return nil
+}
+
+func (h *genericOperand) doSetControllerReference(req *common.HcoRequest, cr client.Object) error {
+	if h.setControllerReference {
+		ref, ok := cr.(metav1.Object)
+		if !ok {
+			return fmt.Errorf("can't convert %T to k8s.io/apimachinery/pkg/apis/meta/v1.Object", cr)
+		}
+		if err := controllerutil.SetControllerReference(req.Instance, ref, h.Scheme); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *genericOperand) doRemoveExistingOwners(req *common.HcoRequest, found client.Object) {
+	if h.removeExistingOwner {
+		existingOwners := h.hooks.getObjectMeta(found).GetOwnerReferences()
+
+		if len(existingOwners) > 0 {
+			req.Logger.Info(h.crType + " has owners, removing...")
+			err := h.Client.Update(req.Ctx, found)
+			if err != nil {
+				req.Logger.Error(err, fmt.Sprintf("Failed to remove %s's previous owners", h.crType))
+				return
+			}
+		}
+
+		// do that only once
+		h.removeExistingOwner = false
+	}
+}
+
+func (h *genericOperand) createNewCr(req *common.HcoRequest, err error, cr client.Object, res *EnsureResult) *EnsureResult {
+	if apierrors.IsNotFound(err) {
+		req.Logger.Info("Creating " + h.crType)
+		err = h.Client.Create(req.Ctx, cr)
+		if err != nil {
+			req.Logger.Error(err, "Failed to create object for "+h.crType)
+			return res.Error(err)
+		}
+		return res.SetCreated()
+	}
+	return res.Error(err)
 }
 
 func (h *genericOperand) reset() {
@@ -169,85 +196,110 @@ func (h *genericOperand) reset() {
 
 // handleComponentConditions - read and process a sub-component conditions.
 // returns true if the the conditions indicates "ready" state and false if not.
-func handleComponentConditions(req *common.HcoRequest, component string, componentConds []conditionsv1.Condition) (isReady bool) {
-	isReady = true
+func handleComponentConditions(req *common.HcoRequest, component string, componentConds []conditionsv1.Condition) bool {
 	if len(componentConds) == 0 {
-		isReady = false
-		reason := fmt.Sprintf("%sConditions", component)
-		message := fmt.Sprintf("%s resource has no conditions", component)
-		req.Logger.Info(fmt.Sprintf("%s's resource is not reporting Conditions on it's Status", component))
+		getConditionsForNewCr(req, component)
+		return false
+	}
+
+	return setConditionsByOperandConditions(req, component, componentConds)
+}
+
+func setConditionsByOperandConditions(req *common.HcoRequest, component string, componentConds []conditionsv1.Condition) bool {
+	isReady := true
+	foundAvailableCond := false
+	foundProgressingCond := false
+	foundDegradedCond := false
+	for _, condition := range componentConds {
+		switch condition.Type {
+		case conditionsv1.ConditionAvailable:
+			foundAvailableCond = true
+			isReady = handleOperandAvailableCond(req, component, condition) && isReady
+
+		case conditionsv1.ConditionProgressing:
+			foundProgressingCond = true
+			isReady = handleOperandProgressingCond(req, component, condition) && isReady
+
+		case conditionsv1.ConditionDegraded:
+			foundDegradedCond = true
+			isReady = handleOperandDegradedCond(req, component, condition) && isReady
+		}
+	}
+
+	if !foundAvailableCond {
+		componentNotAvailable(req, component, `missing "Available" condition`)
+	}
+
+	return isReady && foundAvailableCond && foundProgressingCond && foundDegradedCond
+}
+
+func handleOperandDegradedCond(req *common.HcoRequest, component string, condition conditionsv1.Condition) bool {
+	if condition.Status == corev1.ConditionTrue {
+		req.Logger.Info(fmt.Sprintf("%s is 'Degraded'", component))
 		req.Conditions.SetStatusCondition(conditionsv1.Condition{
-			Type:    conditionsv1.ConditionAvailable,
-			Status:  corev1.ConditionFalse,
-			Reason:  reason,
-			Message: message,
+			Type:    conditionsv1.ConditionDegraded,
+			Status:  corev1.ConditionTrue,
+			Reason:  fmt.Sprintf("%sDegraded", component),
+			Message: fmt.Sprintf("%s is degraded: %v", component, string(condition.Message)),
 		})
+
+		return false
+	}
+	return true
+}
+
+func handleOperandProgressingCond(req *common.HcoRequest, component string, condition conditionsv1.Condition) bool {
+	if condition.Status == corev1.ConditionTrue {
+		req.Logger.Info(fmt.Sprintf("%s is 'Progressing'", component))
 		req.Conditions.SetStatusCondition(conditionsv1.Condition{
 			Type:    conditionsv1.ConditionProgressing,
 			Status:  corev1.ConditionTrue,
-			Reason:  reason,
-			Message: message,
+			Reason:  fmt.Sprintf("%sProgressing", component),
+			Message: fmt.Sprintf("%s is progressing: %v", component, string(condition.Message)),
 		})
 		req.Conditions.SetStatusCondition(conditionsv1.Condition{
 			Type:    conditionsv1.ConditionUpgradeable,
 			Status:  corev1.ConditionFalse,
-			Reason:  reason,
-			Message: message,
+			Reason:  fmt.Sprintf("%sProgressing", component),
+			Message: fmt.Sprintf("%s is progressing: %v", component, string(condition.Message)),
 		})
-	} else {
-		foundAvailableCond := false
-		foundProgressingCond := false
-		foundDegradedCond := false
-		for _, condition := range componentConds {
-			switch condition.Type {
-			case conditionsv1.ConditionAvailable:
-				foundAvailableCond = true
-				if condition.Status == corev1.ConditionFalse {
-					isReady = false
-					msg := fmt.Sprintf("%s is not available: %v", component, string(condition.Message))
-					componentNotAvailable(req, component, msg)
-				}
-			case conditionsv1.ConditionProgressing:
-				foundProgressingCond = true
-				if condition.Status == corev1.ConditionTrue {
-					isReady = false
-					req.Logger.Info(fmt.Sprintf("%s is 'Progressing'", component))
-					req.Conditions.SetStatusCondition(conditionsv1.Condition{
-						Type:    conditionsv1.ConditionProgressing,
-						Status:  corev1.ConditionTrue,
-						Reason:  fmt.Sprintf("%sProgressing", component),
-						Message: fmt.Sprintf("%s is progressing: %v", component, string(condition.Message)),
-					})
-					req.Conditions.SetStatusCondition(conditionsv1.Condition{
-						Type:    conditionsv1.ConditionUpgradeable,
-						Status:  corev1.ConditionFalse,
-						Reason:  fmt.Sprintf("%sProgressing", component),
-						Message: fmt.Sprintf("%s is progressing: %v", component, string(condition.Message)),
-					})
-				}
-			case conditionsv1.ConditionDegraded:
-				foundDegradedCond = true
-				if condition.Status == corev1.ConditionTrue {
-					isReady = false
-					req.Logger.Info(fmt.Sprintf("%s is 'Degraded'", component))
-					req.Conditions.SetStatusCondition(conditionsv1.Condition{
-						Type:    conditionsv1.ConditionDegraded,
-						Status:  corev1.ConditionTrue,
-						Reason:  fmt.Sprintf("%sDegraded", component),
-						Message: fmt.Sprintf("%s is degraded: %v", component, string(condition.Message)),
-					})
-				}
-			}
-		}
 
-		if !foundAvailableCond {
-			componentNotAvailable(req, component, `missing "Available" condition`)
-		}
-
-		isReady = isReady && foundAvailableCond && foundProgressingCond && foundDegradedCond
+		return false
 	}
+	return true
+}
 
-	return isReady
+func handleOperandAvailableCond(req *common.HcoRequest, component string, condition conditionsv1.Condition) bool {
+	if condition.Status == corev1.ConditionFalse {
+		msg := fmt.Sprintf("%s is not available: %v", component, string(condition.Message))
+		componentNotAvailable(req, component, msg)
+		return false
+	}
+	return true
+}
+
+func getConditionsForNewCr(req *common.HcoRequest, component string) {
+	reason := fmt.Sprintf("%sConditions", component)
+	message := fmt.Sprintf("%s resource has no conditions", component)
+	req.Logger.Info(fmt.Sprintf("%s's resource is not reporting Conditions on it's Status", component))
+	req.Conditions.SetStatusCondition(conditionsv1.Condition{
+		Type:    conditionsv1.ConditionAvailable,
+		Status:  corev1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
+	req.Conditions.SetStatusCondition(conditionsv1.Condition{
+		Type:    conditionsv1.ConditionProgressing,
+		Status:  corev1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	})
+	req.Conditions.SetStatusCondition(conditionsv1.Condition{
+		Type:    conditionsv1.ConditionUpgradeable,
+		Status:  corev1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
 }
 
 func componentNotAvailable(req *common.HcoRequest, component string, msg string) {


### PR DESCRIPTION
1. refactor `func (h *genericOperand) ensure()` in pkg/controller/operands/operand.go to get cleaner code.
   Reduce the number of code branches by splitting to smaller functions.
2. refactor `func handleComponentConditions()` in in pkg/controller/operands/operand.go to get cleaner code.
   Reduce the number of code branches by splitting to smaller functions.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

