### PR TITLE
Refactor the operator package

### DIFF
--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -7,11 +7,6 @@ import (
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/operands"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	"github.com/kubevirt/hyperconverged-cluster-operator/version"
 	vmimportv1beta1 "github.com/kubevirt/vm-import-operator/pkg/apis/v2v/v1beta1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,13 +18,20 @@ import (
 	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
 
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	"github.com/kubevirt/hyperconverged-cluster-operator/version"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
 )
 
 // Mock TestRequest to simulate Reconcile() being called on an event for a watched resource
@@ -140,7 +142,7 @@ func getBasicDeployment() *BasicExpected {
 	res.kvStorageRoleBinding = expectedKVStorageRoleBinding
 
 	expectedKV, err := operands.NewKubeVirt(hco, namespace)
-	Expect(err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	expectedKV.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/kubevirts/%s", expectedKV.Namespace, expectedKV.Name)
 	expectedKV.Status.Conditions = []kubevirtv1.KubeVirtCondition{
@@ -160,13 +162,13 @@ func getBasicDeployment() *BasicExpected {
 	res.kv = expectedKV
 
 	expectedCDI, err := operands.NewCDI(hco)
-	Expect(err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	expectedCDI.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/cdis/%s", expectedCDI.Namespace, expectedCDI.Name)
 	expectedCDI.Status.Conditions = getGenericCompletedConditions()
 	res.cdi = expectedCDI
 
 	expectedCNA, err := operands.NewNetworkAddons(hco)
-	Expect(err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	expectedCNA.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/cnas/%s", expectedCNA.Namespace, expectedCNA.Name)
 	expectedCNA.Status.Conditions = getGenericCompletedConditions()
 	res.cna = expectedCNA
@@ -181,7 +183,8 @@ func getBasicDeployment() *BasicExpected {
 	expectedVMI.Status.Conditions = getGenericCompletedConditions()
 	res.vmi = expectedVMI
 
-	res.imsConfig = operands.NewIMSConfigForCR(hco, namespace)
+	res.imsConfig, err = operands.NewIMSConfigForCR(hco, namespace)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	res.imsConfig.Data["v2v-conversion-image"] = commonTestUtils.ConversionImage
 	res.imsConfig.Data["kubevirt-vmware-image"] = commonTestUtils.VmwareImage
 

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -11,10 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -22,21 +18,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 const (
-	kubevirtDefaultNetworkInterfaceValue = "masquerade"
-	// We can import the constants below from Kubevirt virt-config package
-	// after Kubevirt will consume k8s.io v0.19.2 or higher
-	FeatureGatesKey         = "feature-gates"
-	MachineTypeKey          = "machine-type"
-	UseEmulationKey         = "debug.useEmulation"
-	MigrationsConfigKey     = "migrations"
-	NetworkInterfaceKey     = "default-network-interface"
-	SmbiosConfigKey         = "smbios"
-	SELinuxLauncherTypeKey  = "selinuxLauncherType"
-	DefaultNetworkInterface = "bridge"
-
 	SELinuxLauncherType = "virt_launcher.process"
 )
 
@@ -132,7 +121,6 @@ func newKubevirtHandler(Client client.Client, Scheme *runtime.Scheme) *kubevirtH
 		crType:                 "KubeVirt",
 		removeExistingOwner:    false,
 		setControllerReference: true,
-		isCr:                   true,
 		hooks:                  &kubevirtHooks{},
 	}
 }
@@ -153,7 +141,6 @@ func (h *kubevirtHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object,
 }
 
 func (h kubevirtHooks) getEmptyCr() client.Object                          { return &kubevirtv1.KubeVirt{} }
-func (h kubevirtHooks) validate() error                                    { return nil }
 func (h kubevirtHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
 func (h kubevirtHooks) getConditions(cr runtime.Object) []conditionsv1.Condition {
 	return translateKubeVirtConds(cr.(*kubevirtv1.KubeVirt).Status.Conditions)
@@ -401,7 +388,6 @@ func newKvPriorityClassHandler(Client client.Client, Scheme *runtime.Scheme) *kv
 		crType:                 "KubeVirtPriorityClass",
 		removeExistingOwner:    false,
 		setControllerReference: false,
-		isCr:                   false,
 		hooks:                  &kvPriorityClassHooks{},
 	}
 }
@@ -411,15 +397,11 @@ type kvPriorityClassHooks struct{}
 func (h kvPriorityClassHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewKubeVirtPriorityClass(hc), nil
 }
-func (h kvPriorityClassHooks) getEmptyCr() client.Object                               { return &schedulingv1.PriorityClass{} }
-func (h kvPriorityClassHooks) validate() error                                         { return nil }
-func (h kvPriorityClassHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error  { return nil }
-func (h kvPriorityClassHooks) getConditions(_ runtime.Object) []conditionsv1.Condition { return nil }
-func (h kvPriorityClassHooks) checkComponentVersion(_ runtime.Object) bool             { return true }
+func (h kvPriorityClassHooks) getEmptyCr() client.Object                              { return &schedulingv1.PriorityClass{} }
+func (h kvPriorityClassHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
 func (h kvPriorityClassHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*schedulingv1.PriorityClass).ObjectMeta
 }
-func (h kvPriorityClassHooks) reset() { /* no implementation */ }
 
 func (h *kvPriorityClassHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	pc, ok1 := required.(*schedulingv1.PriorityClass)

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -6,17 +6,17 @@ import (
 	"reflect"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 const (
@@ -37,7 +37,6 @@ func newMetricsServiceHandler(Client client.Client, Scheme *runtime.Scheme) *met
 		crType:                 "MetricsService",
 		removeExistingOwner:    false,
 		setControllerReference: true,
-		isCr:                   false,
 		hooks:                  &metricsServiceHooks{},
 	}
 }
@@ -47,11 +46,8 @@ type metricsServiceHooks struct{}
 func (h metricsServiceHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewMetricsService(hc, hc.Namespace), nil
 }
-func (h metricsServiceHooks) getEmptyCr() client.Object                               { return &corev1.Service{} }
-func (h metricsServiceHooks) validate() error                                         { return nil }
-func (h metricsServiceHooks) postFound(*common.HcoRequest, runtime.Object) error      { return nil }
-func (h metricsServiceHooks) getConditions(_ runtime.Object) []conditionsv1.Condition { return nil }
-func (h metricsServiceHooks) checkComponentVersion(_ runtime.Object) bool             { return true }
+func (h metricsServiceHooks) getEmptyCr() client.Object                          { return &corev1.Service{} }
+func (h metricsServiceHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
 func (h metricsServiceHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*corev1.Service).ObjectMeta
 }
@@ -121,7 +117,6 @@ func newMetricsServiceMonitorHandler(Client client.Client, Scheme *runtime.Schem
 		crType:                 "ServiceMonitor",
 		removeExistingOwner:    false,
 		setControllerReference: true,
-		isCr:                   false,
 		hooks:                  &metricsServiceMonitorHooks{},
 	}
 }
@@ -134,12 +129,7 @@ func (h metricsServiceMonitorHooks) getFullCr(hc *hcov1beta1.HyperConverged) (cl
 func (h metricsServiceMonitorHooks) getEmptyCr() client.Object {
 	return &monitoringv1.ServiceMonitor{}
 }
-func (h metricsServiceMonitorHooks) validate() error                                    { return nil }
 func (h metricsServiceMonitorHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
-func (h metricsServiceMonitorHooks) getConditions(_ runtime.Object) []conditionsv1.Condition {
-	return nil
-}
-func (h metricsServiceMonitorHooks) checkComponentVersion(_ runtime.Object) bool { return true }
 func (h metricsServiceMonitorHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*monitoringv1.ServiceMonitor).ObjectMeta
 }
@@ -198,7 +188,6 @@ func newMonitoringPrometheusRuleHandler(Client client.Client, Scheme *runtime.Sc
 		crType:                 "PrometheusRule",
 		removeExistingOwner:    false,
 		setControllerReference: true,
-		isCr:                   false,
 		hooks:                  &prometheusRuleHooks{},
 	}
 }
@@ -208,11 +197,8 @@ type prometheusRuleHooks struct{}
 func (h prometheusRuleHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewPrometheusRule(hc, hc.Namespace), nil
 }
-func (h prometheusRuleHooks) getEmptyCr() client.Object                               { return &monitoringv1.PrometheusRule{} }
-func (h prometheusRuleHooks) validate() error                                         { return nil }
-func (h prometheusRuleHooks) postFound(*common.HcoRequest, runtime.Object) error      { return nil }
-func (h prometheusRuleHooks) getConditions(_ runtime.Object) []conditionsv1.Condition { return nil }
-func (h prometheusRuleHooks) checkComponentVersion(_ runtime.Object) bool             { return true }
+func (h prometheusRuleHooks) getEmptyCr() client.Object                          { return &monitoringv1.PrometheusRule{} }
+func (h prometheusRuleHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
 func (h prometheusRuleHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*monitoringv1.PrometheusRule).ObjectMeta
 }

--- a/pkg/controller/operands/networkAddons.go
+++ b/pkg/controller/operands/networkAddons.go
@@ -7,16 +7,17 @@ import (
 	networkaddonsshared "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	networkaddonsnames "github.com/kubevirt/cluster-network-addons-operator/pkg/names"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 type cnaHandler genericOperand
@@ -26,7 +27,6 @@ func newCnaHandler(Client client.Client, Scheme *runtime.Scheme) *cnaHandler {
 		Client: Client,
 		Scheme: Scheme,
 		crType: "NetworkAddonsConfig",
-		isCr:   true,
 		// Previous versions used to have HCO-operator (scope namespace)
 		// as the owner of NetworkAddons (scope cluster).
 		// It's not legal, so remove that.
@@ -51,7 +51,6 @@ func (h *cnaHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, erro
 }
 
 func (h cnaHooks) getEmptyCr() client.Object                          { return &networkaddonsv1.NetworkAddonsConfig{} }
-func (h cnaHooks) validate() error                                    { return nil }
 func (h cnaHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
 func (h cnaHooks) getConditions(cr runtime.Object) []conditionsv1.Condition {
 	return cr.(*networkaddonsv1.NetworkAddonsConfig).Status.Conditions

--- a/pkg/controller/operands/quickStart.go
+++ b/pkg/controller/operands/quickStart.go
@@ -13,16 +13,16 @@ import (
 
 	"github.com/ghodss/yaml"
 	log "github.com/go-logr/logr"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	consolev1 "github.com/openshift/api/console/v1"
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 // ConsoleQuickStart resources are a short user guids
@@ -38,7 +38,6 @@ func newQuickStartHandler(Client client.Client, Scheme *runtime.Scheme, required
 		Client: Client,
 		Scheme: Scheme,
 		crType: "ConsoleQuickStart",
-		isCr:   false,
 		// Previous versions used to have HCO-operator (scope namespace)
 		// as the owner of NetworkAddons (scope cluster).
 		// It's not legal, so remove that.
@@ -65,21 +64,11 @@ func (h qsHooks) getEmptyCr() client.Object {
 	}
 }
 
-func (h qsHooks) validate() error                                        { return nil }
 func (h qsHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
-func (h qsHooks) getConditions(_ runtime.Object) []conditionsv1.Condition {
-	return nil
-}
-
-func (h qsHooks) checkComponentVersion(_ runtime.Object) bool {
-	return true
-}
 
 func (h qsHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*consolev1.ConsoleQuickStart).ObjectMeta
 }
-
-func (h qsHooks) reset() { /* no implementation */ }
 
 func (h qsHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
 	found, ok := exists.(*consolev1.ConsoleQuickStart)

--- a/pkg/controller/operands/ssp.go
+++ b/pkg/controller/operands/ssp.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"sync"
 
+	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
+
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
 
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
@@ -58,7 +59,6 @@ func newSspHandler(Client client.Client, Scheme *runtime.Scheme) *sspHandler {
 			Client:                 Client,
 			Scheme:                 Scheme,
 			crType:                 "SSP",
-			isCr:                   true,
 			removeExistingOwner:    false,
 			setControllerReference: false,
 			hooks:                  &sspHooks{},
@@ -128,7 +128,6 @@ func (h *sspHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, erro
 	return h.cache, nil
 }
 func (h sspHooks) getEmptyCr() client.Object                          { return &sspv1beta1.SSP{} }
-func (h sspHooks) validate() error                                    { return nil }
 func (h sspHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
 func (h sspHooks) getConditions(cr runtime.Object) []conditionsv1.Condition {
 	return cr.(*sspv1beta1.SSP).Status.Conditions

--- a/pkg/controller/operands/vmImport_test.go
+++ b/pkg/controller/operands/vmImport_test.go
@@ -328,7 +328,8 @@ var _ = Describe("VM-Import", func() {
 		})
 
 		It("should create if not present", func() {
-			expectedResource := NewIMSConfigForCR(hco, commonTestUtils.Namespace)
+			expectedResource, err := NewIMSConfigForCR(hco, commonTestUtils.Namespace)
+			Expect(err).ToNot(HaveOccurred())
 			cl := commonTestUtils.InitClient([]runtime.Object{})
 			handler := (*genericOperand)(newImsConfigHandler(cl, commonTestUtils.GetScheme()))
 			res := handler.ensure(req)
@@ -347,7 +348,9 @@ var _ = Describe("VM-Import", func() {
 		})
 
 		It("should find if present", func() {
-			expectedResource := NewIMSConfigForCR(hco, commonTestUtils.Namespace)
+			expectedResource, err := NewIMSConfigForCR(hco, commonTestUtils.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
 			handler := (*genericOperand)(newImsConfigHandler(cl, commonTestUtils.GetScheme()))
@@ -370,9 +373,13 @@ var _ = Describe("VM-Import", func() {
 			updatableKeys := [...]string{convk, vmwarek}
 			toBeRemovedKey := "toberemoved"
 
-			expectedResource := NewIMSConfigForCR(hco, commonTestUtils.Namespace)
+			expectedResource, err := NewIMSConfigForCR(hco, commonTestUtils.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
-			outdatedResource := NewIMSConfigForCR(hco, commonTestUtils.Namespace)
+			outdatedResource, err := NewIMSConfigForCR(hco, commonTestUtils.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
 			outdatedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", outdatedResource.Namespace, outdatedResource.Name)
 			// values we should update
 			outdatedResource.Data[convk] = "old-conversion-container-value-we-have-to-update"


### PR DESCRIPTION
In golnag, interfaces should be as small as possible, but the `hcoResourceHooks` interface is too large. For some function, the implementation is empty, or just `return nil` etc. So we need to reduce code complexity.

This PR reduces the number of functions in the `hcoResourceHooks` interface, by splitting the operand-only methods (`getConditions` and `checkComponentVersion`) into a new interface - `hcoOperandHooks`

Also, the PR Removes the `validate` and the `reset` functions from the `hcoResourceHooks` interface as it used only in one resource.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

