### PR TITLE
hco, Bump kubevirtci

### DIFF
--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.18'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.19'}
 
-KUBEVIRTCI_VERSION="29a73d524b1a6141e7b4ae04a7e1a270dc2696e9"
+KUBEVIRTCI_VERSION="8f48705333a7b9c4c91cf8a0b96b40bb54ef6c8d"
+export KUBEVIRTCI_TAG=2103111738-8f48705
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 
 function kubevirtci::install() {


### PR DESCRIPTION
As part of the effort to point to quay.io
instead of docker.io, in order to overcome docker.io rate limits,
bump kubevirtci, because the new kubevirtci images
are already point to quay.io.

After this PR
https://github.com/kubevirt/project-infra/pull/1049 
must be merged, in order to use k8s-1.19 which is the stable one
with the new kubevirtci version.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```

