### PR TITLE
[release-1.3] avoid enabling Sidecar FG

### DIFF
--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -24,7 +24,7 @@ const (
 )
 
 const (
-	cmFeatureGates = "DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Sidecar,Snapshot"
+	cmFeatureGates = "DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Snapshot"
 )
 
 // ************  KubeVirt Handler  **************


### PR DESCRIPTION
Sidecar FG was enable by default on the
kubevirt configMap as a fix for:
https://bugzilla.redhat.com/1745328
but now we don't see anymore the need
for that.
Let's disable it by default.

The same feature gate has been already
removed in the master branch with #1167
for the same reason.

The two branches are now too different to
let us try a real cherry-pick.

Fixes: https://bugzilla.redhat.com/1933070

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Avoid enabling Sidecar FG on kubevirt CM
```

