### PR TITLE
Move ConsoleCLIDownload controller to operandHandler

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -92,15 +92,14 @@ func newReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo) reconcile.Reconc
 	}
 
 	return &ReconcileHyperConverged{
-		client:             mgr.GetClient(),
-		scheme:             mgr.GetScheme(),
-		recorder:           mgr.GetEventRecorderFor(hcoutil.HyperConvergedName),
-		cliDownloadHandler: &operands.CLIDownloadHandler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()},
-		operandHandler:     operands.NewOperandHandler(mgr.GetClient(), mgr.GetScheme(), ci.IsOpenshift(), hcoutil.GetEventEmitter()),
-		upgradeMode:        false,
-		ownVersion:         ownVersion,
-		eventEmitter:       hcoutil.GetEventEmitter(),
-		firstLoop:          true,
+		client:         mgr.GetClient(),
+		scheme:         mgr.GetScheme(),
+		recorder:       mgr.GetEventRecorderFor(hcoutil.HyperConvergedName),
+		operandHandler: operands.NewOperandHandler(mgr.GetClient(), mgr.GetScheme(), ci.IsOpenshift(), hcoutil.GetEventEmitter()),
+		upgradeMode:    false,
+		ownVersion:     ownVersion,
+		eventEmitter:   hcoutil.GetEventEmitter(),
+		firstLoop:      true,
 	}
 }
 
@@ -171,15 +170,14 @@ var _ reconcile.Reconciler = &ReconcileHyperConverged{}
 type ReconcileHyperConverged struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client             client.Client
-	scheme             *runtime.Scheme
-	recorder           record.EventRecorder
-	cliDownloadHandler *operands.CLIDownloadHandler
-	operandHandler     *operands.OperandHandler
-	upgradeMode        bool
-	ownVersion         string
-	eventEmitter       hcoutil.EventEmitter
-	firstLoop          bool
+	client         client.Client
+	scheme         *runtime.Scheme
+	recorder       record.EventRecorder
+	operandHandler *operands.OperandHandler
+	upgradeMode    bool
+	ownVersion     string
+	eventEmitter   hcoutil.EventEmitter
+	firstLoop      bool
 }
 
 // Reconcile reads that state of the cluster for a HyperConverged object and makes changes based on the state read
