### PR TITLE
Remove leftover exit

### DIFF
--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -25,7 +25,7 @@ if [[ -n "${KUBECONFIG-}" ]]; then
 fi
 
 ${TEST_OUT_PATH}/func-tests.test -ginkgo.v -installed-namespace="${INSTALLED_NAMESPACE}" -cdi-namespace="${INSTALLED_NAMESPACE}" "${KUBECONFIG_FLAG}"
-exit 0
+
 # wait a minute to allow all VMs to be deleted before attempting to change node placement configuration
 sleep 60
 


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

This exit was added accidentally by me ( #1115 ) and it removes some of the test in practice. We must merge this ASAP.

Also, I noticed the test container doesn't work because of the missing kubectl binary when we delete this line. Since there is no consumer of the image, it is not so urgent. I will fix it tomorrow. 

**Release note**:

```release-note
None
```

