### PR TITLE
Run KV smoke tests on openshift-ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,9 @@ test-functional-prow:
 test-functional-in-container:
 	./hack/run-tests-in-container.sh
 
+test-kv-smoke-prow:
+	./hack/kv-smoke-tests.sh
+
 stageRegistry:
 	@APP_REGISTRY_NAMESPACE=redhat-operators-stage PACKAGE=kubevirt-hyperconverged ./tools/quay-registry.sh $(QUAY_USERNAME) $(QUAY_PASSWORD)
 
@@ -211,6 +214,8 @@ deploy_cr:
 		build-functest \
 		test-functional \
 		test-functional-prow \
+		test-functional-in-container \
+		test-kv-smoke-prow \
 		charts \
 		kubevirt-nightly-test \
 		local \

--- a/hack/kv-smoke-tests.sh
+++ b/hack/kv-smoke-tests.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE:-"kubevirt-hyperconverged"}
+
+source hack/common.sh
+source cluster/kubevirtci.sh
+
+echo "downloading the test binary"
+BIN_DIR="$(pwd)/_out" && mkdir -p "${BIN_DIR}"
+export BIN_DIR
+
+TESTS_BINARY="$BIN_DIR/kv_smoke_tests.test"
+curl -Lo "$TESTS_BINARY" "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/tests.test"
+chmod +x "$TESTS_BINARY"
+
+echo "create testing infrastructure"
+
+cat <<EOF | ${CMD} apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: host-path-disk-alpine
+  labels:
+    kubevirt.io: ""
+    os: "alpine"
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/hostImages/alpine
+EOF
+
+cat <<EOF | ${CMD} apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: host-path-disk-custom
+  labels:
+    kubevirt.io: ""
+    os: "custom"
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/hostImages/custom
+EOF
+
+cat <<EOF | ${CMD} apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: cdi-http-import-server
+  namespace: ${INSTALLED_NAMESPACE}
+  labels:
+    kubevirt.io: "cdi-http-import-server"
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  selector:
+    kubevirt.io: cdi-http-import-server
+EOF
+
+cat <<EOF | ${CMD} apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cdi-http-import-server
+  namespace: ${INSTALLED_NAMESPACE}
+  labels:
+    kubevirt.io: "cdi-http-import-server"
+spec:
+  selector:
+    matchLabels:
+      kubevirt.io: "cdi-http-import-server"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        kubevirt.io: cdi-http-import-server
+    spec:
+      securityContext:
+        runAsUser: 0
+      serviceAccountName: kubevirt-testing
+      containers:
+        - name: cdi-http-import-server
+          image: quay.io/kubevirt/cdi-http-import-server:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+              name: "http"
+              protocol: "TCP"
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+EOF
+
+cat <<EOF | ${CMD} apply -f -
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: disks-images-provider
+  namespace: ${INSTALLED_NAMESPACE}
+  labels:
+    kubevirt.io: "disks-images-provider"
+spec:
+  selector:
+    matchLabels:
+      kubevirt.io: "disks-images-provider"
+  template:
+    metadata:
+      labels:
+        name: disks-images-provider
+        kubevirt.io: disks-images-provider
+      name: disks-images-provider
+    spec:
+      serviceAccountName: kubevirt-testing
+      containers:
+        - name: target
+          image: quay.io/kubevirt/disks-images-provider:latest
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: images
+            mountPath: /hostImages
+          - name: local-storage
+            mountPath: /local-storage
+          securityContext:
+            privileged: true
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /ready
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      volumes:
+        - name: images
+          hostPath:
+            path: /tmp/hostImages
+            type: DirectoryOrCreate
+        - name: local-storage
+          hostPath:
+            path: /mnt/local-storage
+            type: DirectoryOrCreate
+EOF
+
+cat <<EOF | ${CMD} apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-block-storage-cirros
+  labels:
+    kubevirt.io: ""
+    blockstorage: "cirros"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  local:
+    path: /mnt/local-storage/cirros-block-device
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - node01
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-block
+  volumeMode: Block
+EOF
+
+cat <<EOF | ${CMD} apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-testing
+  namespace: ${INSTALLED_NAMESPACE}
+  labels:
+    kubevirt.io: ""
+EOF
+
+cat <<EOF | ${CMD} apply -f -
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-testing-cluster-admin
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-testing
+    namespace: ${INSTALLED_NAMESPACE}
+EOF
+
+
+${CMD} create configmap -n ${INSTALLED_NAMESPACE} kubevirt-test-config --from-file=hack/test-config.json --dry-run=client -o yaml | ${CMD} apply -f -
+
+echo "waiting for testing infrastructure to be ready"
+${CMD} wait deployment cdi-http-import-server -n "${INSTALLED_NAMESPACE}" --for condition=Available --timeout=10m
+${CMD} wait pods -l "kubevirt.io=disks-images-provider" -n "${INSTALLED_NAMESPACE}" --for condition=Ready --timeout=10m
+
+echo "starting tests"
+${TESTS_BINARY} \
+    -cdi-namespace="$INSTALLED_NAMESPACE" \
+    -config=hack/test-config.json \
+    -installed-namespace="$INSTALLED_NAMESPACE" \
+    -junit-output="$(pwd)/_out/junit_kv_smoke_tests.xml" \
+    -kubeconfig="$KUBECONFIG" \
+    -ginkgo.focus='(rfe_id:1177)|(rfe_id:273)|(rfe_id:151)' \
+    -ginkgo.noColor \
+    -ginkgo.seed=0 \
+    -ginkgo.skip='(Slirp Networking)|(with CPU spec)|(with TX offload disabled)|(with cni flannel and ptp plugin interface)|(with ovs-cni plugin)|(test_id:1752)|(SRIOV)|(with EFI)|(Operator)|(GPU)|(DataVolume Integration)|(when virt-handler is not responsive)|(with default cpu model)|(should set the default MachineType when created without explicit value)|(should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself)|(test_id:3468)|(test_id:3466)|(test_id:1015)|(rfe_id:393)' \
+    -ginkgo.slowSpecThreshold=60 \
+    -ginkgo.succinct \
+    -oc-path="$(which oc)" \
+    -kubectl-path="$(which oc)" \
+    -utility-container-prefix=quay.io/kubevirt \
+    -test.timeout=2h

--- a/hack/test-config.json
+++ b/hack/test-config.json
@@ -1,0 +1,7 @@
+{
+  "storageClassLocal": "hostpath-provisioner",
+  "storageClassHostPath": "hostpath-provisioner",
+  "storageClassRhel": "hostpath-provisioner",
+  "storageClassWindows": "hostpath-provisioner",
+  "manageStorageClasses": false
+}


### PR DESCRIPTION
Run KV smoke tests on openshift-ci

Enable a new test line to run KV smoke tests on openshift-ci for each PR on this repo.
Another PR on https://github.com/openshift/release will configure a test lane on azure and on GCP
were we have nested virtualization support. We cannot run it on AWS where we need KVM_EMULATION
which is by far too slow to be reliable.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

