### PR TITLE
Expose API for certificate rotation configuration

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -45,6 +45,48 @@ spec:
           spec:
             description: HyperConvergedSpec defines the desired state of HyperConverged
             properties:
+              certConfig:
+                description: certConfig holds the rotation policy for internal, self-signed
+                  certificates
+                properties:
+                  ca:
+                    default:
+                      duration: 48h
+                      renewBefore: 24h
+                    description: CA configuration - CA certs are kept in the CA bundle
+                      as long as they are valid
+                    properties:
+                      duration:
+                        description: The requested 'duration' (i.e. lifetime) of the
+                          Certificate. This should comply with golang's ParseDuration
+                          format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                      renewBefore:
+                        description: The amount of time before the currently issued
+                          certificate's `notAfter` time that we will begin to attempt
+                          to renew the certificate. This should comply with golang's
+                          ParseDuration format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                    type: object
+                  server:
+                    default:
+                      duration: 24h
+                      renewBefore: 12h
+                    description: Server configuration - Certs are rotated and discarded
+                    properties:
+                      duration:
+                        description: The requested 'duration' (i.e. lifetime) of the
+                          Certificate. This should comply with golang's ParseDuration
+                          format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                      renewBefore:
+                        description: The amount of time before the currently issued
+                          certificate's `notAfter` time that we will begin to attempt
+                          to renew the certificate. This should comply with golang's
+                          ParseDuration format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                    type: object
+                type: object
               featureGates:
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
@@ -45,6 +45,48 @@ spec:
           spec:
             description: HyperConvergedSpec defines the desired state of HyperConverged
             properties:
+              certConfig:
+                description: certConfig holds the rotation policy for internal, self-signed
+                  certificates
+                properties:
+                  ca:
+                    default:
+                      duration: 48h
+                      renewBefore: 24h
+                    description: CA configuration - CA certs are kept in the CA bundle
+                      as long as they are valid
+                    properties:
+                      duration:
+                        description: The requested 'duration' (i.e. lifetime) of the
+                          Certificate. This should comply with golang's ParseDuration
+                          format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                      renewBefore:
+                        description: The amount of time before the currently issued
+                          certificate's `notAfter` time that we will begin to attempt
+                          to renew the certificate. This should comply with golang's
+                          ParseDuration format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                    type: object
+                  server:
+                    default:
+                      duration: 24h
+                      renewBefore: 12h
+                    description: Server configuration - Certs are rotated and discarded
+                    properties:
+                      duration:
+                        description: The requested 'duration' (i.e. lifetime) of the
+                          Certificate. This should comply with golang's ParseDuration
+                          format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                      renewBefore:
+                        description: The amount of time before the currently issued
+                          certificate's `notAfter` time that we will begin to attempt
+                          to renew the certificate. This should comply with golang's
+                          ParseDuration format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                    type: object
+                type: object
               featureGates:
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
@@ -45,6 +45,48 @@ spec:
           spec:
             description: HyperConvergedSpec defines the desired state of HyperConverged
             properties:
