### PR TITLE
Replace operator-courier with operator-sdk bundle validation.

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -51,4 +51,4 @@ jobs:
           path-to-profile: coverprofiles/cover.coverprofile
 
       - name: Verify the current manifests pass validation
-        run: make container-build-operator-courier
+        run: make container-build-validate-bundles

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ container-build-webhook:
 container-build-operator-courier:
 	docker build -f tools/operator-courier/Dockerfile -t hco-courier .
 
+container-build-validate-bundles:
+	docker build -f tools/operator-sdk-validate/Dockerfile -t operator-sdk-validate-hco .
+
 container-build-functest:
 	docker build -f build/Dockerfile.functest -t $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 

--- a/tools/operator-sdk-validate/Dockerfile
+++ b/tools/operator-sdk-validate/Dockerfile
@@ -1,0 +1,9 @@
+FROM quay.io/fedora/fedora:33-x86_64
+
+COPY deploy/olm-catalog/community-kubevirt-hyperconverged /manifests
+COPY tools/operator-sdk-validate/validate-bundles.sh .
+
+RUN ./validate-bundles.sh
+
+ENTRYPOINT ["operator-sdk"]
+CMD ["--help"]

--- a/tools/operator-sdk-validate/validate-bundles.sh
+++ b/tools/operator-sdk-validate/validate-bundles.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+OPERATOR_SDK_VERSION=1.5.0
+LOWEST_VERSION_TO_VALIDATE=1.3.0
+ALL_VERSIONS=( $(ls -d /manifests/*/ | sort -V | cut -d '/' -f 3) )
+
+curl -L -o /usr/local/bin/operator-sdk \
+  "https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64"
+sudo chmod +x /usr/local/bin/operator-sdk
+
+function ver
+{
+  printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' ')
+}
+
+for version in "${ALL_VERSIONS[@]}"
+do
+   if [ "$(ver ${version})" -ge "$(ver ${LOWEST_VERSION_TO_VALIDATE})" ]
+   then
+     set -x
+     operator-sdk bundle validate /manifests/${version}
+     set +x
+   fi
+done


### PR DESCRIPTION
operator-courier validation function is not updated with the new bundle packaging format.
We replace it with the functionality available in operator-sdk tool, using `operator-sdk bundle validate <bundle_path>`
Starting with the version that are compliant with the new format (1.3.0).

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

