### PR TITLE
Add kubevirt.io/qe-tools to the list of release-bumper exclusions

### DIFF
--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -171,8 +171,9 @@ function update_go_mod() {
     EXCLUSION_LIST=(
       "containerized-data-importer"
       "controller-lifecycle-operator-sdk"
+      "qe-tools"
       "ssp-operator"
-      )
+    )
     LAST=$(( ${#EXCLUSION_LIST[*]} - 1 ))
     EXCLUSION='/'
     for excl in "${EXCLUSION_LIST[@]}"; do


### PR DESCRIPTION
kubevirt.io/qe-tools version is not automatically increased with each kubevirt release.
Avoid automatically bumping it.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
```release-note
NONE
```

