### PR TITLE
Add alert tests

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: Unit tests
         run: make test
 
+      - name: Prometheus alerts tests
+        run: make prom-rules-verify
+
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverprofiles/cover.coverprofile

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,16 @@ build-manifests:
 build-manifests-prev:
 	RELEASE_DELTA=1 ./hack/build-manifests.sh
 
+build-prom-spec-dumper: ## Build binary from source
+	go build -i -ldflags="-s -w" -o _out/rule-spec-dumper ./hack/prom-rule-ci/rule-spec-dumper.go
+
+current-dir := $(realpath .)
+
+prom-rules-verify: build-prom-spec-dumper
+	./hack/prom-rule-ci/verify-rules.sh \
+		"${current-dir}/_out/rule-spec-dumper" \
+		"${current-dir}/hack/prom-rule-ci/prom-rules-tests.yaml"
+
 install:
 	go install ./cmd/...
 

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1,0 +1,35 @@
+---
+rule_files:
+  - /tmp/rules.verify
+
+group_eval_order:
+  - kubevirt.hyperconverged.rules
+
+tests:
+  # CR out of band update detected
+  - interval: 1m
+    input_series:
+      - series: 'hyperconverged_cluster_operator_out_of_band_modifications{component_name="kubevirt"}'
+        values: "0 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: KubevirtHyperconvergedClusterOperatorCRModification
+        exp_alerts:
+          - exp_annotations:
+              description: "Out-of-band modification for kubevirt ."
+              summary: "Out-of-band CR modification was detected"
+            exp_labels:
+              severity: "warning"
+              component_name: "kubevirt"
+
+  # No CR out of band updates
+  - interval: 1m
+    input_series:
+      - series: 'hyperconverged_cluster_operator_out_of_band_modifications{component_name="kubevirt"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: KubevirtHyperconvergedClusterOperatorCRModification
+        exp_alerts: []

