### PR TITLE
Fix the Default Values in the FeatureGates field

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -50,7 +50,9 @@ spec:
                   is baremetal.
                 type: boolean
               featureGates:
-                default: null
+                default:
+                  withHostModelCPU: true
+                  withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.

--- a/deploy/index-image/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/index-image/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -50,7 +50,9 @@ spec:
                   is baremetal.
                 type: boolean
               featureGates:
-                default: null
+                default:
+                  withHostModelCPU: true
+                  withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.

--- a/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -50,7 +50,9 @@ spec:
                   is baremetal.
                 type: boolean
               featureGates:
-                default: null
+                default:
+                  withHostModelCPU: true
+                  withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -42,7 +42,7 @@ type HyperConvergedSpec struct {
 	// featureGates is a map of feature gate flags. Setting a flag to `true` will enable
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
 	// +optional
-	// +kubebuilder:default={}
+	// +kubebuilder:default={withHostModelCPU: true, withHostPassthroughCPU: false}
 	FeatureGates *HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
 	// operator version

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -42,6 +42,7 @@ type HyperConvergedSpec struct {
 	// featureGates is a map of feature gate flags. Setting a flag to `true` will enable
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
 	// +optional
+	// +TODO: Always keep the default FeatureGates in sync with the default field values in HyperConvergedFeatureGates //NOSONAR
 	// +kubebuilder:default={withHostModelCPU: true, withHostPassthroughCPU: false}
 	FeatureGates *HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 


### PR DESCRIPTION
PR #1109 added default valuse for several feature gates. In order to do that, it tried to set the default value of the `featureGates` field to an empty object (`{}`), in order to force its existance, and then the flag specific default value shoulf take place.

Although this is working very well by manually editing the CRD, and we get exactlly what we want, this is not possible to set the empty object using an annotation:

``` golang
// +kubebuilder:default={}
FeatureGates *HyperConvergedFeatureGates `json:"featureGates,omitempty"`
```

produces a CRD with default of `null`:
``` yaml
featureGates:
  default: null
```
instead of the required:
``` yaml
featureGates:
  default: {}
```
And that causes to the `featureGates` field to not appear by default as required.

This PR sets the default in two places: both on the `featureGates` field as an object, and on `withHostModelCPU` and the `withHostPassthroughCPU` inner fields as a boolean (no change).

After the change we get the required behavior - the default flags appear if they are missing with their default values, independently - it is possible to set each one of them to other value, but deleting them or the whole `fatureGates` field will cause applying of the default values.

Nahshon Unna-Tsameret <nunnatsa@redhat.com>

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the Default Values in the FeatureGates field
```

