### PR TITLE
Migrate IMS config

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -934,6 +934,10 @@ spec:
                   storage class, use the storage class of the DataVolume, if no storage
                   class specified, use no storage class for scratch space'
                 type: string
+              vddkInitImage:
+                description: VDDK Init Image eventually used to import VMs from external
+                  providers
+                type: string
               version:
                 description: operator version
                 type: string

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
@@ -934,6 +934,10 @@ spec:
                   storage class, use the storage class of the DataVolume, if no storage
                   class specified, use no storage class for scratch space'
                 type: string
+              vddkInitImage:
+                description: VDDK Init Image eventually used to import VMs from external
+                  providers
+                type: string
               version:
                 description: operator version
                 type: string

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
@@ -934,6 +934,10 @@ spec:
                   storage class, use the storage class of the DataVolume, if no storage
                   class specified, use no storage class for scratch space'
                 type: string
+              vddkInitImage:
+                description: VDDK Init Image eventually used to import VMs from external
+                  providers
+                type: string
               version:
                 description: operator version
                 type: string

--- a/docs/api.md
+++ b/docs/api.md
@@ -101,6 +101,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | certConfig | certConfig holds the rotation policy for internal, self-signed certificates | [HyperConvergedCertConfig](#hyperconvergedcertconfig) | {ca: {duration: "48h", renewBefore: "24h"}, server: {duration: "24h", renewBefore: "12h"}} | false |
 | resourceRequirements | ResourceRequirements describes the resource requirements for the operand workloads. | *[OperandResourceRequirements](#operandresourcerequirements) |  | false |
 | scratchSpaceStorageClass | Override the storage class used for scratch space during transfer operations. The scratch space storage class is determined in the following order: value of scratchSpaceStorageClass, if that doesn't exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space | *string |  | false |
+| vddkInitImage | VDDK Init Image eventually used to import VMs from external providers | *string |  | false |
 | version | operator version | string |  | false |
 
 [Back to TOC](#table-of-contents)

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -67,6 +67,10 @@ type HyperConvergedSpec struct {
 	// +optional
 	ScratchSpaceStorageClass *string `json:"scratchSpaceStorageClass,omitempty"`
 
+	// VDDK Init Image eventually used to import VMs from external providers
+	// +optional
+	VddkInitImage *string `json:"vddkInitImage,omitempty"`
+
 	// operator version
 	Version string `json:"version,omitempty"`
 }

--- a/pkg/apis/hco/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.deepcopy.go
@@ -187,6 +187,11 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.VddkInitImage != nil {
+		in, out := &in.VddkInitImage, &out.VddkInitImage
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/hco/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.openapi.go
@@ -224,6 +224,13 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedSpec(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"vddkInitImage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VDDK Init Image eventually used to import VMs from external providers",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
 							Description: "operator version",


### PR DESCRIPTION
migrate IMS config to HCO CR

- add vddkInitImage parameter to HCO CR
- make HCO the source of truth for it
- during upgrade, copy existing values from IMS CM to HCO CR onlyif still not set on HCO CR
- reconcile the whole CM for IMS
- add unit tests

**Release note**:
```release-note
let the user configure vddkInitImage from HCO CR
```

