### PR TITLE
minor fix in CI index-image upgrade test

### DIFF
--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -74,6 +74,7 @@ trap "cleanup" INT TERM EXIT
 source hack/compare_scc.sh
 dump_sccs_before
 
+CSV=$( ${CMD} get csv -o name -n ${HCO_NAMESPACE})
 HCO_API_VERSION=$( ${CMD} get -n ${HCO_NAMESPACE} "${CSV}" -o jsonpath="{ .spec.customresourcedefinitions.owned[?(@.kind=='HyperConverged')].version }")
 sed -e "s|hco.kubevirt.io/v1beta1|hco.kubevirt.io/${HCO_API_VERSION}|g" deploy/hco.cr.yaml | ${CMD} apply -n kubevirt-hyperconverged -f -
 


### PR DESCRIPTION
Adding a missing command of extracting the CSV from the cluster.
Relates to: https://github.com/openshift/release/pull/17442

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

