### PR TITLE
Update Community-Operators Publisher Workflow

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -29,6 +29,42 @@ jobs:
         with:
           ref: ${{ env.TARGET_BRANCH }}
           fetch-depth: 2
+      - name: Get latest version on ${{ env.TARGET_BRANCH }} branch
+        run: |
+          PACKAGE_DIR="./deploy/olm-catalog/community-kubevirt-hyperconverged"
+          CSV_VERSION=$(ls -d ${PACKAGE_DIR}/*/ | sort -rV | awk "NR==1" | cut -d '/' -f 5)
+          echo "CSV_VERSION=${CSV_VERSION}" >> $GITHUB_ENV
+          echo "PACKAGE_DIR=${PACKAGE_DIR}" >> $GITHUB_ENV
+      - name: Build Applications Images
+        env:
+          IMAGE_TAG: ${{ env.CSV_VERSION }}
+        run: |
+          IMAGE_TAG=${CSV_VERSION} make container-build
+      - name: Push Application Images
+        env:
+          IMAGE_TAG: ${{ env.CSV_VERSION }}
+        run: |
+          IMAGE_TAG=${IMAGE_TAG} make container-push
+      - name: Build Digester
+        run: |
+          (cd tools/digester && go build .)
+      - name: Build Manifests for version ${{ env.CSV_VERSION }}
+        env:
+          PACKAGE_DIR: ${{ env.PACKAGE_DIR }}
+          CSV_VERSION: ${{ env.CSV_VERSION }}
+        run: |
+          export HCO_OPERATOR_IMAGE=$(tools/digester/digester --image="quay.io/kubevirt/hyperconverged-cluster-operator:${CSV_VERSION}")
+          export HCO_WEBHOOK_IMAGE=$(tools/digester/digester --image="quay.io/kubevirt/hyperconverged-cluster-webhook:${CSV_VERSION}")
+          ./hack/build-manifests.sh
+          sed -i "/^ \+replaces:/d" ${PACKAGE_DIR}/${CSV_VERSION}/manifests/kubevirt-hyperconverged-operator.v${CSV_VERSION}.clusterserviceversion.yaml
+      - name: Get opm client
+        run: |
+          wget https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/linux-amd64-opm
+          chmod +x linux-amd64-opm
+      - name: Build and Push the Index Image
+        run: |
+          export OPM=$(pwd)/linux-amd64-opm
+          ./hack/build-index-image.sh ${{ env.CSV_VERSION }}
       - name: Run Publisher script
         run: |
           export TAGGED_VERSION=${{ env.TAGGED_VERSION }}

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
-    createdAt: "2021-05-02 15:36:52"
+    createdAt: "2021-05-04 09:24:56"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -52,9 +52,9 @@ LMPATHS=(
 
 echo "Check that certConfig defaults are behaving as expected"
 
-${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type=json kubevirt-hyperconverged -p '[{ "op": "replace", "path": /spec, "value": {} }]'
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": /spec, \"value\": {} }]'"
 for JPATH in "${CERTCONFIGPATHS[@]}"; do
-    ${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type='json' kubevirt-hyperconverged -p '[{ "op": "remove", "path": '"${JPATH}"' }]'
+    ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type='json' kubevirt-hyperconverged -p '[{ \"op\": \"remove\", \"path\": '\"${JPATH}\"' }]'"
     CERTCONFIG=$(${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.certConfig}')
     if [[ $CERTCONFIGDEFAULTS != $CERTCONFIG ]]; then
         echo "Failed checking CR defaults for certConfig"
@@ -65,9 +65,9 @@ done
 
 echo "Check that featureGates defaults are behaving as expected"
 
-${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type=json kubevirt-hyperconverged -p '[{ "op": "replace", "path": /spec, "value": {} }]'
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": /spec, \"value\": {} }]'"
 for JPATH in "${FGPATHS[@]}"; do
-    ${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type='json' kubevirt-hyperconverged -p '[{ "op": "remove", "path": '"${JPATH}"' }]'
+    ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type='json' kubevirt-hyperconverged -p '[{ \"op\": \"remove\", \"path\": '\"${JPATH}\"' }]'"
     FG=$(${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.featureGates}')
     if [[ $FGDEFAULTS != $FG ]]; then
         echo "Failed checking CR defaults for featureGates"
@@ -78,9 +78,9 @@ done
 
 echo "Check that featureGates defaults are behaving as expected"
 
-${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type=json kubevirt-hyperconverged -p '[{ "op": "replace", "path": /spec, "value": {} }]'
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": /spec, \"value\": {} }]'"
 for JPATH in "${LMPATHS[@]}"; do
-    ${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type='json' kubevirt-hyperconverged -p '[{ "op": "remove", "path": '"${JPATH}"' }]'
+    ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type='json' kubevirt-hyperconverged -p '[{ \"op\": \"remove\", \"path\": '\"${JPATH}\"' }]'"
     LM=$(${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.liveMigrationConfig}')
     if [[ $LMDEFAULTS != $LM ]]; then
         echo "Failed checking CR defaults for liveMigrationConfig"

--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -31,7 +31,7 @@
 # and performs various validations against the upgraded version.
 
 
-MAX_STEPS=15
+MAX_STEPS=17
 CUR_STEP=1
 RELEASE_DELTA="${RELEASE_DELTA:-1}"
 HCO_DEPLOYMENT_NAME=hco-operator

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -41,7 +41,7 @@
 # to verify that it is updated to the new operator image from 
 # the local registry.
 
-MAX_STEPS=15
+MAX_STEPS=19
 CUR_STEP=1
 RELEASE_DELTA="${RELEASE_DELTA:-1}"
 HCO_DEPLOYMENT_NAME=hco-operator

--- a/hack/validate-no-offensive-lang.sh
+++ b/hack/validate-no-offensive-lang.sh
@@ -4,6 +4,6 @@ OFFENSIVE_WORDS="black[ -]?list|white[ -]?list|master|slave"
 ALLOW_LIST=".+/master[a-zA-Z]*/?"
 
 if git grep -inE "${OFFENSIVE_WORDS}" -- ':!vendor' ':!deploy' ':!cluster' ":!${BASH_SOURCE[0]}" | grep -viE "${ALLOW_LIST}"; then
-  echo "Validation failed. Found offencive language"
+  echo "Validation failed. Found offensive language"
   exit 1
 fi

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -280,7 +280,7 @@ func (wh WebhookHandler) validateCertConfig(hc *v1beta1.HyperConverged) error {
 	}
 
 	if hc.Spec.CertConfig.CA.Duration.Duration < hc.Spec.CertConfig.Server.Duration.Duration {
-		return errors.New("spec.certConfig: ca.duration is smaller server.duration")
+		return errors.New("spec.certConfig: ca.duration is smaller than server.duration")
 	}
 
 	return nil

--- a/pkg/webhooks/webhooks_test.go
+++ b/pkg/webhooks/webhooks_test.go
@@ -700,7 +700,7 @@ var _ = Describe("webhooks handler", func() {
 						},
 					},
 					"spec.certConfig.server: duration is smaller than renewBefore"),
-				Entry("ca.duration is smaller server.duration",
+				Entry("ca.duration is smaller than server.duration",
 					v1beta1.HyperConverged{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      util.HyperConvergedName,
@@ -719,7 +719,7 @@ var _ = Describe("webhooks handler", func() {
 							},
 						},
 					},
-					"spec.certConfig: ca.duration is smaller server.duration"),
+					"spec.certConfig: ca.duration is smaller than server.duration"),
 			)
 
 		})


### PR DESCRIPTION
Since we are now working with floating tags for hco-operator and hco-webhook in the CSV, there is no need to calculate their digests and re-commit to the CSV after building and pushing them.
Therefore, upon making a tag with a version, the publish action has been extended to:
1. Build and push the application images (hco-operator, hco-webhook).
2. Calculate and replace the floating tags of the application images with their digests, to be published on community-operators.
3. Build and push the bundle and index image in semver mode.

rehearsal: https://github.com/orenc1/hyperconverged-cluster-operator/runs/2487766558?check_suite_focus=true
result: https://github.com/orenc1/community-operators/pull/1, https://github.com/orenc1/community-operators/pull/2

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

