### PR TITLE
Change the InstallMode of HCO Operator to AllNamespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Create the namespace for the HCO.
 kubectl create ns kubevirt-hyperconverged
 ```
 
-Create an OperatorGroup.
+Create an OperatorGroup that watches all namespaces.
 ```bash
 cat <<EOF | kubectl create -f -
 apiVersion: operators.coreos.com/v1
@@ -85,9 +85,6 @@ kind: OperatorGroup
 metadata:
   name: hco-operatorgroup
   namespace: kubevirt-hyperconverged
-spec:
-  targetNamespaces:
-  - "kubevirt-hyperconverged"
 EOF
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ kind: OperatorGroup
 metadata:
   name: hco-operatorgroup
   namespace: kubevirt-hyperconverged
+spec: {}
 EOF
 ```
 

--- a/cmd/cmdcommon/cmdcommon.go
+++ b/cmd/cmdcommon/cmdcommon.go
@@ -95,7 +95,10 @@ func (h HcCmdHelper) checkNameSpace() {
 		actualNS = requiredNS
 	}
 
-	if actualNS != requiredNS {
+	// Allowing the operator to be deployed in OperatorTestNamespace, in addition to OPERATOR_NAMESPACE env var,
+	// to unblock its publish in OperatorHub.io
+	nsAllowList := []string{requiredNS, hcoutil.OperatorTestNamespace}
+	if !stringInSlice(actualNS, nsAllowList) {
 		err := fmt.Errorf("%s is running in different namespace than expected", h.Name)
 		msg := fmt.Sprintf("Please re-deploy this %s into %v namespace", h.Name, requiredNS)
 		h.ExitOnError(err, msg, "Expected.Namespace", requiredNS, "Deployed.Namespace", actualNS)
@@ -115,4 +118,13 @@ func updateFlagSet(flags ...*flag.FlagSet) {
 	for _, f := range flags {
 		pflag.CommandLine.AddGoFlagSet(f)
 	}
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -2514,13 +2514,13 @@ spec:
         serviceAccountName: hostpath-provisioner-operator
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - KubeVirt

--- a/deploy/kustomize/base/operator_group.yaml
+++ b/deploy/kustomize/base/operator_group.yaml
@@ -3,6 +3,4 @@ kind: OperatorGroup
 metadata:
   name: kubevirt-hyperconverged-group
   namespace: kubevirt-hyperconverged
-spec:
-  targetNamespaces:
-    - kubevirt-hyperconverged
+spec: {}

--- a/deploy/nightly-bundle/deploy.sh
+++ b/deploy/nightly-bundle/deploy.sh
@@ -101,9 +101,6 @@ kind: OperatorGroup
 metadata:
   name: "${TARGET_NAMESPACE}-group"
   namespace: "${TARGET_NAMESPACE}"
-spec:
-  targetNamespaces:
-  - "${TARGET_NAMESPACE}"
 EOF
     fi
 

--- a/deploy/nightly-bundle/deploy.sh
+++ b/deploy/nightly-bundle/deploy.sh
@@ -101,6 +101,7 @@ kind: OperatorGroup
 metadata:
   name: "${TARGET_NAMESPACE}-group"
   namespace: "${TARGET_NAMESPACE}"
+spec: {}
 EOF
     fi
 

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:a137fd1ee55ae8806cbdd66912c7931c7f567315f0a927b3a12090112e96edb1
-    createdAt: "2021-02-11 13:21:20"
+    createdAt: "2021-02-18 18:02:24"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -2514,13 +2514,13 @@ spec:
         serviceAccountName: hostpath-provisioner-operator
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - KubeVirt

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -222,7 +222,7 @@ metadata:
       ]
 ```
 
