### PR TITLE
Expose new Kubevirt`s feature gate NonRoot in hco

### DIFF
--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -194,6 +194,12 @@ type HyperConvergedFeatureGates struct {
 	// +optional
 	// +kubebuilder:default=false
 	SRIOVLiveMigration bool `json:"sriovLiveMigration"`
+
+	// Enables non-root implementation of virt-launcher with subset of feauters.
+	// Features that requires root will be run as root.
+	// This should increase security as Kubernetes doesn't use user-namespaces yet.
+	// +kubebuilder:default=false
+	NonRoot bool `json:"nonRoot"`
 }
 
 // PermittedHostDevices holds information about devices allowed for passthrough

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -123,6 +123,7 @@ var (
 const (
 	kvWithHostPassthroughCPU = "WithHostPassthroughCPU"
 	kvSRIOVLiveMigration     = "SRIOVLiveMigration"
+	kvNonRoot                = "NonRoot"
 )
 
 // ************  KubeVirt Handler  **************
@@ -399,6 +400,10 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) [
 
 	if featureGates.SRIOVLiveMigration {
 		fgs = append(fgs, kvSRIOVLiveMigration)
+	}
+
+	if featureGates.NonRoot {
+		fgs = append(fgs, kvNonRoot)
 	}
 
 	return fgs

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -910,7 +910,7 @@ Version: 1.2.3`)
 
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					By("KV CR should contain the HotplugVolumes feature gate", func() {
+					By("KV CR should contain the WithHostPassthroughCPU feature gate", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvWithHostPassthroughCPU))
 					})
@@ -924,7 +924,7 @@ Version: 1.2.3`)
 
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					By("KV CR should contain the HotplugVolumes feature gate", func() {
+					By("KV CR should contain the WithHostPassthroughCPU feature gate", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("WithHostPassthroughCPU"))
 					})
@@ -938,7 +938,7 @@ Version: 1.2.3`)
 
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					By("KV CR should contain the HotplugVolumes feature gate", func() {
+					By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvSRIOVLiveMigration))
 					})
@@ -952,9 +952,35 @@ Version: 1.2.3`)
 
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					By("KV CR should contain the HotplugVolumes feature gate", func() {
+					By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("SRIOVLiveMigration"))
+					})
+				})
+
+				It("should add the NonRoot feature gate if it's set in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						NonRoot: true,
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the NonRoot feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvNonRoot))
+					})
+				})
+
+				It("should not add the NonRoot feature gate if it's disabled in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						NonRoot: false,
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the NonRoot feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("NonRoot"))
 					})
 				})
 


### PR DESCRIPTION
This PR brings new feature gate from Kubevirt. Kubevirt [PR](https://github.com/kubevirt/kubevirt/pull/4922).

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
Functional Changes:
Control Kubevirt `NonRoot` feature-gate from HyperConverged CR.

API Changes:
Add The `NonRoot` optional field `toHyperConvergedFeatureGates`

```
