### PR TITLE
Validate that this repository does not contain offensive language

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DO=eval
 export JOB_TYPE=prow
 endif
 
-sanity: generate-doc
+sanity: generate-doc validate-no-offensive-lang
 	go version
 	go fmt ./...
 	go mod tidy -v
@@ -193,6 +193,9 @@ local:
 deploy_cr:
 	./hack/deploy_only_cr.sh
 
+validate-no-offensive-lang:
+	./hack/validate-no-offensive-lang.sh
+
 .PHONY: start \
 		clean \
 		build \
@@ -230,4 +233,5 @@ deploy_cr:
 		local \
 		deploy_cr \
 		build-docgen \
-		generate-doc
+		generate-doc \
+		validate-no-offensive-lang

--- a/hack/validate-no-offensive-lang.sh
+++ b/hack/validate-no-offensive-lang.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+OFFENSIVE_WORDS="black[ -]?list|white[ -]?list|master|slave"
+ALLOW_LIST=".+/master[a-zA-Z]*/?"
+
+if git grep -inE "${OFFENSIVE_WORDS}" -- ':!vendor' ':!deploy' ':!cluster' ":!${BASH_SOURCE[0]}" | grep -viE "${ALLOW_LIST}"; then
+  echo "Validation failed. Found offencive language"
+  exit 1
+fi


### PR DESCRIPTION
Add a check to the sannity test that fails if there is a usage of offensive language in one of the files.

The script forbit the use of the words `master`, `slave`, `blacklist` and `whitelist`

Sinse `master` is very common word as a name of default branches or as a node name in clusters, the script allows the usage of it if this word is part of a URL or a path. The script does not check several directories that may contain third party usage of the word `master`: `vendor/` `deploy/` and `cluster`.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

