### PR TITLE
Introduce a test container for func-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ REGISTRY_NAMESPACE ?= kubevirt
 IMAGE_TAG          ?= latest
 OPERATOR_IMAGE     ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-operator
 WEBHOOK_IMAGE      ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-webhook
+FUNC_TEST_IMAGE    ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-functest
 
 
 
@@ -61,7 +62,7 @@ bundle-push: container-build-operator-courier
 hack-clean: ## Run ./hack/clean.sh
 	./hack/clean.sh
 
-container-build: container-build-operator container-build-webhook container-build-operator-courier
+container-build: container-build-operator container-build-webhook container-build-operator-courier container-build-functest
 
 container-build-operator:
 	docker build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
@@ -72,7 +73,10 @@ container-build-webhook:
 container-build-operator-courier:
 	docker build -f tools/operator-courier/Dockerfile -t hco-courier .
 
-container-push: quay-login container-push-operator container-push-webhook
+container-build-functest:
+	docker build -f build/Dockerfile.functest -t $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+
+container-push: quay-login container-push-operator container-push-webhook container-push-functest
 
 quay-login:
 	docker login $(IMAGE_REGISTRY) -u $(QUAY_USERNAME) -p $(QUAY_PASSWORD)
@@ -82,6 +86,9 @@ container-push-operator:
 
 container-push-webhook:
 	docker push $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
+
+container-push-functest:
+	docker push $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)
 
 cluster-up:
 	./cluster/up.sh

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -9,14 +9,14 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 ENV USER_UID=1001 \
     TEST_OUT_PATH=/test
 
+WORKDIR ${TEST_OUT_PATH}
+ENTRYPOINT ./hack/run-tests.sh
+USER ${USER_UID}
+
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/_out/func-tests.test  ${TEST_OUT_PATH}/
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/hack  ${TEST_OUT_PATH}/hack
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/deploy  ${TEST_OUT_PATH}/deploy
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/cluster ${TEST_OUT_PATH}/cluster
-
-WORKDIR ${TEST_OUT_PATH}
-ENTRYPOINT  ./hack/run-tests.sh
-USER ${USER_UID}
 
 ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git
 ARG git_sha=NONE

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -1,0 +1,25 @@
+FROM golang:1.15.2 AS builder
+
+WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
+COPY . .
+RUN make build-functest
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+ENV USER_UID=1001 \
+    TEST_OUT_PATH=/test
+
+COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/_out/func-tests.test  ${TEST_OUT_PATH}/
+COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/hack  ${TEST_OUT_PATH}/hack
+COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/deploy  ${TEST_OUT_PATH}/deploy
+COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/cluster ${TEST_OUT_PATH}/cluster
+
+WORKDIR ${TEST_OUT_PATH}
+ENTRYPOINT  ./hack/run-tests.sh
+USER ${USER_UID}
+
+ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git
+ARG git_sha=NONE
+
+LABEL multi.GIT_URL=${git_url} \
+      multi.GIT_SHA=${git_sha}

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -37,8 +37,7 @@ BASE_PATH=${KUBEVIRTCI_CONFIG_PATH:-$PWD}
 KUBEVIRTCI_PATH=$(kubevirtci::path)
 CMD=${CMD:-}
 KUBECTL=${KUBECTL:-}
-TEST_PATH="tests/func-tests"
-TEST_OUT_PATH=${TEST_PATH}/_out
+TEST_OUT_PATH=${TEST_OUT_PATH:-"tests/func-tests/_out"}
 JOB_TYPE=${JOB_TYPE:-}
 
 KUBECTL=$(which kubectl 2> /dev/null) || true

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE:-"kubevirt-hyperconverged"}
+
 source hack/common.sh
 source cluster/kubevirtci.sh
 
@@ -16,16 +18,22 @@ else
     export KUBECTL_BINARY="cluster/kubectl.sh"
 fi
 
-./${TEST_OUT_PATH}/func-tests.test -ginkgo.v -kubeconfig="${KUBECONFIG}" -installed-namespace=kubevirt-hyperconverged -cdi-namespace=kubevirt-hyperconverged
+# when the tests are run in a pod, in-cluster config will be used
+KUBECONFIG_FLAG=""
+if [[ -n "${KUBECONFIG-}" ]]; then
+  KUBECONFIG_FLAG="-kubeconfig="${KUBECONFIG}""
+fi
 
+${TEST_OUT_PATH}/func-tests.test -ginkgo.v -installed-namespace="${INSTALLED_NAMESPACE}" -cdi-namespace="${INSTALLED_NAMESPACE}" "${KUBECONFIG_FLAG}"
+exit 0
 # wait a minute to allow all VMs to be deleted before attempting to change node placement configuration
 sleep 60
 
 # Check the webhook, to see if it allow updating of the HyperConverged CR
-${KUBECTL_BINARY} patch hco -n kubevirt-hyperconverged kubevirt-hyperconverged -p '{"spec":{"infra":{"nodePlacement":{"tolerations":[{"effect":"NoSchedule","key":"key","operator":"Equal","value":"value"}]}}}}' --type=merge
-${KUBECTL_BINARY} patch hco -n kubevirt-hyperconverged kubevirt-hyperconverged -p '{"spec":{"workloads":{"nodePlacement":{"tolerations":[{"effect":"NoSchedule","key":"key","operator":"Equal","value":"value"}]}}}}' --type=merge
+${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -p '{"spec":{"infra":{"nodePlacement":{"tolerations":[{"effect":"NoSchedule","key":"key","operator":"Equal","value":"value"}]}}}}' --type=merge
+${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -p '{"spec":{"workloads":{"nodePlacement":{"tolerations":[{"effect":"NoSchedule","key":"key","operator":"Equal","value":"value"}]}}}}' --type=merge
 # Read the HyperConverged CR
-${KUBECTL_BINARY} get hco -n kubevirt-hyperconverged kubevirt-hyperconverged -o yaml
+${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o yaml
 
 # wait a bit to make sure the VMs are deleted
 sleep 60
@@ -35,4 +43,4 @@ KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/test_quick_start.sh
 ./hack/retry.sh 10 30 "KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_labels.sh"
 
 # Check the webhook, to see if it allow deleteing of the HyperConverged CR
-./hack/retry.sh 10 30 "${KUBECTL_BINARY} delete hco -n kubevirt-hyperconverged kubevirt-hyperconverged"
+./hack/retry.sh 10 30 "${KUBECTL_BINARY} delete hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged"


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

This PR introduces a new container image that contains functional tests of hyperconverged-cluster-operator.  

***Build***
```
container-build-functest
```

***Run***
```
kubectl create clusterrolebinding func-cluster-admin --clusterrole=cluster-admin --serviceaccount=kubevirt-hyperconverged:functest

kubectl create serviceaccount functest

kubectl run functest --image=quay.io/kubevirt/hyperconverged-cluster-functest:latest --env="INSTALLED_NAMESPACE=kubevirt-hyperconverged" --serviceaccount=functest 
```

I did run the container with root user as well. It works. 

**Release note**:
```release-note
None
```

