### PR TITLE
Switch index image to semver mode in "unstable" workflow

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -30,15 +30,13 @@ jobs:
           PACKAGE_DIR="./deploy/olm-catalog/community-kubevirt-hyperconverged"
           CSV_VERSION=$(ls -d ${PACKAGE_DIR}/*/ | sort -rV | awk "NR==$((RELEASE_DELTA+1))" | cut -d '/' -f 5)
           echo "CSV_VERSION=${CSV_VERSION}" >> $GITHUB_ENV
-      - name: set tag for master
-        if: ${{ github.ref == 'refs/heads/master' }}
+          echo "PACKAGE_DIR=${PACKAGE_DIR}" >> $GITHUB_ENV
+      - name: set unstable tag
+        # This workflow always pushes unstable tags, both from main and release branches.
         run: |
           echo "IMAGE_TAG=${CSV_VERSION}-unstable" >> $GITHUB_ENV
           echo "UNSTABLE=UNSTABLE" >> $GITHUB_ENV
 
-      - name: set tag for releases
-        if: ${{ github.ref != 'refs/heads/master' }}
-        run: echo "IMAGE_TAG=${CSV_VERSION}" >> $GITHUB_ENV
       - name: Build Applications Images
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
@@ -55,10 +53,13 @@ jobs:
       - name: Build Manifests with unique CSV semver
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          PACKAGE_DIR: ${{ env.PACKAGE_DIR }}
+          CSV_VERSION: ${{ env.CSV_VERSION }}
         run: |
           export HCO_OPERATOR_IMAGE=$(tools/digester/digester --image="quay.io/kubevirt/hyperconverged-cluster-operator:${IMAGE_TAG}")
           export HCO_WEBHOOK_IMAGE=$(tools/digester/digester --image="quay.io/kubevirt/hyperconverged-cluster-webhook:${IMAGE_TAG}")
           ./hack/build-manifests.sh UNIQUE
+          sed -i "/^ \+replaces:/d" ${PACKAGE_DIR}/${CSV_VERSION}/manifests/kubevirt-hyperconverged-operator.v${CSV_VERSION}.clusterserviceversion.yaml
       - name: Get opm client
         run: |
           wget https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/linux-amd64-opm

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
-    createdAt: "2021-05-01 13:52:47"
+    createdAt: "2021-05-02 15:36:52"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'

--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -50,7 +50,7 @@ function create_index_image() {
   fi
 
   # shellcheck disable=SC2086
-  ${OPM} index add --bundles "${BUNDLE_IMAGE_NAME}" ${INDEX_IMAGE_PARAM} --tag "${INDEX_IMAGE_NAME}" -u docker
+  ${OPM} index add --bundles "${BUNDLE_IMAGE_NAME}" ${INDEX_IMAGE_PARAM} --tag "${INDEX_IMAGE_NAME}" -u docker --mode semver
   docker push "${INDEX_IMAGE_NAME}"
 }
 


### PR DESCRIPTION
When performing an upgrade in CI from 1.4.0-unstable (upgrade-prev), the CSV version of previous version contains timestamp, thus '1.4.0' does not exist and the upgrade is failing. Moving to semver mode will allow us to upgrade from any previous version, without specifying exact previous version ('replaces') in the CSV.

Modified the build-push-images workflow to always push to `*-unstable` tags, even if we are on release branches.
We'll push to "stable" tags (e.g. `1.4.0` , `1.5.0`) only when publishing the tag in the repo.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
switch to index image in semver mode
```

