### PR TITLE
hco, Update file of tests/build in order to trigger postsubmit job

### DIFF
--- a/tests/build/entrypoint.sh
+++ b/tests/build/entrypoint.sh
@@ -19,6 +19,7 @@ set -eo pipefail
 
 source /etc/profile.d/gimme.sh
 
+# Update path to include go binary
 export PATH=${GOPATH}/bin:$PATH
 
 eval "$@"


### PR DESCRIPTION
In order to trigger post submit job, so it will push to quay
after the latest changes,
update the tests/build folder as the job monitors this folder.

See 
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1194
https://github.com/kubevirt/project-infra/pull/1047

Postsubmit rule:
`run_if_changed: "tests/build/.*"`

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```

