### PR TITLE
Change KubevirtHyperconvergedClusterOperatorCRModification alert rule

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -9,7 +9,7 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kubevirt_hco_out_of_band_modifications_count{component_name="kubevirt"}'
-        values: "0 0 0 1 1 1 1 1 1 1 1 1 1"
+        values: "0 0 0 1 2 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3"
 
     alert_rule_test:
       #  No CR out of band updates
@@ -17,29 +17,40 @@ tests:
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts: [ ]
 
-      # CR out of band update detected
-      - eval_time: 5m
+      # CR out of band update detected.
+      - eval_time: 4m
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt ."
-              summary: "Out-of-band CR modification was detected"
+              summary: "2 out-of-band CR modifications were detected in the last 10 minutes."
+            exp_labels:
+              severity: "warning"
+              component_name: "kubevirt"
+
+      # New increase must be recognized
+      - eval_time: 8m
+        alertname: KubevirtHyperconvergedClusterOperatorCRModification
+        exp_alerts:
+          - exp_annotations:
+              description: "Out-of-band modification for kubevirt ."
+              summary: "3 out-of-band CR modifications were detected in the last 10 minutes."
+            exp_labels:
+              severity: "warning"
+              component_name: "kubevirt"
+
+      # Old increases must be ignored.
+      - eval_time: 14m
+        alertname: KubevirtHyperconvergedClusterOperatorCRModification
+        exp_alerts:
+          - exp_annotations:
+              description: "Out-of-band modification for kubevirt ."
+              summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
             exp_labels:
               severity: "warning"
               component_name: "kubevirt"
 
       # Should resolve after 10 minutes
       - eval_time: 15m
-        alertname: KubevirtHyperconvergedClusterOperatorCRModification
-        exp_alerts: []
-
-  # No CR out of band updates
-  - interval: 1m
-    input_series:
-      - series: 'kubevirt_hco_out_of_band_modifications_count{component_name="kubevirt"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0"
-
-    alert_rule_test:
-      - eval_time: 11m
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts: []

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -6,14 +6,19 @@ group_eval_order:
   - kubevirt.hyperconverged.rules
 
 tests:
-  # CR out of band update detected
   - interval: 1m
     input_series:
       - series: 'kubevirt_hco_out_of_band_modifications_count{component_name="kubevirt"}'
-        values: "0 1 1 1 1 1 1 1 1 1 1 1"
+        values: "0 0 0 1 1 1 1 1 1 1 1 1 1"
 
     alert_rule_test:
-      - eval_time: 11m
+      #  No CR out of band updates
+      - eval_time: 2m
+        alertname: KubevirtHyperconvergedClusterOperatorCRModification
+        exp_alerts: [ ]
+
+      # CR out of band update detected
+      - eval_time: 5m
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts:
           - exp_annotations:
@@ -22,6 +27,11 @@ tests:
             exp_labels:
               severity: "warning"
               component_name: "kubevirt"
+
+      # Should resolve after 10 minutes
+      - eval_time: 15m
+        alertname: KubevirtHyperconvergedClusterOperatorCRModification
+        exp_alerts: []
 
   # No CR out of band updates
   - interval: 1m

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -251,8 +251,7 @@ func NewPrometheusRuleSpec() *monitoringv1.PrometheusRuleSpec {
 			Name: alertRuleGroup,
 			Rules: []monitoringv1.Rule{{
 				Alert: outOfBandUpdateAlert,
-				Expr:  intstr.FromString("sum(kubevirt_hco_out_of_band_modifications_count) by (component_name) > 0"),
-				For:   "10m",
+				Expr:  intstr.FromString("sum by(component_name)  (increase(kubevirt_hco_out_of_band_modifications_count[10m])) >  0"),
 				Annotations: map[string]string{
 					"description": "Out-of-band modification for {{ $labels.component_name }} .",
 					"summary":     "Out-of-band CR modification was detected",

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -251,10 +251,10 @@ func NewPrometheusRuleSpec() *monitoringv1.PrometheusRuleSpec {
 			Name: alertRuleGroup,
 			Rules: []monitoringv1.Rule{{
 				Alert: outOfBandUpdateAlert,
-				Expr:  intstr.FromString("sum by(component_name)  (increase(kubevirt_hco_out_of_band_modifications_count[10m])) >  0"),
+				Expr:  intstr.FromString("sum by(component_name) (round(increase(kubevirt_hco_out_of_band_modifications_count[10m]))) > 0"),
 				Annotations: map[string]string{
 					"description": "Out-of-band modification for {{ $labels.component_name }} .",
-					"summary":     "Out-of-band CR modification was detected",
+					"summary":     "{{ $value }} out-of-band CR modifications were detected in the last 10 minutes.",
 				},
 				Labels: map[string]string{
 					"severity": "warning",


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

`kubevirt_hco_out_of_band_modifications_count` metric is a counter which keeps the number of changes on operands that trigger overwrites. 

Current implementation checks whether it is more than zero or not. If it is more than zero, it waits 10 minutes and triggers the alert.  Alert won't resolve without restarting the operator+counter.

This implementation checks whether there is an increment in the last 10 minutes. If there is, it triggers the alert immediately. It resolves if there is no change in the last 10 minutes.

**Release note**:
```release-note
NONE
```

