### PR TITLE
Fix KubevirtHyperconvergedClusterOperatorCRModification alert and metrics

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -8,49 +8,78 @@ group_eval_order:
 tests:
   - interval: 1m
     input_series:
-      - series: 'kubevirt_hco_out_of_band_modifications_count{component_name="kubevirt"}'
-        values: "0 0 0 1 2 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3"
+      - series: 'kubevirt_hco_out_of_band_modifications_count{component_name="kubevirt/kubevirt-kubevirt-hyperconverged"}'
+        # time:  0     1     2 3 4 5 6 7 8 9 10  11 12 13 14 15 16    17    18    19 20 21 22 23 24 25 26 27 28 29 30
+        values: "stale stale 1 2 3 3 3 3 3 3 3   3  3  3  3  3  stale stale stale 1  1  1  1  1  1  2  2  2  2  3  3"
 
     alert_rule_test:
-      #  No CR out of band updates
-      - eval_time: 2m
+      # No metric, no alert
+      - eval_time: 1m
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts: [ ]
 
-      # CR out of band update detected.
+      # First increase must trigger an alert
+      - eval_time: 2m
+        alertname: KubevirtHyperconvergedClusterOperatorCRModification
+        exp_alerts:
+          - exp_annotations:
+              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged ."
+              summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
+            exp_labels:
+              severity: "warning"
+              component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
+
+      # New increases must be detected
       - eval_time: 4m
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts:
           - exp_annotations:
-              description: "Out-of-band modification for kubevirt ."
-              summary: "2 out-of-band CR modifications were detected in the last 10 minutes."
-            exp_labels:
-              severity: "warning"
-              component_name: "kubevirt"
-
-      # New increase must be recognized
-      - eval_time: 8m
-        alertname: KubevirtHyperconvergedClusterOperatorCRModification
-        exp_alerts:
-          - exp_annotations:
-              description: "Out-of-band modification for kubevirt ."
+              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged ."
               summary: "3 out-of-band CR modifications were detected in the last 10 minutes."
             exp_labels:
               severity: "warning"
-              component_name: "kubevirt"
+              component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
       # Old increases must be ignored.
-      - eval_time: 14m
+      - eval_time: 13m
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts:
           - exp_annotations:
-              description: "Out-of-band modification for kubevirt ."
+              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged ."
               summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
             exp_labels:
               severity: "warning"
-              component_name: "kubevirt"
+              component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
-      # Should resolve after 10 minutes
-      - eval_time: 15m
+      # Should resolve after 10 minutes if there is no new change
+      - eval_time: 17m
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts: []
+
+      # The operator may restart and reset the metric.
+      - eval_time: 18m
+        alertname: KubevirtHyperconvergedClusterOperatorCRModification
+        exp_alerts: []
+
+      # After restart, First increase must trigger an alert again
+      - eval_time: 19m
+        alertname: KubevirtHyperconvergedClusterOperatorCRModification
+        exp_alerts:
+          - exp_annotations:
+              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged ."
+              summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
+            exp_labels:
+              severity: "warning"
+              component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
+
+
+      # After restart, new increases must be detected
+      - eval_time: 30m
+        alertname: KubevirtHyperconvergedClusterOperatorCRModification
+        exp_alerts:
+          - exp_annotations:
+              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged ."
+              summary: "2 out-of-band CR modifications were detected in the last 10 minutes."
+            exp_labels:
+              severity: "warning"
+              component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -362,6 +362,7 @@ var _ = Describe("HyperconvergedController", func() {
 				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewNodePlacement()}
 				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewNodePlacement()}
 				existingResource, err := operands.NewKubeVirt(hco, namespace)
+				existingResource.Kind = kubevirtv1.KubeVirtGroupVersionKind.Kind // necessary for metrics
 				Expect(err).ToNot(HaveOccurred())
 
 				// now, modify KV's node placement
@@ -385,7 +386,7 @@ var _ = Describe("HyperconvergedController", func() {
 				rq := request
 				rq.NamespacedName = ph
 
-				counterValueBefore, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(existingResource.Name)
+				counterValueBefore, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(existingResource.Kind, existingResource.Name)
 				Expect(err).To(BeNil())
 
 				// Do the reconcile
@@ -410,7 +411,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("value1"))
 				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("value2"))
 
-				counterValueAfter, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(foundResource.Name)
+				counterValueAfter, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(foundResource.Kind, foundResource.Name)
 				Expect(err).To(BeNil())
 				Expect(counterValueAfter).To(Equal(counterValueBefore + 1))
 
@@ -421,6 +422,7 @@ var _ = Describe("HyperconvergedController", func() {
 				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewNodePlacement()}
 				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewNodePlacement()}
 				existingResource, err := operands.NewKubeVirt(hco, namespace)
