### PR TITLE
hco, Update hco-test-build image to point to quay

### DIFF
--- a/hack/in-docker.sh
+++ b/hack/in-docker.sh
@@ -6,9 +6,9 @@ source hack/common.sh
 
 HCO_DIR="$(readlink -f $(dirname $0)/../)"
 WORK_DIR="/go/src/github.com/kubevirt/hyperconverged-cluster-operator"
-REGISTRY=${REGISTRY:-docker.io/kubevirtci}
+REGISTRY=${REGISTRY:-quay.io/kubevirtci}
 REPOSITORY=${REPOSITORY:-hco-test-build}
-TAG=${TAG:-v20200504-bb3ec38}
+TAG=${TAG:-v20210324-ade7f27}
 BUILD_TAG="${REGISTRY}/${REPOSITORY}:${TAG}"
 
 # Execute the build


### PR DESCRIPTION
We are using `quay.io` instead of `docker.io`
to fix the rate limit problems.

Following the changes that built and pushed
`hco-test-build` to `quay.io` instead of `docker.io`,
point to `quay.io/kubevirtci/hco-test-build`
in order to pull the image from there.

Built by (branch that follows master)
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/publish-hco-test-utils-image/1374674300044316672

See
https://quay.io/repository/kubevirtci/hco-test-build?tab=tags

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```

