### PR TITLE
Add new make target for running tests in pod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,9 @@ test-functional:
 test-functional-prow:
 	./hack/run-tests.sh
 
+test-functional-in-container:
+	./hack/run-tests-in-container.sh
+
 stageRegistry:
 	@APP_REGISTRY_NAMESPACE=redhat-operators-stage PACKAGE=kubevirt-hyperconverged ./tools/quay-registry.sh $(QUAY_USERNAME) $(QUAY_PASSWORD)
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,8 @@ cluster-clean:
 
 ci-functest: build-functest test-functional
 
-functest: build-functest test-functional-prow
+# will revert
+functest: build-functest test-functional-in-container
 
 build-functest:
 	${DO} ./hack/build-tests.sh

--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -17,10 +17,12 @@ fi
 
 if [[ ${JOB_TYPE} = "prow" ]]; then
     KUBECTL_BINARY="oc"
+    component=hyperconverged-cluster-functest
+    computed_test_image=`eval echo ${IMAGE_FORMAT}`
+else
+    operator_image="$($KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" get pod -l name=hyperconverged-cluster-operator -o jsonpath='{.items[0] .spec .containers[?(@.name=="hyperconverged-cluster-operator")] .image}')"
+    computed_test_image="${operator_image//hyperconverged-cluster-operator/hyperconverged-cluster-functest}"
 fi
-
-operator_image="$($KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" get pod -l name=hyperconverged-cluster-operator -o jsonpath='{.items[0] .spec .containers[?(@.name=="hyperconverged-cluster-operator")] .image}')"
-computed_test_image="${operator_image//hyperconverged-cluster-operator/hyperconverged-cluster-functest}"
 
 # the test image can be overwritten by the caller
 FUNC_TEST_IMAGE=${FUNC_TEST_IMAGE:-${computed_test_image}}

--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -7,15 +7,16 @@ INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE:-"kubevirt-hyperconverged"}
 source hack/common.sh
 source cluster/kubevirtci.sh
 
+export KUBECTL_BINARY="kubectl"
+
 if [ "${JOB_TYPE}" == "stdci" ]; then
     KUBECONFIG=$(kubevirtci::kubeconfig)
     source ./hack/upgrade-stdci-config
+    KUBECTL_BINARY="cluster/kubectl.sh"
 fi
 
 if [[ ${JOB_TYPE} = "prow" ]]; then
-    export KUBECTL_BINARY="oc"
-else
-    export KUBECTL_BINARY="cluster/kubectl.sh"
+    KUBECTL_BINARY="oc"
 fi
 
 operator_image="$($KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" get deploy hyperconverged-cluster-operator -o jsonpath='{.spec .template .spec .containers[?(@.name=="hyperconverged-cluster-operator")] .image}')"
@@ -32,11 +33,31 @@ $KUBECTL_BINARY create clusterrolebinding functest-cluster-admin \
     --dry-run -o yaml  |$KUBECTL_BINARY apply -f -
 
 # don't forget to remove this!
