### PR TITLE
Enhancement for the Publisher Workflow

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -10,12 +10,28 @@ jobs:
     name: Publish HCO tagged version to community-operators
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the latest code
+      - name: resolve the correct branch of the tag
+        run: |
+          GIT_TAG=${{ github.ref }}
+          TAGGED_VERSION=${GIT_TAG##*/v}
+          TAGGED_MINOR_VERSION=${TAGGED_VERSION%.*}
+          REPO_BRANCHES=$(curl https://api.github.com/repos/kubevirt/hyperconverged-cluster-operator/branches | jq .[].name)
+          if [[ "${REPO_BRANCHES[@]}" =~ "release-${TAGGED_MINOR_VERSION}" ]]
+          then
+            TARGET_BRANCH=release-${TAGGED_MINOR_VERSION}
+          else
+            TARGET_BRANCH=master
+          fi
+          echo "TARGET_BRANCH=${TARGET_BRANCH}" >> $GITHUB_ENV
+          echo "TAGGED_VERSION=${TAGGED_VERSION}" >> $GITHUB_ENV
+      - name: Checkout the latest code of ${{ env.TARGET_BRANCH }} branch
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: ${{ env.TARGET_BRANCH }}
+          fetch-depth: 2
       - name: Run Publisher script
         run: |
-          GIT_TAG=${{ github.ref }} \
-          HCO_TOKEN=${{ secrets.HCO_BOT_TOKEN }} \
-          ./automation/publisher/publisher.sh
+          export TAGGED_VERSION=${{ env.TAGGED_VERSION }}
+          export TARGET_BRANCH=${{ env.TARGET_BRANCH }}
+          export HCO_BOT_TOKEN=${{ secrets.HCO_BOT_TOKEN }}
+          curl https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/automation/publisher/publisher.sh | bash


### PR DESCRIPTION
1. Tagging a version that has a stabilization branch will checkout the contents of that version in the corresponding branch.
2. The publish will occur if:
  a. The git SHA digest of the second to last commit on the target branch is equal to the git SHA digests of the hco-operator and hco-webhook images in quay.io/kubevirt with the corresponding tags.
  b. The last commit was only updating manifests and images digests in 'deploy' folder.

examples of various runs results can be found here:
https://github.com/hco-bot/community-operators/pulls

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

