### PR TITLE
Fix a bug where HCO failed to trigger some events

### DIFF
--- a/pkg/controller/commonTestUtils/eventEmitterMock.go
+++ b/pkg/controller/commonTestUtils/eventEmitterMock.go
@@ -7,18 +7,57 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sync"
 )
 
-type EventEmitterMock struct{}
+type MockEvent struct {
+	EventType string
+	Reason    string
+	Msg       string
+}
+
+type EventEmitterMock struct {
+	expectedEvents *sync.Map
+}
+
+func NewEventEmitterMock(expectedEvents ...MockEvent) *EventEmitterMock {
+	eem := &EventEmitterMock{}
+	eem.SetExpectedEvents(expectedEvents...)
+
+	return eem
+}
+
+func (eem *EventEmitterMock) SetExpectedEvents(expectedEvents ...MockEvent) {
+	events := &sync.Map{}
+	for _, event := range expectedEvents {
+		events.Store(event, false)
+	}
+
+	eem.expectedEvents = events
+}
 
 func (EventEmitterMock) Init(_ context.Context, _ manager.Manager, _ hcoutil.ClusterInfo, _ logr.Logger) {
 	/* not implemented; mock only */
 }
 
-func (EventEmitterMock) EmitEvent(_ runtime.Object, _, _, _ string) {
-	/* not implemented; mock only */
+func (eem *EventEmitterMock) EmitEvent(_ runtime.Object, eventType, reason, msg string) {
+	eem.expectedEvents.Store(MockEvent{
+		EventType: eventType,
+		Reason:    reason,
+		Msg:       msg,
+	}, true)
 }
 
 func (EventEmitterMock) UpdateClient(_ context.Context, _ client.Reader, _ logr.Logger) {
 	/* not implemented; mock only */
+}
+
+func (eem EventEmitterMock) GotExpectedEvent() bool {
+	gotAllEvents := true
+	eem.expectedEvents.Range(func(key, value interface{}) bool {
+		gotAllEvents = gotAllEvents && value.(bool)
+		return value.(bool)
+	})
+
+	return gotAllEvents
 }

--- a/pkg/controller/commonTestUtils/testUtils.go
+++ b/pkg/controller/commonTestUtils/testUtils.go
@@ -3,6 +3,7 @@ package commonTestUtils
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 
@@ -24,21 +25,21 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 // Name and Namespace of our primary resource
 const (
-	Name             = "kubevirt-hyperconverged"
-	Namespace        = "kubevirt-hyperconverged"
-	Conversion_image = "quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0"
-	Vmware_image     = "quay.io/kubevirt/kubevirt-vmware:v2.0.0"
+	Name            = "kubevirt-hyperconverged"
+	Namespace       = "kubevirt-hyperconverged"
+	ConversionImage = "quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0"
+	VmwareImage     = "quay.io/kubevirt/kubevirt-vmware:v2.0.0"
 )
 
 var (
-	TestLogger  = logf.Log.WithName("controller_hyperconverged")
+	TestLogger  = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("controller_hyperconverged")
 	TestRequest = reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Name:      Name,

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -54,8 +54,8 @@ var _ = Describe("HyperconvergedController", func() {
 		Context("HCO Lifecycle", func() {
 
 			BeforeEach(func() {
-				os.Setenv("CONVERSION_CONTAINER", commonTestUtils.Conversion_image)
-				os.Setenv("VMWARE_CONTAINER", commonTestUtils.Vmware_image)
+				os.Setenv("CONVERSION_CONTAINER", commonTestUtils.ConversionImage)
+				os.Setenv("VMWARE_CONTAINER", commonTestUtils.VmwareImage)
 				os.Setenv("OPERATOR_NAMESPACE", namespace)
 			})
 
@@ -797,8 +797,8 @@ var _ = Describe("HyperconvergedController", func() {
 			origConds := expected.hco.Status.Conditions
 
 			BeforeEach(func() {
-				os.Setenv("CONVERSION_CONTAINER", commonTestUtils.Conversion_image)
-				os.Setenv("VMWARE_CONTAINER", commonTestUtils.Vmware_image)
+				os.Setenv("CONVERSION_CONTAINER", commonTestUtils.ConversionImage)
+				os.Setenv("VMWARE_CONTAINER", commonTestUtils.VmwareImage)
 				os.Setenv("OPERATOR_NAMESPACE", namespace)
 				os.Setenv(hcoutil.HcoKvIoVersionName, version.Version)
 			})
@@ -843,8 +843,8 @@ var _ = Describe("HyperconvergedController", func() {
 			okConds := expected.hco.Status.Conditions
 
 			BeforeEach(func() {
-				os.Setenv("CONVERSION_CONTAINER", commonTestUtils.Conversion_image)
-				os.Setenv("VMWARE_CONTAINER", commonTestUtils.Vmware_image)
+				os.Setenv("CONVERSION_CONTAINER", commonTestUtils.ConversionImage)
+				os.Setenv("VMWARE_CONTAINER", commonTestUtils.VmwareImage)
 				os.Setenv("OPERATOR_NAMESPACE", namespace)
 
 				expected.kv.Status.ObservedKubeVirtVersion = newComponentVersion

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
@@ -706,7 +708,12 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(checkHcoReady()).To(BeTrue())
 				hco := commonTestUtils.NewHco()
 				cl := commonTestUtils.InitClient([]runtime.Object{hco})
-				cl.InitiateWriteErrors(nil, errors.New("fake write error"))
+				cl.InitiateCreateErrors(func(obj client.Object) error {
+					if _, ok := obj.(*cdiv1beta1.CDI); ok {
+						return errors.New("fake create error")
+					}
+					return nil
+				})
 				r := initReconciler(cl)
 
 				// Do the reconcile
@@ -728,7 +735,7 @@ var _ = Describe("HyperconvergedController", func() {
 					if cond.Type == hcov1beta1.ConditionReconcileComplete {
 						foundCond = true
 						Expect(cond.Status).Should(Equal(corev1.ConditionFalse))
-						Expect(cond.Message).Should(ContainSubstring("fake write error"))
+						Expect(cond.Message).Should(ContainSubstring("fake create error"))
 						break
 					}
 				}
@@ -743,7 +750,12 @@ var _ = Describe("HyperconvergedController", func() {
 					FeatureGates: []string{"fakeFg"}, // force update
 				}
 				cl := expected.initClient()
-				cl.InitiateWriteErrors(nil, errors.New("fake write error"))
+				cl.InitiateUpdateErrors(func(obj client.Object) error {
+					if _, ok := obj.(*kubevirtv1.KubeVirt); ok {
+						return errors.New("fake update error")
+					}
+					return nil
+				})
 
 				hcoutil.SetReady(true)
 				Expect(checkHcoReady()).To(BeTrue())
@@ -770,7 +782,7 @@ var _ = Describe("HyperconvergedController", func() {
 					if cond.Type == hcov1beta1.ConditionReconcileComplete {
 						foundCond = true
 						Expect(cond.Status).Should(Equal(corev1.ConditionFalse))
-						Expect(cond.Message).Should(ContainSubstring("fake write error"))
+						Expect(cond.Message).Should(ContainSubstring("fake update error"))
 						break
 					}
 				}
@@ -1459,10 +1471,12 @@ var _ = Describe("HyperconvergedController", func() {
 				expected.hco.Status.Conditions = nil
 				cl := expected.initClient()
 				rsc := schema.GroupResource{Group: hcoutil.APIVersionGroup, Resource: "hyperconvergeds.hco.kubevirt.io"}
-				cl.InitiateWriteErrors(
-					nil,
-					apierrors.NewConflict(rsc, "hco", errors.New("test error")),
-				)
+				cl.InitiateUpdateErrors(func(obj client.Object) error {
+					if _, ok := obj.(*hcov1beta1.HyperConverged); ok {
+						return apierrors.NewConflict(rsc, "hco", errors.New("test error"))
+					}
+					return nil
+				})
 				r := initReconciler(cl)
 
 				r.ownVersion = os.Getenv(hcoutil.HcoKvIoVersionName)

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -42,15 +42,16 @@ var (
 	}
 )
 
-func initReconciler(client client.Client) *ReconcileHyperConverged {
+func initReconciler(client client.Client, expectedEvents ...commonTestUtils.MockEvent) *ReconcileHyperConverged {
 	s := commonTestUtils.GetScheme()
-	operandHandler := operands.NewOperandHandler(client, s, true, &commonTestUtils.EventEmitterMock{})
+	eventEmitter := commonTestUtils.NewEventEmitterMock(expectedEvents...)
+	operandHandler := operands.NewOperandHandler(client, s, true, eventEmitter)
 	// Create a ReconcileHyperConverged object with the scheme and fake client
 	return &ReconcileHyperConverged{
 		client:             client,
 		scheme:             s,
 		operandHandler:     operandHandler,
-		eventEmitter:       &commonTestUtils.EventEmitterMock{},
+		eventEmitter:       eventEmitter,
 		cliDownloadHandler: &operands.CLIDownloadHandler{Client: client, Scheme: s},
 		firstLoop:          true,
 	}

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -42,9 +42,9 @@ var (
 	}
 )
 
-func initReconciler(client client.Client, expectedEvents ...commonTestUtils.MockEvent) *ReconcileHyperConverged {
+func initReconciler(client client.Client) *ReconcileHyperConverged {
 	s := commonTestUtils.GetScheme()
-	eventEmitter := commonTestUtils.NewEventEmitterMock(expectedEvents...)
+	eventEmitter := commonTestUtils.NewEventEmitterMock()
 	operandHandler := operands.NewOperandHandler(client, s, true, eventEmitter)
 	// Create a ReconcileHyperConverged object with the scheme and fake client
 	return &ReconcileHyperConverged{
@@ -189,8 +189,8 @@ func getBasicDeployment() *BasicExpected {
 	res.vmi = expectedVMI
 
 	res.imsConfig = operands.NewIMSConfigForCR(hco, namespace)
-	res.imsConfig.Data["v2v-conversion-image"] = commonTestUtils.Conversion_image
-	res.imsConfig.Data["kubevirt-vmware-image"] = commonTestUtils.Vmware_image
+	res.imsConfig.Data["v2v-conversion-image"] = commonTestUtils.ConversionImage
+	res.imsConfig.Data["kubevirt-vmware-image"] = commonTestUtils.VmwareImage
 
 	return res
 }

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -3,6 +3,7 @@ package operands
 import (
 	"context"
 	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sync"
 	"time"
 
@@ -178,7 +179,7 @@ func (h OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 				errorCh <- err
 			} else {
 				key := client.ObjectKeyFromObject(o)
-				if err := h.client.Get(tCtx, key, o); err == nil {
+				if err := h.client.Get(tCtx, key, o); apierrors.IsNotFound(err) {
 					h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed %s %s", o.GetObjectKind().GroupVersionKind().Kind, key.Name))
 				}
 			}
@@ -200,8 +201,6 @@ func (h OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 
 		return nil
 	}
-
-	return nil
 }
 
 func (h *OperandHandler) Reset() {

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -3,7 +3,6 @@ package operands
 import (
 	"context"
 	"fmt"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sync"
 	"time"
 
@@ -179,9 +178,7 @@ func (h OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 				errorCh <- err
 			} else {
 				key := client.ObjectKeyFromObject(o)
-				if err := h.client.Get(tCtx, key, o); apierrors.IsNotFound(err) {
-					h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed %s %s", o.GetObjectKind().GroupVersionKind().Kind, key.Name))
-				}
+				h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed %s %s", o.GetObjectKind().GroupVersionKind().Kind, key.Name))
 			}
 		}(res, &wg)
 	}

--- a/pkg/controller/operands/operandHandler_test.go
+++ b/pkg/controller/operands/operandHandler_test.go
@@ -1,20 +1,21 @@
 package operands
 
 import (
+	"context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
-	"os"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
 	"github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	consolev1 "github.com/openshift/api/console/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 )
 
 var _ = Describe("Test operandHandler", func() {
@@ -30,75 +31,7 @@ var _ = Describe("Test operandHandler", func() {
 			hco := commonTestUtils.NewHco()
 			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
 
-			eventEmitter := commonTestUtils.NewEventEmitterMock(
-				[]commonTestUtils.MockEvent{
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created ConfigMap kubevirt-config",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created PriorityClass kubevirt-cluster-critical",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created KubeVirt kubevirt-kubevirt-hyperconverged",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created CDI cdi-kubevirt-hyperconverged",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created ConfigMap kubevirt-storage-class-defaults",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created NetworkAddonsConfig cluster",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created VMImportConfig vmimport-kubevirt-hyperconverged",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created ConfigMap v2v-vmware",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created SSP ssp-kubevirt-hyperconverged",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created Service kubevirt-hyperconverged-operator-metrics",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created ServiceMonitor kubevirt-hyperconverged-operator-metrics",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created PrometheusRule kubevirt-hyperconverged-prometheus-rule",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Created",
-						Msg:       "Created ConsoleQuickStart test-quick-start",
-					},
-				}...,
-			)
+			eventEmitter := commonTestUtils.NewEventEmitterMock()
 
 			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
@@ -107,6 +40,74 @@ var _ = Describe("Test operandHandler", func() {
 
 			err = handler.Ensure(req)
 			Expect(err).ToNot(HaveOccurred())
+			expectedEvents := []commonTestUtils.MockEvent{
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created ConfigMap kubevirt-config",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created PriorityClass kubevirt-cluster-critical",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created KubeVirt kubevirt-kubevirt-hyperconverged",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created CDI cdi-kubevirt-hyperconverged",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created ConfigMap kubevirt-storage-class-defaults",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created NetworkAddonsConfig cluster",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created VMImportConfig vmimport-kubevirt-hyperconverged",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created ConfigMap v2v-vmware",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created SSP ssp-kubevirt-hyperconverged",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created Service kubevirt-hyperconverged-operator-metrics",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created ServiceMonitor kubevirt-hyperconverged-operator-metrics",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created PrometheusRule kubevirt-hyperconverged-prometheus-rule",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Created",
+					Msg:       "Created ConsoleQuickStart test-quick-start",
+				},
+			}
+			Expect(eventEmitter.CheckEvents(expectedEvents))
 
 			By("make sure the KV object created", func() {
 				// Read back KV
@@ -173,49 +174,48 @@ var _ = Describe("Test operandHandler", func() {
 			err = handler.Ensure(req)
 			Expect(err).ToNot(HaveOccurred())
 
-			eventEmitter.SetExpectedEvents(
-				[]commonTestUtils.MockEvent{
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Killing",
-						Msg:       "Removed  virtctl-clidownloads-kubevirt-hyperconverged",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Killing",
-						Msg:       "Removed NetworkAddonsConfig cluster",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Killing",
-						Msg:       "Removed CDI cdi-kubevirt-hyperconverged",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Killing",
-						Msg:       "Removed VMImportConfig vmimport-kubevirt-hyperconverged",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Killing",
-						Msg:       "Removed ConsoleQuickStart test-quick-start",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Killing",
-						Msg:       "Removed SSP ssp-kubevirt-hyperconverged",
-					},
-					{
-						EventType: corev1.EventTypeNormal,
-						Reason:    "Killing",
-						Msg:       "Removed KubeVirt kubevirt-kubevirt-hyperconverged",
-					},
-				}...,
-			)
+			eventEmitter.Reset()
 			err = handler.EnsureDeleted(req)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(eventEmitter.GotExpectedEvent()).To(BeTrue())
+			expectedEvents := []commonTestUtils.MockEvent{
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Killing",
+					Msg:       "Removed  virtctl-clidownloads-kubevirt-hyperconverged",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Killing",
+					Msg:       "Removed NetworkAddonsConfig cluster",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Killing",
+					Msg:       "Removed CDI cdi-kubevirt-hyperconverged",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Killing",
+					Msg:       "Removed VMImportConfig vmimport-kubevirt-hyperconverged",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Killing",
+					Msg:       "Removed ConsoleQuickStart test-quick-start",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Killing",
+					Msg:       "Removed SSP ssp-kubevirt-hyperconverged",
+				},
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Killing",
+					Msg:       "Removed KubeVirt kubevirt-kubevirt-hyperconverged",
+				},
+			}
+			Expect(eventEmitter.CheckEvents(expectedEvents)).To(BeTrue())
 
 			By("check that KV is deleted", func() {
 				// Read back KV
@@ -289,18 +289,19 @@ var _ = Describe("Test operandHandler", func() {
 				return nil
 			})
 
-			eventEmitter.SetExpectedEvents(
-				commonTestUtils.MockEvent{
+			expectedEvents := []commonTestUtils.MockEvent{
+				{
 					EventType: corev1.EventTypeWarning,
 					Reason:    ErrVirtUninstall,
 					Msg:       uninstallVirtErrorMsg + fakeError.Error(),
 				},
-			)
+			}
+			eventEmitter.Reset()
 			err = handler.EnsureDeleted(req)
 			Expect(err).Should(Equal(fakeError))
 
 			By("Check that event was emitted", func() {
-				Expect(eventEmitter.GotExpectedEvent()).To(BeTrue())
+				Expect(eventEmitter.CheckEvents(expectedEvents)).To(BeTrue())
 			})
 
 			By("check that KV still exists", func() {
@@ -339,19 +340,20 @@ var _ = Describe("Test operandHandler", func() {
 				return nil
 			})
 
-			eventEmitter.SetExpectedEvents(
-				commonTestUtils.MockEvent{
+			expectedEvents := []commonTestUtils.MockEvent{
+				{
 					EventType: corev1.EventTypeWarning,
 					Reason:    ErrCDIUninstall,
 					Msg:       uninstallCDIErrorMsg + fakeError.Error(),
 				},
-			)
+			}
 
+			eventEmitter.Reset()
 			err = handler.EnsureDeleted(req)
 			Expect(err).Should(Equal(fakeError))
 
 			By("Check that event was emitted", func() {
-				Expect(eventEmitter.GotExpectedEvent()).To(BeTrue())
+				Expect(eventEmitter.CheckEvents(expectedEvents)).To(BeTrue())
 			})
 
 			By("make sure the CDI object still exists", func() {
@@ -391,18 +393,20 @@ var _ = Describe("Test operandHandler", func() {
 				return nil
 			})
 
-			eventEmitter.SetExpectedEvents([]commonTestUtils.MockEvent{
+			expectedEvents := []commonTestUtils.MockEvent{
 				{
 					EventType: corev1.EventTypeWarning,
 					Reason:    ErrHCOUninstall,
 					Msg:       uninstallHCOErrorMsg,
 				},
-			}...)
+			}
+
+			eventEmitter.Reset()
 			err = handler.EnsureDeleted(req)
 			Expect(err).Should(Equal(fakeError))
 
 			By("Check that event was emitted", func() {
-				Expect(eventEmitter.GotExpectedEvent()).To(BeTrue())
+				Expect(eventEmitter.CheckEvents(expectedEvents)).To(BeTrue())
 			})
 
 			By("make sure the CNA object still exists", func() {
@@ -413,6 +417,52 @@ var _ = Describe("Test operandHandler", func() {
 				Expect(cnaList).ToNot(BeNil())
 				Expect(cnaList.Items).To(HaveLen(1))
 				Expect(cnaList.Items[0].Name).Should(Equal("cluster"))
+			})
+		})
+
+		It("delete timeout error handling", func() {
+			err := os.Setenv(manifestLocationVarName, testFileLocation)
+			Expect(err).ToNot(HaveOccurred())
+			hco := commonTestUtils.NewHco()
+			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+
+			eventEmitter := commonTestUtils.NewEventEmitterMock()
+
+			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
+			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
+
+			req := commonTestUtils.NewReq(hco)
+			err = handler.Ensure(req)
+			Expect(err).ToNot(HaveOccurred())
+
+			cli.InitiateDeleteErrors(func(obj client.Object) error {
+				if unstructed, ok := obj.(runtime.Unstructured); ok {
+					kind := unstructed.GetObjectKind()
+					if kind.GroupVersionKind().Kind == "NetworkAddonsConfig" {
+						time.Sleep(time.Millisecond * 500)
+					}
+				}
+				return nil
+			})
+
+			eventEmitter.Reset()
+			ctx, cancelFunc := context.WithTimeout(req.Ctx, time.Millisecond*300)
+			defer cancelFunc()
+			req.Ctx = ctx
+			err = handler.EnsureDeleted(req)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(Equal("context deadline exceeded"))
+
+			expectedEvents := []commonTestUtils.MockEvent{
+				{
+					EventType: corev1.EventTypeNormal,
+					Reason:    "Killing",
+					Msg:       "Removed NetworkAddonsConfig cluster",
+				},
+			}
+
+			By("Check that event was *not* emitted", func() {
+				Expect(eventEmitter.CheckEvents(expectedEvents)).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/controller/operands/operandHandler_test.go
+++ b/pkg/controller/operands/operandHandler_test.go
@@ -269,14 +269,7 @@ var _ = Describe("Test operandHandler", func() {
 			hco := commonTestUtils.NewHco()
 			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
 
-			fakeError := fmt.Errorf("fake KV deletion error")
-			eventEmitter := commonTestUtils.NewEventEmitterMock(
-				commonTestUtils.MockEvent{
-					EventType: corev1.EventTypeWarning,
-					Reason:    ErrVirtUninstall,
-					Msg:       uninstallVirtErrorMsg + fakeError.Error(),
-				},
-			)
+			eventEmitter := commonTestUtils.NewEventEmitterMock()
 
 			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
@@ -285,6 +278,7 @@ var _ = Describe("Test operandHandler", func() {
 			err = handler.Ensure(req)
 			Expect(err).ToNot(HaveOccurred())
 
+			fakeError := fmt.Errorf("fake KV deletion error")
 			cli.InitiateDeleteErrors(func(obj client.Object) error {
 				if unstructed, ok := obj.(runtime.Unstructured); ok {
 					kind := unstructed.GetObjectKind()
@@ -295,6 +289,13 @@ var _ = Describe("Test operandHandler", func() {
 				return nil
 			})
 
+			eventEmitter.SetExpectedEvents(
+				commonTestUtils.MockEvent{
+					EventType: corev1.EventTypeWarning,
+					Reason:    ErrVirtUninstall,
+					Msg:       uninstallVirtErrorMsg + fakeError.Error(),
+				},
+			)
 			err = handler.EnsureDeleted(req)
 			Expect(err).Should(Equal(fakeError))
 
@@ -319,14 +320,7 @@ var _ = Describe("Test operandHandler", func() {
 			hco := commonTestUtils.NewHco()
 			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
 
-			fakeError := fmt.Errorf("fake CDI deletion error")
-			eventEmitter := commonTestUtils.NewEventEmitterMock(
-				commonTestUtils.MockEvent{
-					EventType: corev1.EventTypeWarning,
-					Reason:    ErrCDIUninstall,
-					Msg:       uninstallCDIErrorMsg + fakeError.Error(),
-				},
-			)
+			eventEmitter := commonTestUtils.NewEventEmitterMock()
 			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
 
@@ -334,6 +328,7 @@ var _ = Describe("Test operandHandler", func() {
 			err = handler.Ensure(req)
 			Expect(err).ToNot(HaveOccurred())
 
+			fakeError := fmt.Errorf("fake CDI deletion error")
 			cli.InitiateDeleteErrors(func(obj client.Object) error {
 				if unstructed, ok := obj.(runtime.Unstructured); ok {
 					kind := unstructed.GetObjectKind()
@@ -343,6 +338,14 @@ var _ = Describe("Test operandHandler", func() {
 				}
 				return nil
 			})
+
+			eventEmitter.SetExpectedEvents(
+				commonTestUtils.MockEvent{
+					EventType: corev1.EventTypeWarning,
+					Reason:    ErrCDIUninstall,
+					Msg:       uninstallCDIErrorMsg + fakeError.Error(),
+				},
+			)
 
 			err = handler.EnsureDeleted(req)
 			Expect(err).Should(Equal(fakeError))

--- a/pkg/controller/operands/operandHandler_test.go
+++ b/pkg/controller/operands/operandHandler_test.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -29,7 +30,77 @@ var _ = Describe("Test operandHandler", func() {
 			hco := commonTestUtils.NewHco()
 			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
 
-			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, commonTestUtils.EventEmitterMock{})
+			eventEmitter := commonTestUtils.NewEventEmitterMock(
+				[]commonTestUtils.MockEvent{
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created ConfigMap kubevirt-config",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created PriorityClass kubevirt-cluster-critical",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created KubeVirt kubevirt-kubevirt-hyperconverged",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created CDI cdi-kubevirt-hyperconverged",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created ConfigMap kubevirt-storage-class-defaults",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created NetworkAddonsConfig cluster",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created VMImportConfig vmimport-kubevirt-hyperconverged",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created ConfigMap v2v-vmware",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created SSP ssp-kubevirt-hyperconverged",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created Service kubevirt-hyperconverged-operator-metrics",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created ServiceMonitor kubevirt-hyperconverged-operator-metrics",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created PrometheusRule kubevirt-hyperconverged-prometheus-rule",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Created",
+						Msg:       "Created ConsoleQuickStart test-quick-start",
+					},
+				}...,
+			)
+
+			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
 
 			req := commonTestUtils.NewReq(hco)
@@ -48,7 +119,7 @@ var _ = Describe("Test operandHandler", func() {
 			})
 
 			By("make sure the CNA object created", func() {
-				// Read back KV
+				// Read back CNA
 				cnaList := networkaddonsv1.NetworkAddonsConfigList{}
 				err := cli.List(req.Ctx, &cnaList)
 				Expect(err).ToNot(HaveOccurred())
@@ -58,7 +129,7 @@ var _ = Describe("Test operandHandler", func() {
 			})
 
 			By("make sure the CDI object created", func() {
-				// Read back KV
+				// Read back CDI
 				cdiList := cdiv1beta1.CDIList{}
 				err := cli.List(req.Ctx, &cdiList)
 				Expect(err).ToNot(HaveOccurred())
@@ -68,7 +139,7 @@ var _ = Describe("Test operandHandler", func() {
 			})
 
 			By("make sure the VM-Import object created", func() {
-				// Read back KV
+				// Read back VM-Import
 				vmImportList := v1beta1.VMImportConfigList{}
 				err := cli.List(req.Ctx, &vmImportList)
 				Expect(err).ToNot(HaveOccurred())
@@ -94,15 +165,57 @@ var _ = Describe("Test operandHandler", func() {
 			hco := commonTestUtils.NewHco()
 			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
 
-			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, commonTestUtils.EventEmitterMock{})
+			eventEmitter := commonTestUtils.NewEventEmitterMock()
+			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
 
 			req := commonTestUtils.NewReq(hco)
 			err = handler.Ensure(req)
 			Expect(err).ToNot(HaveOccurred())
 
+			eventEmitter.SetExpectedEvents(
+				[]commonTestUtils.MockEvent{
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Killing",
+						Msg:       "Removed  virtctl-clidownloads-kubevirt-hyperconverged",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Killing",
+						Msg:       "Removed NetworkAddonsConfig cluster",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Killing",
+						Msg:       "Removed CDI cdi-kubevirt-hyperconverged",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Killing",
+						Msg:       "Removed VMImportConfig vmimport-kubevirt-hyperconverged",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Killing",
+						Msg:       "Removed ConsoleQuickStart test-quick-start",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Killing",
+						Msg:       "Removed SSP ssp-kubevirt-hyperconverged",
+					},
+					{
+						EventType: corev1.EventTypeNormal,
+						Reason:    "Killing",
+						Msg:       "Removed KubeVirt kubevirt-kubevirt-hyperconverged",
+					},
+				}...,
+			)
 			err = handler.EnsureDeleted(req)
 			Expect(err).ToNot(HaveOccurred())
+
+			Expect(eventEmitter.GotExpectedEvent()).To(BeTrue())
 
 			By("check that KV is deleted", func() {
 				// Read back KV
@@ -114,7 +227,7 @@ var _ = Describe("Test operandHandler", func() {
 			})
 
 			By("make sure the CNA object deleted", func() {
-				// Read back KV
+				// Read back CNA
 				cnaList := networkaddonsv1.NetworkAddonsConfigList{}
 				err := cli.List(req.Ctx, &cnaList)
 				Expect(err).ToNot(HaveOccurred())
@@ -123,7 +236,7 @@ var _ = Describe("Test operandHandler", func() {
 			})
 
 			By("make sure the CDI object deleted", func() {
-				// Read back KV
+				// Read back CDI
 				cdiList := cdiv1beta1.CDIList{}
 				err := cli.List(req.Ctx, &cdiList)
 				Expect(err).ToNot(HaveOccurred())
@@ -132,7 +245,7 @@ var _ = Describe("Test operandHandler", func() {
 			})
 
 			By("make sure the VM-Import object deleted", func() {
-				// Read back KV
+				// Read back VM-Import
 				vmImportList := v1beta1.VMImportConfigList{}
 				err := cli.List(req.Ctx, &vmImportList)
 				Expect(err).ToNot(HaveOccurred())
@@ -156,14 +269,22 @@ var _ = Describe("Test operandHandler", func() {
 			hco := commonTestUtils.NewHco()
 			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
 
-			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, commonTestUtils.EventEmitterMock{})
+			fakeError := fmt.Errorf("fake KV deletion error")
+			eventEmitter := commonTestUtils.NewEventEmitterMock(
+				commonTestUtils.MockEvent{
+					EventType: corev1.EventTypeWarning,
+					Reason:    ErrVirtUninstall,
+					Msg:       uninstallVirtErrorMsg + fakeError.Error(),
+				},
+			)
+
+			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
 
 			req := commonTestUtils.NewReq(hco)
 			err = handler.Ensure(req)
 			Expect(err).ToNot(HaveOccurred())
 
-			fakeError := fmt.Errorf("fake KV deletion error")
 			cli.InitiateDeleteErrors(func(obj client.Object) error {
 				if unstructed, ok := obj.(runtime.Unstructured); ok {
 					kind := unstructed.GetObjectKind()
@@ -177,7 +298,11 @@ var _ = Describe("Test operandHandler", func() {
 			err = handler.EnsureDeleted(req)
 			Expect(err).Should(Equal(fakeError))
 
-			By("check that KV is deleted", func() {
+			By("Check that event was emitted", func() {
+				Expect(eventEmitter.GotExpectedEvent()).To(BeTrue())
+			})
+
+			By("check that KV still exists", func() {
 				// Read back KV
 				kvList := kubevirtv1.KubeVirtList{}
 				err := cli.List(req.Ctx, &kvList)
@@ -194,14 +319,21 @@ var _ = Describe("Test operandHandler", func() {
 			hco := commonTestUtils.NewHco()
 			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
 
-			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, commonTestUtils.EventEmitterMock{})
+			fakeError := fmt.Errorf("fake CDI deletion error")
+			eventEmitter := commonTestUtils.NewEventEmitterMock(
+				commonTestUtils.MockEvent{
+					EventType: corev1.EventTypeWarning,
+					Reason:    ErrCDIUninstall,
+					Msg:       uninstallCDIErrorMsg + fakeError.Error(),
+				},
+			)
+			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
 
 			req := commonTestUtils.NewReq(hco)
 			err = handler.Ensure(req)
 			Expect(err).ToNot(HaveOccurred())
 
-			fakeError := fmt.Errorf("fake CDI deletion error")
 			cli.InitiateDeleteErrors(func(obj client.Object) error {
 				if unstructed, ok := obj.(runtime.Unstructured); ok {
 					kind := unstructed.GetObjectKind()
@@ -215,7 +347,11 @@ var _ = Describe("Test operandHandler", func() {
 			err = handler.EnsureDeleted(req)
 			Expect(err).Should(Equal(fakeError))
 
-			By("make sure the CDI object created", func() {
+			By("Check that event was emitted", func() {
+				Expect(eventEmitter.GotExpectedEvent()).To(BeTrue())
+			})
+
+			By("make sure the CDI object still exists", func() {
 				// Read back KV
 				cdiList := cdiv1beta1.CDIList{}
 				err := cli.List(req.Ctx, &cdiList)
@@ -223,6 +359,57 @@ var _ = Describe("Test operandHandler", func() {
 				Expect(cdiList).ToNot(BeNil())
 				Expect(cdiList.Items).To(HaveLen(1))
 				Expect(cdiList.Items[0].Name).Should(Equal("cdi-kubevirt-hyperconverged"))
+			})
+		})
+
+		It("default delete error handling", func() {
+			err := os.Setenv(manifestLocationVarName, testFileLocation)
+			Expect(err).ToNot(HaveOccurred())
+			hco := commonTestUtils.NewHco()
+			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+
+			fakeError := fmt.Errorf("fake CNA deletion error")
+			eventEmitter := commonTestUtils.NewEventEmitterMock()
+
+			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
+			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
+
+			req := commonTestUtils.NewReq(hco)
+			err = handler.Ensure(req)
+			Expect(err).ToNot(HaveOccurred())
+
+			cli.InitiateDeleteErrors(func(obj client.Object) error {
+				if unstructed, ok := obj.(runtime.Unstructured); ok {
+					kind := unstructed.GetObjectKind()
+					if kind.GroupVersionKind().Kind == "NetworkAddonsConfig" {
+						return fakeError
+					}
+				}
+				return nil
+			})
+
+			eventEmitter.SetExpectedEvents([]commonTestUtils.MockEvent{
+				{
+					EventType: corev1.EventTypeWarning,
+					Reason:    ErrHCOUninstall,
+					Msg:       uninstallHCOErrorMsg,
+				},
+			}...)
+			err = handler.EnsureDeleted(req)
+			Expect(err).Should(Equal(fakeError))
+
+			By("Check that event was emitted", func() {
+				Expect(eventEmitter.GotExpectedEvent()).To(BeTrue())
+			})
+
+			By("make sure the CNA object still exists", func() {
+				// Read back CNA
+				cnaList := networkaddonsv1.NetworkAddonsConfigList{}
+				err := cli.List(req.Ctx, &cnaList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cnaList).ToNot(BeNil())
+				Expect(cnaList.Items).To(HaveLen(1))
+				Expect(cnaList.Items[0].Name).Should(Equal("cluster"))
 			})
 		})
 	})


### PR DESCRIPTION
This PR was originally about increasing the unit test coverage, but I found and fix a bug diring this work.

The bug was that the HCO failed to trigger delete events for the removed operand resources.

This PR also improves the test utilities:

## Change the fake client to produce error using functions, in order to allow checking specific errors.

The fake client now support the following types and methods:
```golang
type FakeWriteErrorGenerator func(obj client.Object) error
type FakeReadErrorGenerator func(key client.ObjectKey) error

InitiateDeleteErrors(f FakeWriteErrorGenerator)
InitiateUpdateErrors(f FakeWriteErrorGenerator)
InitiateGetErrors(f FakeReadErrorGenerator)
InitiateCreateErrors(f FakeWriteErrorGenerator)
```

Example usage:
```golang
cl := expected.initClient()
cl.InitiateUpdateErrors(func(obj client.Object) error {
	if _, ok := obj.(*kubevirtv1.KubeVirt); ok {
		return errors.New("fake update error")
	}
	return nil
})
```

## Add the ability to check if events are emitted:
This PR introduces the `commonTestUtils.MockEvent` type.

Use the new commonTestUtils.NewEventEmitterMock method to create a fake event emitter. This will initiate a list of events.

Clear the received events to prepare to a new test case by calling to the new `EventEmitterMock.Reset()` method.

To validate if the expected events were actually emitted, use the new `EventEmitterMock.CheckEvents(expectedEvents []MockEvent) bool` method.

## Example
```golang
eventEmitter := commonTestUtils.NewEventEmitterMock()
handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)

...

fakeError := fmt.Errorf("fake KV deletion error")
cli.InitiateDeleteErrors(func(obj client.Object) error {
	if unstructed, ok := obj.(runtime.Unstructured); ok {
		kind := unstructed.GetObjectKind()
		if kind.GroupVersionKind().Kind == "KubeVirt" {
			return fakeError
		}
	}
	return nil
})

eventEmitter.Reset()

err = handler.EnsureDeleted(req)
Expect(err).Should(Equal(fakeError))

By("Check that event was emitted", func() {
	expectedEvents := []commonTestUtils.MockEvent{
		{
			EventType: corev1.EventTypeWarning,
			Reason:    ErrVirtUninstall,
			Msg:       uninstallVirtErrorMsg + fakeError.Error(),
		},
	},
	Expect(eventEmitter.CheckEvents(expectedEvents)).To(BeTrue())
})

```

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