+              certConfig:
+                description: certConfig holds the rotation policy for internal, self-signed
+                  certificates
+                properties:
+                  ca:
+                    default:
+                      duration: 48h
+                      renewBefore: 24h
+                    description: CA configuration - CA certs are kept in the CA bundle
+                      as long as they are valid
+                    properties:
+                      duration:
+                        description: The requested 'duration' (i.e. lifetime) of the
+                          Certificate. This should comply with golang's ParseDuration
+                          format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                      renewBefore:
+                        description: The amount of time before the currently issued
+                          certificate's `notAfter` time that we will begin to attempt
+                          to renew the certificate. This should comply with golang's
+                          ParseDuration format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                    type: object
+                  server:
+                    default:
+                      duration: 24h
+                      renewBefore: 12h
+                    description: Server configuration - Certs are rotated and discarded
+                    properties:
+                      duration:
+                        description: The requested 'duration' (i.e. lifetime) of the
+                          Certificate. This should comply with golang's ParseDuration
+                          format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                      renewBefore:
+                        description: The amount of time before the currently issued
+                          certificate's `notAfter` time that we will begin to attempt
+                          to renew the certificate. This should comply with golang's
+                          ParseDuration format (https://golang.org/pkg/time/#ParseDuration)
+                        type: string
+                    type: object
+                type: object
               featureGates:
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,9 @@ This Document documents the types introduced by the hyperconverged-cluster-opera
 > Note this document is generated from code comments. When contributing a change to this document please do so by changing the code comments.
 
 ## Table of Contents
+* [CertRotateConfig](#certrotateconfig)
 * [HyperConverged](#hyperconverged)
+* [HyperConvergedCertConfig](#hyperconvergedcertconfig)
 * [HyperConvergedConfig](#hyperconvergedconfig)
 * [HyperConvergedFeatureGates](#hyperconvergedfeaturegates)
 * [HyperConvergedList](#hyperconvergedlist)
@@ -18,6 +20,17 @@ This Document documents the types introduced by the hyperconverged-cluster-opera
 * [PermittedHostDevices](#permittedhostdevices)
 * [Version](#version)
 
+## CertRotateConfig
+
+CertConfig contains the tunables for TLS certificates.
+
+| Field | Description | Scheme | Default | Required |
+| ----- | ----------- | ------ | -------- |-------- |
+| duration | The requested 'duration' (i.e. lifetime) of the Certificate. This should comply with golang's ParseDuration format (https://golang.org/pkg/time/#ParseDuration) | metav1.Duration |  | false |
+| renewBefore | The amount of time before the currently issued certificate's `notAfter` time that we will begin to attempt to renew the certificate. This should comply with golang's ParseDuration format (https://golang.org/pkg/time/#ParseDuration) | metav1.Duration |  | false |
+
+[Back to TOC](#table-of-contents)
+
 ## HyperConverged
 
 HyperConverged is the Schema for the hyperconvergeds API
@@ -27,6 +40,17 @@ HyperConverged is the Schema for the hyperconvergeds API
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
 | spec |  | [HyperConvergedSpec](#hyperconvergedspec) |  | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
+
+[Back to TOC](#table-of-contents)
+
+## HyperConvergedCertConfig
+
+HyperConvergedCertConfig holds the CertConfig entries for the HCO operands
+
+| Field | Description | Scheme | Default | Required |
+| ----- | ----------- | ------ | -------- |-------- |
+| ca | CA configuration - CA certs are kept in the CA bundle as long as they are valid | *[CertRotateConfig](#certrotateconfig) | {duration: "48h", renewBefore: "24h"} | false |
+| server | Server configuration - Certs are rotated and discarded | *[CertRotateConfig](#certrotateconfig) | {duration: "24h", renewBefore: "12h"} | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -73,6 +97,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) |  | false |
 | liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) |  | false |
 | permittedHostDevices | PermittedHostDevices holds inforamtion about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
+| certConfig | certConfig holds the rotation policy for internal, self-signed certificates | *[HyperConvergedCertConfig](#hyperconvergedcertconfig) |  | false |
 | version | operator version | string |  | false |
 
 [Back to TOC](#table-of-contents)

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -50,8 +50,38 @@ type HyperConvergedSpec struct {
 	// +optional
 	PermittedHostDevices *PermittedHostDevices `json:"permittedHostDevices,omitempty"`
 
+	// certConfig holds the rotation policy for internal, self-signed certificates
+	// +optional
+	CertConfig *HyperConvergedCertConfig `json:"certConfig,omitempty"`
+
 	// operator version
 	Version string `json:"version,omitempty"`
+}
+
+// CertConfig contains the tunables for TLS certificates.
+type CertRotateConfig struct {
+	// The requested 'duration' (i.e. lifetime) of the Certificate.
+	// This should comply with golang's ParseDuration format (https://golang.org/pkg/time/#ParseDuration)
+	Duration metav1.Duration `json:"duration,omitempty"`
+
+	// The amount of time before the currently issued certificate's `notAfter`
+	// time that we will begin to attempt to renew the certificate.
+	// This should comply with golang's ParseDuration format (https://golang.org/pkg/time/#ParseDuration)
+	RenewBefore metav1.Duration `json:"renewBefore,omitempty"`
+}
+
+// HyperConvergedCertConfig holds the CertConfig entries for the HCO operands
+// +optional
+type HyperConvergedCertConfig struct {
+	// CA configuration -
+	// CA certs are kept in the CA bundle as long as they are valid
+	// +kubebuilder:default={duration: "48h", renewBefore: "24h"}
+	CA *CertRotateConfig `json:"ca,omitempty"`
+
+	// Server configuration -
+	// Certs are rotated and discarded
+	// +kubebuilder:default={duration: "24h", renewBefore: "12h"}
+	Server *CertRotateConfig `json:"server,omitempty"`
 }
 
 // HyperConvergedConfig defines a set of configurations to pass to components

--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -159,6 +159,27 @@ func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, err
 		hc.Spec.Workloads.NodePlacement.DeepCopyInto(&spec.Workloads)
 	}
 
+	certConfig := hc.Spec.CertConfig
+	if certConfig == nil {
+		certConfig = getDefaultCertConfig()
+	}
+
+	spec.CertConfig = &cdiv1beta1.CDICertConfig{}
+
+	if certConfig.CA != nil {
+		spec.CertConfig.CA = &cdiv1beta1.CertConfig{
+			Duration:    certConfig.CA.Duration.DeepCopy(),
+			RenewBefore: certConfig.CA.RenewBefore.DeepCopy(),
+		}
+	}
+
+	if certConfig.Server != nil {
+		spec.CertConfig.Server = &cdiv1beta1.CertConfig{
+			Duration:    certConfig.Server.Duration.DeepCopy(),
+			RenewBefore: certConfig.Server.RenewBefore.DeepCopy(),
+		}
+	}
+
 	cdi := NewCDIWithNameOnly(hc, opts...)
 	cdi.Spec = spec
 

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -3,12 +3,13 @@ package operands
 import (
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
@@ -204,6 +205,8 @@ func NewKubeVirt(hc *hcov1beta1.HyperConverged, opts ...string) (*kubevirtv1.Kub
 		Workloads:         hcoConfig2KvConfig(hc.Spec.Workloads),
 		Configuration:     *config,
 	}
+
+	// TODO: support passing certificate rotation configuration to KubeVirt spec
 
 	kv := NewKubeVirtWithNameOnly(hc, opts...)
 	kv.Spec = spec

--- a/pkg/controller/operands/networkAddons.go
+++ b/pkg/controller/operands/networkAddons.go
@@ -157,6 +157,8 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged, opts ...string) (*networkad
 		}
 	}
 
+	// TODO: support passing certificate rotation configuration to CNAO spec
+
 	cna := NewNetworkAddonsWithNameOnly(hc, opts...)
 	cna.Spec = cnaoSpec
 

--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -337,6 +338,19 @@ func getLabels(hc *hcov1beta1.HyperConverged, component hcoutil.AppComponent) ma
 		hcoutil.AppLabelVersion:   hcoutil.GetHcoKvIoVersion(),
 		hcoutil.AppLabelPartOf:    hcoutil.HyperConvergedCluster,
 		hcoutil.AppLabelComponent: string(component),
+	}
+}
+
+func getDefaultCertConfig() *hcov1beta1.HyperConvergedCertConfig {
+	return &hcov1beta1.HyperConvergedCertConfig{
+		CA: &hcov1beta1.CertRotateConfig{
+			Duration:    metav1.Duration{Duration: 48 * time.Hour},
+			RenewBefore: metav1.Duration{Duration: 24 * time.Hour},
+		},
+		Server: &hcov1beta1.CertRotateConfig{
+			Duration:    metav1.Duration{Duration: 24 * time.Hour},
+			RenewBefore: metav1.Duration{Duration: 12 * time.Hour},
+		},
 	}
 }
 


### PR DESCRIPTION
This commit will make the HCO expose and pass the following
configuration to the CDI:
```
certConfig:
 ca:
  duration:
  renewBefore:
 server:
  duration:
  renewBefore:
```
Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

