### PR TITLE
[release-1.3] Adding publish workflow for release-1.3

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -1,0 +1,37 @@
+name: Publish Tagged Version to Community Operators
+
+on:
+  push:
+    tags:
+      - v1.*
+jobs:
+  publish_hco:
+    if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')
+    name: Publish HCO tagged version to community-operators
+    runs-on: ubuntu-latest
+    steps:
+      - name: resolve the correct branch of the tag
+        run: |
+          GIT_TAG=${{ github.ref }}
+          TAGGED_VERSION=${GIT_TAG##*/v}
+          TAGGED_MINOR_VERSION=${TAGGED_VERSION%.*}
+          REPO_BRANCHES=$(curl https://api.github.com/repos/kubevirt/hyperconverged-cluster-operator/branches | jq .[].name)
+          if [[ "${REPO_BRANCHES[@]}" =~ "release-${TAGGED_MINOR_VERSION}" ]]
+          then
+            TARGET_BRANCH=release-${TAGGED_MINOR_VERSION}
+          else
+            TARGET_BRANCH=master
+          fi
+          echo "TARGET_BRANCH=${TARGET_BRANCH}" >> $GITHUB_ENV
+          echo "TAGGED_VERSION=${TAGGED_VERSION}" >> $GITHUB_ENV
+      - name: Checkout the latest code of ${{ env.TARGET_BRANCH }} branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
+          fetch-depth: 2
+      - name: Run Publisher script
+        run: |
+          export TAGGED_VERSION=${{ env.TAGGED_VERSION }}
+          export TARGET_BRANCH=${{ env.TARGET_BRANCH }}
+          export HCO_BOT_TOKEN=${{ secrets.HCO_BOT_TOKEN }}
+          curl https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/automation/publisher/publisher.sh | bash


### PR DESCRIPTION
The workflow file must be in the release branch as well to be triggered by tags made on this branch.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

