### PR TITLE
Add missing binaries into test container

### DIFF
--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .
 RUN make build-functest
 
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 ENV USER_UID=1001 \
     TEST_OUT_PATH=/test
@@ -12,13 +12,10 @@ ENV USER_UID=1001 \
 WORKDIR ${TEST_OUT_PATH}
 ENTRYPOINT ./hack/run-tests.sh
 
-RUN curl -LO https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl && \
-    chmod +x kubectl && \
-    chown ${USER_UID}:0 kubectl && \
-    mv kubectl /usr/local/bin/kubectl && \
-    dnf install -y jq
-
-USER ${USER_UID}
+RUN curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    chmod a+x /usr/local/bin/kubectl && \
+    curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+    chmod a+x /usr/local/bin/jq
 
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/_out/func-tests.test  ${TEST_OUT_PATH}/
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/hack  ${TEST_OUT_PATH}/hack

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -4,13 +4,20 @@ WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .
 RUN make build-functest
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi
 
 ENV USER_UID=1001 \
     TEST_OUT_PATH=/test
 
 WORKDIR ${TEST_OUT_PATH}
 ENTRYPOINT ./hack/run-tests.sh
+
+RUN curl -LO https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl && \
+    chmod +x kubectl && \
+    chown ${USER_UID}:0 kubectl && \
+    mv kubectl /usr/local/bin/kubectl && \
+    dnf install -y jq
+
 USER ${USER_UID}
 
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/_out/func-tests.test  ${TEST_OUT_PATH}/

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -14,6 +14,8 @@ fi
 
 if [[ ${JOB_TYPE} = "prow" ]]; then
     export KUBECTL_BINARY="oc"
+elif command -v kubectl; then
+    export KUBECTL_BINARY="kubectl"
 else
     export KUBECTL_BINARY="cluster/kubectl.sh"
 fi

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -7,17 +7,16 @@ INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE:-"kubevirt-hyperconverged"}
 source hack/common.sh
 source cluster/kubevirtci.sh
 
+export KUBECTL_BINARY="kubectl"
+
 if [ "${JOB_TYPE}" == "stdci" ]; then
     KUBECONFIG=$(kubevirtci::kubeconfig)
     source ./hack/upgrade-stdci-config
+    KUBECTL_BINARY="cluster/kubectl.sh"
 fi
 
 if [[ ${JOB_TYPE} = "prow" ]]; then
-    export KUBECTL_BINARY="oc"
-elif command -v kubectl; then
-    export KUBECTL_BINARY="kubectl"
-else
-    export KUBECTL_BINARY="cluster/kubectl.sh"
+    KUBECTL_BINARY="oc"
 fi
 
 # when the tests are run in a pod, in-cluster config will be used


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

Our tests require `kubectl` and `jq`. These binaries are missing in our test container at the moment.

**Release note**:
```release-note
None
```

