### PR TITLE
Fix a bug in Obsolete CPU Models

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -900,13 +900,18 @@ spec:
                     description: CPUModels is a list of obsolete CPU models. When
                       the node-labeller obtains the list of obsolete CPU models, it
                       eliminates those CPU models and creates labels for valid CPU
-                      models.
+                      models. The default values for this field is nil, however, HCO
+                      uses opinionated values, and adding values to this list will
+                      add them to the opinionated values.
                     items:
                       type: string
                     type: array
                   minCPUModel:
                     description: MinCPUModel is the Minimum CPU model that is used
-                      for basic CPU features; e.g. Penryn or Haswell
+                      for basic CPU features; e.g. Penryn or Haswell. The default
+                      value for this field is nil, but in KubeVirt, the default value
+                      is "Penryn", if nothing else is set. Use this field to override
+                      KubeVirt default value.
                     type: string
                 type: object
               permittedHostDevices:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
@@ -900,13 +900,18 @@ spec:
                     description: CPUModels is a list of obsolete CPU models. When
                       the node-labeller obtains the list of obsolete CPU models, it
                       eliminates those CPU models and creates labels for valid CPU
-                      models.
+                      models. The default values for this field is nil, however, HCO
+                      uses opinionated values, and adding values to this list will
+                      add them to the opinionated values.
                     items:
                       type: string
                     type: array
                   minCPUModel:
                     description: MinCPUModel is the Minimum CPU model that is used
-                      for basic CPU features; e.g. Penryn or Haswell
+                      for basic CPU features; e.g. Penryn or Haswell. The default
+                      value for this field is nil, but in KubeVirt, the default value
+                      is "Penryn", if nothing else is set. Use this field to override
+                      KubeVirt default value.
                     type: string
                 type: object
               permittedHostDevices:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
@@ -900,13 +900,18 @@ spec:
                     description: CPUModels is a list of obsolete CPU models. When
                       the node-labeller obtains the list of obsolete CPU models, it
                       eliminates those CPU models and creates labels for valid CPU
-                      models.
+                      models. The default values for this field is nil, however, HCO
+                      uses opinionated values, and adding values to this list will
+                      add them to the opinionated values.
                     items:
                       type: string
                     type: array
                   minCPUModel:
                     description: MinCPUModel is the Minimum CPU model that is used
-                      for basic CPU features; e.g. Penryn or Haswell
+                      for basic CPU features; e.g. Penryn or Haswell. The default
+                      value for this field is nil, but in KubeVirt, the default value
+                      is "Penryn", if nothing else is set. Use this field to override
+                      KubeVirt default value.
                     type: string
                 type: object
               permittedHostDevices:

--- a/docs/api.md
+++ b/docs/api.md
@@ -107,8 +107,8 @@ HyperConvergedObsoleteCPUs allows avoiding scheduling of VMs for obsolete CPU mo
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| minCPUModel | MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell | string |  | false |
-| cpuModels | CPUModels is a list of obsolete CPU models. When the node-labeller obtains the list of obsolete CPU models, it eliminates those CPU models and creates labels for valid CPU models. | []string |  | false |
+| minCPUModel | MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell. The default value for this field is nil, but in KubeVirt, the default value is \"Penryn\", if nothing else is set. Use this field to override KubeVirt default value. | string |  | false |
+| cpuModels | CPUModels is a list of obsolete CPU models. When the node-labeller obtains the list of obsolete CPU models, it eliminates those CPU models and creates labels for valid CPU models. The default values for this field is nil, however, HCO uses opinionated values, and adding values to this list will add them to the opinionated values. | []string |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -313,10 +313,34 @@ the CPU models and policy attributes that the node supports. By specifying a lis
 HyperConverged custom resource, you can exclude them from the list of labels created for CPU models.
 
 Through the process of iteration, the list of base CPU features in the minimum CPU model are eliminated from the list of
-labels generated for the node. For example, an environment might have two supported CPU models: `Penryn` and `Haswell`.
+labels generated for the node. For example, an environment might have two supported CPU models: `Penryn` and `Haswell`. 
 
 Use the `spec.obsoleteCPUs` to configure the CPU plugin. Add the obsolete CPU list under `spec.obsoleteCPUs.cpuModels`,
