### PR TITLE
Wire up CNAO SelfSignedConfiguration to HCO

### DIFF
--- a/pkg/controller/operands/networkAddons.go
+++ b/pkg/controller/operands/networkAddons.go
@@ -155,8 +155,7 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged, opts ...string) (*networkad
 			Workloads: cnaoWorkloads,
 		}
 	}
-
-	// TODO: support passing certificate rotation configuration to CNAO spec
+	cnaoSpec.SelfSignConfiguration = hcoCertConfig2CnaoSelfSignedConfig(&hc.Spec.CertConfig)
 
 	cna := NewNetworkAddonsWithNameOnly(hc, opts...)
 	cna.Spec = cnaoSpec
@@ -216,4 +215,13 @@ func hcoAnnotation2CnaoSpec(hcoAnnotations map[string]string) *networkaddonsshar
 		return &networkaddonsshared.Ovs{}
 	}
 	return nil
+}
+
+func hcoCertConfig2CnaoSelfSignedConfig(hcoCertConfig *hcov1beta1.HyperConvergedCertConfig) *networkaddonsshared.SelfSignConfiguration {
+	return &networkaddonsshared.SelfSignConfiguration{
+		CARotateInterval:    hcoCertConfig.CA.Duration.Duration.String(),
+		CAOverlapInterval:   hcoCertConfig.CA.RenewBefore.Duration.String(),
+		CertRotateInterval:  hcoCertConfig.Server.Duration.Duration.String(),
+		CertOverlapInterval: hcoCertConfig.Server.RenewBefore.Duration.String(),
+	}
 }


### PR DESCRIPTION
The HCO cert rotation configurations are not being passed to CNAO
NetworkAddonsConfig, this change wire it up so change on HCO cert
rotation configuration is reflected into CNAO NetworkAddonsConfig.

~~Depends on https://github.com/kubevirt/cluster-network-addons-operator/pull/808~~
~~Depends on https://github.com/kubevirt/cluster-network-addons-operator/pull/813~~

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Integrate HCO cert rotation configuration into CNAO
```

