### PR TITLE
Fix code smells reported by SonarCloud

### DIFF
--- a/pkg/controller/common/hcoConditions.go
+++ b/pkg/controller/common/hcoConditions.go
@@ -22,9 +22,9 @@ func NewHcoConditions() HcoConditions {
 }
 
 func (hc HcoConditions) SetStatusCondition(newCondition conditionsv1.Condition) {
-	existingCondition, ok := hc[newCondition.Type]
+	existingCondition, exists := hc[newCondition.Type]
 
-	if !ok {
+	if !exists {
 		hc[newCondition.Type] = newCondition
 		return
 	}
@@ -38,6 +38,18 @@ func (hc HcoConditions) SetStatusCondition(newCondition conditionsv1.Condition) 
 	hc[newCondition.Type] = existingCondition
 }
 
-func (hc HcoConditions) Empty() bool {
+func (hc HcoConditions) SetStatusConditionIfUnset(newCondition conditionsv1.Condition) {
+	if !hc.HasCondition(newCondition.Type) {
+		hc.SetStatusCondition(newCondition)
+	}
+}
+
+func (hc HcoConditions) IsEmpty() bool {
 	return len(hc) == 0
+}
+
+func (hc HcoConditions) HasCondition(conditionType conditionsv1.ConditionType) bool {
+	_, exists := hc[conditionType]
+
+	return exists
 }

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -524,7 +524,7 @@ func (r *ReconcileHyperConverged) aggregateComponentConditions(req *common.HcoRe
 			captured at one time (ie. if KubeVirt and CDI are both reporting !Available,
 		    you will only see CDI as it updates last).
 	*/
-	allComponentsAreUp := req.Conditions.Empty()
+	allComponentsAreUp := req.Conditions.IsEmpty()
 	req.Conditions.SetStatusCondition(conditionsv1.Condition{
 		Type:    hcov1beta1.ConditionReconcileComplete,
 		Status:  corev1.ConditionTrue,
@@ -532,33 +532,31 @@ func (r *ReconcileHyperConverged) aggregateComponentConditions(req *common.HcoRe
 		Message: reconcileCompletedMessage,
 	})
 
-	if _, conditionFound := req.Conditions[conditionsv1.ConditionDegraded]; conditionFound { // (#chart 1)
-		if _, conditionFound = req.Conditions[conditionsv1.ConditionProgressing]; !conditionFound { // (#chart 2)
-			req.Conditions.SetStatusCondition(conditionsv1.Condition{ // (#chart 3)
-				Type:    conditionsv1.ConditionProgressing,
-				Status:  corev1.ConditionFalse,
-				Reason:  reconcileCompleted,
-				Message: reconcileCompletedMessage,
-			})
-		} // else - Progressing is already exists
+	if req.Conditions.HasCondition(conditionsv1.ConditionDegraded) { // (#chart 1)
 
-		if _, conditionFound = req.Conditions[conditionsv1.ConditionUpgradeable]; !conditionFound { // (#chart 4)
-			req.Conditions.SetStatusCondition(conditionsv1.Condition{ // (#chart 5)
-				Type:    conditionsv1.ConditionUpgradeable,
-				Status:  corev1.ConditionFalse,
-				Reason:  commonDegradedReason,
-				Message: "HCO is not Upgradeable due to degraded components",
-			})
-		} // else - Upgradeable is already exists
-		if _, conditionFound = req.Conditions[conditionsv1.ConditionAvailable]; !conditionFound { // (#chart 6)
-			req.Conditions.SetStatusCondition(conditionsv1.Condition{ // (#chart 7)
-				Type:    conditionsv1.ConditionAvailable,
-				Status:  corev1.ConditionFalse,
-				Reason:  commonDegradedReason,
-				Message: "HCO is not available due to degraded components",
-			})
-		} // else - Available is already exists
+		req.Conditions.SetStatusConditionIfUnset(conditionsv1.Condition{ // (#chart 2,3)
+			Type:    conditionsv1.ConditionProgressing,
+			Status:  corev1.ConditionFalse,
+			Reason:  reconcileCompleted,
+			Message: reconcileCompletedMessage,
+		})
+
+		req.Conditions.SetStatusConditionIfUnset(conditionsv1.Condition{ // (#chart 4,5)
+			Type:    conditionsv1.ConditionUpgradeable,
+			Status:  corev1.ConditionFalse,
+			Reason:  commonDegradedReason,
+			Message: "HCO is not Upgradeable due to degraded components",
+		})
+
+		req.Conditions.SetStatusConditionIfUnset(conditionsv1.Condition{ // (#chart 6,7)
+			Type:    conditionsv1.ConditionAvailable,
+			Status:  corev1.ConditionFalse,
+			Reason:  commonDegradedReason,
+			Message: "HCO is not available due to degraded components",
+		})
+
 	} else {
+
 		// Degraded is not found. add it.
 		req.Conditions.SetStatusCondition(conditionsv1.Condition{ // (#chart 8)
 			Type:    conditionsv1.ConditionDegraded,
@@ -567,26 +565,24 @@ func (r *ReconcileHyperConverged) aggregateComponentConditions(req *common.HcoRe
 			Message: reconcileCompletedMessage,
 		})
 
-		if _, conditionFound = req.Conditions[conditionsv1.ConditionProgressing]; conditionFound { // (#chart 9)
+		if req.Conditions.HasCondition(conditionsv1.ConditionProgressing) { // (#chart 9)
 
-			if _, conditionFound = req.Conditions[conditionsv1.ConditionUpgradeable]; !conditionFound { // (#chart 10)
-				req.Conditions.SetStatusCondition(conditionsv1.Condition{ // (#chart 11)
-					Type:    conditionsv1.ConditionUpgradeable,
-					Status:  corev1.ConditionFalse,
-					Reason:  commonProgressingReason,
-					Message: "HCO is not Upgradeable due to progressing components",
-				})
-			} // else - Upgradeable is already exists
+			req.Conditions.SetStatusConditionIfUnset(conditionsv1.Condition{ // (#chart 10,11)
+				Type:    conditionsv1.ConditionUpgradeable,
+				Status:  corev1.ConditionFalse,
+				Reason:  commonProgressingReason,
+				Message: "HCO is not Upgradeable due to progressing components",
+			})
 
-			if _, conditionFound = req.Conditions[conditionsv1.ConditionAvailable]; !conditionFound { // (#chart 12)
-				req.Conditions.SetStatusCondition(conditionsv1.Condition{ // (#chart 13)
-					Type:    conditionsv1.ConditionAvailable,
-					Status:  corev1.ConditionTrue,
-					Reason:  reconcileCompleted,
-					Message: reconcileCompletedMessage,
-				})
-			} // else - Available is already exists
+			req.Conditions.SetStatusConditionIfUnset(conditionsv1.Condition{ // (#chart 12,13)
+				Type:    conditionsv1.ConditionAvailable,
+				Status:  corev1.ConditionTrue,
+				Reason:  reconcileCompleted,
+				Message: reconcileCompletedMessage,
+			})
+
 		} else {
+
 			req.Conditions.SetStatusCondition(conditionsv1.Condition{ // (#chart 14)
 				Type:    conditionsv1.ConditionProgressing,
 				Status:  corev1.ConditionFalse,
@@ -594,25 +590,23 @@ func (r *ReconcileHyperConverged) aggregateComponentConditions(req *common.HcoRe
 				Message: reconcileCompletedMessage,
 			})
 
-			if _, conditionFound = req.Conditions[conditionsv1.ConditionUpgradeable]; !conditionFound { // (#chart 15)
-				req.Conditions.SetStatusCondition(conditionsv1.Condition{ // (#chart 16)
-					Type:    conditionsv1.ConditionUpgradeable,
-					Status:  corev1.ConditionTrue,
-					Reason:  reconcileCompleted,
-					Message: reconcileCompletedMessage,
-				})
-			}
+			req.Conditions.SetStatusConditionIfUnset(conditionsv1.Condition{ // (#chart 15,16)
+				Type:    conditionsv1.ConditionUpgradeable,
+				Status:  corev1.ConditionTrue,
+				Reason:  reconcileCompleted,
+				Message: reconcileCompletedMessage,
+			})
 
-			if _, conditionFound = req.Conditions[conditionsv1.ConditionAvailable]; !conditionFound { // (#chart 17) {
-				req.Conditions.SetStatusCondition(conditionsv1.Condition{ // (#chart 18)
-					Type:    conditionsv1.ConditionAvailable,
-					Status:  corev1.ConditionTrue,
-					Reason:  reconcileCompleted,
-					Message: reconcileCompletedMessage,
-				})
-			}
+			req.Conditions.SetStatusConditionIfUnset(conditionsv1.Condition{ // (#chart 17,18)
+				Type:    conditionsv1.ConditionAvailable,
+				Status:  corev1.ConditionTrue,
+				Reason:  reconcileCompleted,
+				Message: reconcileCompletedMessage,
+			})
+
 		}
 	}
+
 	return allComponentsAreUp
 }
 

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -184,26 +184,33 @@ type ReconcileHyperConverged struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileHyperConverged) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	hcoTriggered, err := isTriggeredByHyperConverged(request)
+
+	secCRPlaceholder, err := getSecondaryCRPlaceholder()
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	reconcileRequest := request
-	if hcoTriggered {
-		log.Info("Reconciling HyperConverged operator")
-
-		r.operandHandler.Reset()
-	} else {
-		log.Info("The reconciliation got triggered by a secondary CR object")
-
-		reconcileRequest, err = getHyperconvergedReconcileRequest()
+	hcoTriggered := true
+	pRequest := request
+	if request.NamespacedName == secCRPlaceholder {
+		hcoTriggered = false
+		hco, err := getHyperconverged()
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+		pRequest = reconcile.Request{
+			NamespacedName: hco,
+		}
+	} else {
+		r.operandHandler.Reset()
 	}
 
-	req := common.NewHcoRequest(ctx, reconcileRequest, log, r.upgradeMode, hcoTriggered)
+	req := common.NewHcoRequest(ctx, pRequest, log, r.upgradeMode, hcoTriggered)
+	if req.HCOTriggered {
+		req.Logger.Info("Reconciling HyperConverged operator")
+	} else {
+		req.Logger.Info("The reconciliation got triggered by a secondary CR object")
+	}
 
 	// Fetch the HyperConverged instance
 	instance, err := r.getHcoInstanceFromK8s(req)
@@ -228,7 +235,48 @@ func (r *ReconcileHyperConverged) Reconcile(ctx context.Context, request reconci
 		r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, "ReconcileError", err.Error())
 	}
 
-	err = r.updateHyperConverged(req)
+	/*
+		From K8s API reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/
+		============================================================================================================
+		Replace: Replacing a resource object will update the resource by replacing the existing spec with the
+		provided one. For read-then-write operations this is safe because an optimistic lock failure will occur if
+		the resource was modified between the read and write.
+
+		**Note: The ResourceStatus will be ignored by the system and will not be updated. To update the status, one
+		must invoke the specific status update operation.**
+		============================================================================================================
+
+		In addition, updating the status should not update the metadata, so we need to update both the CR and the
+		CR Status, and we need to update the status first, in order to prevent a conflict.
+	*/
+
+	if req.StatusDirty {
+		updateErr := r.client.Status().Update(req.Ctx, req.Instance)
+		if updateErr != nil {
+			updateErrorMsg := "Failed to update HCO Status"
+			r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, "HcoUpdateError", updateErrorMsg)
+			req.Logger.Error(updateErr, updateErrorMsg)
+			err = updateErr
+		}
+	}
+
+	// recover Spec.Version if upgrade missed when upgrade completed
+	// Doing it here because status.update overrides spec for some reason
+	knownHcoVersion, versionFound := req.Instance.Status.GetVersion(hcoVersionName)
+	if (!r.upgradeMode) && versionFound && (knownHcoVersion == r.ownVersion) && (req.Instance.Spec.Version != r.ownVersion) {
+		req.Instance.Spec.Version = r.ownVersion
+		req.Dirty = true
+	}
+
+	if req.Dirty {
+		updateErr := r.client.Update(req.Ctx, req.Instance)
+		if updateErr != nil {
+			updateErrorMsg := "Failed to update HCO CR"
+			r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, "HcoUpdateError", updateErrorMsg)
+			req.Logger.Error(updateErr, updateErrorMsg)
+			err = updateErr
+		}
+	}
 
 	if apierrors.IsConflict(err) {
 		res.Requeue = true
@@ -331,7 +379,7 @@ func (r *ReconcileHyperConverged) getHcoInstanceFromK8s(req *common.HcoRequest) 
 }
 
 func (r *ReconcileHyperConverged) validateNamespace(req *common.HcoRequest) (bool, error) {
-	hco, err := getHyperConverged()
+	hco, err := getHyperconverged()
 	if err != nil {
 		req.Logger.Error(err, "Failed to get HyperConverged namespaced name")
 		return false, err
@@ -736,57 +784,8 @@ func (r *ReconcileHyperConverged) detectTaintedConfiguration(req *common.HcoRequ
 	}
 }
 
-func (r *ReconcileHyperConverged) updateHyperConverged(req *common.HcoRequest) error {
-	/*
-		From K8s API reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/
-		============================================================================================================
-		Replace: Replacing a resource object will update the resource by replacing the existing spec with the
-		provided one. For read-then-write operations this is safe because an optimistic lock failure will occur if
-		the resource was modified between the read and write.
-
-		**Note: The ResourceStatus will be ignored by the system and will not be updated. To update the status, one
-		must invoke the specific status update operation.**
-		============================================================================================================
-
-		In addition, updating the status should not update the metadata, so we need to update both the CR and the
-		CR Status, and we need to update the status first, in order to prevent a conflict.
-	*/
-
-	var err error
-
-	if req.StatusDirty {
-		updateErr := r.client.Status().Update(req.Ctx, req.Instance)
-		if updateErr != nil {
-			updateErrorMsg := "Failed to update HCO Status"
-			r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, "HcoUpdateError", updateErrorMsg)
-			req.Logger.Error(updateErr, updateErrorMsg)
-			err = updateErr
-		}
-	}
-
-	// recover Spec.Version if upgrade missed when upgrade completed
-	// Doing it here because status.update overrides spec for some reason
-	knownHcoVersion, versionFound := req.Instance.Status.GetVersion(hcoVersionName)
-	if (!r.upgradeMode) && versionFound && (knownHcoVersion == r.ownVersion) && (req.Instance.Spec.Version != r.ownVersion) {
-		req.Instance.Spec.Version = r.ownVersion
-		req.Dirty = true
-	}
-
-	if req.Dirty {
-		updateErr := r.client.Update(req.Ctx, req.Instance)
-		if updateErr != nil {
-			updateErrorMsg := "Failed to update HCO CR"
-			r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, "HcoUpdateError", updateErrorMsg)
-			req.Logger.Error(updateErr, updateErrorMsg)
-			err = updateErr
-		}
-	}
-
-	return err
-}
-
-// getHyperConverged returns the name/namespace of the HyperConverged resource
-func getHyperConverged() (types.NamespacedName, error) {
+// getHyperconverged returns the name/namespace of the HyperConverged resource
+func getHyperconverged() (types.NamespacedName, error) {
 	hco := types.NamespacedName{
 		Name: hcoutil.HyperConvergedName,
 	}
@@ -800,20 +799,7 @@ func getHyperConverged() (types.NamespacedName, error) {
 	return hco, nil
 }
 
-// getHyperconvergedReconcileRequest returns the HyperConverged resource's
-// name/namespace wrapped in a reconcile.Request
-func getHyperconvergedReconcileRequest() (reconcile.Request, error) {
-	hco, err := getHyperConverged()
-	if err != nil {
-		return reconcile.Request{}, err
-	}
-
-	return reconcile.Request{
-		NamespacedName: hco,
-	}, nil
-}
-
-// getSecondaryCRPlaceholder returns a placeholder to be able to discriminate
+// getOtherCrPlaceholder returns a placeholder to be able to discriminate
 // reconciliation requests triggered by secondary watched resources
 // use a random generated suffix for security reasons
 func getSecondaryCRPlaceholder() (types.NamespacedName, error) {
@@ -828,18 +814,6 @@ func getSecondaryCRPlaceholder() (types.NamespacedName, error) {
 	hco.Namespace = namespace
 
 	return hco, nil
-}
-
-// isTriggeredByHyperConverged determines whether the reconciliation request has been triggered
-// by a change to the HyperConvereged CR, or a change to one of its secondary watches resources
-func isTriggeredByHyperConverged(request reconcile.Request) (bool, error) {
-	placeholder, err := getSecondaryCRPlaceholder()
-	if err != nil {
-		return false, err
-	}
-
-	isSecondary := request.NamespacedName == placeholder
-	return !isSecondary, nil
 }
 
 func contains(slice []string, s string) bool {


### PR DESCRIPTION
1. Extract duplicate magic strings as constants
2. Rename variables to adhere to naming conventions
3. Refactor methods with high cognitive complexity

**Release note**:
```release-note
NONE
```

