### PR TITLE
Add api documentation with po-docgen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ generate-doc: build-docgen
 	_out/docgen ./pkg/apis/hco/v1beta1/hyperconverged_types.go > docs/api.md
 
 build-docgen:
-	go build -o _out/docgen ./tools/docgen
+	go build -i -ldflags="-s -w" -o _out/docgen ./tools/docgen
 
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'

--- a/Makefile
+++ b/Makefile
@@ -206,3 +206,5 @@ deploy_cr:
 		kubevirt-nightly-test \
 		local \
 		deploy_cr \
+		build-docgen \
+		generate-doc

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DO=eval
 export JOB_TYPE=prow
 endif
 
-sanity:
+sanity: generate-doc
 	go version
 	go fmt ./...
 	go mod tidy -v
@@ -142,6 +142,12 @@ dump-state:
 bump-kubevirtci:
 	rm -rf _kubevirtci
 	./hack/bump-kubevirtci.sh
+
+generate-doc: build-docgen
+	_out/docgen ./pkg/apis/hco/v1beta1/hyperconverged_types.go > docs/api.md
+
+build-docgen:
+	go build -o _out/docgen ./tools/docgen
 
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,7 +32,7 @@ HyperConvergedConfig defines a set of configurations to pass to components
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| nodePlacement | NodePlacement describes node scheduling configuration. | *sdkapi.NodePlacement |  | false |
+| nodePlacement | NodePlacement describes node scheduling configuration. | *[sdkapi.NodePlacement](https://github.com/kubevirt/controller-lifecycle-operator-sdk/blob/bbf16167410b7a781c7b08a3f088fc39551c7a00/pkg/sdk/api/types.go#L49) |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,11 +18,11 @@ This Document documents the types introduced by the hyperconverged-cluster-opera
 
 HyperConverged is the Schema for the hyperconvergeds API
 
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | false |
-| status |  | [HyperConvergedStatus](#hyperconvergedstatus) | false |
+| Field | Description | Scheme | Default | Required |
+| ----- | ----------- | ------ | -------- |-------- |
+| metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) |  | false |
+| status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -30,9 +30,9 @@ HyperConverged is the Schema for the hyperconvergeds API
 
 HyperConvergedConfig defines a set of configurations to pass to components
 
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| nodePlacement | NodePlacement describes node scheduling configuration. | *sdkapi.NodePlacement | false |
+| Field | Description | Scheme | Default | Required |
+| ----- | ----------- | ------ | -------- |-------- |
+| nodePlacement | NodePlacement describes node scheduling configuration. | *sdkapi.NodePlacement |  | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -40,15 +40,15 @@ HyperConvergedConfig defines a set of configurations to pass to components
 
 HyperConvergedFeatureGates is a set of optional feature gates to enable or disable new features that are not enabled by default yet.
 
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. When enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability. This may degrade virt-launcher security. | *bool | false |
-| hotplugVolumes | Allow attaching a data volume to a running VMI | *bool | false |
-| gpu | Allow assigning GPU and vGPU devices to virtual machines | *bool | false |
-| hostDevices | Allow assigning host devices to virtual machines | *bool | false |
-| withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here | *bool | false |
-| withHostModelCPU | Support migration for VMs with host-model CPU mode | *bool | false |
-| hypervStrictCheck | Enable HyperV strict host checking for HyperV enlightenments Defaults to true, even when HyperConvergedFeatureGates is empty | *bool | false |
+| Field | Description | Scheme | Default | Required |
+| ----- | ----------- | ------ | -------- |-------- |
+| sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. When enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability. This may degrade virt-launcher security. | *bool | false | false |
+| hotplugVolumes | Allow attaching a data volume to a running VMI | *bool | false | false |
+| gpu | Allow assigning GPU and vGPU devices to virtual machines | *bool | false | false |
+| hostDevices | Allow assigning host devices to virtual machines | *bool | false | false |
+| withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here | *bool | false | false |
+| withHostModelCPU | Support migration for VMs with host-model CPU mode | *bool | true | false |
+| hypervStrictCheck | Enable HyperV strict host checking for HyperV enlightenments Defaults to true, even when HyperConvergedFeatureGates is empty | *bool | true | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -56,10 +56,10 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 
 HyperConvergedList contains a list of HyperConverged
 
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#listmeta-v1-meta) | false |
-| items |  | [][HyperConverged](#hyperconverged) | true |
+| Field | Description | Scheme | Default | Required |
+| ----- | ----------- | ------ | -------- |-------- |
+| metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#listmeta-v1-meta) |  | false |
+| items |  | [][HyperConverged](#hyperconverged) |  | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -67,13 +67,13 @@ HyperConvergedList contains a list of HyperConverged
 
 HyperConvergedSpec defines the desired state of HyperConverged
 
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| localStorageClassName | LocalStorageClassName the name of the local storage class. | string | false |
-| infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) | false |
-| workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) | false |
-| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | *[HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | false |
-| version | operator version | string | false |
+| Field | Description | Scheme | Default | Required |
+| ----- | ----------- | ------ | -------- |-------- |
+| localStorageClassName | LocalStorageClassName the name of the local storage class. | string |  | false |
+| infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
+| workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
+| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | *[HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {sriovLiveMigration: false, hotplugVolumes: false, gpu: false, hostDevices: false, withHostPassthroughCPU: false, withHostModelCPU: true, hypervStrictCheck: true} | false |
+| version | operator version | string |  | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -81,11 +81,11 @@ HyperConvergedSpec defines the desired state of HyperConverged
 
 HyperConvergedStatus defines the observed state of HyperConverged
 
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| conditions | Conditions describes the state of the HyperConverged resource. | []conditionsv1.Condition | false |
-| relatedObjects | RelatedObjects is a list of objects created and maintained by this operator. Object references will be added to this list after they have been created AND found in the cluster. | []corev1.ObjectReference | false |
-| versions | Versions is a list of HCO component versions, as name/version pairs. The version with a name of \"operator\" is the HCO version itself, as described here: https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version | Versions | false |
+| Field | Description | Scheme | Default | Required |
+| ----- | ----------- | ------ | -------- |-------- |
+| conditions | Conditions describes the state of the HyperConverged resource. | []conditionsv1.Condition |  | false |
+| relatedObjects | RelatedObjects is a list of objects created and maintained by this operator. Object references will be added to this list after they have been created AND found in the cluster. | []corev1.ObjectReference |  | false |
+| versions | Versions is a list of HCO component versions, as name/version pairs. The version with a name of \"operator\" is the HCO version itself, as described here: https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version | Versions |  | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -93,9 +93,9 @@ HyperConvergedStatus defines the observed state of HyperConverged
 
 
 
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| name |  | string | false |
-| version |  | string | false |
+| Field | Description | Scheme | Default | Required |
+| ----- | ----------- | ------ | -------- |-------- |
+| name |  | string |  | false |
+| version |  | string |  | false |
 
 [Back to TOC](#table-of-contents)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,101 @@
+
+# API Docs
+
+This Document documents the types introduced by the hyperconverged-cluster-operator to be consumed by users.
+
+> Note this document is generated from code comments. When contributing a change to this document please do so by changing the code comments.
+
+## Table of Contents
+* [HyperConverged](#hyperconverged)
+* [HyperConvergedConfig](#hyperconvergedconfig)
+* [HyperConvergedFeatureGates](#hyperconvergedfeaturegates)
+* [HyperConvergedList](#hyperconvergedlist)
+* [HyperConvergedSpec](#hyperconvergedspec)
+* [HyperConvergedStatus](#hyperconvergedstatus)
+* [Version](#version)
+
+## HyperConverged
+
+HyperConverged is the Schema for the hyperconvergeds API
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | false |
+| status |  | [HyperConvergedStatus](#hyperconvergedstatus) | false |
+
+[Back to TOC](#table-of-contents)
+
+## HyperConvergedConfig
+
+HyperConvergedConfig defines a set of configurations to pass to components
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| nodePlacement | NodePlacement describes node scheduling configuration. | *sdkapi.NodePlacement | false |
+
+[Back to TOC](#table-of-contents)
+
+## HyperConvergedFeatureGates
+
+HyperConvergedFeatureGates is a set of optional feature gates to enable or disable new features that are not enabled by default yet.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. When enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability. This may degrade virt-launcher security. | *bool | false |
+| hotplugVolumes | Allow attaching a data volume to a running VMI | *bool | false |
+| gpu | Allow assigning GPU and vGPU devices to virtual machines | *bool | false |
+| hostDevices | Allow assigning host devices to virtual machines | *bool | false |
+| withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here | *bool | false |
+| withHostModelCPU | Support migration for VMs with host-model CPU mode | *bool | false |
+| hypervStrictCheck | Enable HyperV strict host checking for HyperV enlightenments Defaults to true, even when HyperConvergedFeatureGates is empty | *bool | false |
+
+[Back to TOC](#table-of-contents)
+
+## HyperConvergedList
+
+HyperConvergedList contains a list of HyperConverged
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#listmeta-v1-meta) | false |
+| items |  | [][HyperConverged](#hyperconverged) | true |
+
+[Back to TOC](#table-of-contents)
+
+## HyperConvergedSpec
+
+HyperConvergedSpec defines the desired state of HyperConverged
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| localStorageClassName | LocalStorageClassName the name of the local storage class. | string | false |
+| infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) | false |
+| workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) | false |
+| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | *[HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | false |
+| version | operator version | string | false |
+
+[Back to TOC](#table-of-contents)
+
+## HyperConvergedStatus
+
+HyperConvergedStatus defines the observed state of HyperConverged
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| conditions | Conditions describes the state of the HyperConverged resource. | []conditionsv1.Condition | false |
+| relatedObjects | RelatedObjects is a list of objects created and maintained by this operator. Object references will be added to this list after they have been created AND found in the cluster. | []corev1.ObjectReference | false |
+| versions | Versions is a list of HCO component versions, as name/version pairs. The version with a name of \"operator\" is the HCO version itself, as described here: https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version | Versions | false |
+
+[Back to TOC](#table-of-contents)
+
+## Version
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| name |  | string | false |
+| version |  | string | false |
+
+[Back to TOC](#table-of-contents)

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -52,8 +52,10 @@ var (
 		"apiextensionsv1.JSON":     "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#json-v1-apiextensions-k8s-io",
 	}
 
-	selfLinks = map[string]string{}
-	typesDoc  = map[string]KubeTypes{}
+	selfLinks = map[string]string{
+		"sdkapi.NodePlacement": "https://github.com/kubevirt/controller-lifecycle-operator-sdk/blob/bbf16167410b7a781c7b08a3f088fc39551c7a00/pkg/sdk/api/types.go#L49",
+	}
+	typesDoc = map[string]KubeTypes{}
 )
 
 const (

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -1,0 +1,302 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The changes can be made visible by diffing this file with the
+// https://github.com/prometheus-operator/prometheus-operator/blob/8497a67b735e65ad779ed19c95a17ffd1c8fbb64/cmd/po-docgen/api.go version
+//
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"strings"
+)
+
+const (
+	firstParagraph = `
+# API Docs
+
+This Document documents the types introduced by the hyperconverged-cluster-operator to be consumed by users.
+
+> Note this document is generated from code comments. When contributing a change to this document please do so by changing the code comments.`
+)
+
+var (
+	links = map[string]string{
+		"metav1.ObjectMeta":        "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta",
+		"metav1.ListMeta":          "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#listmeta-v1-meta",
+		"metav1.LabelSelector":     "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#labelselector-v1-meta",
+		"v1.ResourceRequirements":  "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core",
+		"v1.LocalObjectReference":  "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#localobjectreference-v1-core",
+		"v1.SecretKeySelector":     "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#secretkeyselector-v1-core",
+		"v1.PersistentVolumeClaim": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#persistentvolumeclaim-v1-core",
+		"v1.EmptyDirVolumeSource":  "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#emptydirvolumesource-v1-core",
+		"apiextensionsv1.JSON":     "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#json-v1-apiextensions-k8s-io",
+	}
+
+	selfLinks = map[string]string{}
+	typesDoc  = map[string]KubeTypes{}
+)
+
+func toSectionLink(name string) string {
+	name = strings.ToLower(name)
+	name = strings.Replace(name, " ", "-", -1)
+	return name
+}
+
+func printTOC(types []KubeTypes) {
+	fmt.Printf("\n## Table of Contents\n")
+	for _, t := range types {
+		strukt := t[0]
+		if len(t) > 1 {
+			fmt.Printf("* [%s](#%s)\n", strukt.Name, toSectionLink(strukt.Name))
+		}
+	}
+}
+
+func printAPIDocs(paths []string) {
+	fmt.Println(firstParagraph)
+
+	types := ParseDocumentationFrom(paths)
+	for _, t := range types {
+		strukt := t[0]
+		selfLinks[strukt.Name] = "#" + strings.ToLower(strukt.Name)
+		typesDoc[toLink(strukt.Name)] = t[1:]
+	}
+
+	// we need to parse once more to now add the self links and the inlined fields
+	types = ParseDocumentationFrom(paths)
+
+	printTOC(types)
+
+	for _, t := range types {
+		strukt := t[0]
+		if len(t) > 1 {
+			fmt.Printf("\n## %s\n\n%s\n\n", strukt.Name, strukt.Doc)
+
+			fmt.Println("| Field | Description | Scheme | Required |")
+			fmt.Println("| ----- | ----------- | ------ | -------- |")
+			fields := t[1:(len(t))]
+			for _, f := range fields {
+				fmt.Println("|", f.Name, "|", f.Doc, "|", f.Type, "|", f.Mandatory, "|")
+			}
+			fmt.Println("")
+			fmt.Println("[Back to TOC](#table-of-contents)")
+		}
+	}
+}
+
+// Pair of strings. We keed the name of fields and the doc
+type Pair struct {
+	Name, Doc, Type string
+	Mandatory       bool
+}
+
+// KubeTypes is an array to represent all available types in a parsed file. [0] is for the type itself
+type KubeTypes []Pair
+
+// ParseDocumentationFrom gets all types' documentation and returns them as an
+// array. Each type is again represented as an array (we have to use arrays as we
+// need to be sure for the order of the fields). This function returns fields and
+// struct definitions that have no documentation as {name, ""}.
+func ParseDocumentationFrom(srcs []string) []KubeTypes {
+	var docForTypes []KubeTypes
+
+	for _, src := range srcs {
+		pkg := astFrom(src)
+
+		for _, kubType := range pkg.Types {
+			if structType, ok := kubType.Decl.Specs[0].(*ast.TypeSpec).Type.(*ast.StructType); ok {
+				var ks KubeTypes
+				ks = append(ks, Pair{kubType.Name, fmtRawDoc(kubType.Doc), "", false})
+
+				for _, field := range structType.Fields.List {
+					// Treat inlined fields separately as we don't want the original types to appear in the doc.
+					if isInlined(field) {
+						// Skip external types, as we don't want their content to be part of the API documentation.
+						if isInternalType(field.Type) {
+							ks = append(ks, typesDoc[fieldType(field.Type)]...)
+						}
+						continue
+					}
+
+					typeString := fieldType(field.Type)
+					fieldMandatory := fieldRequired(field)
+					if n := fieldName(field); n != "-" {
+						fieldDoc := fmtRawDoc(field.Doc.Text())
+						ks = append(ks, Pair{n, fieldDoc, typeString, fieldMandatory})
+					}
+				}
+				docForTypes = append(docForTypes, ks)
+			}
+		}
+	}
+
+	return docForTypes
+}
+
+func astFrom(filePath string) *doc.Package {
+	fset := token.NewFileSet()
+	m := make(map[string]*ast.File)
+
+	f, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
+	m[filePath] = f
+	apkg, _ := ast.NewPackage(fset, m, nil, nil)
+
+	return doc.New(apkg, "", 0)
+}
+
+func fmtRawDoc(rawDoc string) string {
+	var buffer bytes.Buffer
+	delPrevChar := func() {
+		if buffer.Len() > 0 {
+			buffer.Truncate(buffer.Len() - 1) // Delete the last " " or "\n"
+		}
+	}
+
+	// Ignore all lines after ---
+	rawDoc = strings.Split(rawDoc, "---")[0]
+
+	for _, line := range strings.Split(rawDoc, "\n") {
+		line = strings.TrimRight(line, " ")
+		leading := strings.TrimLeft(line, " ")
+		switch {
+		case len(line) == 0: // Keep paragraphs
+			delPrevChar()
+			buffer.WriteString("\n\n")
+		case strings.HasPrefix(leading, "TODO"): // Ignore one line TODOs
+		case strings.HasPrefix(leading, "+"): // Ignore instructions to go2idl
+		default:
+			if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+				delPrevChar()
+				line = "\n" + line + "\n" // Replace it with newline. This is useful when we have a line with: "Example:\n\tJSON-someting..."
+			} else {
+				line += " "
+			}
+			buffer.WriteString(line)
+		}
+	}
+
+	postDoc := strings.TrimRight(buffer.String(), "\n")
+	postDoc = strings.Replace(postDoc, "\\\"", "\"", -1) // replace user's \" to "
+	postDoc = strings.Replace(postDoc, "\"", "\\\"", -1) // Escape "
+	postDoc = strings.Replace(postDoc, "\n", "\\n", -1)
+	postDoc = strings.Replace(postDoc, "\t", "\\t", -1)
+	postDoc = strings.Replace(postDoc, "|", "\\|", -1)
+
+	return postDoc
+}
+
+func toLink(typeName string) string {
+	selfLink, hasSelfLink := selfLinks[typeName]
+	if hasSelfLink {
+		return wrapInLink(typeName, selfLink)
+	}
+
+	link, hasLink := links[typeName]
+	if hasLink {
+		return wrapInLink(typeName, link)
+	}
+
+	return typeName
+}
+
+func wrapInLink(text, link string) string {
+	return fmt.Sprintf("[%s](%s)", text, link)
+}
+
+func isInlined(field *ast.Field) bool {
+	jsonTag := reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
+	return strings.Contains(jsonTag, "inline")
+}
+
+func isInternalType(typ ast.Expr) bool {
+	switch typ.(type) {
+	case *ast.SelectorExpr:
+		e := typ.(*ast.SelectorExpr)
+		pkg := e.X.(*ast.Ident)
+		return strings.HasPrefix(pkg.Name, "monitoring")
+	case *ast.StarExpr:
+		return isInternalType(typ.(*ast.StarExpr).X)
+	case *ast.ArrayType:
+		return isInternalType(typ.(*ast.ArrayType).Elt)
+	case *ast.MapType:
+		mapType := typ.(*ast.MapType)
+		return isInternalType(mapType.Key) && isInternalType(mapType.Value)
+	default:
+		return true
+	}
+}
+
+// fieldName returns the name of the field as it should appear in JSON format
+// "-" indicates that this field is not part of the JSON representation
+func fieldName(field *ast.Field) string {
+	jsonTag := reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
+	jsonTag = strings.Split(jsonTag, ",")[0]                                              // This can return "-"
+	if jsonTag == "" {
+		if field.Names != nil {
+			return field.Names[0].Name
+		}
+		return field.Type.(*ast.Ident).Name
+	}
+	return jsonTag
+}
+
+// fieldRequired returns whether a field is a required field.
+func fieldRequired(field *ast.Field) bool {
+	jsonTag := ""
+	if field.Tag != nil {
+		jsonTag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
+		return !strings.Contains(jsonTag, "omitempty")
+	}
+
+	return false
+}
+
+func fieldType(typ ast.Expr) string {
+	switch typ.(type) {
+	case *ast.Ident:
+		return toLink(typ.(*ast.Ident).Name)
+	case *ast.StarExpr:
+		return "*" + toLink(fieldType(typ.(*ast.StarExpr).X))
+	case *ast.SelectorExpr:
+		e := typ.(*ast.SelectorExpr)
+		pkg := e.X.(*ast.Ident)
+		t := e.Sel
+		return toLink(pkg.Name + "." + t.Name)
+	case *ast.ArrayType:
+		return "[]" + toLink(fieldType(typ.(*ast.ArrayType).Elt))
+	case *ast.MapType:
+		mapType := typ.(*ast.MapType)
+		return "map[" + toLink(fieldType(mapType.Key)) + "]" + toLink(fieldType(mapType.Value))
+	default:
+		return ""
+	}
+}
+
+func main() {
+	printAPIDocs(os.Args[1:])
+}


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

The docgen in this PR is based on https://github.com/prometheus-operator/prometheus-operator/blob/8497a67b735e65ad779ed19c95a17ffd1c8fbb64/cmd/po-docgen/api.go with small modifications. I added a warning into the top of the file like https://github.com/kubermatic/kubecarrier/blob/master/hack/docgen/main.go. 

Also, I added `default` column into tables by using `// +kubebuilder:default=` comments of fields.

**Release note**:
```release-note
Adds api.md for documenting HyperConverged custom resource.
```

