### PR TITLE
Apply default CPU model configuration for VM live migration

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -203,6 +203,7 @@ spec:
                   is baremetal.
                 type: boolean
               featureGates:
+                default: null
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
@@ -211,9 +212,11 @@ spec:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean
                   withHostModelCPU:
+                    default: true
                     description: Support migration for VMs with host-model CPU mode
                     type: boolean
                   withHostPassthroughCPU:
+                    default: false
                     description: Allow migrating a virtual machine with CPU host-passthrough
                       mode. This should be enabled only when the Cluster is homogeneous
                       from CPU HW perspective doc here

--- a/deploy/index-image/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/index-image/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -203,6 +203,7 @@ spec:
                   is baremetal.
                 type: boolean
               featureGates:
+                default: null
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
@@ -211,9 +212,11 @@ spec:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean
                   withHostModelCPU:
+                    default: true
                     description: Support migration for VMs with host-model CPU mode
                     type: boolean
                   withHostPassthroughCPU:
+                    default: false
                     description: Allow migrating a virtual machine with CPU host-passthrough
                       mode. This should be enabled only when the Cluster is homogeneous
                       from CPU HW perspective doc here

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -203,6 +203,7 @@ spec:
                   is baremetal.
                 type: boolean
               featureGates:
+                default: null
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
@@ -211,9 +212,11 @@ spec:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean
                   withHostModelCPU:
+                    default: true
                     description: Support migration for VMs with host-model CPU mode
                     type: boolean
                   withHostPassthroughCPU:
+                    default: false
                     description: Allow migrating a virtual machine with CPU host-passthrough
                       mode. This should be enabled only when the Cluster is homogeneous
                       from CPU HW perspective doc here

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:a137fd1ee55ae8806cbdd66912c7931c7f567315f0a927b3a12090112e96edb1
-    createdAt: "2021-01-28 07:31:21"
+    createdAt: "2021-01-28 18:56:06"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -42,6 +42,7 @@ type HyperConvergedSpec struct {
 	// featureGates is a map of feature gate flags. Setting a flag to `true` will enable
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
 	// +optional
+	// +kubebuilder:default={}
 	FeatureGates *HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
 	// operator version
@@ -67,10 +68,12 @@ type HyperConvergedFeatureGates struct {
 	// Allow migrating a virtual machine with CPU host-passthrough mode. This should be
 	// enabled only when the Cluster is homogeneous from CPU HW perspective doc here
 	// +optional
+	// +kubebuilder:default=false
 	WithHostPassthroughCPU *bool `json:"withHostPassthroughCPU,omitempty"`
 
 	// Support migration for VMs with host-model CPU mode
 	// +optional
+	// +kubebuilder:default=true
 	WithHostModelCPU *bool `json:"withHostModelCPU,omitempty"`
 }
 


### PR DESCRIPTION
host-model live migration is helpful in homogenous CPU clusters
therefore it will be enabled by default (withHostModelCPU: true)
host-passthrough live migration is more restrictive since it's
the cluster administrator responsibility to make sure the CPU HW
is identical among the worker nodes, therefore disabled by default
(withHostPassthroughCPU: false)

For more info please refer to BZ comments:
https://bugzilla.redhat.com/show_bug.cgi?id=1760028

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set default CPU model configuration for VM live migration
```

