### PR TITLE
Don't run build-push-images workflow on irrelevant branches and paths

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - release-*
+      - release-[12]*
 jobs:
   build_push:
     if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')

--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - master
-      - release-[12]*
+      - release-1*
+    paths-ignore:
+      - 'docs/**'
+      - 'images/**'
+      - 'automation/**'
+      - 'cluster/**'
+      - 'tests/**'
 jobs:
   build_push:
     if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')


### PR DESCRIPTION
Currently, the branches of release-4.8 and release-4.9 are configured automatically by openshift-ci and are following master.
Thus, we want to prevent merge on them to trigger the workflow of building the pushing the images of hco-operator, hco-webhook,
bundle and index. It will run on our actual release branches (requires to have the workflow file there too).

Also, when files are modified only in the following paths, the workflow won't run, as these paths have no effect on the resulting images:
```
docs/**
images/**
automation/**
cluster/**
tests/**
```


Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [x] PR Message
- [x] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

