### PR TITLE
fix sed command in upgrade-index-ci Dockerfile

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -60,4 +60,4 @@ jobs:
       - name: Build and Push the Index Image
         run: |
           export OPM=$(pwd)/linux-amd64-opm
-          ./hack/build-index-image.sh ${{ env.IMAGE_TAG }} ${{ UNSTABLE }}
+          ./hack/build-index-image.sh ${{ env.IMAGE_TAG }} ${{ env.UNSTABLE }}

--- a/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
@@ -7,8 +7,8 @@ COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/manifests/ /manifests/
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/metadata /metadata/
 RUN mv /manifests/kubevirt-hyperconverged-operator.v${INITIAL_VERSION}.clusterserviceversion.yaml \
     /manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml && \
-    sed -i 's/${INITIAL_VERSION}/${TARGET_VERSION}/g' /manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml && \
-    sed -i 's/${INITIAL_VERSION}/${TARGET_VERSION}/g' /metadata/annotations.yaml
+    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml && \
+    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /metadata/annotations.yaml
 
 FROM scratch
 

--- a/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
@@ -7,8 +7,8 @@ COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/manifests/ /manifests/
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/metadata /metadata/
 RUN mv /manifests/kubevirt-hyperconverged-operator.v${INITIAL_VERSION}.clusterserviceversion.yaml \
     /manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml && \
-    sed -i 's/${INITIAL_VERSION}/${TARGET_VERSION}/g' /manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml && \
-    sed -i 's/${INITIAL_VERSION}/${TARGET_VERSION}/g' /metadata/annotations.yaml
+    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml && \
+    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /metadata/annotations.yaml
 
 FROM scratch
 


### PR DESCRIPTION
When using single quotes in the dockerfile, the variables are not evaluated in the sed command, thus changing to double quotes.
Also, fixing unstable publish workflow - 'env' was missing in UNSTABLE env var.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

