### PR TITLE
Keep forcing the absence of the KubeVirt ConfigMap after upgrade

### DIFF
--- a/pkg/controller/operands/kubevirtConfigMap.go
+++ b/pkg/controller/operands/kubevirtConfigMap.go
@@ -56,7 +56,7 @@ func (handler kubeVirtCmHandler) ensure(req *common.HcoRequest) *EnsureResult {
 
 	unstructuredCm, err := hcoutils.ToUnstructured(cm)
 	if err != nil {
-		return res.Error(fmt.Errorf("failed to get Unstructured object form the %s ConfigMap; %w", kvCmName, err))
+		return res.Error(fmt.Errorf("failed to get Unstructured object from the %s ConfigMap; %w", kvCmName, err))
 	}
 
 	policy := metav1.DeletePropagationForeground

--- a/pkg/controller/operands/kubevirtConfigMap.go
+++ b/pkg/controller/operands/kubevirtConfigMap.go
@@ -1,0 +1,77 @@
+package operands
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	hcoutils "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const kvCmName = "kubevirt-config"
+
+// Make sure that the kubevirt-config configMap does not exist
+type kubeVirtCmHandler struct {
+	client  client.Client
+	emitter hcoutils.EventEmitter
+}
+
+func newKubeVirtCmHandler(client client.Client, emitter hcoutils.EventEmitter) Operand {
+	return &kubeVirtCmHandler{
+		client:  client,
+		emitter: emitter,
+	}
+}
+
+func (handler kubeVirtCmHandler) ensure(req *common.HcoRequest) *EnsureResult {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kvCmName,
+			Namespace: req.Namespace,
+		},
+	}
+
+	res := NewEnsureResult(cm).SetUpgradeDone(true)
+	if req.UpgradeMode {
+		// There is different handling during upgrade mode, that also creates backup.
+		// In case of error when creating the backup, we want to try again, so we don't
+		// want to remove the CM before trying again.
+		return res
+	}
+
+	err := hcoutils.GetRuntimeObject(req.Ctx, handler.client, cm, req.Logger)
+	if apierrors.IsNotFound(err) {
+		return res
+	}
+
+	if err != nil {
+		return res.Error(fmt.Errorf("failed to read the %s ConfigMap; %w", kvCmName, err))
+	}
+
+	req.Logger.Info(fmt.Sprintf("removing the unused %s ConfigMap", kvCmName))
+
+	unstructuredCm, err := hcoutils.ToUnstructured(cm)
+	if err != nil {
+		return res.Error(fmt.Errorf("failed to get Unstructured object form the %s ConfigMap; %w", kvCmName, err))
+	}
+
+	policy := metav1.DeletePropagationForeground
+	wait := &client.DeleteOptions{
+		PropagationPolicy: &policy,
+	}
+
+	err = handler.client.Delete(req.Ctx, unstructuredCm, wait)
+	if err != nil {
+		return res.Error(fmt.Errorf("failed to delete the %s ConfigMap; %w", kvCmName, err))
+	}
+
+	handler.emitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed ConfigMap %s", kvCmName))
+
+	return res
+}
+
+func (kubeVirtCmHandler) reset() { /* Not Implemented */ }

