### PR TITLE
Add GPU and HostDevices Feature Gates to HCO

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -54,6 +54,12 @@ spec:
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
+                  gpu:
+                    description: Allow assigning GPU and vGPU devices to virtual machines
+                    type: boolean
+                  hostDevices:
+                    description: Allow assigning host devices to virtual machines
+                    type: boolean
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -47,6 +47,8 @@ spec:
             properties:
               featureGates:
                 default:
+                  gpu: false
+                  hostDevices: false
                   hypervStrictCheck: true
                   withHostModelCPU: true
                   withHostPassthroughCPU: false
@@ -55,9 +57,11 @@ spec:
                   the feature gate, disables the feature.
                 properties:
                   gpu:
+                    default: false
                     description: Allow assigning GPU and vGPU devices to virtual machines
                     type: boolean
                   hostDevices:
+                    default: false
                     description: Allow assigning host devices to virtual machines
                     type: boolean
                   hotplugVolumes:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -54,6 +54,12 @@ spec:
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
+                  gpu:
+                    description: Allow assigning GPU and vGPU devices to virtual machines
+                    type: boolean
+                  hostDevices:
+                    description: Allow assigning host devices to virtual machines
+                    type: boolean
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -47,6 +47,8 @@ spec:
             properties:
               featureGates:
                 default:
+                  gpu: false
+                  hostDevices: false
                   hypervStrictCheck: true
                   withHostModelCPU: true
                   withHostPassthroughCPU: false
@@ -55,9 +57,11 @@ spec:
                   the feature gate, disables the feature.
                 properties:
                   gpu:
+                    default: false
                     description: Allow assigning GPU and vGPU devices to virtual machines
                     type: boolean
                   hostDevices:
+                    default: false
                     description: Allow assigning host devices to virtual machines
                     type: boolean
                   hotplugVolumes:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -54,6 +54,12 @@ spec:
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
+                  gpu:
+                    description: Allow assigning GPU and vGPU devices to virtual machines
+                    type: boolean
+                  hostDevices:
+                    description: Allow assigning host devices to virtual machines
+                    type: boolean
                   hotplugVolumes:
                     description: Allow attaching a data volume to a running VMI
                     type: boolean

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/hco00.crd.yaml
@@ -47,6 +47,8 @@ spec:
             properties:
               featureGates:
                 default:
+                  gpu: false
+                  hostDevices: false
                   hypervStrictCheck: true
                   withHostModelCPU: true
                   withHostPassthroughCPU: false
@@ -55,9 +57,11 @@ spec:
                   the feature gate, disables the feature.
                 properties:
                   gpu:
+                    default: false
                     description: Allow assigning GPU and vGPU devices to virtual machines
                     type: boolean
                   hostDevices:
