### PR TITLE
Fix the build and push job

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -29,7 +29,14 @@ jobs:
         run: |
           PACKAGE_DIR="./deploy/olm-catalog/community-kubevirt-hyperconverged"
           CSV_VERSION=$(ls -d ${PACKAGE_DIR}/*/ | sort -rV | awk "NR==$((RELEASE_DELTA+1))" | cut -d '/' -f 5)
+          REPLACES_CSV_VERSION=$(ls -d ${PACKAGE_DIR}/*/ | sort -rV | awk "NR==$((RELEASE_DELTA+2))" | cut -d '/' -f 5)
           echo "CSV_VERSION=${CSV_VERSION}" >> $GITHUB_ENV
+          if git ls-remote --tags | grep $(echo ${REPLACES_CSV_VERSION} | sed s/\\./\\\\./g)$; then
+            echo "REPLACES_CSV_VERSION=${REPLACES_CSV_VERSION}" >> $GITHUB_ENV
+          else
+            echo "REPLACES_CSV_VERSION=${REPLACES_CSV_VERSION}-unstable" >> $GITHUB_ENV
+          fi
+
       - name: set tag for master
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
@@ -55,10 +62,11 @@ jobs:
       - name: Build Manifests with unique CSV semver
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          REPLACES_CSV_VERSION: ${{ env.REPLACES_CSV_VERSION }}
         run: |
           export HCO_OPERATOR_IMAGE=$(tools/digester/digester --image="quay.io/kubevirt/hyperconverged-cluster-operator:${IMAGE_TAG}")
           export HCO_WEBHOOK_IMAGE=$(tools/digester/digester --image="quay.io/kubevirt/hyperconverged-cluster-webhook:${IMAGE_TAG}")
-          ./hack/build-manifests.sh UNIQUE
+          REPLACES_CSV_VERSION=${REPLACES_CSV_VERSION} ./hack/build-manifests.sh UNIQUE
       - name: Get opm client
         run: |
           wget https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/linux-amd64-opm

--- a/hack/config
+++ b/hack/config
@@ -17,4 +17,4 @@ RELEASE_DELTA="${RELEASE_DELTA:-0}"
 
 PACKAGE_DIR="./deploy/olm-catalog/community-kubevirt-hyperconverged"
 CSV_VERSION=$(ls -d ${PACKAGE_DIR}/*/ | sort -rV | awk "NR==$((RELEASE_DELTA+1))" | cut -d '/' -f 5)
-REPLACES_CSV_VERSION=$(ls -d ${PACKAGE_DIR}/*/ | sort -rV | awk "NR==$((RELEASE_DELTA+2))" | cut -d '/' -f 5)
+REPLACES_CSV_VERSION=${REPLACES_CSV_VERSION:-$(ls -d ${PACKAGE_DIR}/*/ | sort -rV | awk "NR==$((RELEASE_DELTA+2))" | cut -d '/' -f 5)}


### PR DESCRIPTION
hack/config that called from hack/build-manifests.sh, compute the replaces-cnv-version as from the folder name. but version 1.4.0 does not exist yet, and the job fails.

This PR allow injecting the REPLACES_CSV_VERSION environment variable, then it add the "-unstable" postfix if the previous version was not released yet.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