--- a/pkg/controller/operands/kubevirtConfigMap_test.go
+++ b/pkg/controller/operands/kubevirtConfigMap_test.go
@@ -1,0 +1,212 @@
+package operands
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
+	hcoutils "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+var _ = Describe("Test kubeVirtCmHandler", func() {
+	var (
+		hco            *hcov1beta1.HyperConverged
+		req            *common.HcoRequest
+		expectedEvents = []commonTestUtils.MockEvent{
+			{
+				EventType: corev1.EventTypeNormal,
+				Reason:    "Killing",
+				Msg:       fmt.Sprintf("Removed ConfigMap %s", kvCmName),
+			},
+		}
+		emitter = commonTestUtils.NewEventEmitterMock()
+	)
+
+	BeforeEach(func() {
+		hco = commonTestUtils.NewHco()
+		req = commonTestUtils.NewReq(hco)
+
+		req.SetUpgradeMode(false)
+
+		emitter.Reset()
+	})
+
+	It("should do nothing if the configMap does not exist", func() {
+		c := commonTestUtils.InitClient([]runtime.Object{hco})
+		handler := newKubeVirtCmHandler(c, emitter)
+
+		res := handler.ensure(req)
+
+		Expect(res.Err).ToNot(HaveOccurred())
+		Expect(res.UpgradeDone).To(BeTrue())
+
+		Expect(emitter.CheckEvents(expectedEvents)).To(BeFalse())
+	})
+
+	It("should remove the configMap if it exists", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kvCmName,
+				Namespace: commonTestUtils.Namespace,
+			},
+			Data: map[string]string{
+				"fakeKey": "fakeValue",
+			},
+		}
+		c := commonTestUtils.InitClient([]runtime.Object{hco, cm})
+		handler := newKubeVirtCmHandler(c, emitter)
+
+		res := handler.ensure(req)
+
+		Expect(res.Err).ToNot(HaveOccurred())
+		Expect(res.UpgradeDone).To(BeTrue())
+
+		Expect(emitter.CheckEvents(expectedEvents)).To(BeTrue())
+
+		resCm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kvCmName,
+				Namespace: commonTestUtils.Namespace,
+			},
+		}
+
+		err := hcoutils.GetRuntimeObject(context.TODO(), c, resCm, req.Logger)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should not remove the configMap during upgrade", func() {
+		req.SetUpgradeMode(true)
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kvCmName,
+				Namespace: commonTestUtils.Namespace,
+			},
+			Data: map[string]string{
+				"fakeKey": "fakeValue",
+			},
+		}
+		c := commonTestUtils.InitClient([]runtime.Object{hco, cm})
+		handler := newKubeVirtCmHandler(c, emitter)
+
+		res := handler.ensure(req)
+
+		Expect(res.Err).ToNot(HaveOccurred())
+		Expect(res.UpgradeDone).To(BeTrue())
+
+		Expect(emitter.CheckEvents(expectedEvents)).To(BeFalse())
+
+		resCm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kvCmName,
+				Namespace: commonTestUtils.Namespace,
+			},
+		}
+
+		err := hcoutils.GetRuntimeObject(context.TODO(), c, resCm, req.Logger)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resCm.Data).ToNot(BeEmpty())
+		Expect(resCm.Data["fakeKey"]).Should(Equal("fakeValue"))
+	})
+
+	It("should return error if failed to read the configMap", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kvCmName,
+				Namespace: commonTestUtils.Namespace,
+			},
+			Data: map[string]string{
+				"fakeKey": "fakeValue",
+			},
+		}
+		c := commonTestUtils.InitClient([]runtime.Object{hco, cm})
+		fakeError := fmt.Errorf("fake get error")
+		c.InitiateGetErrors(func(key client.ObjectKey) error {
+			if key.Name == kvCmName {
+				return fakeError
+			}
+			return nil
+		})
+
+		handler := newKubeVirtCmHandler(c, emitter)
+
+		res := handler.ensure(req)
+
+		Expect(res.Err).To(HaveOccurred())
+		Expect(res.Err).To(MatchError(fakeError))
+		Expect(res.UpgradeDone).To(BeTrue())
+
+		Expect(emitter.CheckEvents(expectedEvents)).To(BeFalse())
+
+		resCm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kvCmName,
+				Namespace: commonTestUtils.Namespace,
+			},
+		}
+
+		c.InitiateGetErrors(nil) // cancel fake error
+		err := hcoutils.GetRuntimeObject(context.TODO(), c, resCm, req.Logger)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resCm.Data).ToNot(BeEmpty())
+		Expect(resCm.Data["fakeKey"]).Should(Equal("fakeValue"))
+	})
+
+	It("should return error if failed to delete the configMap", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kvCmName,
+				Namespace: commonTestUtils.Namespace,
+			},
+			Data: map[string]string{
+				"fakeKey": "fakeValue",
+			},
+		}
+		c := commonTestUtils.InitClient([]runtime.Object{hco, cm})
+		fakeError := fmt.Errorf("fake delete error")
+		c.InitiateDeleteErrors(func(obj client.Object) error {
+			if unstructed, ok := obj.(runtime.Unstructured); ok {
+				kind := unstructed.GetObjectKind()
+				if kind.GroupVersionKind().Kind == "ConfigMap" && obj.GetName() == kvCmName {
+					return fakeError
+				}
+			}
+			return nil
+		})
+
+		handler := newKubeVirtCmHandler(c, emitter)
+
+		res := handler.ensure(req)
+
+		Expect(res.Err).To(HaveOccurred())
+		Expect(res.Err).To(MatchError(fakeError))
+		Expect(res.UpgradeDone).To(BeTrue())
+
+		Expect(emitter.CheckEvents(expectedEvents)).To(BeFalse())
+
+		resCm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kvCmName,
+				Namespace: commonTestUtils.Namespace,
+			},
+		}
+
+		err := hcoutils.GetRuntimeObject(context.TODO(), c, resCm, req.Logger)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resCm.Data).ToNot(BeEmpty())
+		Expect(resCm.Data["fakeKey"]).Should(Equal("fakeValue"))
+	})
+})

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -53,6 +53,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, isOpenshift
 		(*genericOperand)(newCnaHandler(client, scheme)),
 		(*genericOperand)(newVmImportHandler(client, scheme)),
 		(*genericOperand)(newImsConfigHandler(client, scheme)),
+		newKubeVirtCmHandler(client, eventEmitter),
 	}
 
 	Initiate(isOpenshiftCluster)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -184,9 +184,9 @@ func GetCSVfromPod(pod *corev1.Pod, c client.Reader, logger logr.Logger) (*csvv1
 	return csv, nil
 }
 
-// toUnstructured convers an arbitrary object (which MUST obey the
+// ToUnstructured convers an arbitrary object (which MUST obey the
 // k8s object conventions) to an Unstructured
-func toUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
+func ToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 	b, err := json.Marshal(obj)
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ func GetRuntimeObject(ctx context.Context, c client.Client, obj client.Object, l
 // ComponentResourceRemoval removes the resource `obj` if it exists and belongs to the HCO
 // with wait=true it will wait, (util ctx timeout, please set it!) for the resource to be effectively deleted
 func ComponentResourceRemoval(ctx context.Context, c client.Client, obj interface{}, hcoName string, logger logr.Logger, dryRun bool, wait bool) error {
-	resource, err := toUnstructured(obj)
+	resource, err := ToUnstructured(obj)
 	if err != nil {
 		logger.Error(err, "Failed to convert object to Unstructured")
 		return err


### PR DESCRIPTION
This PR add code to the reconcile logic, to keep search the KubeVirt ConfigMap, and if it created, HCO will remove it.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

