### PR TITLE
Change the enforced min value for cert rotation

### DIFF
--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -257,7 +257,7 @@ func (wh WebhookHandler) HandleMutatingNsDelete(ns *corev1.Namespace, dryRun boo
 }
 
 func (wh WebhookHandler) validateCertConfig(hc *v1beta1.HyperConverged) error {
-	minimalDuration := metav1.Duration{Duration: 60 * time.Minute}
+	minimalDuration := metav1.Duration{Duration: 10 * time.Minute}
 
 	ccValues := make(map[string]time.Duration)
 	ccValues["spec.certConfig.ca.duration"] = hc.Spec.CertConfig.CA.Duration.Duration

--- a/pkg/webhooks/webhooks_test.go
+++ b/pkg/webhooks/webhooks_test.go
@@ -589,7 +589,7 @@ var _ = Describe("webhooks handler", func() {
 						Spec: v1beta1.HyperConvergedSpec{
 							CertConfig: v1beta1.HyperConvergedCertConfig{
 								CA: v1beta1.CertRotateConfigCA{
-									Duration:    metav1.Duration{Duration: 30 * time.Minute},
+									Duration:    metav1.Duration{Duration: 8 * time.Minute},
 									RenewBefore: metav1.Duration{Duration: 24 * time.Hour},
 								},
 								Server: v1beta1.CertRotateConfigServer{
@@ -610,7 +610,7 @@ var _ = Describe("webhooks handler", func() {
 							CertConfig: v1beta1.HyperConvergedCertConfig{
 								CA: v1beta1.CertRotateConfigCA{
 									Duration:    metav1.Duration{Duration: 48 * time.Hour},
-									RenewBefore: metav1.Duration{Duration: 30 * time.Minute},
+									RenewBefore: metav1.Duration{Duration: 8 * time.Minute},
 								},
 								Server: v1beta1.CertRotateConfigServer{
 									Duration:    metav1.Duration{Duration: 24 * time.Hour},
@@ -633,7 +633,7 @@ var _ = Describe("webhooks handler", func() {
 									RenewBefore: metav1.Duration{Duration: 24 * time.Hour},
 								},
 								Server: v1beta1.CertRotateConfigServer{
-									Duration:    metav1.Duration{Duration: 30 * time.Minute},
+									Duration:    metav1.Duration{Duration: 8 * time.Minute},
 									RenewBefore: metav1.Duration{Duration: 12 * time.Hour},
 								},
 							},
@@ -654,7 +654,7 @@ var _ = Describe("webhooks handler", func() {
 								},
 								Server: v1beta1.CertRotateConfigServer{
 									Duration:    metav1.Duration{Duration: 24 * time.Hour},
-									RenewBefore: metav1.Duration{Duration: 30 * time.Minute},
+									RenewBefore: metav1.Duration{Duration: 8 * time.Minute},
 								},
 							},
 						},


### PR DESCRIPTION
Change the enforced min value for cert rotation from
60 to 10 minutes to enable faster e2e tests on
cert rotation.

Fixes: https://bugzilla.redhat.com/1956245

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
change the enforced min value for cert rotation to 10 minutes
```