-and the minCPUModel as the value of  `spec.obsoleteCPUs.minCPUModel`.
+and the minCPUModel as the value of `spec.obsoleteCPUs.minCPUModel`.
+
+The default value for the `spec.obsoleteCPUs.minCPUModel` field in KubeVirt is `"Penryn"`, but it won't be visible if 
+missing in the CR. The default value for the `spec.obsoleteCPUs.cpuModels` field is hardcoded predefined list and is not
+visible. You can add new CPU models to the list, but can't remove CPU models from the predefined list. The predefined list
+is not visible in the HyperConverged CR.
+
+The hard-coded predefined list of obsolete CPU modes is:
+* `486`
+* `pentium`
+* `pentium2`
+* `pentium3`
+* `pentiumpro`
+* `coreduo`
+* `n270`
+* `core2duo`
+* `Conroe`
+* `athlon`
+* `phenom`
+* `qemu64`
+* `qemu32`
+* `kvm64`
+* `kvm32`
+
+You don't need to add a CPU model to the `spec.obsoleteCPUs.cpuModels` field if it is in this list. 
 
 ### CPU Plugin Configurations Example
 ```yaml

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -233,10 +233,15 @@ type OperandResourceRequirements struct {
 // HyperConvergedObsoleteCPUs allows avoiding scheduling of VMs for obsolete CPU models
 // +k8s:openapi-gen=true
 type HyperConvergedObsoleteCPUs struct {
-	// MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell
+	// MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell.
+	// The default value for this field is nil, but in KubeVirt, the default value is "Penryn", if nothing else is set.
+	// Use this field to override KubeVirt default value.
+	// +optional
 	MinCPUModel string `json:"minCPUModel,omitempty"`
 	// CPUModels is a list of obsolete CPU models. When the node-labeller obtains the list of obsolete CPU models, it
 	// eliminates those CPU models and creates labels for valid CPU models.
+	// The default values for this field is nil, however, HCO uses opinionated values, and adding values to this list
+	// will add them to the opinionated values.
 	// +optional
 	CPUModels []string `json:"cpuModels,omitempty"`
 }

--- a/pkg/apis/hco/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.openapi.go
@@ -207,14 +207,14 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedObsoleteCPUs(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"minCPUModel": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell",
+							Description: "MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell. The default value for this field is nil, but in KubeVirt, the default value is \"Penryn\", if nothing else is set. Use this field to override KubeVirt default value.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"cpuModels": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CPUModels is a list of obsolete CPU models. When the node-labeller obtains the list of obsolete CPU models, it eliminates those CPU models and creates labels for valid CPU models.",
+							Description: "CPUModels is a list of obsolete CPU models. When the node-labeller obtains the list of obsolete CPU models, it eliminates those CPU models and creates labels for valid CPU models. The default values for this field is nil, however, HCO uses opinionated values, and adding values to this list will add them to the opinionated values.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -125,6 +125,27 @@ const (
 	kvSRIOVLiveMigration     = "SRIOVLiveMigration"
 )
 
+// CPU Plugin default values
+var (
+	hardcodedObsoleteCPUModels = []string{
+		"486",
+		"pentium",
+		"pentium2",
+		"pentium3",
+		"pentiumpro",
+		"coreduo",
+		"n270",
+		"core2duo",
+		"Conroe",
+		"athlon",
+		"phenom",
+		"qemu64",
+		"qemu32",
+		"kvm64",
+		"kvm32",
+	}
+)
+
 // ************  KubeVirt Handler  **************
 type kubevirtHandler genericOperand
 
@@ -265,16 +286,21 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtv1.KubeVirtConfigurati
 }
 
 func getObsoleteCPUConfig(hcObsoleteCPUConf *hcov1beta1.HyperConvergedObsoleteCPUs) (map[string]bool, string) {
+	obsoleteCPUModels := make(map[string]bool)
+	for _, cpu := range hardcodedObsoleteCPUModels {
+		obsoleteCPUModels[cpu] = true
+	}
+	minCPUModel := ""
+
 	if hcObsoleteCPUConf != nil {
-		obsoleteCPUModels := make(map[string]bool)
 		for _, cpu := range hcObsoleteCPUConf.CPUModels {
 			obsoleteCPUModels[cpu] = true
 		}
 
-		return obsoleteCPUModels, hcObsoleteCPUConf.MinCPUModel
+		minCPUModel = hcObsoleteCPUConf.MinCPUModel
 	}
 
-	return nil, ""
+	return obsoleteCPUModels, minCPUModel
 }
 
 func toKvPermittedHostDevices(permittedDevices *hcov1beta1.PermittedHostDevices) *kubevirtv1.PermittedHostDevices {

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -1298,10 +1298,13 @@ Version: 1.2.3`)
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(3))
+					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
 					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("aaa", true))
 					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("bbb", true))
 					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("ccc", true))
