### PR TITLE
Reduce SonarClaud number of warnings

### DIFF
--- a/pkg/controller/commonTestUtils/eventEmitterMock.go
+++ b/pkg/controller/commonTestUtils/eventEmitterMock.go
@@ -12,10 +12,13 @@ import (
 type EventEmitterMock struct{}
 
 func (EventEmitterMock) Init(_ context.Context, _ manager.Manager, _ hcoutil.ClusterInfo, _ logr.Logger) {
+	/* not implemented; mock only */
 }
 
 func (EventEmitterMock) EmitEvent(_ runtime.Object, _, _, _ string) {
+	/* not implemented; mock only */
 }
 
 func (EventEmitterMock) UpdateClient(_ context.Context, _ client.Reader, _ logr.Logger) {
+	/* not implemented; mock only */
 }

--- a/pkg/controller/operands/quickStart.go
+++ b/pkg/controller/operands/quickStart.go
@@ -107,6 +107,11 @@ func (h qsHooks) updateCr(req *common.HcoRequest, Client client.Client, exists r
 	return false, false, nil
 }
 
+// This function returns 3-state error:
+//   err := checkCrdExists(...)
+//   err == nil - OK, CRD exists
+//   err != nil && errors.Unwrap(err) == nil - CRD does not exist, but that ok
+//   err != nil && errors.Unwrap(err) != nil - actual error
 func checkCrdExists(ctx context.Context, Client client.Client, logger log.Logger) error {
 	qsCrd := &extv1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
@@ -153,6 +158,11 @@ func getQuickstartDirPath() string {
 	return filesLocation
 }
 
+// This function returns 3-state error:
+//   err := validateQuickstartDir(...)
+//   err == nil - OK: quickstart directory exists
+//   err != nil && errors.Unwrap(err) == nil - quickstart directory does not exist, but that ok
+//   err != nil && errors.Unwrap(err) != nil - actual error
 func validateQuickstartDir(filesLocation string) error {
 	info, err := os.Stat(filesLocation)
 	if err != nil {
@@ -163,7 +173,8 @@ func validateQuickstartDir(filesLocation string) error {
 	}
 
 	if !info.IsDir() {
-		return newProcessingError(nil) // return error, but don't stop processing
+		err := fmt.Errorf("%s is not a directory", filesLocation)
+		return newProcessingError(err) // return error
 	}
 	return nil
 }

--- a/pkg/controller/operands/quickStart_test.go
+++ b/pkg/controller/operands/quickStart_test.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,20 +28,19 @@ var _ = Describe("QuickStart tests", func() {
 	)
 
 	Context("test checkCrdExists", func() {
-		It("should return false if not exists, with no error", func() {
+		It("should return not-stop-processing if not exists", func() {
 			cli := commonTestUtils.InitClient([]runtime.Object{})
 
-			supported, err := checkCrdExists(context.TODO(), cli, logger)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(supported).To(BeFalse())
+			err := checkCrdExists(context.TODO(), cli, logger)
+			Expect(err).Should(HaveOccurred())
+			Expect(errors.Unwrap(err)).To(BeNil())
 		})
 
 		It("should return true if CRD exists, with no error", func() {
 			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd})
 
-			supported, err := checkCrdExists(context.TODO(), cli, logger)
+			err := checkCrdExists(context.TODO(), cli, logger)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(supported).To(BeTrue())
 		})
 	})
 

--- a/pkg/controller/operands/ssp.go
+++ b/pkg/controller/operands/ssp.go
@@ -32,6 +32,10 @@ const (
 	defaultTemplateValidatorReplicas = 2
 
 	defaultCommonTemplatesNamespace = hcoutil.OpenshiftNamespace
+
+	// These group are no longer supported. Use these constants to remove unused resources
+	prevSspGroup = "ssp.kubevirt.io"
+	origSspGroup = "kubevirt.io"
 )
 
 type sspHandler struct {
@@ -63,17 +67,17 @@ func newSspHandler(Client client.Client, Scheme *runtime.Scheme) *sspHandler {
 		crdsToRemove: []schema.GroupKind{
 			// These are the 2nd generation SSP CRDs,
 			// where the group name has been changed to "ssp.kubevirt.io"
-			{Group: "ssp.kubevirt.io", Kind: "KubevirtCommonTemplatesBundle"},
-			{Group: "ssp.kubevirt.io", Kind: "KubevirtNodeLabellerBundle"},
-			{Group: "ssp.kubevirt.io", Kind: "KubevirtTemplateValidator"},
-			{Group: "ssp.kubevirt.io", Kind: "KubevirtMetricsAggregation"},
+			{Group: prevSspGroup, Kind: "KubevirtCommonTemplatesBundle"},
+			{Group: prevSspGroup, Kind: "KubevirtNodeLabellerBundle"},
+			{Group: prevSspGroup, Kind: "KubevirtTemplateValidator"},
+			{Group: prevSspGroup, Kind: "KubevirtMetricsAggregation"},
 
 			// These are the original SSP CRDs, with the group name "kubevirt.io".
 			// We attempt to remove these too, for upgrades from even older version.
-			{Group: "kubevirt.io", Kind: "KubevirtCommonTemplatesBundle"},
-			{Group: "kubevirt.io", Kind: "KubevirtNodeLabellerBundle"},
-			{Group: "kubevirt.io", Kind: "KubevirtTemplateValidator"},
-			{Group: "kubevirt.io", Kind: "KubevirtMetricsAggregation"},
+			{Group: origSspGroup, Kind: "KubevirtCommonTemplatesBundle"},
+			{Group: origSspGroup, Kind: "KubevirtNodeLabellerBundle"},
+			{Group: origSspGroup, Kind: "KubevirtTemplateValidator"},
+			{Group: origSspGroup, Kind: "KubevirtMetricsAggregation"},
 		},
 	}
 


### PR DESCRIPTION
1. In SSP operator handler, use a constant instead of "ssp.kubevirt.io"
2. In SSP operator handler, use a constant instead of "kubevirt.io"
3. refactor `func getQuickStartHandlers()` in pkg/controller/operands/quickStart.go to get cleaner code. Reduce the number of code branches by splitting to smaller functions.
4. refactor `func ComponentResourceRemoval()` in pkg/util/util.go to get cleaner code. Reduce the number of code branches by splitting to smaller functions.
5. in `pkg/controller/commonTestUtils/eventEmitterMock.go`, add comments to explain non implemented mock methods.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

