### PR TITLE
Workaround for SSP stuck upgrades

### DIFF
--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -15,11 +15,12 @@ if [ "${JOB_TYPE}" == "travis" ]; then
     PACKAGE_PATH="pkg/"
     ginkgo -r -cover ${PACKAGE_PATH}
 else
-    GOFLAGS= go get github.com/onsi/ginkgo/ginkgo
-    GOFLAGS= go get github.com/onsi/gomega/...
     test_path="tests/func-tests"
+    (cd $test_path; GOFLAGS= go get github.com/onsi/ginkgo/ginkgo)
+    (cd $test_path; GOFLAGS= go get github.com/onsi/gomega)
+    (cd $test_path; go mod  tidy; go mod vendor)
     test_out_path=${test_path}/_out
     mkdir -p ${test_out_path}
-    ginkgo build ${test_path}
+    (cd $test_path; ginkgo build .)
     mv ${test_path}/func-tests.test ${test_out_path}
 fi


### PR DESCRIPTION
SSP operator occasionally can get stuck on upgrades and
it will stay in that state forever.
As a workaround we can periodically (every 12 minutes)
refresh an annotation on KubeVirtCommonTemplateBundle CR just
to trigger another reconciliation loop on the ansible operator.
The annotation will be removed at the end of the upgrade process.

Fixes: https://bugzilla.redhat.com/1909975

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
Introduce a workaround for SSP stuck upgrades
```

