### PR TITLE
Move cmds' common code to a new package

### DIFF
--- a/cmd/cmdcommon/cmdcommon.go
+++ b/cmd/cmdcommon/cmdcommon.go
@@ -1,0 +1,118 @@
+package cmdcommon
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/pflag"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+type HcCmdHelper struct {
+	Logger     logr.Logger
+	runInLocal bool
+	Name       string
+}
+
+func NewHelper(logger logr.Logger, name string) *HcCmdHelper {
+	return &HcCmdHelper{
+		Logger:     logger,
+		Name:       name,
+		runInLocal: hcoutil.IsRunModeLocal(),
+	}
+}
+
+// InitiateCommand adds flags registered by imported packages (e.g. glog and
+// controller-runtime)
+func (h HcCmdHelper) InitiateCommand() {
+	zapFlagSet := flag.NewFlagSet("zap", flag.ExitOnError)
+
+	updateFlagSet(flag.CommandLine, zapFlagSet)
+	pflag.Parse()
+
+	zapLogger := getZapLogger(zapFlagSet)
+	logf.SetLogger(zapLogger)
+
+	h.printVersion()
+
+	h.checkNameSpace()
+}
+
+func (h HcCmdHelper) GetWatchNS() string {
+	if !h.runInLocal {
+		watchNamespace, err := hcoutil.GetWatchNamespace()
+		h.ExitOnError(err, "Failed to get watch namespace")
+		return watchNamespace
+	}
+
+	return ""
+}
+
+func (h HcCmdHelper) ExitOnError(err error, message string, keysAndValues ...interface{}) {
+	if err != nil {
+		h.Logger.Error(err, message, keysAndValues...)
+		os.Exit(1)
+	}
+}
+
+func (h HcCmdHelper) IsRunInLocal() bool {
+	return h.runInLocal
+}
+
+func (h HcCmdHelper) AddToScheme(mgr manager.Manager, addToSchemeFuncs []func(*apiruntime.Scheme) error) {
+	for _, f := range addToSchemeFuncs {
+		err := f(mgr.GetScheme())
+		h.ExitOnError(err, "Failed to add to scheme")
+	}
+}
+
+func (h HcCmdHelper) printVersion() {
+	h.Logger.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	h.Logger.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+}
+
+func (h HcCmdHelper) checkNameSpace() {
+	// Get the namespace that we should be deployed in.
+	requiredNS, err := hcoutil.GetOperatorNamespaceFromEnv()
+	h.ExitOnError(err, "Failed to get namespace from the environment")
+
+	// Get the namespace the we are currently deployed in.
+	var actualNS string
+	if !h.runInLocal {
+		var err error
+		actualNS, err = hcoutil.GetOperatorNamespace(h.Logger)
+		h.ExitOnError(err, "Failed to get namespace")
+	} else {
+		h.Logger.Info("running locally")
+		actualNS = requiredNS
+	}
+
+	if actualNS != requiredNS {
+		err := fmt.Errorf("%s is running in different namespace than expected", h.Name)
+		msg := fmt.Sprintf("Please re-deploy this %s into %v namespace", h.Name, requiredNS)
+		h.ExitOnError(err, msg, "Expected.Namespace", requiredNS, "Deployed.Namespace", actualNS)
+	}
+}
+
+func getZapLogger(zapFlagSet *flag.FlagSet) logr.Logger {
+	// Use a zap logr.Logger implementation. If none of the zap
+	// flags are configured (or if the zap flag set is not being
+	// used), this defaults to a production zap logger.
+	zapOpts := &zap.Options{}
+	zapOpts.BindFlags(zapFlagSet)
+	return zap.New(zap.UseFlagOptions(zapOpts))
+}
+
+func updateFlagSet(flags ...*flag.FlagSet) {
+	for _, f := range flags {
+		pflag.CommandLine.AddGoFlagSet(f)
+	}
+}

--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -2,19 +2,16 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
-	"runtime"
 
