### PR TITLE
Apply retry logic in check_defaults.sh

### DIFF
--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -52,9 +52,9 @@ LMPATHS=(
 
 echo "Check that certConfig defaults are behaving as expected"
 
-${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type=json kubevirt-hyperconverged -p '[{ "op": "replace", "path": /spec, "value": {} }]'
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": /spec, \"value\": {} }]'"
 for JPATH in "${CERTCONFIGPATHS[@]}"; do
-    ${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type='json' kubevirt-hyperconverged -p '[{ "op": "remove", "path": '"${JPATH}"' }]'
+    ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type='json' kubevirt-hyperconverged -p '[{ \"op\": \"remove\", \"path\": '\"${JPATH}\"' }]'"
     CERTCONFIG=$(${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.certConfig}')
     if [[ $CERTCONFIGDEFAULTS != $CERTCONFIG ]]; then
         echo "Failed checking CR defaults for certConfig"
@@ -65,9 +65,9 @@ done
 
 echo "Check that featureGates defaults are behaving as expected"
 
-${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type=json kubevirt-hyperconverged -p '[{ "op": "replace", "path": /spec, "value": {} }]'
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": /spec, \"value\": {} }]'"
 for JPATH in "${FGPATHS[@]}"; do
-    ${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type='json' kubevirt-hyperconverged -p '[{ "op": "remove", "path": '"${JPATH}"' }]'
+    ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type='json' kubevirt-hyperconverged -p '[{ \"op\": \"remove\", \"path\": '\"${JPATH}\"' }]'"
     FG=$(${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.featureGates}')
     if [[ $FGDEFAULTS != $FG ]]; then
         echo "Failed checking CR defaults for featureGates"
@@ -78,9 +78,9 @@ done
 
 echo "Check that featureGates defaults are behaving as expected"
 
-${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type=json kubevirt-hyperconverged -p '[{ "op": "replace", "path": /spec, "value": {} }]'
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": /spec, \"value\": {} }]'"
 for JPATH in "${LMPATHS[@]}"; do
-    ${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" --type='json' kubevirt-hyperconverged -p '[{ "op": "remove", "path": '"${JPATH}"' }]'
+    ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type='json' kubevirt-hyperconverged -p '[{ \"op\": \"remove\", \"path\": '\"${JPATH}\"' }]'"
     LM=$(${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.liveMigrationConfig}')
     if [[ $LMDEFAULTS != $LM ]]; then
         echo "Failed checking CR defaults for liveMigrationConfig"


### PR DESCRIPTION
Apply retry logic in check_defaults.sh to prevent flakiness due
to conflicts by the validating webhook cause by side effects
from the previous changes.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [x] PR Message
- [x] Commit Messages
- [x] How to test
- [x] Unit Tests
- [x] Functional Tests
- [x] User Documentation
- [x] Developer Documentation
- [x] Upgrade Scenario
- [x] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

