### PR TITLE
[TEST ONLY] - check that kvci test not triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The deployment is completed when HCO custom resource reports its condition as `A
 
 For more explanation and advanced options for HCO deployment using kustomize, refer to [kustomize deployment documentation](deploy/kustomize/README.md).
 
+Just checking
+
 ## Installing Unreleased Bundle Using A Custom Catalog Source  
 
 Hyperconverged Cluster Operator is publishing the latest bundle to [quay.io/kubevirt](https://quay.io/repository/kubevirt) 


### PR DESCRIPTION
pull-hyperconverged-cluster-operator-e2e-k8s-1.17 should not run for documentation changes.

/hold

Signed-off-by: Nahshon Unna-Tsameret nunnatsa@redhat.com

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