-**_Note:_** The full configurations options for Kubevirt, CDI and CNAO which are avialbale on the cluster, can be explored by using `kubectl explain <resource name>.spec`. For example:  
+**_Note:_** The full configurations options for Kubevirt, CDI and CNAO which are available on the cluster, can be explored by using `kubectl explain <resource name>.spec`. For example:  
 ```yaml
 $ kubectl explain kv.spec
 KIND:     KubeVirt

--- a/hack/kubevirt-nightly-test.sh
+++ b/hack/kubevirt-nightly-test.sh
@@ -70,9 +70,6 @@ kind: OperatorGroup
 metadata:
   name: hco-operatorgroup
   namespace: ${HCO_NAMESPACE}
-spec:
-  targetNamespaces:
-  - ${HCO_NAMESPACE}
 EOF
 
 cat <<EOF | ${CMD} create -f -

--- a/hack/kubevirt-nightly-test.sh
+++ b/hack/kubevirt-nightly-test.sh
@@ -70,6 +70,7 @@ kind: OperatorGroup
 metadata:
   name: hco-operatorgroup
   namespace: ${HCO_NAMESPACE}
+spec: {}
 EOF
 
 cat <<EOF | ${CMD} create -f -

--- a/hack/patch_og.sh
+++ b/hack/patch_og.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+function patch_og() {
+  CSV_VERSION=$1
+
+  CSV=$( ${CMD} get csv -o name -n ${HCO_NAMESPACE} | grep ${CSV_VERSION})
+  ALL_NAMESPACES_INSTALLMODE=$(${CMD} get ${CSV} -n ${HCO_NAMESPACE} -o jsonpath='{.spec.installModes[?(@.type=="AllNamespaces")].supported}')
+  OG_SPEC=$(${CMD} get og ${HCO_OPERATORGROUP_NAME} -n ${HCO_NAMESPACE} -o jsonpath='{.spec}')
+  if [ "${ALL_NAMESPACES_INSTALLMODE}" == "true" ] && [ "${OG_SPEC}" != "{}" ]
+  then
+    echo "CSV is supporting AllNamespaces InstallMode but OperatorGroup is watching a single namespace. Patching OperatorGroup..."
+    ${CMD} patch og "${HCO_OPERATORGROUP_NAME}" -n ${HCO_NAMESPACE} --type json -p '[{"op": "remove", "path": "/spec/targetNamespaces"}]'
+    OG_PATCHED=1
+  elif [ "${ALL_NAMESPACES_INSTALLMODE}" == "false" ] && [ "${OG_SPEC}" == "{}" ]
+  then
+    echo "CSV is not supporting AllNamespaces InstallMode, and OperatorGroup is watching all namespaces. Patching OperatorGroup..."
+    ${CMD} patch og "${HCO_OPERATORGROUP_NAME}" -n ${HCO_NAMESPACE} --type json -p "[{\"op\": \"replace\", \"path\": \"/spec/targetNamespaces\", \"value\": [${HCO_NAMESPACE}]}]"
+    OG_PATCHED=1
+  else
+    OG_PATCHED=0
+  fi
+}

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -127,6 +127,7 @@ kind: OperatorGroup
 metadata:
   name: ${HCO_OPERATORGROUP_NAME}
   namespace: ${HCO_NAMESPACE}
+spec: {}
 EOF
 
 cat <<EOF | ${CMD} create -f -
@@ -176,6 +177,13 @@ EOF
 # Allow time for the install plan to be created a for the
 # hco-operator to be created. Otherwise kubectl wait will report EOF.
 ./hack/retry.sh 20 30 "${CMD} get subscription -n ${HCO_NAMESPACE} | grep -v EOF"
+
+# Wait for the CSV to be created
+./hack/retry.sh 20 30 "${CMD} get csv -n ${HCO_NAMESPACE} | grep -v EOF"
+# Adjust the OperatorGroup to the supported InstallMode of the CSV
+source hack/patch_og.sh
+patch_og ${INITIAL_CHANNEL}
+
 ./hack/retry.sh 20 30 "${CMD} get pods -n ${HCO_NAMESPACE} | grep hco-operator"
 
 ${CMD} wait deployment ${HCO_DEPLOYMENT_NAME} ${HCO_WH_DEPLOYMENT_NAME} --for condition=Available -n ${HCO_NAMESPACE} --timeout="1200s"
@@ -227,7 +235,19 @@ ${CMD} patch subscription ${HCO_SUBSCRIPTION_NAME} -n ${HCO_NAMESPACE} -p "{\"sp
 Msg "Verify the subscription's currentCSV and installedCSV have moved to the new version"
 
 sleep 60
+patch_og ${TARGET_CHANNEL}
+sleep 30
+CSV=$( ${CMD} get csv -o name -n ${HCO_NAMESPACE} | grep ${INITIAL_CHANNEL})
+if [ -n "${CSV}" ] && [ ${OG_PATCHED} -eq 1 ]
+then
+  ${CMD} delete "${CSV}" -n ${HCO_NAMESPACE}
+fi
+
+sleep 30
+
 ${CMD} get pods -n ${HCO_NAMESPACE}
+./hack/retry.sh 30 60 "${CMD} get deployment -n ${HCO_NAMESPACE} | grep ${HCO_DEPLOYMENT_NAME}"
+
 ${CMD} wait deployment ${HCO_DEPLOYMENT_NAME} --for condition=Available -n ${HCO_NAMESPACE} --timeout="1200s"
 ${CMD} wait deployment ${HCO_WH_DEPLOYMENT_NAME} --for condition=Available -n ${HCO_NAMESPACE} --timeout="1200s"
 

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -127,9 +127,6 @@ kind: OperatorGroup
 metadata:
   name: ${HCO_OPERATORGROUP_NAME}
   namespace: ${HCO_NAMESPACE}
-spec:
-  targetNamespaces:
-  - ${HCO_NAMESPACE}
 EOF
 
 cat <<EOF | ${CMD} create -f -

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -1146,11 +1146,11 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 			InstallModes: []csvv1alpha1.InstallMode{
 				csvv1alpha1.InstallMode{
 					Type:      csvv1alpha1.InstallModeTypeOwnNamespace,
-					Supported: true,
+					Supported: false,
 				},
 				csvv1alpha1.InstallMode{
 					Type:      csvv1alpha1.InstallModeTypeSingleNamespace,
-					Supported: true,
+					Supported: false,
 				},
 				csvv1alpha1.InstallMode{
 					Type:      csvv1alpha1.InstallModeTypeMultiNamespace,
@@ -1158,7 +1158,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 				},
 				csvv1alpha1.InstallMode{
 					Type:      csvv1alpha1.InstallModeTypeAllNamespaces,
-					Supported: false,
+					Supported: true,
 				},
 			},
 			// Skip this in favor of having a separate function to get

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -20,6 +20,7 @@ const (
 	AppLabel               = "app"
 	UndefinedNamespace     = ""
 	OpenshiftNamespace     = "openshift"
+	OperatorTestNamespace  = "test-operators"
 	APIVersionAlpha        = "v1alpha1"
 	APIVersionBeta         = "v1beta1"
 	CurrentAPIVersion      = APIVersionBeta


### PR DESCRIPTION
Changing the InstallMode to support only AllNamespaces, rather than OwnNamespace and SingleNamespace, will enforce HCO operator to be installed only once throughout the cluster (singleton), because the API will be owned all across the cluster, on all namespaces.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

