### PR TITLE
[release-1.4] Fix hco-e2e-upgrade-*index-* lanes

### DIFF
--- a/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
@@ -1,5 +1,6 @@
 FROM quay.io/fedora/fedora:33-x86_64 AS builder
 ARG INITIAL_VERSION=1.4.0
+ARG INITIAL_VERSION_SED="1\.4\.0"
 ARG TARGET_VERSION=100.0.0
 ARG PACKAGE_NAME=community-kubevirt-hyperconverged
 ARG CSV_FILE=/manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml
@@ -8,8 +9,8 @@ ARG OLM_SKIP_RANGE="<${TARGET_VERSION}"
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/manifests/ /manifests/
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/metadata /metadata/
 RUN mv /manifests/kubevirt-hyperconverged-operator.v${INITIAL_VERSION}.clusterserviceversion.yaml ${CSV_FILE} && \
-    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" ${CSV_FILE} && \
-    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /metadata/annotations.yaml && \
+    sed -i "s/${INITIAL_VERSION_SED}/${TARGET_VERSION}/g" ${CSV_FILE} && \
+    sed -i "s/${INITIAL_VERSION_SED}/${TARGET_VERSION}/g" /metadata/annotations.yaml && \
     sed -i "/olm.skipRange:/d" ${CSV_FILE} && \
     sed -i "s/^  annotations:.*$/  annotations:\n    olm.skipRange: \"${OLM_SKIP_RANGE}\"/g" ${CSV_FILE}
 

--- a/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
@@ -1,5 +1,6 @@
 FROM quay.io/fedora/fedora:33-x86_64 AS builder
 ARG INITIAL_VERSION=1.4.0
+ARG INITIAL_VERSION_SED="1\.4\.0"
 ARG TARGET_VERSION=100.0.0
 ARG PACKAGE_NAME=community-kubevirt-hyperconverged
 ARG CSV_FILE=/manifests/kubevirt-hyperconverged-operator.v${TARGET_VERSION}.clusterserviceversion.yaml
@@ -8,8 +9,8 @@ ARG OLM_SKIP_RANGE="<${TARGET_VERSION}"
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/manifests/ /manifests/
 COPY ${PACKAGE_NAME}/${INITIAL_VERSION}/metadata /metadata/
 RUN mv /manifests/kubevirt-hyperconverged-operator.v${INITIAL_VERSION}.clusterserviceversion.yaml ${CSV_FILE} && \
-    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" ${CSV_FILE} && \
-    sed -i "s/${INITIAL_VERSION}/${TARGET_VERSION}/g" /metadata/annotations.yaml && \
+    sed -i "s/${INITIAL_VERSION_SED}/${TARGET_VERSION}/g" ${CSV_FILE} && \
+    sed -i "s/${INITIAL_VERSION_SED}/${TARGET_VERSION}/g" /metadata/annotations.yaml && \
     sed -i "/olm.skipRange:/d" ${CSV_FILE} && \
     sed -i "s/^  annotations:.*$/  annotations:\n    olm.skipRange: \"${OLM_SKIP_RANGE}\"/g" ${CSV_FILE}
 


### PR DESCRIPTION
Fix hco-e2e-upgrade-*index-* lanes escaping the version for sed commands

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

