### PR TITLE
WIP: Switch to 'stable' channel

### DIFF
--- a/deploy/index-image/bundle.Dockerfile
+++ b/deploy/index-image/bundle.Dockerfile
@@ -6,8 +6,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=community-kubevirt-hyperconverged
-LABEL operators.operatorframework.io.bundle.channels.v1=${VERSION}
-LABEL operators.operatorframework.io.bundle.channel.default.v1=${VERSION}
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 
 COPY community-kubevirt-hyperconverged/${VERSION}/*.yaml /manifests/
 COPY community-kubevirt-hyperconverged/${VERSION}/metadata /metadata/

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/metadata/annotations.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: 1.4.0
-  operators.operatorframework.io.bundle.channels.v1: 1.4.0
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/deploy/olm-catalog/bundle.Dockerfile
+++ b/deploy/olm-catalog/bundle.Dockerfile
@@ -6,8 +6,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=community-kubevirt-hyperconverged
-LABEL operators.operatorframework.io.bundle.channels.v1=${VERSION}
-LABEL operators.operatorframework.io.bundle.channel.default.v1=${VERSION}
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 
 COPY community-kubevirt-hyperconverged/${VERSION}/*.yaml /manifests/
 COPY community-kubevirt-hyperconverged/${VERSION}/metadata /metadata/

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:a137fd1ee55ae8806cbdd66912c7931c7f567315f0a927b3a12090112e96edb1
-    createdAt: "2021-02-07 10:25:50"
+    createdAt: "2021-02-07 18:43:39"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/metadata/annotations.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: 1.4.0
-  operators.operatorframework.io.bundle.channels.v1: 1.4.0
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -283,8 +283,8 @@ mkdir -p "${CSV_DIR}/metadata"
 
 cat << EOF > "${CSV_DIR}/metadata/annotations.yaml"
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: ${CSV_VERSION}
-  operators.operatorframework.io.bundle.channels.v1: ${CSV_VERSION}
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
New stable releases will be published on the _stable_ channel from now on. This is a prerequisite for publishing the Kubevirt HyperConverged Cluster operator on OperatorHub.io.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
switch to stable channel.
```

