### PR TITLE
Force go 1.15.8 on github action for consistency

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -26,7 +26,10 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15' # The Go version to download (if necessary) and use.
+          # TODO: go.sum from go 1.16.0 and the one generated from go 1.15.z
+          # are currently different, let's force this for consistency
+          # until we are able to workaround this or definitively move to go 1.16
+          go-version: '1.15.8' # The Go version to download (if necessary) and use.
 
       - name: Do sanity checks
         run: make sanity


### PR DESCRIPTION
github action started using go 1.16 by default introducing
inconsistencies in go.sum between go 1.15.z and 1.16.

Forcing go 1.15.8 on github action until we are ready to
completely move to 1.16.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