+					for _, cpu := range hardcodedObsoleteCPUModels {
+						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+					}
 
 					Expect(kv.Spec.Configuration.MinCPUModel).Should(BeEmpty())
 				})
@@ -1314,7 +1317,10 @@ Version: 1.2.3`)
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(kv.Spec.Configuration.ObsoleteCPUModels).Should(BeEmpty())
+					Expect(kv.Spec.Configuration.ObsoleteCPUModels).ShouldNot(BeEmpty())
+					for _, cpu := range hardcodedObsoleteCPUModels {
+						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+					}
 					Expect(kv.Spec.Configuration.MinCPUModel).Should(Equal("Penryn"))
 				})
 
@@ -1322,16 +1328,24 @@ Version: 1.2.3`)
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(kv.Spec.Configuration.ObsoleteCPUModels).Should(BeEmpty())
+					Expect(kv.Spec.Configuration.ObsoleteCPUModels).Should(HaveLen(len(hardcodedObsoleteCPUModels)))
+					for _, cpu := range hardcodedObsoleteCPUModels {
+						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+					}
+
 					Expect(kv.Spec.Configuration.MinCPUModel).Should(BeEmpty())
 				})
 
-				It("should not add min CPU Model and obsolete CPU Models if ObsoleteCPUs is empty", func() {
+				It("should not add min CPU Model and add only the hard coded obsolete CPU Models if ObsoleteCPUs is empty", func() {
 					hco.Spec.ObsoleteCPUs = &hcov1beta1.HyperConvergedObsoleteCPUs{}
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(kv.Spec.Configuration.ObsoleteCPUModels).Should(BeEmpty())
+					Expect(kv.Spec.Configuration.ObsoleteCPUModels).Should(HaveLen(len(hardcodedObsoleteCPUModels)))
+					for _, cpu := range hardcodedObsoleteCPUModels {
+						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+					}
+
 					Expect(kv.Spec.Configuration.MinCPUModel).Should(BeEmpty())
 				})
 			})
@@ -1362,10 +1376,13 @@ Version: 1.2.3`)
 					).To(BeNil())
 
 					By("KV CR should contain the HC obsolete CPU models and minCPUModel", func() {
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveLen(3))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("aaa", true))
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("bbb", true))
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("ccc", true))
+						for _, cpu := range hardcodedObsoleteCPUModels {
+							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+						}
 
 						Expect(foundKV.Spec.Configuration.MinCPUModel).Should(Equal("Penryn"))
 					})
@@ -1403,10 +1420,14 @@ Version: 1.2.3`)
 					).To(BeNil())
 
 					By("KV CR should contain the HC obsolete CPU models and minCPUModel", func() {
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveLen(3))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("shouldStay", true))
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("shouldBeTrue", true))
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("newOne", true))
+						for _, cpu := range hardcodedObsoleteCPUModels {
+							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+						}
+
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).ShouldNot(HaveKey("shouldBeRemoved"))
 
 						Expect(foundKV.Spec.Configuration.MinCPUModel).Should(Equal("Penryn"))
@@ -1438,11 +1459,16 @@ Version: 1.2.3`)
 							foundKV),
 					).To(BeNil())
 
-					By("KV CR should not contain the HC obsolete CPU models and minCPUModel", func() {
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(BeEmpty())
-						Expect(foundKV.Spec.Configuration.MinCPUModel).Should(BeEmpty())
+					By("KV CR ObsoleteCPUModels field should contain only the hard-coded values", func() {
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).ShouldNot(BeEmpty())
+						for _, cpu := range hardcodedObsoleteCPUModels {
+							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+						}
 					})
 
+					By("KV CR minCPUModel field should be empty", func() {
+						Expect(foundKV.Spec.Configuration.MinCPUModel).Should(BeEmpty())
+					})
 				})
 			})
 		})


### PR DESCRIPTION
HCO exposes the Obsolete CPU Model configuration in it's API, with no default. The KV behavior is that it uses a predefnine hardcoded
list, if the values are not set. This is not visible in the KV CR. The same is for the minCPUModel field.

The problem is that setting the HC by the user, will override the KV defaults.

This PR copied the default values from KV, and always populate the KV's `obsoleteCPUModels` field with these value. The user can only add
more CPU models, but can't remove CPU models from the predefined list. The predefined list is not visible in the HyperConverged CR.

This PR also removes the upgrade handling for the obsolete CPU models, because we're using the defaults anyway, and in the past, the user couldn't
change the values in the configmap, so there is no user modified data.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [x] PR Message
- [x] Commit Messages
- [ ] How to test
- [x] Unit Tests
- [ ] Functional Tests
- [x] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [x] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