@@ -320,11 +318,7 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 }
 
 func (r *ReconcileHyperConverged) EnsureOperandAndComplete(req *common.HcoRequest, init bool) (reconcile.Result, error) {
-	// TODO(Erkan): This will be updated by a dedicated PR
-	_ = r.cliDownloadHandler.Ensure(req)
-
-	err := r.operandHandler.Ensure(req)
-	if err != nil {
+	if err := r.operandHandler.Ensure(req); err != nil {
 		r.updateConditions(req)
 		hcoutil.SetReady(false)
 		return reconcile.Result{Requeue: init}, nil
@@ -335,7 +329,7 @@ func (r *ReconcileHyperConverged) EnsureOperandAndComplete(req *common.HcoReques
 	// Requeue if we just created everything
 	if init {
 		hcoutil.SetReady(false)
-		return reconcile.Result{Requeue: true}, err
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	r.completeReconciliation(req)

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -3,6 +3,7 @@ package hyperconverged
 import (
 	"context"
 	"fmt"
+	consolev1 "github.com/openshift/api/console/v1"
 	"os"
 
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
@@ -73,6 +74,7 @@ type BasicExpected struct {
 	mService             *corev1.Service
 	serviceMonitor       *monitoringv1.ServiceMonitor
 	promRule             *monitoringv1.PrometheusRule
+	cliDownload          *consolev1.ConsoleCLIDownload
 }
 
 func (be BasicExpected) toArray() []runtime.Object {
@@ -91,6 +93,7 @@ func (be BasicExpected) toArray() []runtime.Object {
 		be.mService,
 		be.serviceMonitor,
 		be.promRule,
+		be.cliDownload,
 	}
 }
 
@@ -186,6 +189,10 @@ func getBasicDeployment() *BasicExpected {
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	res.imsConfig.Data["v2v-conversion-image"] = commonTestUtils.ConversionImage
 	res.imsConfig.Data["kubevirt-vmware-image"] = commonTestUtils.VmwareImage
+
+	expectedCliDownload := operands.NewConsoleCLIDownload(hco)
+	expectedCliDownload.SelfLink = fmt.Sprintf("/apis/console.openshift.io/v1/consoleclidownloads/%s", expectedCliDownload.Name)
+	res.cliDownload = expectedCliDownload
 
 	return res
 }

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -50,12 +50,11 @@ func initReconciler(client client.Client) *ReconcileHyperConverged {
 	operandHandler := operands.NewOperandHandler(client, s, true, eventEmitter)
 	// Create a ReconcileHyperConverged object with the scheme and fake client
 	return &ReconcileHyperConverged{
-		client:             client,
-		scheme:             s,
-		operandHandler:     operandHandler,
-		eventEmitter:       eventEmitter,
-		cliDownloadHandler: &operands.CLIDownloadHandler{Client: client, Scheme: s},
-		firstLoop:          true,
+		client:         client,
+		scheme:         s,
+		operandHandler: operandHandler,
+		eventEmitter:   eventEmitter,
+		firstLoop:      true,
 	}
 }
 

--- a/pkg/controller/operands/cliDownload.go
+++ b/pkg/controller/operands/cliDownload.go
@@ -16,50 +16,50 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type cLIDownloadHandler genericOperand
+type cliDownloadHandler genericOperand
 
-func newCLIDownloadHandler(Client client.Client, Scheme *runtime.Scheme) *cLIDownloadHandler {
-	return &cLIDownloadHandler{
+func newCLIDownloadHandler(Client client.Client, Scheme *runtime.Scheme) *cliDownloadHandler {
+	return &cliDownloadHandler{
 		Client:                 Client,
 		Scheme:                 Scheme,
 		crType:                 "ConsoleCLIDownload",
 		removeExistingOwner:    false,
 		setControllerReference: false,
-		hooks:                  &cLIDownloadHooks{},
+		hooks:                  &cliDownloadHooks{},
 	}
 }
 
-type cLIDownloadHooks struct{}
+type cliDownloadHooks struct{}
 
-func (h cLIDownloadHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h cliDownloadHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewConsoleCLIDownload(hc), nil
 }
 
-func (h cLIDownloadHooks) getEmptyCr() client.Object {
+func (h cliDownloadHooks) getEmptyCr() client.Object {
 	return &consolev1.ConsoleCLIDownload{}
 }
 
-func (h cLIDownloadHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
+func (h cliDownloadHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
 
-func (h cLIDownloadHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
+func (h cliDownloadHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*consolev1.ConsoleCLIDownload).ObjectMeta
 }
 
-func (h *cLIDownloadHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
-	desired, ok1 := required.(*consolev1.ConsoleCLIDownload)
+func (h *cliDownloadHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+	ccd, ok1 := required.(*consolev1.ConsoleCLIDownload)
 	found, ok2 := exists.(*consolev1.ConsoleCLIDownload)
 	if !ok1 || !ok2 {
 		return false, false, errors.New("can't convert to ConsoleCLIDownload")
 	}
-	if !reflect.DeepEqual(found.Spec, desired.Spec) ||
-		!reflect.DeepEqual(found.Labels, desired.Labels) {
+	if !reflect.DeepEqual(found.Spec, ccd.Spec) ||
+		!reflect.DeepEqual(found.Labels, ccd.Labels) {
 		if req.HCOTriggered {
 			req.Logger.Info("Updating existing ConsoleCLIDownload's Spec to new opinionated values")
 		} else {
 			req.Logger.Info("Reconciling an externally updated ConsoleCLIDownload's Spec to its opinionated values")
 		}
-		util.DeepCopyLabels(&desired.ObjectMeta, &found.ObjectMeta)
-		desired.Spec.DeepCopyInto(&found.Spec)
+		util.DeepCopyLabels(&ccd.ObjectMeta, &found.ObjectMeta)
+		ccd.Spec.DeepCopyInto(&found.Spec)
 		err := Client.Update(req.Ctx, found)
 		if err != nil {
 			return false, false, err

--- a/pkg/controller/operands/cliDownload.go
+++ b/pkg/controller/operands/cliDownload.go
@@ -1,57 +1,72 @@
 package operands
 
 import (
+	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
 	"os"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	consolev1 "github.com/openshift/api/console/v1"
-	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/reference"
 )
 
-type CLIDownloadHandler genericOperand
+type cLIDownloadHandler genericOperand
 
-func (h CLIDownloadHandler) Ensure(req *common.HcoRequest) error {
-	ccd := NewConsoleCLIDownload(req.Instance)
-
-	found := NewConsoleCLIDownload(req.Instance)
-	err := hcoutil.EnsureCreated(req.Ctx, h.Client, found, req.Logger)
-	if err != nil {
-		if meta.IsNoMatchError(err) {
-			req.Logger.Info("ConsoleCLIDownload was not found, skipping")
-		}
-		return err
+func newCLIDownloadHandler(Client client.Client, Scheme *runtime.Scheme) *cLIDownloadHandler {
+	return &cLIDownloadHandler{
+		Client:                 Client,
+		Scheme:                 Scheme,
+		crType:                 "ConsoleCLIDownload",
+		removeExistingOwner:    false,
+		setControllerReference: false,
+		hooks:                  &cLIDownloadHooks{},
 	}
+}
 
-	// Make sure we hold the right link spec
-	if reflect.DeepEqual(found.Spec, ccd.Spec) {
-		objectRef, err := reference.GetReference(h.Scheme, found)
-		if err != nil {
-			req.Logger.Error(err, "failed getting object reference for ConsoleCLIDownload")
-			return err
-		}
-		err = objectreferencesv1.SetObjectReference(&req.Instance.Status.RelatedObjects, *objectRef)
-		if err != nil {
-			req.Logger.Error(err, "failed setting object reference for ConsoleCLIDownload")
-			return err
-		}
+type cLIDownloadHooks struct{}
 
-		if reflect.DeepEqual(found.Labels, ccd.Labels) {
-			return nil
-		}
+func (h cLIDownloadHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+	return NewConsoleCLIDownload(hc), nil
+}
+
+func (h cLIDownloadHooks) getEmptyCr() client.Object {
+	return &consolev1.ConsoleCLIDownload{}
+}
+
+func (h cLIDownloadHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
+
+func (h cLIDownloadHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
+	return &cr.(*consolev1.ConsoleCLIDownload).ObjectMeta
+}
+
+func (h *cLIDownloadHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+	desired, ok1 := required.(*consolev1.ConsoleCLIDownload)
+	found, ok2 := exists.(*consolev1.ConsoleCLIDownload)
+	if !ok1 || !ok2 {
+		return false, false, errors.New("can't convert to ConsoleCLIDownload")
 	}
-
-	ccd.Spec.DeepCopyInto(&found.Spec)
-	util.DeepCopyLabels(&ccd.ObjectMeta, &found.ObjectMeta)
-
-	return h.Client.Update(req.Ctx, found)
+	if !reflect.DeepEqual(found.Spec, desired.Spec) ||
+		!reflect.DeepEqual(found.Labels, desired.Labels) {
+		if req.HCOTriggered {
+			req.Logger.Info("Updating existing ConsoleCLIDownload's Spec to new opinionated values")
+		} else {
+			req.Logger.Info("Reconciling an externally updated ConsoleCLIDownload's Spec to its opinionated values")
+		}
+		util.DeepCopyLabels(&desired.ObjectMeta, &found.ObjectMeta)
+		desired.Spec.DeepCopyInto(&found.Spec)
+		err := Client.Update(req.Ctx, found)
+		if err != nil {
+			return false, false, err
+		}
+		return true, !req.HCOTriggered, nil
+	}
+	return false, false, nil
 }
 
 func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLIDownload {

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -64,6 +64,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, isOpenshift
 			(*genericOperand)(newMetricsServiceHandler(client, scheme)),
 			(*genericOperand)(newMetricsServiceMonitorHandler(client, scheme)),
 			(*genericOperand)(newMonitoringPrometheusRuleHandler(client, scheme)),
+			(*genericOperand)(newCLIDownloadHandler(client, scheme)),
 		}...)
 	}
 

--- a/pkg/controller/operands/operandHandler_test.go
+++ b/pkg/controller/operands/operandHandler_test.go
@@ -228,7 +228,7 @@ var _ = Describe("Test operandHandler", func() {
 				{
 					EventType: corev1.EventTypeNormal,
 					Reason:    "Killing",
-					Msg:       "Removed  virtctl-clidownloads-kubevirt-hyperconverged",
+					Msg:       "Removed ConsoleCLIDownload virtctl-clidownloads-kubevirt-hyperconverged",
 				},
 				{
 					EventType: corev1.EventTypeNormal,


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

While fixing linter issues, we noticed that we are ignoring the error coming from cliDownloadHandler. Then we questioned why we behave ConsoleCliDownload objects differently and we decided to move it into existing operandHandler. 

This PR is supposed to not change anything in terms of operator behaviour. It should only change the implementation. 

***Note for reviwers***
Old implementation didn't have any openshift check and it was trying to create the object in all environments. It was checking the errors and it was ignoring `meta.NoResourceMatchError` errors.

New implementation assumes that `ConsoleCliDownload` CRD exists in Openshift clusters. The controller is simply disabled for vanilla Kubernetes. 

**Release note**:
```release-note
NONE
```

