### PR TITLE
Fix sonarCloud warnings at tools/manifest-templator/manifest-templator.go

### DIFF
--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -22,6 +22,7 @@ package main
 import (
 	"flag"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	"log"
 	"os"
 	"path"
 	"sort"
@@ -38,6 +39,10 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	rbacAPI = rbacv1.GroupName + "/v1"
 )
 
 // flags for the command line arguments we accept
@@ -72,40 +77,299 @@ var (
 // check handles errors
 func check(err error) {
 	if err != nil {
+		log.Println("error: ", err)
 		panic(err)
+	}
+}
+func init() {
+	processCommandlineParams()
+}
+
+func processCommandlineParams() {
+	flag.Parse()
+
+	if webhookImage == nil || *webhookImage == "" {
+		*webhookImage = *operatorImage
 	}
 }
 
 func main() {
-	flag.Parse()
-
-	// open files for writing
-	operatorYaml, err := os.Create(path.Join(*deployDir, "operator.yaml"))
-	check(err)
-	saYaml, err := os.Create(path.Join(*deployDir, "service_account.yaml"))
-	check(err)
-	crbYaml, err := os.Create(path.Join(*deployDir, "cluster_role_binding.yaml"))
-	check(err)
-	crYaml, err := os.Create(path.Join(*deployDir, "cluster_role.yaml"))
-	check(err)
-	operatorCrd, err := os.Create(path.Join(*deployDir, "crds/hco.crd.yaml"))
-	check(err)
-	v2vCrd, err := os.Create(path.Join(*deployDir, "crds/v2vvmware.crd.yaml"))
-	check(err)
-	v2voVirtCrd, err := os.Create(path.Join(*deployDir, "crds/v2vovirt.crd.yaml"))
-	check(err)
-	operatorCr, err := os.Create(path.Join(*deployDir, "hco.cr.yaml"))
-	check(err)
-	defer operatorYaml.Close()
-	defer saYaml.Close()
-	defer crbYaml.Close()
-	defer crYaml.Close()
-	defer operatorCrd.Close()
-	defer operatorCr.Close()
-	defer v2vCrd.Close()
-	defer v2voVirtCrd.Close()
-
 	// the CSVs we expect to handle
+	componentsWithCSVs := getCsvWithComponent()
+
+	operatorParams := getOperatorParameters()
+
+	// these represent the bare necessities for the HCO manifests, that is,
+	// enough to deploy the HCO itself.
+	// 1 deployment
+	// 1 service account
+	// 1 cluster role
+	// 1 cluster role binding
+	// as we handle each CSV we will add to our slices of deployments,
+	// permissions, role bindings, cluster permissions, and cluster role bindings.
+	// service accounts are represented as a map to prevent us from generating the
+	// same service account multiple times.
+	deployments := []appsv1.Deployment{
+		components.GetDeploymentOperator(operatorParams),
+		components.GetDeploymentWebhook(
+			*operatorNamespace,
+			*webhookImage,
+			"IfNotPresent",
+			*hcoKvIoVersion,
+			[]corev1.EnvVar{},
+		),
+	}
+	// hco-operator and hco-webhook
+	for i := range deployments {
+		overwriteDeploymentLabels(&deployments[i], hcoutil.AppComponentDeployment)
+	}
+
+	services := []v1.Service{
+		components.GetServiceWebhook(*operatorNamespace),
+	}
+
+	serviceAccounts := map[string]v1.ServiceAccount{
+		"hyperconverged-cluster-operator": components.GetServiceAccount(*operatorNamespace),
+	}
+	permissions := make([]rbacv1.Role, 0)
+	roleBindings := make([]rbacv1.RoleBinding, 0)
+	clusterPermissions := []rbacv1.ClusterRole{
+		components.GetClusterRole(),
+	}
+	clusterRoleBindings := []rbacv1.ClusterRoleBinding{
+		components.GetClusterRoleBinding(*operatorNamespace),
+	}
+
+	for _, csvStr := range componentsWithCSVs {
+		if csvStr.Csv == "" {
+			continue
+		}
+		csvBytes := []byte(csvStr.Csv)
+
+		csvStruct := &csvv1alpha1.ClusterServiceVersion{}
+
+		check(yaml.Unmarshal(csvBytes, csvStruct))
+
+		services = getServices(csvStruct, services)
+
+		strategySpec := csvStruct.Spec.InstallStrategy.StrategySpec
+
+		// CSVs only contain the deployment spec, we must wrap
+		// the spec with the Type and Object Meta to make it a valid
+		// manifest
+		for _, deploymentSpec := range strategySpec.DeploymentSpecs {
+			deploy := getBasicDeployment(deploymentSpec)
+			injectWebhookMounts(csvStruct.Spec.WebhookDefinitions, &deploy)
+			overwriteDeploymentLabels(&deploy, csvStr.Component)
+			deployments = append(deployments, deploy)
+		}
+
+		// Every permission we encounter in a CSV means we need to (potentially)
+		// add a service account to our map, add a Role to our slice of permissions
+		// (much like we did with deployments we need to wrap the rules with the
+		// Type and Object Meta to make a valid Role), and add a RoleBinding to our
+		// slice.
+		for _, permission := range strategySpec.Permissions {
+			serviceAccounts[permission.ServiceAccountName] = getBasicServiceAccount(permission)
+			permissions = append(permissions, getRole(permission))
+			roleBindings = append(roleBindings, getRoleBinding(permission))
+		}
+
+		// Same as permissions except ClusterRole instead of Role and
+		// ClusterRoleBinding instead of RoleBinding.
+		for _, clusterPermission := range strategySpec.ClusterPermissions {
+			serviceAccounts[clusterPermission.ServiceAccountName] = createServiceAccount(clusterPermission)
+			clusterPermissions = append(clusterPermissions, createClusterRole(clusterPermission))
+			clusterRoleBindings = append(clusterRoleBindings, createClusterRoleBinding(clusterPermission))
+		}
+	}
+
+	// Write out CRDs and CR
+	writeOperatorCr()
+	// Write out deployments
+	writeOperatorCrd()
+
+	writev2vCrd()
+	writev2vVirtCrd()
+	writeOperatorYaml(deployments, services)
+
+	// Write out rbac
+	// since maps are not ordered we must enforce one before writing
+	writeSaYaml(serviceAccounts)
+	writeCrbYaml(roleBindings, clusterRoleBindings)
+	writeCrYaml(permissions, clusterPermissions)
+}
+
+func getServices(csvStruct *csvv1alpha1.ClusterServiceVersion, services []v1.Service) []v1.Service {
+	for _, webhook := range csvStruct.Spec.WebhookDefinitions {
+		services = append(services, createService(webhook, csvStruct))
+	}
+	return services
+}
+
+func createClusterRoleBinding(clusterPermission csvv1alpha1.StrategyDeploymentPermissions) rbacv1.ClusterRoleBinding {
+	return rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rbacAPI,
+			Kind:       "ClusterRoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterPermission.ServiceAccountName,
+			Labels: map[string]string{
+				"name": clusterPermission.ServiceAccountName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     clusterPermission.ServiceAccountName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      clusterPermission.ServiceAccountName,
+				Namespace: *operatorNamespace,
+			},
+		},
+	}
+}
+
+func createClusterRole(clusterPermission csvv1alpha1.StrategyDeploymentPermissions) rbacv1.ClusterRole {
+	return rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rbacAPI,
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterPermission.ServiceAccountName,
+			Labels: map[string]string{
+				"name": clusterPermission.ServiceAccountName,
+			},
+		},
+		Rules: clusterPermission.Rules,
+	}
+}
+
+func createServiceAccount(clusterPermission csvv1alpha1.StrategyDeploymentPermissions) v1.ServiceAccount {
+	return v1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterPermission.ServiceAccountName,
+			Namespace: *operatorNamespace,
+			Labels: map[string]string{
+				"name": clusterPermission.ServiceAccountName,
+			},
+		},
+	}
+}
+
+func getRoleBinding(permission csvv1alpha1.StrategyDeploymentPermissions) rbacv1.RoleBinding {
+	return rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rbacAPI,
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      permission.ServiceAccountName,
+			Namespace: *operatorNamespace,
+			Labels: map[string]string{
+				"name": permission.ServiceAccountName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     permission.ServiceAccountName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      permission.ServiceAccountName,
+				Namespace: *operatorNamespace,
+			},
+		},
+	}
+}
+
+func getRole(permission csvv1alpha1.StrategyDeploymentPermissions) rbacv1.Role {
+	return rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rbacAPI,
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: permission.ServiceAccountName,
+			Labels: map[string]string{
+				"name": permission.ServiceAccountName,
+			},
+		},
+		Rules: permission.Rules,
+	}
+}
+
+func getBasicServiceAccount(permission csvv1alpha1.StrategyDeploymentPermissions) v1.ServiceAccount {
+	return v1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      permission.ServiceAccountName,
+			Namespace: *operatorNamespace,
+			Labels: map[string]string{
+				"name": permission.ServiceAccountName,
+			},
+		},
+	}
+}
+
+func getBasicDeployment(deploymentSpec csvv1alpha1.StrategyDeploymentSpec) appsv1.Deployment {
+	return appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: deploymentSpec.Name,
+			Labels: map[string]string{
+				"name": deploymentSpec.Name,
+			},
+		},
+		Spec: deploymentSpec.Spec,
+	}
+}
+
+func createService(webhook csvv1alpha1.WebhookDescription, csvStruct *csvv1alpha1.ClusterServiceVersion) v1.Service {
+	return v1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: webhook.DeploymentName + "-service",
+			Labels: map[string]string{
+				"name": webhook.DeploymentName,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Selector: getSelectorOfWebhookDeployment(webhook.DeploymentName, csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs),
+			Ports: []v1.ServicePort{
+				{
+					Name:       strconv.Itoa(int(webhook.ContainerPort)),
+					Port:       webhook.ContainerPort,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(int(webhook.ContainerPort)),
+				},
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+}
+
+func getCsvWithComponent() []util.CsvWithComponent {
 	componentsWithCsvs := []util.CsvWithComponent{
 		{
 			Csv:       *cnaCsv,
@@ -136,11 +400,25 @@ func main() {
 			Component: hcoutil.AppComponentImport,
 		},
 	}
+	return componentsWithCsvs
+}
 
-	if webhookImage == nil || *webhookImage == "" {
-		*webhookImage = *operatorImage
-	}
+func writev2vVirtCrd() {
+	v2voVirtCrd, err := os.Create(path.Join(*deployDir, "crds/v2vovirt.crd.yaml"))
+	check(err)
+	defer v2voVirtCrd.Close()
+	check(util.MarshallObject(components.GetV2VOvirtProviderCRD(), v2voVirtCrd))
+}
 
+func writev2vCrd() {
+	v2vCrd, err := os.Create(path.Join(*deployDir, "crds/v2vvmware.crd.yaml"))
+	check(err)
+	defer v2vCrd.Close()
+
+	check(util.MarshallObject(components.GetV2VCRD(), v2vCrd))
+}
+
+func getOperatorParameters() *components.DeploymentOperatorParams {
 	params := &components.DeploymentOperatorParams{
 		Namespace:           *operatorNamespace,
 		Image:               *operatorImage,
@@ -159,265 +437,77 @@ func main() {
 		VMImportVersion:     *vmImportVersion,
 		Env:                 []corev1.EnvVar{},
 	}
+	return params
+}
 
-	// these represent the bare necessities for the HCO manifests, that is,
-	// enough to deploy the HCO itself.
-	// 1 deployment
-	// 1 service account
-	// 1 cluster role
-	// 1 cluster role binding
-	// as we handle each CSV we will add to our slices of deployments,
-	// permissions, role bindings, cluster permissions, and cluster role bindings.
-	// service accounts are represented as a map to prevent us from generating the
-	// same service account multiple times.
-	deployments := []appsv1.Deployment{
-		components.GetDeploymentOperator(params),
-		components.GetDeploymentWebhook(
-			*operatorNamespace,
-			*webhookImage,
-			"IfNotPresent",
-			*hcoKvIoVersion,
-			[]corev1.EnvVar{},
-		),
-	}
-	// hco-operator and hco-webhook
-	for i, _ := range deployments {
-		overwriteDeploymentLabels(&deployments[i], hcoutil.AppComponentDeployment)
-	}
+func writeOperatorCr() {
+	operatorCr, err := os.Create(path.Join(*deployDir, "hco.cr.yaml"))
+	check(err)
+	defer operatorCr.Close()
+	check(util.MarshallObject(components.GetOperatorCR(), operatorCr))
+}
 
-	services := []v1.Service{
-		components.GetServiceWebhook(
-			*operatorNamespace,
-		),
-	}
+func writeOperatorCrd() {
+	operatorCrd, err := os.Create(path.Join(*deployDir, "crds/hco.crd.yaml"))
+	check(err)
+	defer operatorCrd.Close()
+	check(util.MarshallObject(components.GetOperatorCRD(*apiSources), operatorCrd))
+}
 
-	serviceAccounts := map[string]v1.ServiceAccount{
-		"hyperconverged-cluster-operator": components.GetServiceAccount(*operatorNamespace),
-	}
-	permissions := []rbacv1.Role{}
-	roleBindings := []rbacv1.RoleBinding{}
-	clusterPermissions := []rbacv1.ClusterRole{
-		components.GetClusterRole(),
-	}
-	clusterRoleBindings := []rbacv1.ClusterRoleBinding{
-		components.GetClusterRoleBinding(*operatorNamespace),
-	}
-
-	for _, csvStr := range componentsWithCsvs {
-		if csvStr.Csv != "" {
-			csvBytes := []byte(csvStr.Csv)
-
-			csvStruct := &csvv1alpha1.ClusterServiceVersion{}
-
-			err := yaml.Unmarshal(csvBytes, csvStruct)
-			if err != nil {
-				panic(err)
-			}
-
-			for _, webhook := range csvStruct.Spec.WebhookDefinitions {
-				services = append(services, v1.Service{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "v1",
-						Kind:       "Service",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name: webhook.DeploymentName + "-service",
-						Labels: map[string]string{
-							"name": webhook.DeploymentName,
-						},
-					},
-					Spec: v1.ServiceSpec{
-						Selector: getSelectorOfWebhookDeployment(webhook.DeploymentName, csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs),
-						Ports: []v1.ServicePort{
-							{
-								Name:       strconv.Itoa(int(webhook.ContainerPort)),
-								Port:       webhook.ContainerPort,
-								Protocol:   corev1.ProtocolTCP,
-								TargetPort: intstr.FromInt(int(webhook.ContainerPort)),
-							},
-						},
-						Type: corev1.ServiceTypeClusterIP,
-					},
-				})
-			}
-
-			strategySpec := csvStruct.Spec.InstallStrategy.StrategySpec
-
-			// CSVs only contain the deployment spec, we must wrap
-			// the spec with the Type and Object Meta to make it a valid
-			// manifest
-			for _, deploymentSpec := range strategySpec.DeploymentSpecs {
-				deploy := appsv1.Deployment{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "apps/v1",
-						Kind:       "Deployment",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name: deploymentSpec.Name,
-						Labels: map[string]string{
-							"name": deploymentSpec.Name,
-						},
-					},
-					Spec: deploymentSpec.Spec,
-				}
-				injectWebhookMounts(csvStruct.Spec.WebhookDefinitions, &deploy)
-				overwriteDeploymentLabels(&deploy, csvStr.Component)
-				deployments = append(deployments, deploy)
-			}
-
-			// Every permission we encounter in a CSV means we need to (potentially)
-			// add a service account to our map, add a Role to our slice of permissions
-			// (much like we did with deployments we need to wrap the rules with the
-			// Type and Object Meta to make a valid Role), and add a RoleBinding to our
-			// slice.
-			for _, permission := range strategySpec.Permissions {
-				serviceAccounts[permission.ServiceAccountName] = v1.ServiceAccount{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "v1",
-						Kind:       "ServiceAccount",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      permission.ServiceAccountName,
-						Namespace: *operatorNamespace,
-						Labels: map[string]string{
-							"name": permission.ServiceAccountName,
-						},
-					},
-				}
-				permissions = append(permissions, rbacv1.Role{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "rbac.authorization.k8s.io/v1",
-						Kind:       "Role",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name: permission.ServiceAccountName,
-						Labels: map[string]string{
-							"name": permission.ServiceAccountName,
-						},
-					},
-					Rules: permission.Rules,
-				})
-				roleBindings = append(roleBindings, rbacv1.RoleBinding{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "rbac.authorization.k8s.io/v1",
-						Kind:       "RoleBinding",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      permission.ServiceAccountName,
-						Namespace: *operatorNamespace,
-						Labels: map[string]string{
-							"name": permission.ServiceAccountName,
-						},
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: "rbac.authorization.k8s.io",
-						Kind:     "Role",
-						Name:     permission.ServiceAccountName,
-					},
-					Subjects: []rbacv1.Subject{
-						rbacv1.Subject{
-							Kind:      "ServiceAccount",
-							Name:      permission.ServiceAccountName,
-							Namespace: *operatorNamespace,
-						},
-					},
-				})
-			}
-
-			// Same as permissions except ClusterRole instead of Role and
-			// ClusterRoleBinding instead of RoleBinding.
-			for _, clusterPermission := range strategySpec.ClusterPermissions {
-				serviceAccounts[clusterPermission.ServiceAccountName] = v1.ServiceAccount{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "v1",
-						Kind:       "ServiceAccount",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      clusterPermission.ServiceAccountName,
-						Namespace: *operatorNamespace,
-						Labels: map[string]string{
-							"name": clusterPermission.ServiceAccountName,
-						},
-					},
-				}
-				clusterPermissions = append(clusterPermissions, rbacv1.ClusterRole{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "rbac.authorization.k8s.io/v1",
-						Kind:       "ClusterRole",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name: clusterPermission.ServiceAccountName,
-						Labels: map[string]string{
-							"name": clusterPermission.ServiceAccountName,
-						},
-					},
-					Rules: clusterPermission.Rules,
-				})
-				clusterRoleBindings = append(clusterRoleBindings, rbacv1.ClusterRoleBinding{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "rbac.authorization.k8s.io/v1",
-						Kind:       "ClusterRoleBinding",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name: clusterPermission.ServiceAccountName,
-						Labels: map[string]string{
-							"name": clusterPermission.ServiceAccountName,
-						},
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: "rbac.authorization.k8s.io",
-						Kind:     "ClusterRole",
-						Name:     clusterPermission.ServiceAccountName,
-					},
-					Subjects: []rbacv1.Subject{
-						rbacv1.Subject{
-							Kind:      "ServiceAccount",
-							Name:      clusterPermission.ServiceAccountName,
-							Namespace: *operatorNamespace,
-						},
-					},
-				})
-			}
-		}
-	}
-
-	// Write out CRDs and CR
-	util.MarshallObject(components.GetOperatorCR(), operatorCr)
-	util.MarshallObject(components.GetOperatorCRD(*apiSources), operatorCrd)
-	util.MarshallObject(components.GetV2VCRD(), v2vCrd)
-	util.MarshallObject(components.GetV2VOvirtProviderCRD(), v2voVirtCrd)
-
-	// Write out deployments
+func writeOperatorYaml(deployments []appsv1.Deployment, services []v1.Service) {
+	operatorYaml, err := os.Create(path.Join(*deployDir, "operator.yaml"))
+	check(err)
+	defer operatorYaml.Close()
 	for _, deployment := range deployments {
-		util.MarshallObject(deployment, operatorYaml)
+		check(util.MarshallObject(deployment, operatorYaml))
 	}
 
 	// Write out deployments
 	for _, service := range services {
-		util.MarshallObject(service, operatorYaml)
+		check(util.MarshallObject(service, operatorYaml))
 	}
+}
 
