### PR TITLE
hco, Use quay.io kubevirt repository

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -28,8 +28,8 @@ go mod vendor
 # set envs
 build_date="$(date +%Y%m%d)"
 export IMAGE_REGISTRY=quay.io
-export IMAGE_TAG="${build_date}_$(git show -s --format=%h)"
-export DOCKER_PREFIX=kubevirtnightlybuilds
+export IMAGE_TAG="nb_${build_date}_$(git show -s --format=%h)"
+export DOCKER_PREFIX=kubevirtci
 TEMP_OPERATOR_IMAGE=${DOCKER_PREFIX}/hyperconverged-cluster-operator
 TEMP_WEBHOOK_IMAGE=${DOCKER_PREFIX}/hyperconverged-cluster-webhook
 


### PR DESCRIPTION
Once we migrate to quay.io,
in order to ease maintaining, use existing the kubevirt repo.
Tag the nightly builds with nb_ prefix to assist user
determining which are the nightly builds.

Due to 
https://github.com/kubevirt/project-infra/pull/1087#issuecomment-806808090

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```

