### PR TITLE
Use skipRange to enable upgrade in semver mode

### DIFF
--- a/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
@@ -2,16 +2,19 @@ FROM quay.io/fedora/fedora:33-x86_64 AS builder
 ARG INITIAL_VERSION=1.4.0
 ARG TARGET_VERSION=100.0.0
 ARG PACKAGE_NAME=community-kubevirt-hyperconverged
+ARG CSV_FILE=/manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml
+ARG OLM_SKIP_RANGE=">=${INITIAL_VERSION} <${TARGET_VERSION}"
 
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/manifests/ /manifests/
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/metadata /metadata/
-RUN mv /manifests/kubevirt-hyperconverged-operator.v${INITIAL_VERSION}.clusterserviceversion.yaml \
-    /manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml && \
-    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml && \
-    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /metadata/annotations.yaml
+RUN mv /manifests/kubevirt-hyperconverged-operator.v${INITIAL_VERSION}.clusterserviceversion.yaml ${CSV_FILE} && \
+    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" ${CSV_FILE} && \
+    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /metadata/annotations.yaml && \
+    sed -i "/olm.skipRange:/d" ${CSV_FILE} && \
+    sed -i "s/^  annotations:.*$/  annotations:\n    olm.skipRange: $OLM_SKIP_RANGE/g" ${CSV_FILE}
+
 
 FROM scratch
-
 ARG VERSION=100.0.0
 ARG PACKAGE_NAME=community-kubevirt-hyperconverged
 

--- a/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
@@ -2,16 +2,19 @@ FROM quay.io/fedora/fedora:33-x86_64 AS builder
 ARG INITIAL_VERSION=1.4.0
 ARG TARGET_VERSION=100.0.0
 ARG PACKAGE_NAME=community-kubevirt-hyperconverged
+ARG CSV_FILE=/manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml
+ARG OLM_SKIP_RANGE=">=${INITIAL_VERSION} <${TARGET_VERSION}"
 
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/manifests/ /manifests/
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/metadata /metadata/
-RUN mv /manifests/kubevirt-hyperconverged-operator.v${INITIAL_VERSION}.clusterserviceversion.yaml \
-    /manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml && \
-    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml && \
-    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /metadata/annotations.yaml
+RUN mv /manifests/kubevirt-hyperconverged-operator.v${INITIAL_VERSION}.clusterserviceversion.yaml ${CSV_FILE} && \
+    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" ${CSV_FILE} && \
+    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /metadata/annotations.yaml && \
+    sed -i "/olm.skipRange:/d" ${CSV_FILE} && \
+    sed -i "s/^  annotations:.*$/  annotations:\n    olm.skipRange: $OLM_SKIP_RANGE/g" ${CSV_FILE}
+
 
 FROM scratch
-
 ARG VERSION=100.0.0
 ARG PACKAGE_NAME=community-kubevirt-hyperconverged
 


### PR DESCRIPTION
The new version, 100.0.0, is being added to a new channel (with the same name as the version), and because it is the only bundle in the channel, when switching to the new channel, the upgrade is not trigerred without using the skipRange annotation.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