-	// Write out rbac
-	// since maps are not ordered we must enforce one before writing
+func writeSaYaml(serviceAccounts map[string]v1.ServiceAccount) {
 	var keys []string
 	for saName := range serviceAccounts {
 		keys = append(keys, saName)
 	}
 	sort.Strings(keys)
+
+	saYaml, err := os.Create(path.Join(*deployDir, "service_account.yaml"))
+	check(err)
+	defer saYaml.Close()
+
 	for _, k := range keys {
-		util.MarshallObject(serviceAccounts[k], saYaml)
+		check(util.MarshallObject(serviceAccounts[k], saYaml))
 	}
-	for _, permission := range permissions {
-		util.MarshallObject(permission, crYaml)
-	}
+}
+
+func writeCrbYaml(roleBindings []rbacv1.RoleBinding, clusterRoleBindings []rbacv1.ClusterRoleBinding) {
+	crbYaml, err := os.Create(path.Join(*deployDir, "cluster_role_binding.yaml"))
+	check(err)
+	defer crbYaml.Close()
+
 	for _, roleBinding := range roleBindings {
-		util.MarshallObject(roleBinding, crbYaml)
+		check(util.MarshallObject(roleBinding, crbYaml))
+	}
+
+	for _, clusterRoleBinding := range clusterRoleBindings {
+		check(util.MarshallObject(clusterRoleBinding, crbYaml))
+	}
+}
+
+func writeCrYaml(permissions []rbacv1.Role, clusterPermissions []rbacv1.ClusterRole) {
+	crYaml, err := os.Create(path.Join(*deployDir, "cluster_role.yaml"))
+	check(err)
+	defer crYaml.Close()
+
+	for _, permission := range permissions {
+		check(util.MarshallObject(permission, crYaml))
 	}
 	for _, clusterPermission := range clusterPermissions {
-		util.MarshallObject(clusterPermission, crYaml)
-	}
-	for _, clusterRoleBinding := range clusterRoleBindings {
-		util.MarshallObject(clusterRoleBinding, crbYaml)
+		check(util.MarshallObject(clusterPermission, crYaml))
 	}
 }
 


### PR DESCRIPTION
1. Define a constant instead of duplicating this literal "rbac.authorization.k8s.io/v1" 4 times.
2. Refactor this method to reduce its Cognitive Complexity from 29 to the 15 allowed.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

