### PR TITLE
Adjustments to the test upgrade index-image script

### DIFF
--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -43,8 +43,11 @@ function create_index_image() {
   docker build -t "${BUNDLE_IMAGE_NAME}" -f bundle.Dockerfile --build-arg "VERSION=${CURRENT_VERSION}" .
   docker push "${BUNDLE_IMAGE_NAME}"
 
-  # Extract the digest of the bundle image, to be added to the index image
-  BUNDLE_IMAGE_NAME=$("${PROJECT_ROOT}/tools/digester/digester" --image "${BUNDLE_IMAGE_NAME}")
+  # In case of stable version, extract the digest of the bundle image, to be added to the index image
+  # Otherwise use a floating tag for the unstable bundle image.
+  if [[ "${UNSTABLE}" != "UNSTABLE" ]]; then
+    BUNDLE_IMAGE_NAME=$("${PROJECT_ROOT}/tools/digester/digester" --image "${BUNDLE_IMAGE_NAME}")
+  fi
 
   # shellcheck disable=SC2086
   ${OPM} index add --bundles "${BUNDLE_IMAGE_NAME}" ${INDEX_IMAGE_PARAM} --tag "${INDEX_IMAGE_NAME}" -u docker


### PR DESCRIPTION
When the subscription is created with `"installPlanApproval":"Manual"`, patching it to `"Automatic"` doesn't auto-approve the install plan of the new version (100.0.0 in this case), thus we have to approve it.

Also, when publishing the unstable bundle image, use floating tag instead of sha digest.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

