### PR TITLE
Refactor ReconcileHyperConverged.Reconcile()

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -339,6 +339,12 @@ func (r *ReconcileHyperConverged) getHyperConverged(req *common.HcoRequest) (*hc
 	instance := &hcov1beta1.HyperConverged{}
 	err := r.client.Get(req.Ctx, req.NamespacedName, instance)
 
+	// Green path first
+	if err == nil {
+		return instance, nil
+	}
+
+	// Error path
 	if apierrors.IsNotFound(err) {
 		req.Logger.Info("No HyperConverged resource")
 		// Request object not found, could have been deleted after reconcile request.
@@ -347,12 +353,9 @@ func (r *ReconcileHyperConverged) getHyperConverged(req *common.HcoRequest) (*hc
 		return nil, nil
 	}
 
-	if err != nil {
-		// Error reading the object - requeue the request.
-		return nil, err
-	}
-
-	return instance, nil
+	// Another error reading the object.
+	// Just return the error so that the request is requeued.
+	return nil, err
 }
 
 // updateHyperConverged updates the HyperConverged resource according to its state in the request.


### PR DESCRIPTION
Fixes a code smell (high cognitive complexity) reported by SonarCloud.

This is a another attempt to refactor this method after c953851 in #1104 resulted in unexplained test failures (timeouts in deleting secondary objects). This time I'll apply the refactoring gradually until the test failures are reproduced.

FOOTNOTE:
Yes, these refactoring iterations are supposed to be done locally accompanied by frequent unit testing executions. However, these particular failures aren't caught by the unit tests - only by the heavyweight CI tests.

Signed-off-by: Zvi Cahana <zvic@il.ibm.com>

**Release note**:
-->
```release-note
NONE
```

