### PR TITLE
Add log when can't complete the upgrade

### DIFF
--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -130,7 +130,12 @@ func (h *genericOperand) completeEnsureOperands(req *common.HcoRequest, found cl
 	// Handle KubeVirt resource conditions
 	isReady := handleComponentConditions(req, h.crType, h.hooks.getConditions(found))
 
-	upgradeDone := req.UpgradeMode && isReady && h.hooks.checkComponentVersion(found)
+	versionUpdated := h.hooks.checkComponentVersion(found)
+	if isReady && !versionUpdated {
+		req.Logger.Info(fmt.Sprintf("could not complete the upgrade process. %s is not with the expected version. Check %s observed version in the status field of its CR", h.crType, h.crType))
+	}
+
+	upgradeDone := req.UpgradeMode && isReady && versionUpdated
 	return res.SetUpgradeDone(upgradeDone)
 }
 


### PR DESCRIPTION
When one of the operands reports readiness by its conditions, but its observed version does not match the expected version, print a message to the log.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
When one of the operands reports readiness by its conditions, but its observed version does not match the expected version, print a message to the log.
```