+				existingResource.Kind = kubevirtv1.KubeVirtGroupVersionKind.Kind // necessary for metrics
 				Expect(err).ToNot(HaveOccurred())
 
 				// now, modify KV's node placement
@@ -438,7 +440,7 @@ var _ = Describe("HyperconvergedController", func() {
 				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
 				r := initReconciler(cl)
 
-				counterValueBefore, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(existingResource.Name)
+				counterValueBefore, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(existingResource.Kind, existingResource.Name)
 				Expect(err).To(BeNil())
 
 				// Do the reconcile triggered by HCO
@@ -463,7 +465,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("value1"))
 				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("value2"))
 
-				counterValueAfter, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(foundResource.Name)
+				counterValueAfter, err := metrics.HcoMetrics.GetOverwrittenModificationsCount(foundResource.Kind, foundResource.Name)
 				Expect(err).To(BeNil())
 				Expect(counterValueAfter).To(Equal(counterValueBefore))
 

--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -353,7 +353,7 @@ func (h *storageConfigHooks) updateCr(req *common.HcoRequest, Client client.Clie
 		if err != nil {
 			return false, false, err
 		}
-		return true, false, nil
+		return true, !req.HCOTriggered, nil
 	}
 
 	return false, false, nil

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -251,7 +251,7 @@ func NewPrometheusRuleSpec() *monitoringv1.PrometheusRuleSpec {
 			Name: alertRuleGroup,
 			Rules: []monitoringv1.Rule{{
 				Alert: outOfBandUpdateAlert,
-				Expr:  intstr.FromString("sum by(component_name) (round(increase(kubevirt_hco_out_of_band_modifications_count[10m]))) > 0"),
+				Expr:  intstr.FromString("sum by(component_name) ((round(increase(kubevirt_hco_out_of_band_modifications_count[10m]))>0 and kubevirt_hco_out_of_band_modifications_count offset 10m) or (kubevirt_hco_out_of_band_modifications_count != 0 unless kubevirt_hco_out_of_band_modifications_count offset 10m))"),
 				Annotations: map[string]string{
 					"description": "Out-of-band modification for {{ $labels.component_name }} .",
 					"summary":     "{{ $value }} out-of-band CR modifications were detected in the last 10 minutes.",

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -119,7 +119,7 @@ func (h OperandHandler) Ensure(req *common.HcoRequest) error {
 				h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Updated", fmt.Sprintf("Updated %s %s", res.Type, res.Name))
 			} else {
 				h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, "Overwritten", fmt.Sprintf("Overwritten %s %s", res.Type, res.Name))
-				metrics.HcoMetrics.IncOverwrittenModifications(res.Name)
+				metrics.HcoMetrics.IncOverwrittenModifications(res.Type, res.Name)
 			}
 		}
 

--- a/pkg/controller/operands/vmImport.go
+++ b/pkg/controller/operands/vmImport.go
@@ -160,7 +160,7 @@ func (h *imsConfigHooks) updateCr(req *common.HcoRequest, Client client.Client, 
 		if err != nil {
 			return false, false, err
 		}
-		return true, false, nil
+		return true, !req.HCOTriggered, nil
 	}
 
 	return false, false, nil

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"strings"
 )
 
 // HcoMetrics wrapper for all hco metrics
@@ -30,13 +31,17 @@ func (hm *hcoMetrics) init() {
 }
 
 // IncOverwrittenModifications increments counter by 1
-func (hm *hcoMetrics) IncOverwrittenModifications(componentName string) {
-	hm.overwrittenModifications.With(prometheus.Labels{"component_name": componentName}).Inc()
+func (hm *hcoMetrics) IncOverwrittenModifications(kind, name string) {
+	hm.overwrittenModifications.With(getLabelsForObj(kind, name)).Inc()
 }
 
 // GetOverwrittenModificationsCount returns current value of counter. If error is not nil then value is undefined
-func (hm *hcoMetrics) GetOverwrittenModificationsCount(componentName string) (float64, error) {
+func (hm *hcoMetrics) GetOverwrittenModificationsCount(kind, name string) (float64, error) {
 	var m = &dto.Metric{}
-	err := hm.overwrittenModifications.With(prometheus.Labels{"component_name": componentName}).Write(m)
+	err := hm.overwrittenModifications.With(getLabelsForObj(kind, name)).Write(m)
 	return m.Counter.GetValue(), err
+}
+
+func getLabelsForObj(kind string, name string) prometheus.Labels {
+	return prometheus.Labels{"component_name": strings.ToLower(kind + "/" + name)}
 }


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1956304


- Current alert misses the first increment. The new query fixes that issue.

- Current component_name label contains only the name of the operand but it is hard
to diagnose. This PR adds object type to label as well.

- Now, the operator doesn't update the metric for configmap/kubevirt-storage-class-defaults
and configmap/v2v-vmware. This PR fixes that issue as well.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
NONE
```