--- a/hack/prom-rule-ci/rule-spec-dumper.go
+++ b/hack/prom-rule-ci/rule-spec-dumper.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/json"
+
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/operands"
+)
+
+func verifyArgs(args []string) error {
+	numOfArgs := len(os.Args[1:])
+	if numOfArgs != 1 {
+		return fmt.Errorf("expected exactly 1 argument, got: %d", numOfArgs)
+	}
+	return nil
+}
+
+func main() {
+	if err := verifyArgs(os.Args); err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+
+	targetFile := os.Args[1]
+
+	promRuleSpec := operands.NewPrometheusRuleSpec()
+	b, err := json.Marshal(promRuleSpec)
+	if err != nil {
+		panic(err)
+	}
+
+	err = ioutil.WriteFile(targetFile, b, 0644)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+
+readonly PROM_IMAGE="docker.io/prom/prometheus:v2.15.2"
+
+function cleanup() {
+    local cleanup_files=("${@:?}")
+    for file in "${cleanup_files[@]}"; do
+        rm -f "$file"
+    done
+}
+
+function lint() {
+    local target_file="${1:?}"
+    docker run --rm --entrypoint=/bin/promtool \
+        -v "$target_file":/tmp/rules.verify:ro "$PROM_IMAGE" \
+        check rules /tmp/rules.verify
+}
+
+function unit_test() {
+    local target_file="${1:?}"
+    local tests_file="${2:?}"
+    docker run --rm --entrypoint=/bin/promtool \
+        -v "$tests_file":/tmp/rules.test:ro \
+        -v "$target_file":/tmp/rules.verify:ro \
+        "$PROM_IMAGE" \
+        test rules /tmp/rules.test
+}
+
+function main() {
+    local prom_spec_dumper="${1:?}"
+    local tests_file="${2:?}"
+    local target_file
+    target_file="$(mktemp --tmpdir -u tmp.prom_rules.XXXXX)"
+    trap "cleanup $target_file" RETURN EXIT INT
+    "$prom_spec_dumper" "$target_file"
+    echo "INFO: Rules file content:"
+    cat "$target_file"
+    echo
+    lint "$target_file"
+    unit_test "$target_file" "$tests_file"
+}
+
+main "$@"

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -260,21 +260,21 @@ func NewPrometheusRule(hc *hcov1beta1.HyperConverged, namespace string) *monitor
 
 // NewPrometheusRuleSpec creates PrometheusRuleSpec for alert rules
 func NewPrometheusRuleSpec() *monitoringv1.PrometheusRuleSpec {
-        return &monitoringv1.PrometheusRuleSpec{
-                Groups: []monitoringv1.RuleGroup{{
-                        Name: alertRuleGroup,
-                        Rules: []monitoringv1.Rule{{
-                                Alert: outOfBandUpdateAlert,
-                                Expr:  intstr.FromString("sum(hyperconverged_cluster_operator_out_of_band_modifications) by (component_name) > 0"),
-                                For:   "10m",
-                                Annotations: map[string]string{
-                                        "description": "Out-of-band modification for {{ $labels.component_name }} .",
-                                        "summary":     "Out-of-band CR modification was detected",
-                                },
-                                Labels: map[string]string{
-                                        "severity": "warning",
-                                },
-                        }},
-                }},
-        }
+	return &monitoringv1.PrometheusRuleSpec{
+		Groups: []monitoringv1.RuleGroup{{
+			Name: alertRuleGroup,
+			Rules: []monitoringv1.Rule{{
+				Alert: outOfBandUpdateAlert,
+				Expr:  intstr.FromString("sum(hyperconverged_cluster_operator_out_of_band_modifications) by (component_name) > 0"),
+				For:   "10m",
+				Annotations: map[string]string{
+					"description": "Out-of-band modification for {{ $labels.component_name }} .",
+					"summary":     "Out-of-band CR modification was detected",
+				},
+				Labels: map[string]string{
+					"severity": "warning",
+				},
+			}},
+		}},
+	}
 }

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -244,24 +244,6 @@ func (h *prometheusRuleHooks) updateCr(req *common.HcoRequest, Client client.Cli
 
 // NewPrometheusRule creates PrometheusRule resource to define alert rules
 func NewPrometheusRule(hc *hcov1beta1.HyperConverged, namespace string) *monitoringv1.PrometheusRule {
-	spec := monitoringv1.PrometheusRuleSpec{
-		Groups: []monitoringv1.RuleGroup{{
-			Name: alertRuleGroup,
-			Rules: []monitoringv1.Rule{{
-				Alert: outOfBandUpdateAlert,
-				Expr:  intstr.FromString("sum(increase(hyperconverged_cluster_operator_out_of_band_modifications[1m])) by (component_name) > 0"),
-				For:   "60m",
-				Annotations: map[string]string{
-					"description": "Out-of-band modification for {{ $labels.component_name }} .",
-					"summary":     "Out-of-band CR modification was detected",
-				},
-				Labels: map[string]string{
-					"severity": "warning",
-				},
-			}},
-		}},
-	}
-
 	return &monitoringv1.PrometheusRule{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: monitoringv1.SchemeGroupVersion.String(),
@@ -272,6 +254,27 @@ func NewPrometheusRule(hc *hcov1beta1.HyperConverged, namespace string) *monitor
 			Labels:    getLabels(hc, hcoutil.AppComponentMonitoring),
 			Namespace: namespace,
 		},
-		Spec: spec,
+		Spec: *NewPrometheusRuleSpec(),
 	}
+}
+
+// NewPrometheusRuleSpec creates PrometheusRuleSpec for alert rules
+func NewPrometheusRuleSpec() *monitoringv1.PrometheusRuleSpec {
+        return &monitoringv1.PrometheusRuleSpec{
+                Groups: []monitoringv1.RuleGroup{{
+                        Name: alertRuleGroup,
+                        Rules: []monitoringv1.Rule{{
+                                Alert: outOfBandUpdateAlert,
+                                Expr:  intstr.FromString("sum(hyperconverged_cluster_operator_out_of_band_modifications) by (component_name) > 0"),
+                                For:   "10m",
+                                Annotations: map[string]string{
+                                        "description": "Out-of-band modification for {{ $labels.component_name }} .",
+                                        "summary":     "Out-of-band CR modification was detected",
+                                },
+                                Labels: map[string]string{
+                                        "severity": "warning",
+                                },
+                        }},
+                }},
+        }
 }


### PR DESCRIPTION
Signed-off-by: Andrey Odarenko <andreyo@il.ibm.com>

This PR will add Prometheus alert rules validation and alert tests using promtool.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

