### PR TITLE
Fix the go version in all go-based github actions to 1.15.10

### DIFF
--- a/.github/workflows/digester_bot.yml
+++ b/.github/workflows/digester_bot.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-go@v2
         if: ${{ env.NEW_PR }}
         with:
-          go-version: '^1.15' # The Go version to download (if necessary) and use.
+          go-version: '1.15.10' # The Go version to download (if necessary) and use.
 
       - name: Get dependencies
         if: ${{ env.NEW_PR }}

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -29,7 +29,7 @@ jobs:
           # TODO: go.sum from go 1.16.0 and the one generated from go 1.15.z
           # are currently different, let's force this for consistency
           # until we are able to workaround this or definitively move to go 1.16
-          go-version: '1.15.8' # The Go version to download (if necessary) and use.
+          go-version: '1.15.10' # The Go version to download (if necessary) and use.
 
       - name: Do sanity checks
         run: make sanity

--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15' # The Go version to download (if necessary) and use.
+          go-version: '1.15.10' # The Go version to download (if necessary) and use.
 
       - name: Check for new releases and update
         run: |


### PR DESCRIPTION
The previous setting in some actions was `^1.15` so it became 1.16

We don't use 1.16 yet, so we need to fix it to the latests 1.15.x

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