-functest_image="quay.io/erkanerol/hyperconverged-cluster-functest:v12"
+# functest_image="quay.io/erkanerol/hyperconverged-cluster-functest:v15"
 
 $KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" delete pod functest --ignore-not-found --wait=true
 
 $KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" run functest \
-  --image="$functest_image" --serviceaccount=functest \
-  --env="INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE}" \
-  --restart=Never
+ --image="$functest_image" --serviceaccount=functest \
+ --env="INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE}" \
+ --restart=Never
+
+phase="Running"
+for i in $(seq 1 60); do
+  phase=$($KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" get pod/functest -o jsonpath='{.status.phase}')
+
+  if [[ "${phase}" == "Succeeded" || "${phase}" == "Failed" ]]; then
+    break
+  fi
+
+  echo "Waiting for completion... Iteration:$i Phase:$phase"
+  sleep 10
+done
+
+$KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" logs functest
+
+echo "Exiting... Last phase status: $phase"
+
+# exit non-zero if the last phase is not Succeeded
+[[ "${phase}" == "Succeeded" ]]
+

--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE:-"kubevirt-hyperconverged"}
+
+source hack/common.sh
+source cluster/kubevirtci.sh
+
+if [ "${JOB_TYPE}" == "stdci" ]; then
+    KUBECONFIG=$(kubevirtci::kubeconfig)
+    source ./hack/upgrade-stdci-config
+fi
+
+if [[ ${JOB_TYPE} = "prow" ]]; then
+    export KUBECTL_BINARY="oc"
+else
+    export KUBECTL_BINARY="cluster/kubectl.sh"
+fi
+
+operator_image="$($KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" get deploy hyperconverged-cluster-operator -o jsonpath='{.spec .template .spec .containers[?(@.name=="hyperconverged-cluster-operator")] .image}')"
+functest_image="${operator_image//hyperconverged-cluster-operator/hyperconverged-cluster-functest}"
+
+echo "Running tests with $functest_image"
+
+$KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" create serviceaccount functest \
+  --dry-run -o yaml  |$KUBECTL_BINARY apply -f -
+
+$KUBECTL_BINARY create clusterrolebinding functest-cluster-admin \
+    --clusterrole=cluster-admin \
+    --serviceaccount="${INSTALLED_NAMESPACE}":functest \
+    --dry-run -o yaml  |$KUBECTL_BINARY apply -f -
+
+# don't forget to remove this!
+functest_image="quay.io/erkanerol/hyperconverged-cluster-functest:v12"
+
+$KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" delete pod functest --ignore-not-found --wait=true
+
+$KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" run functest \
+  --image="$functest_image" --serviceaccount=functest \
+  --env="INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE}" \
+  --restart=Never

--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -19,7 +19,7 @@ if [[ ${JOB_TYPE} = "prow" ]]; then
     KUBECTL_BINARY="oc"
 fi
 
-operator_image="$($KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" get deploy hyperconverged-cluster-operator -o jsonpath='{.spec .template .spec .containers[?(@.name=="hyperconverged-cluster-operator")] .image}')"
+operator_image="$($KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" get pod -l name=hyperconverged-cluster-operator -o jsonpath='{.items[0] .spec .containers[?(@.name=="hyperconverged-cluster-operator")] .image}')"
 functest_image="${operator_image//hyperconverged-cluster-operator/hyperconverged-cluster-functest}"
 
 echo "Running tests with $functest_image"

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -17,8 +17,6 @@ fi
 
 if [[ ${JOB_TYPE} = "prow" ]]; then
     KUBECTL_BINARY="oc"
-elif command -v kubectl; then
-    export KUBECTL_BINARY="kubectl"
 fi
 
 # when the tests are run in a pod, in-cluster config will be used

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -17,6 +17,8 @@ fi
 
 if [[ ${JOB_TYPE} = "prow" ]]; then
     KUBECTL_BINARY="oc"
+elif command -v kubectl; then
+    export KUBECTL_BINARY="kubectl"
 fi
 
 # when the tests are run in a pod, in-cluster config will be used


### PR DESCRIPTION
This PR adds a new make target `test-functional-in-container` which basically runs a pod with  `hyperconverged-cluster-functest` image.

### Design Decisions:

**Changing make functest**
This PR replaces `test-functional-prow` with `test-functional-in-container`. It is for checking whether the new make target works or not. We can revert it and then change the command in `openshift/release` repo so that old `make functest` remains same. 

**Container of func test image**
For prow jobs, it uses `IMAGE_FORMAT` env variable to render the container image. For other cases, It assumes that the registry+image tag of test container is the same as the operator. 

The script allows you to overwrite them with an environment variable ( `FUNC_TEST_IMAGE` ). 

**How to run the tests? Job vs Pod**
- `kubectl run` will be deprecated for running jobs.
- Our retry mechanisms are embedded in the test scripts so we don't need a re-try mechanism with a k8s job at this level. 
- `kubectl create job` doesn't allow us to set env variable so we need to maintain a yaml for this.  

**How to wait the running pod?**
`kubectl wait` doesn't work well for pods. Also, it is not possible to wait until success/failure at the same time. See https://stackoverflow.com/questions/55073453

That is why I implemented a small wait loop.


**Release note**:
```release-note
NONE
```

