### PR TITLE
[index image upgrade script] patch subscription's installPlanApproval

### DIFF
--- a/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
@@ -3,7 +3,7 @@ ARG INITIAL_VERSION=1.4.0
 ARG TARGET_VERSION=100.0.0
 ARG PACKAGE_NAME=community-kubevirt-hyperconverged
 ARG CSV_FILE=/manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml
-ARG OLM_SKIP_RANGE=">=${INITIAL_VERSION} <${TARGET_VERSION}"
+ARG OLM_SKIP_RANGE=">=${INITIAL_VERSION}-1 <${TARGET_VERSION}"
 
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/manifests/ /manifests/
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/metadata /metadata/

--- a/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
@@ -3,7 +3,7 @@ ARG INITIAL_VERSION=1.4.0
 ARG TARGET_VERSION=100.0.0
 ARG PACKAGE_NAME=community-kubevirt-hyperconverged
 ARG CSV_FILE=/manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml
-ARG OLM_SKIP_RANGE=">=${INITIAL_VERSION} <${TARGET_VERSION}"
+ARG OLM_SKIP_RANGE=">=${INITIAL_VERSION}-1 <${TARGET_VERSION}"
 
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/manifests/ /manifests/
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/metadata /metadata/

--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -118,6 +118,7 @@ fi
 Msg "Patch the subscription to move to the new channel"
 HCO_SUBSCRIPTION_NAME=$(${CMD} get subscription -n ${HCO_NAMESPACE} -o name)
 ${CMD} patch ${HCO_SUBSCRIPTION_NAME} -n ${HCO_NAMESPACE} -p "{\"spec\": {\"channel\": \"${TARGET_CHANNEL}\"}}"  --type merge
+${CMD} patch ${HCO_SUBSCRIPTION_NAME} -n ${HCO_NAMESPACE} -p '{"spec": {"installPlanApproval": "Automatic"}}' --type merge
 
 # Patch the OperatorGroup to match the required InstallMode of the new version
 sleep 60


### PR DESCRIPTION
instead of having to approve the InstallPlan of new version after its creation.
also, adding -1 to the starting version in olm.skipRange to make it lower value of semver, so v1.4.0- will be included in the range.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

