### PR TITLE
Add SRIOV Live Migration feature-gate to HyperConverged CR

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -60,6 +60,12 @@ spec:
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean
+                  sriovLiveMigration:
+                    description: Allow migrating a virtual machine with SRIOV interfaces.
+                      When enabled virt-launcher pods of virtual machines with SRIOV
+                      interfaces run with CAP_SYS_RESOURCE capability. This may degrade
+                      virt-launcher security.
+                    type: boolean
                   withHostModelCPU:
                     default: true
                     description: Support migration for VMs with host-model CPU mode

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -60,6 +60,12 @@ spec:
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean
+                  sriovLiveMigration:
+                    description: Allow migrating a virtual machine with SRIOV interfaces.
+                      When enabled virt-launcher pods of virtual machines with SRIOV
+                      interfaces run with CAP_SYS_RESOURCE capability. This may degrade
+                      virt-launcher security.
+                    type: boolean
                   withHostModelCPU:
                     default: true
                     description: Support migration for VMs with host-model CPU mode

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -60,6 +60,12 @@ spec:
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean
+                  sriovLiveMigration:
+                    description: Allow migrating a virtual machine with SRIOV interfaces.
+                      When enabled virt-launcher pods of virtual machines with SRIOV
+                      interfaces run with CAP_SYS_RESOURCE capability. This may degrade
+                      virt-launcher security.
+                    type: boolean
                   withHostModelCPU:
                     default: true
                     description: Support migration for VMs with host-model CPU mode

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:a137fd1ee55ae8806cbdd66912c7931c7f567315f0a927b3a12090112e96edb1
-    createdAt: "2021-02-03 10:34:01"
+    createdAt: "2021-02-03 15:33:15"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -62,6 +62,13 @@ type HyperConvergedConfig struct {
 // +optional
 // +k8s:openapi-gen=true
 type HyperConvergedFeatureGates struct {
+	// Allow migrating a virtual machine with SRIOV interfaces.
+	// When enabled virt-launcher pods of virtual machines with SRIOV
+	// interfaces run with CAP_SYS_RESOURCE capability.
+	// This may degrade virt-launcher security.
+	// +optional
+	SRIOVLiveMigration *bool `json:"sriovLiveMigration,omitempty"`
+
 	// Allow attaching a data volume to a running VMI
 	// +optional
 	HotplugVolumes *bool `json:"hotplugVolumes,omitempty"`
@@ -80,6 +87,10 @@ type HyperConvergedFeatureGates struct {
 
 func (fgs *HyperConvergedFeatureGates) IsHotplugVolumesEnabled() bool {
 	return (fgs != nil) && (fgs.HotplugVolumes != nil) && (*fgs.HotplugVolumes)
+}
+
+func (fgs *HyperConvergedFeatureGates) IsSRIOVLiveMigrationEnabled() bool {
+	return (fgs != nil) && (fgs.SRIOVLiveMigration != nil) && (*fgs.SRIOVLiveMigration)
 }
 
 func (fgs *HyperConvergedFeatureGates) IsWithHostPassthroughCPUEnabled() bool {

--- a/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
@@ -327,6 +327,34 @@ var _ = Describe("HyperconvergedTypes", func() {
 			})
 		})
 
+		Context("Test IsSRIOVLiveMigrationEnabled", func() {
+			It("Should return false if HyperConvergedFeatureGates is nil", func() {
+				var fgs *HyperConvergedFeatureGates = nil
+				Expect(fgs.IsSRIOVLiveMigrationEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsSRIOVLiveMigrationEnabled does not exist", func() {
+				fgs := &HyperConvergedFeatureGates{}
+				Expect(fgs.IsSRIOVLiveMigrationEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsSRIOVLiveMigrationEnabled is false", func() {
+				disabled := false
+				fgs := &HyperConvergedFeatureGates{
+					SRIOVLiveMigration: &disabled,
+				}
+				Expect(fgs.IsSRIOVLiveMigrationEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsSRIOVLiveMigrationEnabled is true", func() {
+				enabled := true
+				fgs := &HyperConvergedFeatureGates{
+					SRIOVLiveMigration: &enabled,
+				}
+				Expect(fgs.IsSRIOVLiveMigrationEnabled()).To(BeTrue())
+			})
+		})
+
 		Context("Test IsWithHostPassthroughCPUEnabled", func() {
 			It("Should return false if HyperConvergedFeatureGates is nil", func() {
 				var fgs *HyperConvergedFeatureGates = nil

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -33,6 +33,7 @@ const (
 	SELinuxLauncherTypeKey  = "selinuxLauncherType"
 	DefaultNetworkInterface = "bridge"
 	HotplugVolumesGate      = "HotplugVolumes"
+	SRIOVLiveMigrationGate  = "SRIOVLiveMigration"
 )
 
 const (
@@ -311,6 +312,11 @@ func filterOutDisabledFeatureGates(req *common.HcoRequest, foundFgSplit []string
 				fgChanged = true
 				continue
 			}
+		case SRIOVLiveMigrationGate:
+			if !req.Instance.Spec.FeatureGates.IsSRIOVLiveMigrationEnabled() {
+				fgChanged = true
+				continue
+			}
 		}
 		resultFg = append(resultFg, fg)
 	}
@@ -516,6 +522,10 @@ func getKvFeatureGateList(fgs *hcov1beta1.HyperConvergedFeatureGates) []string {
 
 	if fgs.IsWithHostModelCPUEnabled() {
 		res = append(res, kvWithHostModelCPU)
+	}
+
+	if fgs.IsSRIOVLiveMigrationEnabled() {
+		res = append(res, SRIOVLiveMigrationGate)
 	}
 
 	return res

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -257,7 +257,7 @@ func (h *kvConfigHooks) updateDataNotOnUpgrade(req *common.HcoRequest, found *co
 	resultFg := make([]string, 0, len(foundFgSplit))
 
 	// 2. Remove only managed FGs from the list, if are not in the HC CR
-	changed, resultFg := h.filterDisabledFeatureGates(req, foundFgSplit, resultFg)
+	changed, resultFg := filterOutDisabledFeatureGates(req, foundFgSplit, resultFg)
 
 	// 3. Add managed FGs if set in the HC CR
 	added := false
@@ -291,7 +291,7 @@ func (h *kvConfigHooks) addEnabledFeatureGates(req *common.HcoRequest, foundFgSp
 	return resultFg, fgChanged
 }
 
-func (h *kvConfigHooks) filterDisabledFeatureGates(req *common.HcoRequest, foundFgSplit []string, resultFg []string) (bool, []string) {
+func filterOutDisabledFeatureGates(req *common.HcoRequest, foundFgSplit []string, resultFg []string) (bool, []string) {
 	fgChanged := false
 	for _, fg := range foundFgSplit {
 		// Remove if not in HC CR


### PR DESCRIPTION
Following kubevirt/kubevirt/pull/4874, as part of SRIOV Live Migration feature it is 
necessary to enable HCO to control this feature-gate

This PR add's SRIOV Live Migration feature-gate on HyperConverged CR
and handle it accordingly.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Functional Changes:
Control Kubevirt `SRIOVLiveMigration` feature-gate from HyperConverged CR.

API Changes:
Add The `SRIOVLiveMigration` optional field `toHyperConvergedFeatureGates`
```

