### PR TITLE
Fix CSV upgrade workflow

### DIFF
--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -40,6 +40,11 @@ function create_index_image() {
 
   docker build -t "${BUNDLE_IMAGE_NAME}" -f bundle.Dockerfile --build-arg "VERSION=${CURRENT_VERSION}" .
   docker push "${BUNDLE_IMAGE_NAME}"
+
+  # Extract the digest of the bundle image, to be added to the index image
+  DIGEST=$("${PROJECT_ROOT}/tools/digester/digester" --image "${BUNDLE_IMAGE_NAME}" -d)
+  BUNDLE_IMAGE_NAME="${IMAGE_REGISTRY}/${REGISTRY_NAMESPACE}/${BUNDLE_REGISTRY_IMAGE_NAME}@sha256:${DIGEST}"
+
   # shellcheck disable=SC2086
   ${OPM} index add --bundles "${BUNDLE_IMAGE_NAME}" ${INDEX_IMAGE_PARAM} --tag "${INDEX_IMAGE_NAME}" -u docker
   docker push "${INDEX_IMAGE_NAME}"


### PR DESCRIPTION
Currently, the "unstable" bundle image specified in the "unstable" index image at _quay.io/kubevirt_, stays with the same tag upon updates, which causing the cluster not to pull the updated bundle image when an upgrade is available, because the same tag already exists on the cluster's nodes.
This PR adds the bundle image's digest to the index, instead of unchanging tag, ensuring that a cluster subscribed to `quay.io/kubevirt/hyperconverged-cluster-index:1.4.0-unstable` will be able to be upgraded automatically when the index image is polled.


Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

