### PR TITLE
Fix metric name to fit the kubevirt guidelines

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -9,7 +9,7 @@ tests:
   # CR out of band update detected
   - interval: 1m
     input_series:
-      - series: 'hyperconverged_cluster_operator_out_of_band_modifications{component_name="kubevirt"}'
+      - series: 'kubevirt_hco_out_of_band_modifications_count{component_name="kubevirt"}'
         values: "0 1 1 1 1 1 1 1 1 1 1 1"
 
     alert_rule_test:
@@ -26,7 +26,7 @@ tests:
   # No CR out of band updates
   - interval: 1m
     input_series:
-      - series: 'hyperconverged_cluster_operator_out_of_band_modifications{component_name="kubevirt"}'
+      - series: 'kubevirt_hco_out_of_band_modifications_count{component_name="kubevirt"}'
         values: "0 0 0 0 0 0 0 0 0 0 0 0 0"
 
     alert_rule_test:

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -251,7 +251,7 @@ func NewPrometheusRuleSpec() *monitoringv1.PrometheusRuleSpec {
 			Name: alertRuleGroup,
 			Rules: []monitoringv1.Rule{{
 				Alert: outOfBandUpdateAlert,
-				Expr:  intstr.FromString("sum(hyperconverged_cluster_operator_out_of_band_modifications) by (component_name) > 0"),
+				Expr:  intstr.FromString("sum(kubevirt_hco_out_of_band_modifications_count) by (component_name) > 0"),
 				For:   "10m",
 				Annotations: map[string]string{
 					"description": "Out-of-band modification for {{ $labels.component_name }} .",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 // HcoMetrics wrapper for all hco metrics
 var HcoMetrics = hcoMetrics{prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Name: "hyperconverged_cluster_operator_out_of_band_modifications",
+		Name: "kubevirt_hco_out_of_band_modifications_count",
 		Help: "Count of out-of-band modifications overwritten by HCO",
 	},
 	[]string{"component_name"},


### PR DESCRIPTION
Replaced hyperconverged_cluster_operator_out_of_band_modifications
metric name to kubevirt_hco_out_of_band_modifications_count.

kubevirt metric should have a kubevirt_ prefix and
a unit as a suffix.

Signed-off-by: Shirly Radco <sradco@redhat.com>

**Release note**:
```release-note
NONE
```

