### PR TITLE
Add reviewer checks to pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,18 @@
+**Reviewer Checklist**
+<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->
+
+- [ ] PR Message
+- [ ] Commit Messages
+- [ ] How to test
+- [ ] Unit Tests
+- [ ] Functional Tests
+- [ ] User Documentation
+- [ ] Developer Documentation
+- [ ] Upgrade Scenario
+- [ ] Uninstallation Scenario
+- [ ] Backward Compatibility
+- [ ] Troubleshooting Friendly
+  
 **Release note**:
 <!--  Write your release note:
 1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,41 @@ test and deploy. Sometimes, however, HCO cannot guess what is the right thing to
 configurable is exposed in its Resource. Each configurable must be documented, so it is clear for a human operator when
 it should be used, and why the correct value cannot be guessed automatically.
 
+## Expectations from a PR
+
+The items below must be checked per PR by the author and reviewers. Authors are responsible for stating the status of PR and reviewers are responsible for checking/verifying them. 
+
+- ***PR Message:*** PR message must explain the purpose of the PR clearly. If it fixes a bug, describe the bug or mention the github issue/bugzilla id.
+If it adds a new feature, explain why we add it and how to use it.
+It is totally OK to copy/paste documentation into PR message.
+
+- ***Commit Messages:*** Commits in a PR are squashed and merged into the target branch as a single commit by kubevirt-bot. The message of that single commit consists of PR title and messages of all squashed commits. Therefore, commit messages must be clear, concise and comprehensive.
+
+
+- ***How to test:***: If automated tests are not applicable for the PR, explain how to test the functionality in the PR. 
+  
+- ***Unit Tests:*** Production code under `pkg` folder must have unit test. PRs should not decrease the test coverage. 
+
+- ***Functional Tests:*** New features must have functional tests under `tests/func-tests`. 
+  
+- ***User Documentation:*** If the PR adds/changes something which affect end users, user documents (e.g. /docs/api.md ) must be updated.
+  
+- ***Developer Documentation:*** If the PR adds/changes something which affect developers of this repo, developer documents (e.g. /docs/run-locally.md ) must be updated.
+  
+- ***Upgrade Scenario:*** Upgrade scenario must be handled/tested in the PR. For example, if the PR adds new labels to an operand, it must be handled that existing operands during upgrades are labelled as well. If the PR removes an operand from desired state, it must handle removal of the operand during upgrade as well. 
+  
+- ***Uninstallation Scenario:*** Uninstallation scenario must be handled/tested in the PR. 
+  
+- ***Backward Compatibility:*** The APIs/interfaces we provide via this repository can be used by anyone, and we don't want to break our consumers. Changes in PRs must be backward compatible. Otherwise, it must state explicitly why we have to do it and how the community agreed on it.
+  
+- ***Troubleshooting Friendly:*** When there is a failure, the root cause must be able to be pinpointed quickly. Error mechanism must provide enough information (e.g. logs, events etc. ).
+
+<br>
+
+> If one of the checks above is not applicable for a PR, the author must put "N/A" in the PR description like below. 
+> - [ ] Upgrade Scenario -> N/A
+
+
 ### Add new Feature Gate
 
 Think twice before you do. Feature gates make HCO very hard to test; each of them essentially duplicates our test


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

We decided to list the items we want to check while reviewing PRs. This PR updates `PULL_REQUEST_TEMPLATE.md` so that each author can know what is expected and reviewers can easily go over a list while reviewing it. 

**Items that reviewers should check**

- PR Message:  "Added in detail" 
- How to test: "Not easy at the moment but we will see it after merging this PR"
- Unit Tests:  "N/A" 
- Functional Tests: "N/A"
- User Documentation:  "N/A" 
- Developer Documentation:  "Updated with the PR template" 
- Upgrade Scenario:  "N/A"
- Uninstallation Scenario: "N/A"
- Backward Compatibility:  "N/A" 
- Troubleshooting Friendly: "N/A"
  
**Release note**:
```release-note
NONE
```