+                    default: false
                     description: Allow assigning host devices to virtual machines
                     type: boolean
                   hotplugVolumes:

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -40,7 +40,7 @@ type HyperConvergedSpec struct {
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
 	// +optional
 	// +TODO: Always keep the default FeatureGates in sync with the default field values in HyperConvergedFeatureGates //NOSONAR
-	// +kubebuilder:default={withHostModelCPU: true, withHostPassthroughCPU: false, hypervStrictCheck: true}
+	// +kubebuilder:default={withHostModelCPU: true, withHostPassthroughCPU: false, hypervStrictCheck: true, gpu: false, hostDevices: false}
 	FeatureGates *HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
 	// operator version
@@ -73,10 +73,12 @@ type HyperConvergedFeatureGates struct {
 
 	// Allow assigning GPU and vGPU devices to virtual machines
 	// +optional
+	// +kubebuilder:default=false
 	GPU *bool `json:"gpu,omitempty"`
 
 	// Allow assigning host devices to virtual machines
 	// +optional
+	// +kubebuilder:default=false
 	HostDevices *bool `json:"hostDevices,omitempty"`
 
 	// Allow migrating a virtual machine with CPU host-passthrough mode. This should be

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -71,6 +71,14 @@ type HyperConvergedFeatureGates struct {
 	// +optional
 	HotplugVolumes *bool `json:"hotplugVolumes,omitempty"`
 
+	// Allow assigning GPU and vGPU devices to virtual machines
+	// +optional
+	GPU *bool `json:"gpu,omitempty"`
+
+	// Allow assigning host devices to virtual machines
+	// +optional
+	HostDevices *bool `json:"hostDevices,omitempty"`
+
 	// Allow migrating a virtual machine with CPU host-passthrough mode. This should be
 	// enabled only when the Cluster is homogeneous from CPU HW perspective doc here
 	// +optional
@@ -91,6 +99,14 @@ type HyperConvergedFeatureGates struct {
 
 func (fgs *HyperConvergedFeatureGates) IsHotplugVolumesEnabled() bool {
 	return (fgs != nil) && (fgs.HotplugVolumes != nil) && (*fgs.HotplugVolumes)
+}
+
+func (fgs *HyperConvergedFeatureGates) IsGPUAssignmentEnabled() bool {
+	return (fgs != nil) && (fgs.GPU != nil) && (*fgs.GPU)
+}
+
+func (fgs *HyperConvergedFeatureGates) IsHostDevicesAssignmentEnabled() bool {
+	return (fgs != nil) && (fgs.HostDevices != nil) && (*fgs.HostDevices)
 }
 
 func (fgs *HyperConvergedFeatureGates) IsSRIOVLiveMigrationEnabled() bool {

--- a/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
@@ -358,6 +358,62 @@ var _ = Describe("HyperconvergedTypes", func() {
 			})
 		})
 
+		Context("Test IsGPUAssignmentEnabled", func() {
+			It("Should return false if HyperConvergedFeatureGates is nil", func() {
+				var fgs *HyperConvergedFeatureGates = nil
+				Expect(fgs.IsGPUAssignmentEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsGPUAssignmentEnabled does not exist", func() {
+				fgs := &HyperConvergedFeatureGates{}
+				Expect(fgs.IsGPUAssignmentEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsGPUAssignmentEnabled is false", func() {
+				disabled := false
+				fgs := &HyperConvergedFeatureGates{
+					GPU: &disabled,
+				}
+				Expect(fgs.IsGPUAssignmentEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsGPUAssignmentEnabled is true", func() {
+				enabled := true
+				fgs := &HyperConvergedFeatureGates{
+					GPU: &enabled,
+				}
+				Expect(fgs.IsGPUAssignmentEnabled()).To(BeTrue())
+			})
+		})
+
+		Context("Test IsHostDevicesAssignmentEnabled", func() {
+			It("Should return false if HyperConvergedFeatureGates is nil", func() {
+				var fgs *HyperConvergedFeatureGates = nil
+				Expect(fgs.IsHostDevicesAssignmentEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsHostDevicesAssignmentEnabled does not exist", func() {
+				fgs := &HyperConvergedFeatureGates{}
+				Expect(fgs.IsHostDevicesAssignmentEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsHostDevicesAssignmentEnabled is false", func() {
+				disabled := false
+				fgs := &HyperConvergedFeatureGates{
+					HostDevices: &disabled,
+				}
+				Expect(fgs.IsHostDevicesAssignmentEnabled()).To(BeFalse())
+			})
+
+			It("Should return false if IsHostDevicesAssignmentEnabled is true", func() {
+				enabled := true
+				fgs := &HyperConvergedFeatureGates{
+					HostDevices: &enabled,
+				}
+				Expect(fgs.IsHostDevicesAssignmentEnabled()).To(BeTrue())
+			})
+		})
+
 		Context("Test IsWithHostPassthroughCPUEnabled", func() {
 			It("Should return false if HyperConvergedFeatureGates is nil", func() {
 				var fgs *HyperConvergedFeatureGates = nil

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -34,6 +34,8 @@ const (
 	DefaultNetworkInterface = "bridge"
 	HotplugVolumesGate      = "HotplugVolumes"
 	SRIOVLiveMigrationGate  = "SRIOVLiveMigration"
+	GPUGate                 = "GPU"
+	HostDevicesGate         = "HostDevices"
 )
 
 const (
@@ -322,6 +324,8 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) f
 		kvWithHostModelCPU:       featureGates.IsWithHostModelCPUEnabled,
 		SRIOVLiveMigrationGate:   featureGates.IsSRIOVLiveMigrationEnabled,
 		kvHypervStrictCheck:      featureGates.IsHypervStrictCheckEnabled,
+		GPUGate:                  featureGates.IsGPUAssignmentEnabled,
+		HostDevicesGate:          featureGates.IsHostDevicesAssignmentEnabled,
 	}
 }
 

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -310,6 +310,24 @@ var _ = Describe("KubeVirt Operand", func() {
 				Expect(foundResource.Data[FeatureGatesKey]).Should(Equal(cmFeatureGates))
 			})
 
+			It("should add GPU feature gate if enabled", func() {
+				hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+					GPU: &enabled,
+				}
+
+				existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
+				Expect(existingResource.Data[FeatureGatesKey]).Should(ContainSubstring(GPUGate))
+			})
+
+			It("should add HostDevices feature gate if enabled", func() {
+				hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+					HostDevices: &enabled,
+				}
+
+				existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
+				Expect(existingResource.Data[FeatureGatesKey]).Should(ContainSubstring(HostDevicesGate))
+			})
+
 			It("should add SRIOVLiveMigration if enabled", func() {
 				hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
 					SRIOVLiveMigration: &enabled,
@@ -411,6 +429,35 @@ var _ = Describe("KubeVirt Operand", func() {
 					Expect(foundResource.Data[FeatureGatesKey]).Should(Equal(cmFeatureGates))
 				})
 
+				It("Should remove GPU the CM when its FeatureGate is disabled", func() {
+					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
+					existingResource.Data[FeatureGatesKey] = fmt.Sprintf("%s,%s", cmFeatureGates, GPUGate)
+
+					hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+						GPU: &disabled,
+					}
+
+					foundResource := &corev1.ConfigMap{}
+					reconcileCm(hco, req, true, existingResource, foundResource)
+
+					Expect(foundResource.Data[FeatureGatesKey]).Should(Equal(cmFeatureGates))
+				})
+
+				It("Should remove HostDevices the CM when its FeatureGate is disabled", func() {
+					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
+					existingResource.Data[FeatureGatesKey] = fmt.Sprintf("%s,%s", cmFeatureGates, HostDevicesGate)
+
+					hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+						HostDevices: &disabled,
+					}
+
+					foundResource := &corev1.ConfigMap{}
+					reconcileCm(hco, req, true, existingResource, foundResource)
+
+					Expect(foundResource.Data[FeatureGatesKey]).Should(Equal(cmFeatureGates))
+				})
+
+
 				It("Should keep the HotplugVolumes gate from the CM if the HotplugVolumes FeatureGates is enabled", func() {
 					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
 					existingResource.Data[FeatureGatesKey] = fmt.Sprintf("%s,%s", cmFeatureGates, HotplugVolumesGate)
@@ -477,6 +524,36 @@ var _ = Describe("KubeVirt Operand", func() {
 					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring(SRIOVLiveMigrationGate))
 				})
 
+				It("Should add GPU gate to the CM if its FeatureGate is enabled", func() {
+					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
+					existingResource.Data[FeatureGatesKey] = cmFeatureGates
+
+					hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+						GPU: &enabled,
+					}
+
+					foundResource := &corev1.ConfigMap{}
+					reconcileCm(hco, req, true, existingResource, foundResource)
+
+					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring(cmFeatureGates))
+					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring(GPUGate))
+				})
+
+				It("Should add HostDevices gate to the CM if its FeatureGate is enabled", func() {
+					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
+					existingResource.Data[FeatureGatesKey] = cmFeatureGates
+
+					hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+						HostDevices: &enabled,
+					}
+
+					foundResource := &corev1.ConfigMap{}
+					reconcileCm(hco, req, true, existingResource, foundResource)
+
+					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring(cmFeatureGates))
+					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring(HostDevicesGate))
+				})
+
 				It("Should not modify user modified FGs if the HotplugVolumes FeatureGates is enabled", func() {
 					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
 					existingResource.Data[FeatureGatesKey] = cmFeatureGates + ",userDefinedFG"
@@ -509,6 +586,38 @@ var _ = Describe("KubeVirt Operand", func() {
 					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring("userDefinedFG"))
 				})
 
+				It("Should not modify user modified FGs if GPU FeatureGate is enabled", func() {
+					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
+					existingResource.Data[FeatureGatesKey] = cmFeatureGates + ",userDefinedFG"
+
+					hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+						GPU: &enabled,
+					}
+
+					foundResource := &corev1.ConfigMap{}
+					reconcileCm(hco, req, true, existingResource, foundResource)
+
+					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring(cmFeatureGates))
+					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring(GPUGate))
+					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring("userDefinedFG"))
+				})
+
+				It("Should not modify user modified FGs if HostDevices FeatureGate is enabled", func() {
+					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
+					existingResource.Data[FeatureGatesKey] = cmFeatureGates + ",userDefinedFG"
+
+					hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+						HostDevices: &enabled,
+					}
+
+					foundResource := &corev1.ConfigMap{}
+					reconcileCm(hco, req, true, existingResource, foundResource)
+
+					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring(cmFeatureGates))
+					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring(HostDevicesGate))
+					Expect(foundResource.Data[FeatureGatesKey]).Should(ContainSubstring("userDefinedFG"))
+				})
+
 				It("Should not modify user modified FGs if the HotplugVolumes FeatureGates is disabe", func() {
 					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
 					existingResource.Data[FeatureGatesKey] = cmFeatureGates + ",userDefinedFG"
@@ -538,6 +647,38 @@ var _ = Describe("KubeVirt Operand", func() {
 
 					Expect(foundResource.Data[FeatureGatesKey]).To(ContainSubstring(cmFeatureGates))
 					Expect(foundResource.Data[FeatureGatesKey]).ToNot(ContainSubstring(SRIOVLiveMigrationGate))
+					Expect(foundResource.Data[FeatureGatesKey]).To(ContainSubstring("userDefinedFG"))
+				})
+
+				It("Should not modify user modified FGs if GPU FeatureGate is disabled", func() {
+					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
+					existingResource.Data[FeatureGatesKey] = cmFeatureGates + ",userDefinedFG"
+
+					hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+						GPU: &disabled,
+					}
+
+					foundResource := &corev1.ConfigMap{}
+					reconcileCm(hco, req, false, existingResource, foundResource)
+
+					Expect(foundResource.Data[FeatureGatesKey]).To(ContainSubstring(cmFeatureGates))
+					Expect(foundResource.Data[FeatureGatesKey]).ToNot(ContainSubstring(GPUGate))
+					Expect(foundResource.Data[FeatureGatesKey]).To(ContainSubstring("userDefinedFG"))
+				})
+
+				It("Should not modify user modified FGs if HostDevices FeatureGate is disabled", func() {
+					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
+					existingResource.Data[FeatureGatesKey] = cmFeatureGates + ",userDefinedFG"
+
+					hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+						HostDevices: &disabled,
+					}
+
+					foundResource := &corev1.ConfigMap{}
+					reconcileCm(hco, req, false, existingResource, foundResource)
+
+					Expect(foundResource.Data[FeatureGatesKey]).To(ContainSubstring(cmFeatureGates))
+					Expect(foundResource.Data[FeatureGatesKey]).ToNot(ContainSubstring(HostDevicesGate))
 					Expect(foundResource.Data[FeatureGatesKey]).To(ContainSubstring("userDefinedFG"))
 				})
 			})
