### PR TITLE
[Release 1.3] Wait to set CDI featuregates until "config authority" annotation is set (#1165)

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -24,7 +24,10 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15' # The Go version to download (if necessary) and use.
+          # TODO: go.sum from go 1.16.0 and the one generated from go 1.15.z
+          # are currently different, let's force this for consistency
+          # until we are able to workaround this or definitively move to go 1.16
+          go-version: '1.15.8' # The Go version to download (if necessary) and use.
 
       - name: Do sanity checks
         run: make sanity

--- a/pkg/controller/operands/cdi_test.go
+++ b/pkg/controller/operands/cdi_test.go
@@ -47,6 +47,7 @@ var _ = Describe("CDI Operand", func() {
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
 			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commonTestUtils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
+			Expect(foundResource.Annotations).To(Equal(map[string]string{"cdi.kubevirt.io/configAuthority": ""}))
 		})
 
 		It("should find if present", func() {
@@ -313,6 +314,32 @@ var _ = Describe("CDI Operand", func() {
 			// additionally contains HonorWaitForFirstConsumer
 			Expect(foundResource.Spec.Config.FeatureGates).To(ContainElement("HonorWaitForFirstConsumer"))
 
+		})
+
+		It("should NOT add HonorWaitForFirstConsumer featuregate if configauthority not set", func() {
+			expectedResource := NewCDI(hco)
+			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
+			expectedResource.Spec.Config = nil
+			delete(expectedResource.Annotations, "cdi.kubevirt.io/configAuthority")
+
+			// mock a reconciliation triggered by a change in CDI CR
+			req.HCOTriggered = false
+
+			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
+			handler := (*genericOperand)(newCdiHandler(cl, commonTestUtils.GetScheme()))
+			res := handler.ensure(req)
+			Expect(res.UpgradeDone).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Overwritten).To(BeFalse())
+			Expect(res.Err).To(BeNil())
+
+			foundResource := &cdiv1beta1.CDI{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
+					foundResource),
+			).To(BeNil())
+			Expect(foundResource.Spec.Config).To(BeNil())
 		})
 
 		It("should add HonorWaitForFirstConsumer featuregate if Spec.Config if empty", func() {


### PR DESCRIPTION
This is a manual cherry pick of #1165

* Wait to set CDI featuregates until "config authority" annotation  is set
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

#Fixes: https://bugzilla.redhat.com/1935030

**Release note**:
```release-note
BugFix:  Wait to set CDI featuregates until "config authority" annotation is set
```

