### PR TITLE
hco, Update build-in-docker.sh to use quay.io

### DIFF
--- a/hack/build-in-docker.sh
+++ b/hack/build-in-docker.sh
@@ -7,7 +7,7 @@ main() {
   HCO_DIR="$(readlink -f $(dirname $0)/../)"
   local BUILD_DIR=${HCO_DIR}/tests/build
   local BUILD_TAG="hco-test-build"
-  local REGISTRY="docker.io/kubevirtci"
+  local REGISTRY="quay.io/kubevirtci"
   local TAG
   TAG="$(get_image_tag)"
   local TEST_BUILD_TAG="${REGISTRY}/${BUILD_TAG}:${TAG}"


### PR DESCRIPTION
In order to fix the rate limit of docker.io
migrate from docker.io to quay.io


See https://github.com/kubevirt/project-infra/pull/1047

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```

