### PR TITLE
Add pprof instrumentation for optional cpu and memory profiling

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -70,8 +70,10 @@ func main() {
 	// Create a new Cmd to provide shared dependencies and start components
 	// TODO: consider changing LeaderElectionResourceLock to new default "configmapsleases".
 	mgr, err := manager.New(cfg, getManagerOptions(watchNamespace, needLeaderElection))
-
 	cmdHelper.ExitOnError(err, "can't initiate manager")
+
+	// register pprof instrumentation if HCO_PPROF_ADDR is set
+	cmdHelper.ExitOnError(cmdHelper.RegisterPPROFServer(mgr), "can't register pprof server")
 
 	logger.Info("Registering Components.")
 

--- a/cmd/hyperconverged-cluster-webhook/main.go
+++ b/cmd/hyperconverged-cluster-webhook/main.go
@@ -68,8 +68,10 @@ func main() {
 		LivenessEndpointName:   hcoutil.LivenessEndpointName,
 		LeaderElection:         false,
 	})
-
 	cmdHelper.ExitOnError(err, "failed to create manager")
+
+	// register pprof instrumentation if HCO_PPROF_ADDR is set
+	cmdHelper.ExitOnError(cmdHelper.RegisterPPROFServer(mgr), "can't register pprof server")
 
 	logger.Info("Registering Components.")
 


### PR DESCRIPTION
Adding pprof for optional cpu and memory profiling to debug memory spikes and inform us about needed requests/limits for our operator.

This PR starts a new HTTP server if `HCO_PPROF_ADDR` env var is set. From this server memory allocation, cpu profiles and heap information can be downloaded while the operator is deployed on a cluster [1].

Basic commands to do something
```shell
# port forward to the operator pod (blocking)
$ kubectl port-forward pod/<hco-pod-name-goes-here> 8065:<port from HCO_PPROF_ADDR>

# download and inspect cpu profile
$ go tool pprof http://localhost:8065

# get and inspect memory allocation profile
$ curl -sK -v http://localhost:8065/debug/pprof/allocs > allocs.out
$ go tool pprof allocs.out

# get and inspect heap profile
$ curl -sK -v http://localhost:8065/debug/pprof/heap > heap.out
$ go tool pprof heap.out
```

use `web` in the pprof console to start a new browser tab with a svg diagram.

Ref:
[1] https://golang.org/pkg/net/http/pprof/
https://blog.golang.org/pprof
https://www.freecodecamp.org/news/how-i-investigated-memory-leaks-in-go-using-pprof-on-a-large-codebase-4bec4325e192/

Signed-off-by: Nico Schieder <nschieder@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

