### PR TITLE
Introduces configuration interface for functional test container

### DIFF
--- a/docs/functest-container.md
+++ b/docs/functest-container.md
@@ -27,23 +27,44 @@ kubectl run functest --image=quay.io/kubevirt/hyperconverged-cluster-functest:1.
 - If your systems are running in a namespace different from `kubevirt-hypercongerged`, you have to set the environment variable `INSTALLED_NAMESPACE` 
 
 
-## Arguments
+## Arguments and Configuration
 
-The arguments passed to this container image are directly passed to `func-tests.test` binary in the image.
+The arguments passed to this container image are directly passed to `func-tests.test` binary in the image. See [the example](#example-command)
+
+There is a special flag in the test binary which allows you to provide test specific configuration. You can mount your configuration file into the image and pass it with the flag. 
+```shell
+docker run \
+  -v /my-test-conf.yaml:/tmp/testconf \
+  quay.io/kubevirt/hyperconverged-cluster-functest:1.4.0-unstable \
+  --config-file /tmp/testconf    
+```
+
+The content of the configuration file must be a valid yaml representation of `TestConfig` in [config.go](../tests/func-tests/config.go)
+
+***Configuration File Example***
+```yaml
+quickStart:
+  testItems:
+    - name: create-rhel-vm
+      displayName: Creating a Red Hat Enterprise Linux virtual machine
+```
 
 ## Example Command
 
 ```shell
 docker run  --network=host  \
-  --env KUBECONFIG=/tmp/conf \
-  -v $KUBECONFIG:/tmp/conf \
-  -v /tmp/out:/tmp/out  \
-  quay.io/kubevirt/hyperconverged-cluster-functest:1.4.0-unstable  \
-  --polarion-execution=true \
-  --polarion-project-id=CNV \
-  --polarion-report-file=/tmp/out/polarion_results.xml 
-  --test-suite-params="env_tier=tier1" \
-  --junit-output=/tmp/out/junit.xml \
-  --polarion-custom-plannedin=234235
-
+    --env INSTALLED_NAMESPACE=openshift-cnv \
+    --env KUBECONFIG=/tmp/kubeconf \
+    -v $KUBECONFIG:/tmp/kubeconf \
+    -v $MY_TEST_CONF:/tmp/testconf \
+    -v /tmp/out:/tmp/out  \
+    quay.io/kubevirt/hyperconverged-cluster-functest:1.4.0-unstable   \
+    --polarion-execution=true \
+    --polarion-project-id=CNV \
+    --polarion-report-file=/tmp/out/polarion_results.xml \
+    --test-suite-params="env_tier=tier1" \
+    --junit-output=/tmp/out/junit.xml \
+    --polarion-custom-plannedin=234235 \
+    --config-file /tmp/testconf
 ```
+

--- a/docs/functest-container.md
+++ b/docs/functest-container.md
@@ -31,10 +31,10 @@ kubectl run functest --image=quay.io/kubevirt/hyperconverged-cluster-functest:1.
 
 The arguments passed to this container image are directly passed to `func-tests.test` binary in the image. See [the example](#example-command)
 
-There is a special flag in the test binary which allows you to provide test specific configuration. You can mount your configuration file into the image and pass it with the flag. 
+To provide test configuration, use `--config-file` flag and mount your configuration file into that path. 
 ```shell
 docker run \
-  -v /my-test-conf.yaml:/tmp/testconf \
+  -v /put-your-configuration-file-here.yaml:/tmp/testconf \
   quay.io/kubevirt/hyperconverged-cluster-functest:1.4.0-unstable \
   --config-file /tmp/testconf    
 ```
@@ -45,8 +45,8 @@ The content of the configuration file must be a valid yaml representation of `Te
 ```yaml
 quickStart:
   testItems:
-    - name: create-rhel-vm
-      displayName: Creating a Red Hat Enterprise Linux virtual machine
+    - name: test-quick-start
+      displayName: Test Quickstart Tour
 ```
 
 ## Example Command

--- a/hack/check_labels.sh
+++ b/hack/check_labels.sh
@@ -21,7 +21,7 @@
 set -euo pipefail
 
 KUBECTL_BINARY="${KUBECTL_BINARY:-"kubectl"}"
-HCO_NAMESPACE="${HCO_NAMESPACE:-"kubevirt-hyperconverged"}"
+INSTALLED_NAMESPACE="${INSTALLED_NAMESPACE:-"kubevirt-hyperconverged"}"
 HCO_RESOURCE_NAME="${HCO_RESOURCE_NAME:-"kubevirt-hyperconverged"}"
 
 function check_label_value() {
@@ -59,7 +59,7 @@ function check_labels(){
 }
 
 echo "Fetching related objects..."
-related_obj_json="$(${KUBECTL_BINARY} get  hco "${HCO_RESOURCE_NAME}" -n "${HCO_NAMESPACE}" -o jsonpath='{.status .relatedObjects}')"
+related_obj_json="$(${KUBECTL_BINARY} get  hco "${HCO_RESOURCE_NAME}" -n "${INSTALLED_NAMESPACE}" -o jsonpath='{.status .relatedObjects}')"
 
 echo "Putting related objects into array..."
 related_obj_array=()

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -39,8 +39,6 @@ ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o
 # wait a bit to make sure the VMs are deleted
 sleep 60
 
-KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/test_quick_start.sh
-
 ./hack/retry.sh 10 30 "KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_labels.sh"
 
 # Check the webhook, to see if it allow deleteing of the HyperConverged CR

--- a/tests/func-tests/config.go
+++ b/tests/func-tests/config.go
@@ -1,0 +1,61 @@
+package tests
+
+import (
+	"flag"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"sync"
+)
+
+const (
+	ConfigFileFlag = "config-file"
+)
+
+var (
+	configFileName string
+	config         *TestConfig
+)
+
+type QuickStartTestItem struct {
+	Name        string `yaml:"name,omitempty"`
+	DisplayName string `yaml:"displayName,omitempty"`
+}
+
+type QuickStartTestConfig struct {
+	TestItems []QuickStartTestItem `yaml:"testItems,omitempty"`
+}
+
+type TestConfig struct {
+	QuickStart QuickStartTestConfig `yaml:"quickStart,omitempty"`
+}
+
+func init() {
+	flag.StringVar(&configFileName, ConfigFileFlag, "", "File contains test configuration")
+}
+
+func GetConfig() *TestConfig {
+	once := sync.Once{}
+	once.Do(func() {
+		config = loadConfig(configFileName)
+	})
+
+	return config
+}
+
+func loadConfig(fileName string) *TestConfig {
+	config := TestConfig{}
+
+	if fileName != "" {
+		configContent, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			panic(err)
+		}
+
+		err = yaml.Unmarshal(configContent, &config)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return &config
+}

--- a/tests/func-tests/quickstart_test.go
+++ b/tests/func-tests/quickstart_test.go
@@ -1,0 +1,75 @@
+package tests_test
+
+import (
+	"flag"
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	consolev1 "github.com/openshift/api/console/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"kubevirt.io/client-go/kubecli"
+	"time"
+)
+
+type QuickStartTestCase struct {
+	Name        string
+	DisplayName string
+}
+
+var defaultCases = []QuickStartTestCase{{Name: "test-quick-start", DisplayName: "Test Quickstart Tour"}}
+
+var _ = Describe("[rfe_id:xxx][crit:xxx][vendor:cnv-qe@redhat.com][level:system]ConsoleQuickStart objects", func() {
+	flag.Parse()
+
+	BeforeEach(func() {
+		tests.BeforeEach()
+
+	})
+
+	It("[test_id:xxx]should create ConsoleQuickStart objects", func() {
+		virtCli, err := kubecli.GetKubevirtClient()
+		Expect(err).ToNot(HaveOccurred())
+
+		client, err := kubecli.GetKubevirtClientFromRESTConfig(virtCli.Config())
+		Expect(err).ToNot(HaveOccurred())
+
+		skipIfQuickStartCrdDoesNotExist(virtCli)
+		checkExpectedQuickStarts(client, defaultCases)
+	})
+
+})
+
+func skipIfQuickStartCrdDoesNotExist(cli kubecli.KubevirtClient) {
+	By("Checking ConsoleQuickStarts CRD exists or not")
+
+	_, err := cli.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get("consolequickstarts.console.openshift.io", metav1.GetOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		Skip("ConsoleQuickStarts CRD does not exist")
+	}
+	ExpectWithOffset(1, err).Should(BeNil())
+}
+
+func checkExpectedQuickStarts(client kubecli.KubevirtClient, cases []QuickStartTestCase) {
+	By("Checking expected quickstart objects")
+
+	s := scheme.Scheme
+	_ = consolev1.Install(s)
+	s.AddKnownTypes(consolev1.GroupVersion)
+
+	for _, qs := range cases {
+		// use a fresh object for each loop. get requests only override non-empty fields
+		var cqs consolev1.ConsoleQuickStart
+		err := client.RestClient().Get().
+			Resource("consolequickstarts").
+			Name(qs.Name).
+			AbsPath("/apis", consolev1.GroupVersion.Group, consolev1.GroupVersion.Version).
+			Timeout(10 * time.Second).
+			Do().Into(&cqs)
+
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		ExpectWithOffset(1, cqs.Spec.DisplayName).Should(Equal(qs.DisplayName))
+	}
+
+}

--- a/tests/func-tests/quickstart_test.go
+++ b/tests/func-tests/quickstart_test.go
@@ -15,14 +15,14 @@ import (
 
 var defaultItems = []tests.QuickStartTestItem{{Name: "test-quick-start", DisplayName: "Test Quickstart Tour"}}
 
-var _ = Describe("[rfe_id:xxx][crit:xxx][vendor:cnv-qe@redhat.com][level:system]ConsoleQuickStart objects", func() {
+var _ = Describe("[rfe_id:5882][crit:high][vendor:cnv-qe@redhat.com][level:system]ConsoleQuickStart objects", func() {
 	flag.Parse()
 
 	BeforeEach(func() {
 		tests.BeforeEach()
 	})
 
-	It("[test_id:xxx]should create ConsoleQuickStart objects", func() {
+	It("[test_id:5883]should create ConsoleQuickStart objects", func() {
 		virtCli, err := kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/func-tests/quickstart_test.go
+++ b/tests/func-tests/quickstart_test.go
@@ -13,19 +13,13 @@ import (
 	"time"
 )
 
-type QuickStartTestCase struct {
-	Name        string
-	DisplayName string
-}
-
-var defaultCases = []QuickStartTestCase{{Name: "test-quick-start", DisplayName: "Test Quickstart Tour"}}
+var defaultItems = []tests.QuickStartTestItem{{Name: "test-quick-start", DisplayName: "Test Quickstart Tour"}}
 
 var _ = Describe("[rfe_id:xxx][crit:xxx][vendor:cnv-qe@redhat.com][level:system]ConsoleQuickStart objects", func() {
 	flag.Parse()
 
 	BeforeEach(func() {
 		tests.BeforeEach()
-
 	})
 
 	It("[test_id:xxx]should create ConsoleQuickStart objects", func() {
@@ -36,7 +30,8 @@ var _ = Describe("[rfe_id:xxx][crit:xxx][vendor:cnv-qe@redhat.com][level:system]
 		Expect(err).ToNot(HaveOccurred())
 
 		skipIfQuickStartCrdDoesNotExist(virtCli)
-		checkExpectedQuickStarts(client, defaultCases)
+
+		checkExpectedQuickStarts(client)
 	})
 
 })
@@ -51,14 +46,17 @@ func skipIfQuickStartCrdDoesNotExist(cli kubecli.KubevirtClient) {
 	ExpectWithOffset(1, err).Should(BeNil())
 }
 
-func checkExpectedQuickStarts(client kubecli.KubevirtClient, cases []QuickStartTestCase) {
+func checkExpectedQuickStarts(client kubecli.KubevirtClient) {
 	By("Checking expected quickstart objects")
-
 	s := scheme.Scheme
 	_ = consolev1.Install(s)
 	s.AddKnownTypes(consolev1.GroupVersion)
 
-	for _, qs := range cases {
+	items := defaultItems
+	if tests.GetConfig().QuickStart.TestItems != nil {
+		items = tests.GetConfig().QuickStart.TestItems
+	}
+	for _, qs := range items {
 		// use a fresh object for each loop. get requests only override non-empty fields
 		var cqs consolev1.ConsoleQuickStart
 		err := client.RestClient().Get().

--- a/tests/func-tests/unprivileged_test.go
+++ b/tests/func-tests/unprivileged_test.go
@@ -15,8 +15,8 @@ var _ = Describe("[rfe_id:393][crit:medium][vendor:cnv-qe@redhat.com][level:syst
 	virtClient, err := kubecli.GetKubevirtClient()
 	testscore.PanicOnError(err)
 
-	cfg := virtClient.Config()
-
+	// don't break other tests
+	cfg := rest.CopyConfig(virtClient.Config())
 	cfg.Impersonate = rest.ImpersonationConfig{
 		UserName: "non-existent-user",
 		Groups:   []string{"system:authenticated"},

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -14,10 +14,11 @@ require (
 	github.com/golang/mock v1.4.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/kubevirt/cluster-network-addons-operator v0.43.0
+	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	google.golang.org/appengine v1.6.5 // indirect
-	k8s.io/api v0.19.0-rc.2
-	k8s.io/apimachinery v0.19.0-rc.2
+	k8s.io/api v0.19.2
+	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v12.0.0+incompatible
 	kubevirt.io/client-go v0.36.0
 	kubevirt.io/kubevirt v0.36.0
@@ -64,9 +65,9 @@ replace (
 	kubevirt.io/client-go => kubevirt.io/client-go v0.36.0
 )
 
-// Aligning with https://github.com/kubevirt/containerized-data-importer/blob/release-v1.24.1
+// Aligning with https://github.com/kubevirt/containerized-data-importer/blob/release-v1.31.0
 replace (
-	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
+	github.com/openshift/api => github.com/openshift/api v0.0.0-20201120165435-072a4cd8ca42
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a
 	github.com/openshift/library-go => github.com/mhenriks/library-go v0.0.0-20200116194830-9fcc1a687a9d
 	sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v0.0.0-20190302045857-e85c7b244fd2

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	google.golang.org/appengine v1.6.5 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v12.0.0+incompatible

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -291,6 +291,8 @@ github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80n
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
+github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v0.1.1/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
@@ -716,8 +718,9 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190618234442-a950415649c7/go.m
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
-github.com/openshift/api v0.0.0-20191219222812-2987a591a72c h1:WRWMmqacvmZDbUat6WYqpuCy2yEfIeDsxFD/Htgp2T0=
-github.com/openshift/api v0.0.0-20191219222812-2987a591a72c/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20201120165435-072a4cd8ca42 h1:meFswbseUxIkrfb2+g91gHbPwh+16Kj/8E1AiR1jv6A=
+github.com/openshift/api v0.0.0-20201120165435-072a4cd8ca42/go.mod h1:RDvBcRQMGLa3aNuDuejVBbTEQj/2i14NXdpOLqbNBvM=
+github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a h1:Otk3CuCAEHiMUr4Er6b+csq4Ar6qilAs9h93tbea+qM=
 github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/cluster-network-operator v0.0.0-20200324123637-74e803688dd9/go.mod h1:M9dusM6U0OOmpKjTacoXquDKPhRPu23PvFA/ws8QML0=
@@ -1167,6 +1170,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e h1:4nW4NLDYnU28ojHaHO8OVxFHk/aQ33U01a9cjED+pzE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
@@ -1312,6 +1316,8 @@ k8s.io/klog v0.4.0 h1:lCJCxf/LIowc2IGS9TPjWDyXY4nOmdGdfcwwDQCOURQ=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
+k8s.io/klog/v2 v2.2.0 h1:XRvcwJozkgZ1UQJmfMGpvRthQHOvihEhYtDfAaxMz/A=
+k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/kube-aggregator v0.16.4 h1:AxxgeFsi9Pnj8Ok4nm3pl9qU3BG4LiBij7IMsnFp7j0=
 k8s.io/kube-aggregator v0.16.4/go.mod h1:QN0sEFj0q/oSnqrQmF5AkXiGjLaAImieDv8RXynyNw4=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a h1:UcxjrRMyNx/i/y8G7kPvLyy7rfbeuf1PYyBf973pgyU=


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

We predict that we will need more and more configuration for our functional tests in the future. We decided to introduce a configuration interface that allows users to provide inputs for their environments.

In this PR, we are starting to use that interface for ConsoleQuickStart objects. 

Note that the new interface is implemented as backward compatible. You don't need to pass the flag if the current tests are OK for you. 

**Release note**:
```release-note
NONE
```

