### PR TITLE
Change the implemntation of the Feature Gates to get more robust results

### DIFF
--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -390,13 +390,18 @@ func hcoConfig2KvConfig(hcoConfig hcov1beta1.HyperConvergedConfig) *kubevirtv1.C
 	return nil
 }
 
-type featureGateChecks map[string]bool
+func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) []string {
+	fgs := make([]string, 0, 2)
 
-func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) featureGateChecks {
-	return map[string]bool{
-		kvWithHostPassthroughCPU: featureGates.WithHostPassthroughCPU,
-		kvSRIOVLiveMigration:     featureGates.SRIOVLiveMigration,
+	if featureGates.WithHostPassthroughCPU {
+		fgs = append(fgs, kvWithHostPassthroughCPU)
 	}
+
+	if featureGates.SRIOVLiveMigration {
+		fgs = append(fgs, kvSRIOVLiveMigration)
+	}
+
+	return fgs
 }
 
 // ***********  KubeVirt Priority Class  ************
@@ -508,12 +513,7 @@ func getKvFeatureGateList(fgs *hcov1beta1.HyperConvergedFeatureGates) []string {
 	checks := getFeatureGateChecks(fgs)
 	res := make([]string, 0, len(checks)+len(mandatoryKvFeatureGates))
 	res = append(res, mandatoryKvFeatureGates...)
-
-	for gate, check := range checks {
-		if check {
-			res = append(res, gate)
-		}
-	}
+	res = append(res, checks...)
 
 	return res
 }


### PR DESCRIPTION
One of the feature gate unit tests was failed from time to time. The test makes sure that when KV holds the same FGs as HCO, HCO does not perform an update to KV. But from time to time, the test failed because HCO did update KV CR. The reason was the implementation was based on a map, that does not promise ordering when looping over its items, so the result list of feature gates was with different order than the one in KV CR, and so HCO updated KV.

KV feature gate list before HCO updated it
``` json
"featureGates": [
  "DataVolumes",
  "SRIOV",
  "LiveMigration",
  "CPUManager",
  "CPUNodeDiscovery",
  "Snapshot",
  "HotplugVolumes",
  "GPU",
  "HostDevices",
  "SRIOVLiveMigration",
  "WithHostPassthroughCPU"
]
```

KV feature gate list after HCO updated it:
``` json
"featureGates": [
  "DataVolumes",
  "SRIOV",
  "LiveMigration",
  "CPUManager",
  "CPUNodeDiscovery",
  "Snapshot",
  "HotplugVolumes",
  "GPU",
  "HostDevices",
  "WithHostPassthroughCPU",    //   <======
  "SRIOVLiveMigration"
]
```

This PR fixes the problem by adding the feature gates to the list in a constant order.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [x] PR Message
- [x] Commit Messages
- [ ] How to test
- [x] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [x] Upgrade Scenario
- [x] Uninstallation Scenario
- [x] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