+	"github.com/kubevirt/hyperconverged-cluster-operator/cmd/cmdcommon"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/operands"
-	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
@@ -39,104 +36,9 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	log = logf.Log.WithName("cmd")
-)
-
-func printVersion() {
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-}
-
-func main() {
-
-	// Add flags registered by imported packages (e.g. glog and
-	// controller-runtime)
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-
-	zapfs := flag.NewFlagSet("zap", flag.ExitOnError)
-	zopts := &zap.Options{}
-	zopts.BindFlags(zapfs)
-	pflag.CommandLine.AddGoFlagSet(zapfs)
-
-	pflag.Parse()
-
-	// Use a zap logr.Logger implementation. If none of the zap
-	// flags are configured (or if the zap flag set is not being
-	// used), this defaults to a production zap logger.
-	logf.SetLogger(zap.New(zap.UseFlagOptions(zopts)))
-
-	printVersion()
-
-	// Get the namespace the operator is currently deployed in.
-	depOperatorNs, err := hcoutil.GetOperatorNamespace(log)
-	runInLocal := false
-	if err != nil {
-		if err == hcoutil.ErrRunLocal {
-			runInLocal = true
-		} else {
-			log.Error(err, "Failed to get operator namespace")
-			os.Exit(1)
-		}
-	}
-
-	if runInLocal {
-		log.Info("running locally")
-	}
-
-	watchNamespace := ""
-
-	if !runInLocal {
-		watchNamespace, err = hcoutil.GetWatchNamespace()
-		exitOnError(err, "Failed to get watch namespace")
-	}
-
-	// Get the namespace the operator should be deployed in.
-	operatorNsEnv, err := hcoutil.GetOperatorNamespaceFromEnv()
-	exitOnError(err, "Failed to get operator namespace from the environment")
-
-	if runInLocal {
-		depOperatorNs = operatorNsEnv
-	}
-
-	if depOperatorNs != operatorNsEnv {
-		log.Error(
-			fmt.Errorf("operator running in different namespace than expected"),
-			fmt.Sprintf("Please re-deploy this operator into %v namespace", operatorNsEnv),
-			"Expected.Namespace", operatorNsEnv,
-			"Deployed.Namespace", depOperatorNs,
-		)
-		os.Exit(1)
-	}
-
-	// Get a config to talk to the apiserver
-	cfg, err := config.GetConfig()
-	exitOnError(err, "can't load configuration")
-
-	ctx := context.TODO()
-
-	// a lock is not needed in webhook mode
-	// TODO: remove this once we will move to OLM operator conditions
-	needLeaderElection := !runInLocal
-
-	// Create a new Cmd to provide shared dependencies and start components
-	// TODO: consider changing LeaderElectionResourceLock to new default "configmapsleases".
-	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:                  watchNamespace,
-		MetricsBindAddress:         fmt.Sprintf("%s:%d", hcoutil.MetricsHost, hcoutil.MetricsPort),
-		HealthProbeBindAddress:     fmt.Sprintf("%s:%d", hcoutil.HealthProbeHost, hcoutil.HealthProbePort),
-		ReadinessEndpointName:      hcoutil.ReadinessEndpointName,
-		LivenessEndpointName:       hcoutil.LivenessEndpointName,
-		LeaderElection:             needLeaderElection,
-		LeaderElectionResourceLock: "configmaps",
-		LeaderElectionID:           "hyperconverged-cluster-operator-lock",
-	})
-
-	exitOnError(err, "can't initiate manager")
-
-	log.Info("Registering Components.")
-
-	// Setup Scheme for all resources
-	for _, f := range []func(*apiruntime.Scheme) error{
+	logger               = logf.Log.WithName("hyperconverged-operator-cmd")
+	cmdHelper            = cmdcommon.NewHelper(logger, "operator")
+	resourcesSchemeFuncs = []func(*apiruntime.Scheme) error{
 		apis.AddToScheme,
 		cdiv1beta1.AddToScheme,
 		networkaddons.AddToScheme,
@@ -149,45 +51,81 @@ func main() {
 		monitoringv1.AddToScheme,
 		consolev1.AddToScheme,
 		apiextensionsv1.AddToScheme,
-	} {
-		err := f(mgr.GetScheme())
-		exitOnError(err, "Failed to add to scheme")
 	}
+)
+
+func main() {
+	cmdHelper.InitiateCommand()
+
+	watchNamespace := cmdHelper.GetWatchNS()
+
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	cmdHelper.ExitOnError(err, "can't load configuration")
+
+	// a lock is not needed in webhook mode
+	// TODO: remove this once we will move to OLM operator conditions
+	needLeaderElection := !cmdHelper.IsRunInLocal()
+
+	// Create a new Cmd to provide shared dependencies and start components
+	// TODO: consider changing LeaderElectionResourceLock to new default "configmapsleases".
+	mgr, err := manager.New(cfg, getMnanagerOptions(watchNamespace, needLeaderElection))
+
+	cmdHelper.ExitOnError(err, "can't initiate manager")
+
+	logger.Info("Registering Components.")
+
+	// Setup Scheme for all resources
+	cmdHelper.AddToScheme(mgr, resourcesSchemeFuncs)
 
 	// Detect OpenShift version
+	ctx := context.TODO()
 	ci := hcoutil.GetClusterInfo()
-	err = ci.CheckRunningInOpenshift(mgr.GetAPIReader(), ctx, log, runInLocal)
-	exitOnError(err, "Cannot detect cluster type")
+	err = ci.CheckRunningInOpenshift(mgr.GetAPIReader(), ctx, logger, cmdHelper.IsRunInLocal())
+	cmdHelper.ExitOnError(err, "Cannot detect cluster type")
 
 	eventEmitter := hcoutil.GetEventEmitter()
 	// Set temporary configuration, until the regular client is ready
-	eventEmitter.Init(ctx, mgr, ci, log)
+	eventEmitter.Init(ctx, mgr, ci, logger)
 
 	err = mgr.AddHealthzCheck("ping", healthz.Ping)
-	exitOnError(err, "unable to add health check")
+	cmdHelper.ExitOnError(err, "unable to add health check")
 
 	readyCheck := hcoutil.GetHcoPing()
 
 	err = mgr.AddReadyzCheck("ready", readyCheck)
-	exitOnError(err, "unable to add ready check")
+	cmdHelper.ExitOnError(err, "unable to add ready check")
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr, ci); err != nil {
-		log.Error(err, "")
+		logger.Error(err, "")
 		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to register component; "+err.Error())
 		os.Exit(1)
 	}
 
 	err = createPriorityClass(ctx, mgr)
-	exitOnError(err, "Failed creating PriorityClass")
+	cmdHelper.ExitOnError(err, "Failed creating PriorityClass")
 
-	log.Info("Starting the Cmd.")
+	logger.Info("Starting the Cmd.")
 	eventEmitter.EmitEvent(nil, corev1.EventTypeNormal, "Init", "Starting the HyperConverged Pod")
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		log.Error(err, "Manager exited non-zero")
+		logger.Error(err, "Manager exited non-zero")
 		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "UnexpectedError", "HyperConverged crashed; "+err.Error())
 		os.Exit(1)