@@ -886,6 +1027,34 @@ var _ = Describe("KubeVirt Operand", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
 							To(ContainElement(SRIOVLiveMigrationGate))
+					})
+				})
+
+				It("should add the GPU feature gate if it's set in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+						GPU: &enabled,
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the GPU feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
+							To(ContainElement(GPUGate))
+					})
+				})
+
+				It("should add the HostDevices feature gate if it's set in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = &hcov1beta1.HyperConvergedFeatureGates{
+						HostDevices: &enabled,
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the GPU feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
+							To(ContainElement(HostDevicesGate))
 					})
 				})
 

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -457,7 +457,6 @@ var _ = Describe("KubeVirt Operand", func() {
 					Expect(foundResource.Data[FeatureGatesKey]).Should(Equal(cmFeatureGates))
 				})
 
-
 				It("Should keep the HotplugVolumes gate from the CM if the HotplugVolumes FeatureGates is enabled", func() {
 					existingResource := NewKubeVirtConfigForCR(hco, commonTestUtils.Namespace)
 					existingResource.Data[FeatureGatesKey] = fmt.Sprintf("%s,%s", cmFeatureGates, HotplugVolumesGate)


### PR DESCRIPTION
This PR marelly adds the ability fot HCO to control KubeVirt's GPU and HostDevices features gates.
This is following the existing functionality in KubeVirt, RE: https://github.com/kubevirt/kubevirt/pull/3937

**Release note**:
```release-note
allow controlling KubeVirt's `GPU` and `HostDevices` feature-gates from HyperConverged CR.
```

