### PR TITLE
Add missing environment variables to run locally

### DIFF
--- a/hack/generate_local_env.py
+++ b/hack/generate_local_env.py
@@ -3,8 +3,8 @@
 import sys
 import re
 from os import environ, linesep
+import csv
 
-CSV_VERSION = '1.4.0'
 KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION = 'v1'
 
 def get_env(line):
@@ -21,18 +21,35 @@ def get_env_file(outdir, file_format='txt'):
         sep = ';'
         ext = '.txt'
 
+    vars_list = ""
     with open('hack/config') as infile:
-        with open(f'{outdir}/envs{ext}', 'w') as out:
-            vars_list = [line.strip() for line in infile if rgx.match(line)]
-            vars_list.append('KUBECONFIG=None')
-            vars_list.append('WEBHOOK_MODE=false')
-            vars_list = map(lambda s: get_env(s), vars_list)
-            var_str = f"{sep.join(vars_list)}{sep}WATCH_NAMESPACE=kubevirt-hyperconverged{sep}OSDK_FORCE_RUN_MODE=local{sep}OPERATOR_NAMESPACE=kubevirt-hyperconverged"
-            var_str = var_str + f"{sep}WEBHOOK_CERT_DIR=./_local/certs"
-            var_str = var_str + f"{sep}HCO_KV_IO_VERSION={CSV_VERSION}"
-            var_str = var_str + f"{sep}KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION={KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION}"
-            var_str = var_str.replace("CONVERSION_CONTAINER_VERSION=", "CONVERSION_CONTAINER=").replace("VMWARE_CONTAINER_VERSION=", "VMWARE_CONTAINER=")
-            out.write(var_str)
+        vars_list = [line.strip() for line in infile if rgx.match(line)]
+    vars_list.append("KUBECONFIG=None")
+
+    vars_list = list(map(lambda s: get_env(s), vars_list))
+
+    with open('deploy/images.csv') as image_file:
+        reader = csv.DictReader(image_file, delimiter=',')
+        for row in reader:
+            if row['image_var'] in ['VMWARE_IMAGE', 'CONVERSION_IMAGE', 'KUBEVIRT_VIRTIO_IMAGE']:
+                image = f"{row['name']}@sha256:{row['digest']}"
+                env = 'VIRTIOWIN_CONTAINER' if row['image_var'] == 'KUBEVIRT_VIRTIO_IMAGE' else row['image_var']
+                vars_list.append(f"{env}={image}")
+
+    vars_list.extend([
+        f"HCO_KV_IO_VERSION={environ.get('CSV_VERSION')}",
+        "WEBHOOK_MODE=false",
+        "WEBHOOK_CERT_DIR=./_local/certs",
+        f"KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION={KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION}",
+        "WATCH_NAMESPACE=kubevirt-hyperconverged",
+        "OSDK_FORCE_RUN_MODE=local",
+        "OPERATOR_NAMESPACE=kubevirt-hyperconverged",
+    ])
+
+    var_str = sep.join(vars_list)
+
+    with open(f'{outdir}/envs{ext}', 'w') as out:
+        out.write(var_str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the missing `VIRTIOWIN_CONTAINER` variable, and chege its value and the values of `CONVERSION_IMAGE` and `KUBEVIRT_VIRTIO_IMAGE` to be a full image name. These values are taken from the `deploy/images.csv` file.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