+	}
+}
+
+func getMnanagerOptions(watchNamespace string, needLeaderElection bool) manager.Options {
+	return manager.Options{
+		Namespace:                  watchNamespace,
+		MetricsBindAddress:         fmt.Sprintf("%s:%d", hcoutil.MetricsHost, hcoutil.MetricsPort),
+		HealthProbeBindAddress:     fmt.Sprintf("%s:%d", hcoutil.HealthProbeHost, hcoutil.HealthProbePort),
+		ReadinessEndpointName:      hcoutil.ReadinessEndpointName,
+		LivenessEndpointName:       hcoutil.LivenessEndpointName,
+		LeaderElection:             needLeaderElection,
+		LeaderElectionResourceLock: "configmaps",
+		LeaderElectionID:           "hyperconverged-cluster-operator-lock",
 	}
 }
 
@@ -201,16 +139,9 @@ func createPriorityClass(ctx context.Context, mgr manager.Manager) error {
 
 	err := mgr.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(pc), pc)
 	if err != nil && apierrors.IsNotFound(err) {
-		log.Info("Creating KubeVirt PriorityClass")
+		logger.Info("Creating KubeVirt PriorityClass")
 		return mgr.GetClient().Create(ctx, pc, &client.CreateOptions{})
 	}
 
 	return err
-}
-
-func exitOnError(err error, message string) {
-	if err != nil {
-		log.Error(err, message)
-		os.Exit(1)
-	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -58,13 +58,13 @@ func GetOperatorNamespaceFromEnv() (string, error) {
 	return "", fmt.Errorf("%s unset or empty in environment", OperatorNamespaceEnv)
 }
 
-func isRunModeLocal() bool {
+func IsRunModeLocal() bool {
 	return os.Getenv(ForceRunModeEnv) == string(LocalRunMode)
 }
 
 // GetOperatorNamespace returns the namespace the operator should be running in.
 func GetOperatorNamespace(logger logr.Logger) (string, error) {
-	if isRunModeLocal() {
+	if IsRunModeLocal() {
 		return "", ErrRunLocal
 	}
 	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")


### PR DESCRIPTION
In order to reduce code duplication, added the new `cmdcommon` package that contains code that was common to the operator and the webhook commands.

`cmdcommon.HcCmdHelper` is the type that holds the common methods.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

