### PR TITLE
Align 1.3.0 manifests for upgrade testing

### DIFF
--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.3.0/manifests/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.3.0/manifests/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -7,8 +7,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional
     certified: "false"
-    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:172c85edfc45fec4bb0a820c7c67bcd6f2449629811ff0953a7646564eba1d0e
-    createdAt: "2021-01-18 15:57:46"
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:46b81b9c5c9ff6be953bddcbf3537258d5f96ade8ddfbf355e67075fbe670368
+    createdAt: "2021-03-17 12:16:11"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -1802,7 +1802,7 @@ spec:
                   value: OPERATOR
                 - name: KVM_EMULATION
                 - name: OPERATOR_IMAGE
-                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:172c85edfc45fec4bb0a820c7c67bcd6f2449629811ff0953a7646564eba1d0e
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:46b81b9c5c9ff6be953bddcbf3537258d5f96ade8ddfbf355e67075fbe670368
                 - name: OPERATOR_NAME
                   value: hyperconverged-cluster-operator
                 - name: OPERATOR_NAMESPACE
@@ -1831,14 +1831,14 @@ spec:
                 - name: NETWORK_ADDONS_VERSION
                   value: v0.44.0
                 - name: SSP_VERSION
-                  value: v0.1.0-rc.2
+                  value: v0.1.3
                 - name: NMO_VERSION
                   value: v0.7.0
                 - name: HPPO_VERSION
                   value: v0.7.0
                 - name: VM_IMPORT_VERSION
                   value: v0.2.5
-                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:172c85edfc45fec4bb0a820c7c67bcd6f2449629811ff0953a7646564eba1d0e
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:46b81b9c5c9ff6be953bddcbf3537258d5f96ade8ddfbf355e67075fbe670368
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 1
@@ -1881,7 +1881,7 @@ spec:
                 - name: APP
                   value: WEBHOOK
                 - name: OPERATOR_IMAGE
-                  value: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:69c3ea3c629812320bfef6d8b7b5be13230c69fb1d67dd6059df62694e3d3c6b
+                  value: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:de74593d3339d13a49c0b8fe42d92628607061b3e4dc5915913b51e19cf6ca78
                 - name: OPERATOR_NAME
                   value: hyperconverged-cluster-webhook
                 - name: OPERATOR_NAMESPACE
@@ -1891,7 +1891,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: WATCH_NAMESPACE
-                image: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:69c3ea3c629812320bfef6d8b7b5be13230c69fb1d67dd6059df62694e3d3c6b
+                image: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:de74593d3339d13a49c0b8fe42d92628607061b3e4dc5915913b51e19cf6ca78
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 1
@@ -2074,14 +2074,14 @@ spec:
                 command:
                 - /manager
                 env:
-                - name: KVM_IMAGE
+                - name: KVM_INFO_IMAGE
                 - name: VALIDATOR_IMAGE
                 - name: VIRT_LAUNCHER_IMAGE
                 - name: NODE_LABELLER_IMAGE
                 - name: CPU_PLUGIN_IMAGE
                 - name: OPERATOR_VERSION
-                  value: v0.1.0-rc.2
-                image: quay.io/kubevirt/ssp-operator@sha256:1466407727c1c802b2b1191b1f5a22a0a8933a39bdf68556a2f97607f7c523aa
+                  value: v0.1.3
+                image: quay.io/kubevirt/ssp-operator@sha256:efe94ed877c7c6f7dc9486ac3929d217d21f3601f7d139bf7bf177e1607b58c8
                 name: manager
                 ports:
                 - containerPort: 9443
@@ -2473,9 +2473,9 @@ spec:
     name: hostpath-provisioner
   - image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:a51e9b075a60600244757386f5894b314170543edb1d7f4738f4860a19602072
     name: hostpath-provisioner-operator
-  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:172c85edfc45fec4bb0a820c7c67bcd6f2449629811ff0953a7646564eba1d0e
+  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:46b81b9c5c9ff6be953bddcbf3537258d5f96ade8ddfbf355e67075fbe670368
     name: hyperconverged-cluster-operator
-  - image: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:69c3ea3c629812320bfef6d8b7b5be13230c69fb1d67dd6059df62694e3d3c6b
+  - image: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:de74593d3339d13a49c0b8fe42d92628607061b3e4dc5915913b51e19cf6ca78
     name: hyperconverged-cluster-webhook
   - image: quay.io/kubevirt/kubemacpool@sha256:e68811ce7697ab0f1257f307fcd63b08b6295de7f300e01a982e4e624bfa7398
     name: kubemacpool
@@ -2495,7 +2495,7 @@ spec:
     name: ovs-cni-marker
   - image: quay.io/kubevirt/ovs-cni-plugin@sha256:d43d34ed4b1bd0b107c2049d21e33f9f870c36e5bf6dc1d80ab567271735c8da
     name: ovs-cni-plugin
-  - image: quay.io/kubevirt/ssp-operator@sha256:1466407727c1c802b2b1191b1f5a22a0a8933a39bdf68556a2f97607f7c523aa
+  - image: quay.io/kubevirt/ssp-operator@sha256:efe94ed877c7c6f7dc9486ac3929d217d21f3601f7d139bf7bf177e1607b58c8
     name: ssp-operator
   - image: docker.io/kubevirt/virt-api@sha256:4d778f63d2f5ecb61d4f6fe8b5ead010836d46d75349f3c3634f5862614e4a21
     name: virt-api

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.3.0/manifests/scheduling-scale-performance00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.3.0/manifests/scheduling-scale-performance00.crd.yaml
@@ -838,6 +838,9 @@ spec:
               operatorVersion:
                 description: The version of the resource as defined by the operator
                 type: string
+              paused:
+                description: Paused is true when the operator notices paused annotation.
+                type: boolean
               phase:
                 description: Phase is the current phase of the deployment
                 type: string


### PR DESCRIPTION
Align 1.3.0 manifests after #1192
to properly feed the upgrade testing lanes.

We should still figure out how to properly
automate this.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

