### PR TITLE
Prevent git Conflicts

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -413,6 +413,14 @@ fi
 # Intentionally removing last so failure leaves around the templates
 rm -rf ${TEMPDIR}
 
+# If the only change in the CSV file is its "created_at" field, rollback this change as it causes git conflicts for
+# no good reason.
+CSV_FILE="${CSV_DIR}/kubevirt-hyperconverged-operator.v${CSV_VERSION}.${CSV_EXT}"
+if git difftool -y --trust-exit-code --extcmd=./hack/diff-csv.sh ${CSV_FILE}; then
+  git checkout ${CSV_FILE}
+fi
+
+# Prepare files for index-image files that will be used for testing in openshift CI
 rm -rf "${INDEX_IMAGE_DIR:?}"
 mkdir -p "${INDEX_IMAGE_DIR:?}/${PACKAGE_NAME}"
 cp -r "${CSV_DIR%/*}" "${INDEX_IMAGE_DIR:?}/${PACKAGE_NAME}/"


### PR DESCRIPTION
If the only change in the newly generated CSV file is its `createdAt` field, cancel this change. This will prevent git conflicts in many cases.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

