### PR TITLE
Fix csplit delimiter in build-manifests.sh

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -95,7 +95,7 @@ function gen_csv() {
     --prefix="${operatorName}" \
     --suffix-format="%02d.${CRD_EXT}" \
     $crds \
-    "/---/" "{*}"
+    "/^---$/" "{*}"
 }
 
 function create_virt_csv() {


### PR DESCRIPTION
CRDs might contain the '---' string inside their body, and they will be splitted on that line, resulting in malformed yaml.
This fix will split the CRDs only if a line contain only '---'.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

