### PR TITLE
Default Permitted PCI Host Devices

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -4,7 +4,7 @@ set -ex
 
 # Get golang
 docker login --username "$(cat "${QUAY_USER}")" --password-stdin quay.io < "${QUAY_PASSWORD}"
-wget -q https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz
+wget -q https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz
 tar -C /usr/local -xf go*.tar.gz
 export PATH=/usr/local/go/bin:$PATH
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2 AS builder
+FROM golang:1.15.11 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -1,4 +1,4 @@
-FROM golang:1.15.2 AS builder
+FROM golang:1.15.11 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM golang:1.15.2 AS builder
+FROM golang:1.15.11 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -962,7 +962,7 @@ spec:
                           description: indicates that this resource is being provided
                             by an external device plugin
                           type: boolean
-                        pciVendorSelector:
+                        pciDeviceSelector:
                           description: a combination of a vendor_id:product_id required
                             to identify a PCI device on a host.
                           type: string
@@ -971,12 +971,12 @@ spec:
                             requested
                           type: string
                       required:
-                      - pciVendorSelector
+                      - pciDeviceSelector
                       - resourceName
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - pciVendorSelector
+                    - pciDeviceSelector
                     x-kubernetes-list-type: map
                 type: object
               resourceRequirements:

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -945,7 +945,9 @@ spec:
                       - resourceName
                       type: object
                     type: array
-                    x-kubernetes-list-type: atomic
+                    x-kubernetes-list-map-keys:
+                    - mdevNameSelector
+                    x-kubernetes-list-type: map
                   pciHostDevices:
                     items:
                       description: PciHostDevice represents a host PCI device allowed
@@ -973,7 +975,9 @@ spec:
                       - resourceName
                       type: object
                     type: array
-                    x-kubernetes-list-type: atomic
+                    x-kubernetes-list-map-keys:
+                    - pciVendorSelector
+                    x-kubernetes-list-type: map
                 type: object
               resourceRequirements:
                 description: ResourceRequirements describes the resource requirements

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -924,12 +924,21 @@ spec:
                         allowed for passthrough
                       properties:
                         disabled:
+                          description: HCO enforces the existence of several MediatedHostDevice
+                            objects. Set disabled field to true instead of remove
+                            these objects.
                           type: boolean
                         externalResourceProvider:
+                          description: indicates that this resource is being provided
+                            by an external device plugin
                           type: boolean
                         mdevNameSelector:
+                          description: name of a mediated device type required to
+                            identify a mediated device on a host
                           type: string
                         resourceName:
+                          description: name by which a device is advertised and being
+                            requested
                           type: string
                       required:
                       - mdevNameSelector
@@ -943,12 +952,21 @@ spec:
                         for passthrough
                       properties:
                         disabled:
+                          description: HCO enforces the existence of several PciHostDevice
+                            objects. Set disabled field to true instead of remove
+                            these objects.
                           type: boolean
                         externalResourceProvider:
+                          description: indicates that this resource is being provided
+                            by an external device plugin
                           type: boolean
                         pciVendorSelector:
+                          description: a combination of a vendor_id:product_id required
+                            to identify a PCI device on a host.
                           type: string
                         resourceName:
+                          description: name by which a device is advertised and being
+                            requested
                           type: string
                       required:
                       - pciVendorSelector

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -923,6 +923,8 @@ spec:
                       description: MediatedHostDevice represents a host mediated device
                         allowed for passthrough
                       properties:
+                        disabled:
+                          type: boolean
                         externalResourceProvider:
                           type: boolean
                         mdevNameSelector:
@@ -940,6 +942,8 @@ spec:
                       description: PciHostDevice represents a host PCI device allowed
                         for passthrough
                       properties:
+                        disabled:
+                          type: boolean
                         externalResourceProvider:
                           type: boolean
                         pciVendorSelector:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -962,7 +962,7 @@ spec:
                           description: indicates that this resource is being provided
                             by an external device plugin
                           type: boolean
-                        pciVendorSelector:
+                        pciDeviceSelector:
                           description: a combination of a vendor_id:product_id required
                             to identify a PCI device on a host.
                           type: string
@@ -971,12 +971,12 @@ spec:
                             requested
                           type: string
                       required:
-                      - pciVendorSelector
+                      - pciDeviceSelector
                       - resourceName
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - pciVendorSelector
+                    - pciDeviceSelector
                     x-kubernetes-list-type: map
                 type: object
               resourceRequirements:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -945,7 +945,9 @@ spec:
                       - resourceName
                       type: object
                     type: array
-                    x-kubernetes-list-type: atomic
+                    x-kubernetes-list-map-keys:
+                    - mdevNameSelector
+                    x-kubernetes-list-type: map
                   pciHostDevices:
                     items:
                       description: PciHostDevice represents a host PCI device allowed
@@ -973,7 +975,9 @@ spec:
                       - resourceName
                       type: object
                     type: array
-                    x-kubernetes-list-type: atomic
+                    x-kubernetes-list-map-keys:
+                    - pciVendorSelector
+                    x-kubernetes-list-type: map
                 type: object
               resourceRequirements:
                 description: ResourceRequirements describes the resource requirements

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -924,12 +924,21 @@ spec:
                         allowed for passthrough
                       properties:
                         disabled:
+                          description: HCO enforces the existence of several MediatedHostDevice
+                            objects. Set disabled field to true instead of remove
+                            these objects.
                           type: boolean
                         externalResourceProvider:
+                          description: indicates that this resource is being provided
+                            by an external device plugin
                           type: boolean
                         mdevNameSelector:
+                          description: name of a mediated device type required to
+                            identify a mediated device on a host
                           type: string
                         resourceName:
+                          description: name by which a device is advertised and being
+                            requested
                           type: string
                       required:
                       - mdevNameSelector
@@ -943,12 +952,21 @@ spec:
                         for passthrough
                       properties:
                         disabled:
+                          description: HCO enforces the existence of several PciHostDevice
+                            objects. Set disabled field to true instead of remove
+                            these objects.
                           type: boolean
                         externalResourceProvider:
+                          description: indicates that this resource is being provided
+                            by an external device plugin
                           type: boolean
                         pciVendorSelector:
+                          description: a combination of a vendor_id:product_id required
+                            to identify a PCI device on a host.
                           type: string
                         resourceName:
+                          description: name by which a device is advertised and being
+                            requested
                           type: string
                       required:
                       - pciVendorSelector

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -923,6 +923,8 @@ spec:
                       description: MediatedHostDevice represents a host mediated device
                         allowed for passthrough
                       properties:
+                        disabled:
+                          type: boolean
                         externalResourceProvider:
                           type: boolean
                         mdevNameSelector:
@@ -940,6 +942,8 @@ spec:
                       description: PciHostDevice represents a host PCI device allowed
                         for passthrough
                       properties:
+                        disabled:
+                          type: boolean
                         externalResourceProvider:
                           type: boolean
                         pciVendorSelector:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -2681,10 +2681,7 @@ spec:
     containerPort: 4343
     deploymentName: hco-webhook
     failurePolicy: Fail
-    generateName: defualter-hco.kubevirt.io
-    objectSelector:
-      matchLabels:
-        name: kubevirt-hyperconverged
+    generateName: defaulter-hco.kubevirt.io
     rules:
     - apiGroups:
       - hco.kubevirt.io

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -2676,6 +2676,30 @@ spec:
     type: MutatingAdmissionWebhook
     webhookPath: /mutate-ns-hco-kubevirt-io
   - admissionReviewVersions:
+    - v1beta1
+    - v1
+    containerPort: 4343
+    deploymentName: hco-webhook
+    failurePolicy: Fail
+    generateName: defualter-hco.kubevirt.io
+    objectSelector:
+      matchLabels:
+        name: kubevirt-hyperconverged
+    rules:
+    - apiGroups:
+      - hco.kubevirt.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - hyperconvergeds
+    sideEffects: None
+    timeoutSeconds: 30
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-hco-kubevirt-io-v1beta1-hyperconverged
+  - admissionReviewVersions:
     - v1
     - v1beta1
     containerPort: 9443

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -962,7 +962,7 @@ spec:
                           description: indicates that this resource is being provided
                             by an external device plugin
                           type: boolean
-                        pciVendorSelector:
+                        pciDeviceSelector:
                           description: a combination of a vendor_id:product_id required
                             to identify a PCI device on a host.
                           type: string
@@ -971,12 +971,12 @@ spec:
                             requested
                           type: string
                       required:
-                      - pciVendorSelector
+                      - pciDeviceSelector
                       - resourceName
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - pciVendorSelector
+                    - pciDeviceSelector
                     x-kubernetes-list-type: map
                 type: object
               resourceRequirements:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -945,7 +945,9 @@ spec:
                       - resourceName
                       type: object
                     type: array
-                    x-kubernetes-list-type: atomic
+                    x-kubernetes-list-map-keys:
+                    - mdevNameSelector
+                    x-kubernetes-list-type: map
                   pciHostDevices:
                     items:
                       description: PciHostDevice represents a host PCI device allowed
@@ -973,7 +975,9 @@ spec:
                       - resourceName
                       type: object
                     type: array
-                    x-kubernetes-list-type: atomic
+                    x-kubernetes-list-map-keys:
+                    - pciVendorSelector
+                    x-kubernetes-list-type: map
                 type: object
               resourceRequirements:
                 description: ResourceRequirements describes the resource requirements

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -924,12 +924,21 @@ spec:
                         allowed for passthrough
                       properties:
                         disabled:
+                          description: HCO enforces the existence of several MediatedHostDevice
+                            objects. Set disabled field to true instead of remove
+                            these objects.
                           type: boolean
                         externalResourceProvider:
+                          description: indicates that this resource is being provided
+                            by an external device plugin
                           type: boolean
                         mdevNameSelector:
+                          description: name of a mediated device type required to
+                            identify a mediated device on a host
                           type: string
                         resourceName:
+                          description: name by which a device is advertised and being
+                            requested
                           type: string
                       required:
                       - mdevNameSelector
@@ -943,12 +952,21 @@ spec:
                         for passthrough
                       properties:
                         disabled:
+                          description: HCO enforces the existence of several PciHostDevice
+                            objects. Set disabled field to true instead of remove
+                            these objects.
                           type: boolean
                         externalResourceProvider:
+                          description: indicates that this resource is being provided
+                            by an external device plugin
                           type: boolean
                         pciVendorSelector:
+                          description: a combination of a vendor_id:product_id required
+                            to identify a PCI device on a host.
                           type: string
                         resourceName:
+                          description: name by which a device is advertised and being
+                            requested
                           type: string
                       required:
                       - pciVendorSelector

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -923,6 +923,8 @@ spec:
                       description: MediatedHostDevice represents a host mediated device
                         allowed for passthrough
                       properties:
+                        disabled:
+                          type: boolean
                         externalResourceProvider:
                           type: boolean
                         mdevNameSelector:
@@ -940,6 +942,8 @@ spec:
                       description: PciHostDevice represents a host PCI device allowed
                         for passthrough
                       properties:
+                        disabled:
+                          type: boolean
                         externalResourceProvider:
                           type: boolean
                         pciVendorSelector:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
-    createdAt: "2021-05-06 14:09:31"
+    createdAt: "2021-05-07 09:38:48"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -2675,6 +2675,27 @@ spec:
     timeoutSeconds: 30
     type: MutatingAdmissionWebhook
     webhookPath: /mutate-ns-hco-kubevirt-io
+  - admissionReviewVersions:
+    - v1beta1
+    - v1
+    containerPort: 4343
+    deploymentName: hco-webhook
+    failurePolicy: Fail
+    generateName: defaulter-hco.kubevirt.io
+    rules:
+    - apiGroups:
+      - hco.kubevirt.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - hyperconvergeds
+    sideEffects: None
+    timeoutSeconds: 30
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-hco-kubevirt-io-v1beta1-hyperconverged
   - admissionReviewVersions:
     - v1
     - v1beta1

--- a/deploy/webhooks.yaml
+++ b/deploy/webhooks.yaml
@@ -57,6 +57,71 @@ webhooks:
   sideEffects: None
   timeoutSeconds: 30
 ---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutate-hco.kubevirt.io
+  annotations:
+    cert-manager.io/inject-ca-from: kubevirt-hyperconverged/hyperconverged-cluster-webhook-service-cert
+  labels:
+    name: hyperconverged-cluster-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    # caBundle: WILL BE INJECTED BY CERT-MANAGER BECAUSE OF THE ANNOTATION
+    service:
+      name: hyperconverged-cluster-webhook-service
+      namespace: kubevirt-hyperconverged
+      path: /mutate-ns-hco-kubevirt-io
+      port: 4343
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: mutate-ns-hco.kubevirt.io
+  objectSelector: { }
+  rules:
+  - apiGroups:
+    - hco.kubevirt.io
+    apiVersions:
+    - v1alpha1
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - namespaces
+    scope: '*'
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 30
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    # caBundle: WILL BE INJECTED BY CERT-MANAGER BECAUSE OF THE ANNOTATION
+    service:
+      name: hyperconverged-cluster-webhook-service
+      namespace: kubevirt-hyperconverged
+      path: /mutate-hco-kubevirt-io-v1beta1-hyperconverged
+      port: 4343
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: defualter-hco.kubevirt.io
+  objectSelector: { }
+  rules:
+  - apiGroups:
+    - hco.kubevirt.io
+    apiVersions:
+    - v1alpha1
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - hyperconvergeds
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 30
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/deploy/webhooks.yaml
+++ b/deploy/webhooks.yaml
@@ -105,7 +105,7 @@ webhooks:
       port: 4343
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: defualter-hco.kubevirt.io
+  name: defaulter-hco.kubevirt.io
   objectSelector: { }
   rules:
   - apiGroups:

--- a/docs/api.md
+++ b/docs/api.md
@@ -166,16 +166,16 @@ MediatedHostDevice represents a host mediated device allowed for passthrough
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| mdevNameSelector |  | string |  | true |
-| resourceName |  | string |  | true |
-| externalResourceProvider |  | bool |  | false |
-| disabled |  | bool |  | false |
+| mdevNameSelector | name of a mediated device type required to identify a mediated device on a host | string |  | true |
+| resourceName | name by which a device is advertised and being requested | string |  | true |
+| externalResourceProvider | indicates that this resource is being provided by an external device plugin | bool |  | false |
+| disabled | HCO enforces the existence of several MediatedHostDevice objects. Set disabled field to true instead of remove these objects. | bool |  | false |
 
 [Back to TOC](#table-of-contents)
 
 ## OperandResourceRequirements
 
-ResourceRequirements is a list of resource requirements for the operand workloads pods
+OperandResourceRequirements is a list of resource requirements for the operand workloads pods
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
@@ -189,10 +189,10 @@ PciHostDevice represents a host PCI device allowed for passthrough
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| pciVendorSelector |  | string |  | true |
-| resourceName |  | string |  | true |
-| externalResourceProvider |  | bool |  | false |
-| disabled |  | bool |  | false |
+| pciVendorSelector | a combination of a vendor_id:product_id required to identify a PCI device on a host. | string |  | true |
+| resourceName | name by which a device is advertised and being requested | string |  | true |
+| externalResourceProvider | indicates that this resource is being provided by an external device plugin | bool |  | false |
+| disabled | HCO enforces the existence of several PciHostDevice objects. Set disabled field to true instead of remove these objects. | bool |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -189,7 +189,7 @@ PciHostDevice represents a host PCI device allowed for passthrough
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| pciVendorSelector | a combination of a vendor_id:product_id required to identify a PCI device on a host. | string |  | true |
+| pciDeviceSelector | a combination of a vendor_id:product_id required to identify a PCI device on a host. | string |  | true |
 | resourceName | name by which a device is advertised and being requested | string |  | true |
 | externalResourceProvider | indicates that this resource is being provided by an external device plugin | bool |  | false |
 | disabled | HCO enforces the existence of several PciHostDevice objects. Set disabled field to true instead of remove these objects. | bool |  | false |

--- a/docs/api.md
+++ b/docs/api.md
@@ -169,6 +169,7 @@ MediatedHostDevice represents a host mediated device allowed for passthrough
 | mdevNameSelector |  | string |  | true |
 | resourceName |  | string |  | true |
 | externalResourceProvider |  | bool |  | false |
+| disabled |  | bool |  | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -191,6 +192,7 @@ PciHostDevice represents a host PCI device allowed for passthrough
 | pciVendorSelector |  | string |  | true |
 | resourceName |  | string |  | true |
 | externalResourceProvider |  | bool |  | false |
+| disabled |  | bool |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -225,7 +225,7 @@ The `permittedHostDevices` field contains two optional arrays: the `pciHostDevic
 HCO propagates these arrays as is to the KubeVirt custom resource; i.e. no merge is done, but a replacement.
 
 The `pciHostDevices` array is an array of `PciHostDevice` objects. The fields of this object are:
-* `pciVendorSelector` - a combination of a **`vendor_id:product_id`** required to identify a PCI device on a host.
+* `pciDeviceSelector` - a combination of a **`vendor_id:product_id`** required to identify a PCI device on a host.
 
    This identifier 10de:1eb8 can be found using `lspci`; for example:
    ```shell
@@ -261,9 +261,9 @@ HCO enforces the existence of two PCI Host Devices in the list:
 
 ```yaml
 pciHostDevices:
-- pciVendorSelector: "10DE:1DB6"
+- pciDeviceSelector: "10DE:1DB6"
   resourceName: "nvidia.com/GV100GL_Tesla_V100",
-- pciVendorSelector: "10DE:1EB8",
+- pciDeviceSelector: "10DE:1EB8",
   resourceName: "nvidia.com/TU104GL_Tesla_T4",
 ```
 
@@ -283,12 +283,12 @@ metadata:
 spec:
   permittedHostDevices:
     pciHostDevices:
-    - pciVendorSelector: "10DE:1DB6"
+    - pciDeviceSelector: "10DE:1DB6"
       resourceName: "nvidia.com/GV100GL_Tesla_V100",
-    - pciVendorSelector: "10DE:1EB8"
+    - pciDeviceSelector: "10DE:1EB8"
       resourceName: "nvidia.com/TU104GL_Tesla_T4"
       disabled: true
-    - pciVendorSelector: "8086:6F54"
+    - pciDeviceSelector: "8086:6F54"
       resourceName: "intel.com/qat"
       externalResourceProvider: true
     mediatedDevices:

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -18,10 +18,6 @@
 #
 # This script checks the defaulting mechanism
 
-# TEMP: TODO: Remove the following two lines
-echo "Read all MutatingWebhookConfiguration's, to debug the defaulter webhook"
-${KUBECTL_BINARY} get MutatingWebhookConfiguration -n "${INSTALLED_NAMESPACE}" -o yaml
-
 echo "Read the CR's spec before starting the test"
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o json | jq '.spec'
 

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -24,8 +24,8 @@ ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o
 CERTCONFIGDEFAULTS='{"ca":{"duration":"48h0m0s","renewBefore":"24h0m0s"},"server":{"duration":"24h0m0s","renewBefore":"12h0m0s"}}'
 FGDEFAULTS='{"sriovLiveMigration":false,"withHostPassthroughCPU":false}'
 LMDEFAULTS='{"bandwidthPerMigration":"64Mi","completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
-PERMITTED_HOST_DEVICES_DEFAULT1='{"pciVendorSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
-PERMITTED_HOST_DEVICES_DEFAULT2='{"pciVendorSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'
+PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
+PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'
 
 CERTCONFIGPATHS=(
     "/spec/certConfig/ca/duration"
@@ -122,7 +122,7 @@ done
 
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": /spec, \"value\": {} }]'"
 JPATH="/spec/permittedHostDevices/pciHostDevices/-"
-OBJ='{"pciVendorSelector":"new_one","resourceName":"new_one"}'
+OBJ='{"pciDeviceSelector":"new_one","resourceName":"new_one"}'
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"add\", \"path\": \"${JPATH}\", \"value\": ${OBJ}}]'"
 PHD=$(${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.permittedHostDevices}')
 if ! echo "${PHD}" | grep "${PERMITTED_HOST_DEVICES_DEFAULT1}"; then
@@ -142,11 +142,11 @@ fi
 sleep 2
 
 JPATH="/spec/permittedHostDevices/pciHostDevices/0/disabled"
-OBJ='{"pciVendorSelector":"new_one","resourceName":"new_one"}'
+OBJ='{"pciDeviceSelector":"new_one","resourceName":"new_one"}'
 
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"add\", \"path\": \"${JPATH}\", \"value\": true}]'"
 PHD=$(${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.permittedHostDevices.pciHostDevices[0]}')
-if [[ "${PHD}" != '{"disabled":true,"pciVendorSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}' ]]; then
+if [[ "${PHD}" != '{"disabled":true,"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}' ]]; then
     echo "Failed checking CR defaults for permittedHostDevices"
     exit 1
 fi

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -208,22 +208,36 @@ type PermittedHostDevices struct {
 // PciHostDevice represents a host PCI device allowed for passthrough
 // +k8s:openapi-gen=true
 type PciHostDevice struct {
-	PCIVendorSelector        string `json:"pciVendorSelector"`
-	ResourceName             string `json:"resourceName"`
-	ExternalResourceProvider bool   `json:"externalResourceProvider,omitempty"`
-	Disabled                 bool   `json:"disabled,omitempty"`
+	// a combination of a vendor_id:product_id required to identify a PCI device on a host.
+	PCIVendorSelector string `json:"pciVendorSelector"`
+	// name by which a device is advertised and being requested
+	ResourceName string `json:"resourceName"`
+	// indicates that this resource is being provided by an external device plugin
+	// +optional
+	ExternalResourceProvider bool `json:"externalResourceProvider,omitempty"`
+	// HCO enforces the existence of several PciHostDevice objects. Set disabled field to true instead of remove
+	// these objects.
+	// +optional
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // MediatedHostDevice represents a host mediated device allowed for passthrough
 // +k8s:openapi-gen=true
 type MediatedHostDevice struct {
-	MDEVNameSelector         string `json:"mdevNameSelector"`
-	ResourceName             string `json:"resourceName"`
-	ExternalResourceProvider bool   `json:"externalResourceProvider,omitempty"`
-	Disabled                 bool   `json:"disabled,omitempty"`
+	// name of a mediated device type required to identify a mediated device on a host
+	MDEVNameSelector string `json:"mdevNameSelector"`
+	// name by which a device is advertised and being requested
+	ResourceName string `json:"resourceName"`
+	// indicates that this resource is being provided by an external device plugin
+	// +optional
+	ExternalResourceProvider bool `json:"externalResourceProvider,omitempty"`
+	// HCO enforces the existence of several MediatedHostDevice objects. Set disabled field to true instead of remove
+	// these objects.
+	// +optional
+	Disabled bool `json:"disabled,omitempty"`
 }
 
-// ResourceRequirements is a list of resource requirements for the operand workloads pods
+// OperandResourceRequirements is a list of resource requirements for the operand workloads pods
 // +k8s:openapi-gen=true
 type OperandResourceRequirements struct {
 	// StorageWorkloads defines the resources requirements for storage workloads. It will propagate to the CDI custom

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -199,9 +199,11 @@ type HyperConvergedFeatureGates struct {
 // PermittedHostDevices holds information about devices allowed for passthrough
 // +k8s:openapi-gen=true
 type PermittedHostDevices struct {
-	// +listType=atomic
+	// +listType=map
+	// +listMapKey=pciVendorSelector
 	PciHostDevices []PciHostDevice `json:"pciHostDevices,omitempty"`
-	// +listType=atomic
+	// +listType=map
+	// +listMapKey=mdevNameSelector
 	MediatedDevices []MediatedHostDevice `json:"mediatedDevices,omitempty"`
 }
 

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -211,6 +211,7 @@ type PciHostDevice struct {
 	PCIVendorSelector        string `json:"pciVendorSelector"`
 	ResourceName             string `json:"resourceName"`
 	ExternalResourceProvider bool   `json:"externalResourceProvider,omitempty"`
+	Disabled                 bool   `json:"disabled,omitempty"`
 }
 
 // MediatedHostDevice represents a host mediated device allowed for passthrough
@@ -219,6 +220,7 @@ type MediatedHostDevice struct {
 	MDEVNameSelector         string `json:"mdevNameSelector"`
 	ResourceName             string `json:"resourceName"`
 	ExternalResourceProvider bool   `json:"externalResourceProvider,omitempty"`
+	Disabled                 bool   `json:"disabled,omitempty"`
 }
 
 // ResourceRequirements is a list of resource requirements for the operand workloads pods

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -200,7 +200,7 @@ type HyperConvergedFeatureGates struct {
 // +k8s:openapi-gen=true
 type PermittedHostDevices struct {
 	// +listType=map
-	// +listMapKey=pciVendorSelector
+	// +listMapKey=pciDeviceSelector
 	PciHostDevices []PciHostDevice `json:"pciHostDevices,omitempty"`
 	// +listType=map
 	// +listMapKey=mdevNameSelector
@@ -211,7 +211,7 @@ type PermittedHostDevices struct {
 // +k8s:openapi-gen=true
 type PciHostDevice struct {
 	// a combination of a vendor_id:product_id required to identify a PCI device on a host.
-	PCIVendorSelector string `json:"pciVendorSelector"`
+	PCIDeviceSelector string `json:"pciDeviceSelector"`
 	// name by which a device is advertised and being requested
 	ResourceName string `json:"resourceName"`
 	// indicates that this resource is being provided by an external device plugin

--- a/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
@@ -349,7 +349,7 @@ var _ = Describe("HyperconvergedTypes", func() {
 				PermittedHostDevices: &PermittedHostDevices{
 					PciHostDevices: []PciHostDevice{
 						{
-							PCIVendorSelector:        "PCIVendorSelector",
+							PCIDeviceSelector:        "PCIDeviceSelector",
 							ResourceName:             "ResourceName",
 							ExternalResourceProvider: true,
 						},

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
@@ -198,11 +198,11 @@ func (a *nsMutator) InjectDecoder(d *admission.Decoder) error {
 
 var defaultPciHostDevices = []PciHostDevice{
 	{
-		PCIVendorSelector: "10DE:1DB6",
+		PCIDeviceSelector: "10DE:1DB6",
 		ResourceName:      "nvidia.com/GV100GL_Tesla_V100",
 	},
 	{
-		PCIVendorSelector: "10DE:1EB8",
+		PCIDeviceSelector: "10DE:1EB8",
 		ResourceName:      "nvidia.com/TU104GL_Tesla_T4",
 	},
 }
@@ -228,7 +228,7 @@ func (r *HyperConverged) Default() {
 
 func findPciHostDevice(list []PciHostDevice, dev PciHostDevice) bool {
 	for _, phd := range list {
-		if phd.PCIVendorSelector == dev.PCIVendorSelector {
+		if phd.PCIDeviceSelector == dev.PCIDeviceSelector {
 			return true
 		}
 	}

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
@@ -198,7 +198,7 @@ func (a *nsMutator) InjectDecoder(d *admission.Decoder) error {
 
 func (r *HyperConverged) Default() {
 	hcolog.Info("handle the HyperConverged default values")
-	if r.Spec.PermittedHostDevices == nil {
+	if r.Spec.PermittedHostDevices == nil || r.Spec.PermittedHostDevices.PciHostDevices == nil {
 		hcolog.Info("add default values for HyperConverged")
 		r.Spec.PermittedHostDevices = &PermittedHostDevices{
 			PciHostDevices: []PciHostDevice{

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook.go
@@ -219,16 +219,16 @@ func (r *HyperConverged) Default() {
 		copy(r.Spec.PermittedHostDevices.PciHostDevices, defaultPciHostDevices)
 	} else {
 		for _, phd := range defaultPciHostDevices {
-			if !findPciHosDevice(r.Spec.PermittedHostDevices.PciHostDevices, phd) {
+			if !findPciHostDevice(r.Spec.PermittedHostDevices.PciHostDevices, phd) {
 				r.Spec.PermittedHostDevices.PciHostDevices = append(r.Spec.PermittedHostDevices.PciHostDevices, phd)
 			}
 		}
 	}
 }
 
-func findPciHosDevice(list []PciHostDevice, dev PciHostDevice) bool {
+func findPciHostDevice(list []PciHostDevice, dev PciHostDevice) bool {
 	for _, phd := range list {
-		if phd.PCIVendorSelector == dev.PCIVendorSelector && phd.ResourceName == dev.ResourceName {
+		if phd.PCIVendorSelector == dev.PCIVendorSelector {
 			return true
 		}
 	}

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook_test.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Hyperconverged API: Webhook", func() {
 				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
 
 				for _, phd := range defaultPciHostDevices {
-					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+					Expect(findPciHostDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
 				}
 			})
 
@@ -28,7 +28,7 @@ var _ = Describe("Hyperconverged API: Webhook", func() {
 				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
 
 				for _, phd := range defaultPciHostDevices {
-					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+					Expect(findPciHostDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
 				}
 			})
 
@@ -45,7 +45,7 @@ var _ = Describe("Hyperconverged API: Webhook", func() {
 				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
 
 				for _, phd := range defaultPciHostDevices {
-					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+					Expect(findPciHostDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
 				}
 			})
 
@@ -61,7 +61,7 @@ var _ = Describe("Hyperconverged API: Webhook", func() {
 				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
 
 				for _, phd := range defaultPciHostDevices {
-					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+					Expect(findPciHostDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
 				}
 			})
 
@@ -79,7 +79,7 @@ var _ = Describe("Hyperconverged API: Webhook", func() {
 				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
 
 				for _, phd := range defaultPciHostDevices {
-					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+					Expect(findPciHostDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
 				}
 			})
 
@@ -99,7 +99,7 @@ var _ = Describe("Hyperconverged API: Webhook", func() {
 				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
 
 				for _, phd := range defaultPciHostDevices {
-					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+					Expect(findPciHostDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
 				}
 
 				By("check that the Default() function didn't change the modification we made", func() {

--- a/pkg/apis/hco/v1beta1/hyperconverged_webhook_test.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_webhook_test.go
@@ -1,0 +1,111 @@
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Hyperconverged API: Webhook", func() {
+	Context("Test Defaulter", func() {
+		Context("test default PciHostDevices", func() {
+			It("Should add the default PCI Host Devices to empty spec", func() {
+				hco := HyperConverged{Spec: HyperConvergedSpec{}}
+				hco.Default()
+				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
+
+				for _, phd := range defaultPciHostDevices {
+					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+				}
+			})
+
+			It("Should add the default PCI Host Devices to empty PermittedHostDevices", func() {
+				hco := HyperConverged{
+					Spec: HyperConvergedSpec{
+						PermittedHostDevices: &PermittedHostDevices{},
+					},
+				}
+				hco.Default()
+				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
+
+				for _, phd := range defaultPciHostDevices {
+					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+				}
+			})
+
+			It("Should add the default PCI Host Devices to nil PciHostDevices list", func() {
+				hco := HyperConverged{
+					Spec: HyperConvergedSpec{
+						PermittedHostDevices: &PermittedHostDevices{
+							PciHostDevices: nil,
+						},
+					},
+				}
+				hco.Default()
+
+				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
+
+				for _, phd := range defaultPciHostDevices {
+					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+				}
+			})
+
+			It("Should add the default PCI Host Devices to empty PciHostDevices list", func() {
+				hco := HyperConverged{
+					Spec: HyperConvergedSpec{
+						PermittedHostDevices: &PermittedHostDevices{
+							PciHostDevices: make([]PciHostDevice, 0),
+						},
+					},
+				}
+				hco.Default()
+				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
+
+				for _, phd := range defaultPciHostDevices {
+					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+				}
+			})
+
+			It("Should add a default PCI Host Device if missing from the PciHostDevices list", func() {
+				hco := HyperConverged{
+					Spec: HyperConvergedSpec{
+						PermittedHostDevices: &PermittedHostDevices{
+							PciHostDevices: []PciHostDevice{
+								defaultPciHostDevices[0],
+							},
+						},
+					},
+				}
+				hco.Default()
+				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
+
+				for _, phd := range defaultPciHostDevices {
+					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+				}
+			})
+
+			It("Should not add a default PCI Host Device if it already in the PciHostDevices list", func() {
+				hco := HyperConverged{
+					Spec: HyperConvergedSpec{
+						PermittedHostDevices: &PermittedHostDevices{
+							PciHostDevices: make([]PciHostDevice, len(defaultPciHostDevices)),
+						},
+					},
+				}
+
+				copy(hco.Spec.PermittedHostDevices.PciHostDevices, defaultPciHostDevices)
+				hco.Spec.PermittedHostDevices.PciHostDevices[0].Disabled = true
+
+				hco.Default()
+				Expect(hco.Spec.PermittedHostDevices.PciHostDevices).To(HaveLen(len(defaultPciHostDevices)))
+
+				for _, phd := range defaultPciHostDevices {
+					Expect(findPciHosDevice(hco.Spec.PermittedHostDevices.PciHostDevices, phd)).Should(BeTrue())
+				}
+
+				By("check that the Default() function didn't change the modification we made", func() {
+					Expect(hco.Spec.PermittedHostDevices.PciHostDevices[0].Disabled).Should(BeTrue())
+				})
+			})
+		})
+	})
+})

--- a/pkg/apis/hco/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.openapi.go
@@ -462,6 +462,12 @@ func schema_pkg_apis_hco_v1beta1_MediatedHostDevice(ref common.ReferenceCallback
 							Format: "",
 						},
 					},
+					"disabled": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"mdevNameSelector", "resourceName"},
 			},
@@ -510,6 +516,12 @@ func schema_pkg_apis_hco_v1beta1_PciHostDevice(ref common.ReferenceCallback) com
 						},
 					},
 					"externalResourceProvider": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"disabled": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",

--- a/pkg/apis/hco/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.openapi.go
@@ -507,7 +507,7 @@ func schema_pkg_apis_hco_v1beta1_PciHostDevice(ref common.ReferenceCallback) com
 				Description: "PciHostDevice represents a host PCI device allowed for passthrough",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"pciVendorSelector": {
+					"pciDeviceSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "a combination of a vendor_id:product_id required to identify a PCI device on a host.",
 							Type:        []string{"string"},
@@ -536,7 +536,7 @@ func schema_pkg_apis_hco_v1beta1_PciHostDevice(ref common.ReferenceCallback) com
 						},
 					},
 				},
-				Required: []string{"pciVendorSelector", "resourceName"},
+				Required: []string{"pciDeviceSelector", "resourceName"},
 			},
 		},
 	}
@@ -553,7 +553,7 @@ func schema_pkg_apis_hco_v1beta1_PermittedHostDevices(ref common.ReferenceCallba
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
 								"x-kubernetes-list-map-keys": []interface{}{
-									"pciVendorSelector",
+									"pciDeviceSelector",
 								},
 								"x-kubernetes-list-type": "map",
 							},

--- a/pkg/apis/hco/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.openapi.go
@@ -446,26 +446,30 @@ func schema_pkg_apis_hco_v1beta1_MediatedHostDevice(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"mdevNameSelector": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "name of a mediated device type required to identify a mediated device on a host",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"resourceName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "name by which a device is advertised and being requested",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"externalResourceProvider": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Description: "indicates that this resource is being provided by an external device plugin",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"disabled": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Description: "HCO enforces the existence of several MediatedHostDevice objects. Set disabled field to true instead of remove these objects.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},
@@ -479,7 +483,7 @@ func schema_pkg_apis_hco_v1beta1_OperandResourceRequirements(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ResourceRequirements is a list of resource requirements for the operand workloads pods",
+				Description: "OperandResourceRequirements is a list of resource requirements for the operand workloads pods",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"storageWorkloads": {
@@ -505,26 +509,30 @@ func schema_pkg_apis_hco_v1beta1_PciHostDevice(ref common.ReferenceCallback) com
 				Properties: map[string]spec.Schema{
 					"pciVendorSelector": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "a combination of a vendor_id:product_id required to identify a PCI device on a host.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"resourceName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "name by which a device is advertised and being requested",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"externalResourceProvider": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Description: "indicates that this resource is being provided by an external device plugin",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"disabled": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Description: "HCO enforces the existence of several PciHostDevice objects. Set disabled field to true instead of remove these objects.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/hco/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.openapi.go
@@ -552,7 +552,10 @@ func schema_pkg_apis_hco_v1beta1_PermittedHostDevices(ref common.ReferenceCallba
 					"pciHostDevices": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"pciVendorSelector",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -569,7 +572,10 @@ func schema_pkg_apis_hco_v1beta1_PermittedHostDevices(ref common.ReferenceCallba
 					"mediatedDevices": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"mdevNameSelector",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -1072,7 +1072,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 		FailurePolicy:           &failurePolicy,
 		TimeoutSeconds:          &webhookTimeout,
 		Rules: []admissionregistrationv1.RuleWithOperations{
-			admissionregistrationv1.RuleWithOperations{
+			{
 				Operations: []admissionregistrationv1.OperationType{
 					admissionregistrationv1.Create,
 					admissionregistrationv1.Delete,
@@ -1104,7 +1104,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 			MatchLabels: map[string]string{"name": params.Namespace},
 		},
 		Rules: []admissionregistrationv1.RuleWithOperations{
-			admissionregistrationv1.RuleWithOperations{
+			{
 				Operations: []admissionregistrationv1.OperationType{
 					admissionregistrationv1.Delete,
 				},
@@ -1116,6 +1116,37 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 			},
 		},
 		WebhookPath: &mutatingWebhookPath,
+	}
+
+	defaulterWebhookSideEffects := admissionregistrationv1.SideEffectClassNone
+	defalterWebhookPath := util.DefaulterWebhookPath
+
+	defalterWebhook := csvv1alpha1.WebhookDescription{
+		GenerateName:            util.HcoDefaulterWebhookNS,
+		Type:                    csvv1alpha1.MutatingAdmissionWebhook,
+		DeploymentName:          hcoWhDeploymentName,
+		ContainerPort:           util.WebhookPort,
+		AdmissionReviewVersions: []string{"v1beta1", "v1"},
+		SideEffects:             &defaulterWebhookSideEffects,
+		FailurePolicy:           &failurePolicy,
+		TimeoutSeconds:          &webhookTimeout,
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"name": params.Namespace},
+		},
+		Rules: []admissionregistrationv1.RuleWithOperations{
+			{
+				Operations: []admissionregistrationv1.OperationType{
+					admissionregistrationv1.Create,
+					admissionregistrationv1.Update,
+				},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{util.APIVersionGroup},
+					APIVersions: []string{util.APIVersionBeta},
+					Resources:   []string{"hyperconvergeds"},
+				},
+			},
+		},
+		WebhookPath: &defalterWebhookPath,
 	}
 
 	return &csvv1alpha1.ClusterServiceVersion{
@@ -1206,7 +1237,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 			// Skip this in favor of having a separate function to get
 			// the actual StrategyDetailsDeployment when merging CSVs
 			InstallStrategy:    csvv1alpha1.NamedInstallStrategy{},
-			WebhookDefinitions: []csvv1alpha1.WebhookDescription{validatingWebhook, mutatingWebhook},
+			WebhookDefinitions: []csvv1alpha1.WebhookDescription{validatingWebhook, mutatingWebhook, defalterWebhook},
 			CustomResourceDefinitions: csvv1alpha1.CustomResourceDefinitions{
 				Owned: []csvv1alpha1.CRDDescription{
 					{

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -1119,7 +1119,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 	}
 
 	defaulterWebhookSideEffects := admissionregistrationv1.SideEffectClassNone
-	defalterWebhookPath := util.DefaulterWebhookPath
+	defaulterWebhookPath := util.DefaulterWebhookPath
 
 	defalterWebhook := csvv1alpha1.WebhookDescription{
 		GenerateName:            util.HcoDefaulterWebhookNS,
@@ -1130,9 +1130,6 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 		SideEffects:             &defaulterWebhookSideEffects,
 		FailurePolicy:           &failurePolicy,
 		TimeoutSeconds:          &webhookTimeout,
-		ObjectSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{"name": params.Namespace},
-		},
 		Rules: []admissionregistrationv1.RuleWithOperations{
 			{
 				Operations: []admissionregistrationv1.OperationType{
@@ -1146,7 +1143,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 				},
 			},
 		},
-		WebhookPath: &defalterWebhookPath,
+		WebhookPath: &defaulterWebhookPath,
 	}
 
 	return &csvv1alpha1.ClusterServiceVersion{

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -333,11 +333,15 @@ func toKvPciHostDevices(hcoPciHostdevices []hcov1beta1.PciHostDevice) []kubevirt
 func toKvMediatedDevices(hcoMediatedDevices []hcov1beta1.MediatedHostDevice) []kubevirtv1.MediatedHostDevice {
 	if len(hcoMediatedDevices) > 0 {
 		mediatedDevices := make([]kubevirtv1.MediatedHostDevice, len(hcoMediatedDevices))
-		for i, hcoMediatedHostDevice := range hcoMediatedDevices {
-			mediatedDevices[i] = kubevirtv1.MediatedHostDevice{
-				MDEVNameSelector:         hcoMediatedHostDevice.MDEVNameSelector,
-				ResourceName:             hcoMediatedHostDevice.ResourceName,
-				ExternalResourceProvider: hcoMediatedHostDevice.ExternalResourceProvider,
+		i := 0
+		for _, hcoMediatedHostDevice := range hcoMediatedDevices {
+			if !hcoMediatedHostDevice.Disabled {
+				mediatedDevices[i] = kubevirtv1.MediatedHostDevice{
+					MDEVNameSelector:         hcoMediatedHostDevice.MDEVNameSelector,
+					ResourceName:             hcoMediatedHostDevice.ResourceName,
+					ExternalResourceProvider: hcoMediatedHostDevice.ExternalResourceProvider,
+				}
+				i++
 			}
 		}
 

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -316,12 +316,14 @@ func toKvPermittedHostDevices(permittedDevices *hcov1beta1.PermittedHostDevices)
 
 func toKvPciHostDevices(hcoPciHostdevices []hcov1beta1.PciHostDevice) []kubevirtv1.PciHostDevice {
 	if len(hcoPciHostdevices) > 0 {
-		pciHostDevices := make([]kubevirtv1.PciHostDevice, len(hcoPciHostdevices))
-		for i, hcoPciHostDevice := range hcoPciHostdevices {
-			pciHostDevices[i] = kubevirtv1.PciHostDevice{
-				PCIVendorSelector:        hcoPciHostDevice.PCIVendorSelector,
-				ResourceName:             hcoPciHostDevice.ResourceName,
-				ExternalResourceProvider: hcoPciHostDevice.ExternalResourceProvider,
+		pciHostDevices := make([]kubevirtv1.PciHostDevice, 0, len(hcoPciHostdevices))
+		for _, hcoPciHostDevice := range hcoPciHostdevices {
+			if !hcoPciHostDevice.Disabled {
+				pciHostDevices = append(pciHostDevices, kubevirtv1.PciHostDevice{
+					PCIVendorSelector:        hcoPciHostDevice.PCIVendorSelector,
+					ResourceName:             hcoPciHostDevice.ResourceName,
+					ExternalResourceProvider: hcoPciHostDevice.ExternalResourceProvider,
+				})
 			}
 		}
 
@@ -332,16 +334,14 @@ func toKvPciHostDevices(hcoPciHostdevices []hcov1beta1.PciHostDevice) []kubevirt
 
 func toKvMediatedDevices(hcoMediatedDevices []hcov1beta1.MediatedHostDevice) []kubevirtv1.MediatedHostDevice {
 	if len(hcoMediatedDevices) > 0 {
-		mediatedDevices := make([]kubevirtv1.MediatedHostDevice, len(hcoMediatedDevices))
-		i := 0
+		mediatedDevices := make([]kubevirtv1.MediatedHostDevice, 0, len(hcoMediatedDevices))
 		for _, hcoMediatedHostDevice := range hcoMediatedDevices {
 			if !hcoMediatedHostDevice.Disabled {
-				mediatedDevices[i] = kubevirtv1.MediatedHostDevice{
+				mediatedDevices = append(mediatedDevices, kubevirtv1.MediatedHostDevice{
 					MDEVNameSelector:         hcoMediatedHostDevice.MDEVNameSelector,
 					ResourceName:             hcoMediatedHostDevice.ResourceName,
 					ExternalResourceProvider: hcoMediatedHostDevice.ExternalResourceProvider,
-				}
-				i++
+				})
 			}
 		}
 

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -320,7 +320,7 @@ func toKvPciHostDevices(hcoPciHostdevices []hcov1beta1.PciHostDevice) []kubevirt
 		for _, hcoPciHostDevice := range hcoPciHostdevices {
 			if !hcoPciHostDevice.Disabled {
 				pciHostDevices = append(pciHostDevices, kubevirtv1.PciHostDevice{
-					PCIVendorSelector:        hcoPciHostDevice.PCIVendorSelector,
+					PCIVendorSelector:        hcoPciHostDevice.PCIDeviceSelector,
 					ResourceName:             hcoPciHostDevice.ResourceName,
 					ExternalResourceProvider: hcoPciHostDevice.ExternalResourceProvider,
 				})

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -428,23 +428,23 @@ Version: 1.2.3`)
 				hco.Spec.PermittedHostDevices = &hcov1beta1.PermittedHostDevices{
 					PciHostDevices: []hcov1beta1.PciHostDevice{
 						{
-							PCIVendorSelector:        "vendor1",
+							PCIDeviceSelector:        "vendor1",
 							ResourceName:             "resourceName1",
 							ExternalResourceProvider: true,
 						},
 						{
-							PCIVendorSelector:        "vendor2",
+							PCIDeviceSelector:        "vendor2",
 							ResourceName:             "resourceName2",
 							ExternalResourceProvider: false,
 						},
 						{
-							PCIVendorSelector:        "vendor3",
+							PCIDeviceSelector:        "vendor3",
 							ResourceName:             "resourceName3",
 							ExternalResourceProvider: true,
 							Disabled:                 false,
 						},
 						{
-							PCIVendorSelector:        "disabled4",
+							PCIDeviceSelector:        "disabled4",
 							ResourceName:             "disabled4",
 							ExternalResourceProvider: true,
 							Disabled:                 true,
@@ -591,23 +591,23 @@ Version: 1.2.3`)
 				hco.Spec.PermittedHostDevices = &hcov1beta1.PermittedHostDevices{
 					PciHostDevices: []hcov1beta1.PciHostDevice{
 						{
-							PCIVendorSelector:        "vendor1",
+							PCIDeviceSelector:        "vendor1",
 							ResourceName:             "resourceName1",
 							ExternalResourceProvider: true,
 						},
 						{
-							PCIVendorSelector:        "vendor2",
+							PCIDeviceSelector:        "vendor2",
 							ResourceName:             "resourceName2",
 							ExternalResourceProvider: false,
 						},
 						{
-							PCIVendorSelector:        "vendor3",
+							PCIDeviceSelector:        "vendor3",
 							ResourceName:             "resourceName3",
 							ExternalResourceProvider: true,
 							Disabled:                 false,
 						},
 						{
-							PCIVendorSelector:        "disabled4",
+							PCIDeviceSelector:        "disabled4",
 							ResourceName:             "disabled4",
 							ExternalResourceProvider: true,
 							Disabled:                 true,
@@ -2071,23 +2071,23 @@ Version: 1.2.3`)
 			hcoCopy := &hcov1beta1.PermittedHostDevices{
 				PciHostDevices: []hcov1beta1.PciHostDevice{
 					{
-						PCIVendorSelector:        "vendor1",
+						PCIDeviceSelector:        "vendor1",
 						ResourceName:             "resourceName1",
 						ExternalResourceProvider: true,
 					},
 					{
-						PCIVendorSelector:        "vendor2",
+						PCIDeviceSelector:        "vendor2",
 						ResourceName:             "resourceName2",
 						ExternalResourceProvider: false,
 					},
 					{
-						PCIVendorSelector:        "vendor3",
+						PCIDeviceSelector:        "vendor3",
 						ResourceName:             "resourceName3",
 						ExternalResourceProvider: true,
 						Disabled:                 false,
 					},
 					{
-						PCIVendorSelector:        "disabledSelector",
+						PCIDeviceSelector:        "disabledSelector",
 						ResourceName:             "disabledName",
 						ExternalResourceProvider: true,
 						Disabled:                 true,

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -420,204 +420,75 @@ Version: 1.2.3`)
 			Expect(*mc.ProgressTimeout).To(Equal(progressTimeout))
 		})
 
-		It("should propagate the permitted host devices configuration from the HC", func() {
-			existKv, err := NewKubeVirt(hco)
-			Expect(err).ToNot(HaveOccurred())
+		Context("test permitted host devices", func() {
+			It("should propagate the permitted host devices configuration from the HC", func() {
+				existKv, err := NewKubeVirt(hco)
+				Expect(err).ToNot(HaveOccurred())
 
-			hco.Spec.PermittedHostDevices = &hcov1beta1.PermittedHostDevices{
-				PciHostDevices: []hcov1beta1.PciHostDevice{
-					{
-						PCIVendorSelector:        "vendor1",
-						ResourceName:             "resourceName1",
-						ExternalResourceProvider: true,
+				hco.Spec.PermittedHostDevices = &hcov1beta1.PermittedHostDevices{
+					PciHostDevices: []hcov1beta1.PciHostDevice{
+						{
+							PCIVendorSelector:        "vendor1",
+							ResourceName:             "resourceName1",
+							ExternalResourceProvider: true,
+						},
+						{
+							PCIVendorSelector:        "vendor2",
+							ResourceName:             "resourceName2",
+							ExternalResourceProvider: false,
+						},
+						{
+							PCIVendorSelector:        "vendor3",
+							ResourceName:             "resourceName3",
+							ExternalResourceProvider: true,
+							Disabled:                 false,
+						},
+						{
+							PCIVendorSelector:        "disabled4",
+							ResourceName:             "disabled4",
+							ExternalResourceProvider: true,
+							Disabled:                 true,
+						},
 					},
-					{
-						PCIVendorSelector:        "vendor2",
-						ResourceName:             "resourceName2",
-						ExternalResourceProvider: false,
+					MediatedDevices: []hcov1beta1.MediatedHostDevice{
+						{
+							MDEVNameSelector:         "selector1",
+							ResourceName:             "resource1",
+							ExternalResourceProvider: true,
+						},
+						{
+							MDEVNameSelector:         "selector2",
+							ResourceName:             "resource2",
+							ExternalResourceProvider: false,
+						},
+						{
+							MDEVNameSelector:         "selector3",
+							ResourceName:             "resource3",
+							ExternalResourceProvider: true,
+						},
+						{
+							MDEVNameSelector:         "selector4",
+							ResourceName:             "resource4",
+							ExternalResourceProvider: false,
+							Disabled:                 false,
+						},
+						{
+							MDEVNameSelector:         "disabled5",
+							ResourceName:             "disabled5",
+							ExternalResourceProvider: false,
+							Disabled:                 true,
+						},
 					},
-					{
-						PCIVendorSelector:        "vendor3",
-						ResourceName:             "resourceName3",
-						ExternalResourceProvider: true,
-					},
-				},
-				MediatedDevices: []hcov1beta1.MediatedHostDevice{
-					{
-						MDEVNameSelector:         "selector1",
-						ResourceName:             "resource1",
-						ExternalResourceProvider: true,
-					},
-					{
-						MDEVNameSelector:         "selector2",
-						ResourceName:             "resource2",
-						ExternalResourceProvider: false,
-					},
-					{
-						MDEVNameSelector:         "selector3",
-						ResourceName:             "resource3",
-						ExternalResourceProvider: true,
-					},
-					{
-						MDEVNameSelector:         "selector4",
-						ResourceName:             "resource4",
-						ExternalResourceProvider: false,
-					},
-				},
-			}
+				}
 
-			cl := commonTestUtils.InitClient([]runtime.Object{hco, existKv})
-			handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
-			res := handler.ensure(req)
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existKv})
+				handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
+				res := handler.ensure(req)
 
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Updated).To(BeTrue())
-			Expect(res.Err).To(BeNil())
+				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.Updated).To(BeTrue())
+				Expect(res.Err).To(BeNil())
 
-			foundResource := &kubevirtv1.KubeVirt{}
-			Expect(
-				cl.Get(context.TODO(),
-					types.NamespacedName{Name: existKv.Name, Namespace: existKv.Namespace},
-					foundResource),
-			).To(BeNil())
-
-			phd := foundResource.Spec.Configuration.PermittedHostDevices
-			Expect(phd).ToNot(BeNil())
-			Expect(phd.PciHostDevices).To(HaveLen(3))
-			Expect(phd.PciHostDevices).To(ContainElements(
-				kubevirtv1.PciHostDevice{
-					PCIVendorSelector:        "vendor1",
-					ResourceName:             "resourceName1",
-					ExternalResourceProvider: true,
-				},
-				kubevirtv1.PciHostDevice{
-					PCIVendorSelector:        "vendor2",
-					ResourceName:             "resourceName2",
-					ExternalResourceProvider: false,
-				},
-				kubevirtv1.PciHostDevice{
-					PCIVendorSelector:        "vendor3",
-					ResourceName:             "resourceName3",
-					ExternalResourceProvider: true,
-				},
-			))
-
-			Expect(phd.MediatedDevices).To(HaveLen(4))
-			Expect(phd.MediatedDevices).To(ContainElements(
-				kubevirtv1.MediatedHostDevice{
-					MDEVNameSelector:         "selector1",
-					ResourceName:             "resource1",
-					ExternalResourceProvider: true,
-				},
-				kubevirtv1.MediatedHostDevice{
-					MDEVNameSelector:         "selector2",
-					ResourceName:             "resource2",
-					ExternalResourceProvider: false,
-				},
-				kubevirtv1.MediatedHostDevice{
-					MDEVNameSelector:         "selector3",
-					ResourceName:             "resource3",
-					ExternalResourceProvider: true,
-				},
-				kubevirtv1.MediatedHostDevice{
-					MDEVNameSelector:         "selector4",
-					ResourceName:             "resource4",
-					ExternalResourceProvider: false,
-				},
-			))
-		})
-
-		It("should update the permitted host devices configuration from the HC", func() {
-			existKv, err := NewKubeVirt(hco)
-			Expect(err).ToNot(HaveOccurred())
-
-			existKv.Spec.Configuration.PermittedHostDevices = &kubevirtv1.PermittedHostDevices{
-				PciHostDevices: []kubevirtv1.PciHostDevice{
-					{
-						PCIVendorSelector:        "other1",
-						ResourceName:             "otherResourceName1",
-						ExternalResourceProvider: true,
-					},
-					{
-						PCIVendorSelector:        "other2",
-						ResourceName:             "otherResourceName2",
-						ExternalResourceProvider: false,
-					},
-					{
-						PCIVendorSelector:        "other3",
-						ResourceName:             "otherResourceName3",
-						ExternalResourceProvider: true,
-					},
-					{
-						PCIVendorSelector:        "other4",
-						ResourceName:             "otherResourceName4",
-						ExternalResourceProvider: true,
-					},
-				},
-				MediatedDevices: []kubevirtv1.MediatedHostDevice{
-					{
-						MDEVNameSelector:         "otherSelector1",
-						ResourceName:             "otherResource1",
-						ExternalResourceProvider: false,
-					},
-					{
-						MDEVNameSelector:         "otherSelector2",
-						ResourceName:             "otherResource2",
-						ExternalResourceProvider: true,
-					},
-					{
-						MDEVNameSelector:         "otherSelector3",
-						ResourceName:             "otherResource3",
-						ExternalResourceProvider: true,
-					},
-				},
-			}
-
-			hco.Spec.PermittedHostDevices = &hcov1beta1.PermittedHostDevices{
-				PciHostDevices: []hcov1beta1.PciHostDevice{
-					{
-						PCIVendorSelector:        "vendor1",
-						ResourceName:             "resourceName1",
-						ExternalResourceProvider: true,
-					},
-					{
-						PCIVendorSelector:        "vendor2",
-						ResourceName:             "resourceName2",
-						ExternalResourceProvider: false,
-					},
-					{
-						PCIVendorSelector:        "vendor3",
-						ResourceName:             "resourceName3",
-						ExternalResourceProvider: true,
-					},
-				},
-				MediatedDevices: []hcov1beta1.MediatedHostDevice{
-					{
-						MDEVNameSelector:         "selector1",
-						ResourceName:             "resource1",
-						ExternalResourceProvider: true,
-					},
-					{
-						MDEVNameSelector:         "selector2",
-						ResourceName:             "resource2",
-						ExternalResourceProvider: false,
-					},
-					{
-						MDEVNameSelector:         "selector3",
-						ResourceName:             "resource3",
-						ExternalResourceProvider: true,
-					},
-					{
-						MDEVNameSelector:         "selector4",
-						ResourceName:             "resource4",
-						ExternalResourceProvider: false,
-					},
-				},
-			}
-
-			cl := commonTestUtils.InitClient([]runtime.Object{hco, existKv})
-
-			By("Check before reconciling", func() {
 				foundResource := &kubevirtv1.KubeVirt{}
 				Expect(
 					cl.Get(context.TODO(),
@@ -627,110 +498,269 @@ Version: 1.2.3`)
 
 				phd := foundResource.Spec.Configuration.PermittedHostDevices
 				Expect(phd).ToNot(BeNil())
-				Expect(phd.PciHostDevices).To(HaveLen(4))
+				Expect(phd.PciHostDevices).To(HaveLen(3))
 				Expect(phd.PciHostDevices).To(ContainElements(
 					kubevirtv1.PciHostDevice{
-						PCIVendorSelector:        "other1",
-						ResourceName:             "otherResourceName1",
+						PCIVendorSelector:        "vendor1",
+						ResourceName:             "resourceName1",
 						ExternalResourceProvider: true,
 					},
 					kubevirtv1.PciHostDevice{
-						PCIVendorSelector:        "other2",
-						ResourceName:             "otherResourceName2",
+						PCIVendorSelector:        "vendor2",
+						ResourceName:             "resourceName2",
 						ExternalResourceProvider: false,
 					},
 					kubevirtv1.PciHostDevice{
-						PCIVendorSelector:        "other3",
-						ResourceName:             "otherResourceName3",
-						ExternalResourceProvider: true,
-					},
-					kubevirtv1.PciHostDevice{
-						PCIVendorSelector:        "other4",
-						ResourceName:             "otherResourceName4",
+						PCIVendorSelector:        "vendor3",
+						ResourceName:             "resourceName3",
 						ExternalResourceProvider: true,
 					},
 				))
 
-				Expect(phd.MediatedDevices).To(HaveLen(3))
+				Expect(phd.MediatedDevices).To(HaveLen(4))
 				Expect(phd.MediatedDevices).To(ContainElements(
 					kubevirtv1.MediatedHostDevice{
-						MDEVNameSelector:         "otherSelector1",
-						ResourceName:             "otherResource1",
-						ExternalResourceProvider: false,
-					},
-					kubevirtv1.MediatedHostDevice{
-						MDEVNameSelector:         "otherSelector2",
-						ResourceName:             "otherResource2",
+						MDEVNameSelector:         "selector1",
+						ResourceName:             "resource1",
 						ExternalResourceProvider: true,
 					},
 					kubevirtv1.MediatedHostDevice{
-						MDEVNameSelector:         "otherSelector3",
-						ResourceName:             "otherResource3",
+						MDEVNameSelector:         "selector2",
+						ResourceName:             "resource2",
+						ExternalResourceProvider: false,
+					},
+					kubevirtv1.MediatedHostDevice{
+						MDEVNameSelector:         "selector3",
+						ResourceName:             "resource3",
+						ExternalResourceProvider: true,
+					},
+					kubevirtv1.MediatedHostDevice{
+						MDEVNameSelector:         "selector4",
+						ResourceName:             "resource4",
+						ExternalResourceProvider: false,
+					},
+				))
+			})
+
+			It("should update the permitted host devices configuration from the HC", func() {
+				existKv, err := NewKubeVirt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				existKv.Spec.Configuration.PermittedHostDevices = &kubevirtv1.PermittedHostDevices{
+					PciHostDevices: []kubevirtv1.PciHostDevice{
+						{
+							PCIVendorSelector:        "other1",
+							ResourceName:             "otherResourceName1",
+							ExternalResourceProvider: true,
+						},
+						{
+							PCIVendorSelector:        "other2",
+							ResourceName:             "otherResourceName2",
+							ExternalResourceProvider: false,
+						},
+						{
+							PCIVendorSelector:        "other3",
+							ResourceName:             "otherResourceName3",
+							ExternalResourceProvider: true,
+						},
+						{
+							PCIVendorSelector:        "other4",
+							ResourceName:             "otherResourceName4",
+							ExternalResourceProvider: true,
+						},
+					},
+					MediatedDevices: []kubevirtv1.MediatedHostDevice{
+						{
+							MDEVNameSelector:         "otherSelector1",
+							ResourceName:             "otherResource1",
+							ExternalResourceProvider: false,
+						},
+						{
+							MDEVNameSelector:         "otherSelector2",
+							ResourceName:             "otherResource2",
+							ExternalResourceProvider: true,
+						},
+						{
+							MDEVNameSelector:         "otherSelector3",
+							ResourceName:             "otherResource3",
+							ExternalResourceProvider: true,
+						},
+					},
+				}
+
+				hco.Spec.PermittedHostDevices = &hcov1beta1.PermittedHostDevices{
+					PciHostDevices: []hcov1beta1.PciHostDevice{
+						{
+							PCIVendorSelector:        "vendor1",
+							ResourceName:             "resourceName1",
+							ExternalResourceProvider: true,
+						},
+						{
+							PCIVendorSelector:        "vendor2",
+							ResourceName:             "resourceName2",
+							ExternalResourceProvider: false,
+						},
+						{
+							PCIVendorSelector:        "vendor3",
+							ResourceName:             "resourceName3",
+							ExternalResourceProvider: true,
+							Disabled:                 false,
+						},
+						{
+							PCIVendorSelector:        "disabled4",
+							ResourceName:             "disabled4",
+							ExternalResourceProvider: true,
+							Disabled:                 true,
+						},
+					},
+					MediatedDevices: []hcov1beta1.MediatedHostDevice{
+						{
+							MDEVNameSelector:         "selector1",
+							ResourceName:             "resource1",
+							ExternalResourceProvider: true,
+						},
+						{
+							MDEVNameSelector:         "selector2",
+							ResourceName:             "resource2",
+							ExternalResourceProvider: false,
+						},
+						{
+							MDEVNameSelector:         "selector3",
+							ResourceName:             "resource3",
+							ExternalResourceProvider: true,
+						},
+						{
+							MDEVNameSelector:         "selector4",
+							ResourceName:             "resource4",
+							ExternalResourceProvider: false,
+							Disabled:                 false,
+						},
+						{
+							MDEVNameSelector:         "disabled5",
+							ResourceName:             "disabled5",
+							ExternalResourceProvider: false,
+							Disabled:                 true,
+						},
+					},
+				}
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existKv})
+
+				By("Check before reconciling", func() {
+					foundResource := &kubevirtv1.KubeVirt{}
+					Expect(
+						cl.Get(context.TODO(),
+							types.NamespacedName{Name: existKv.Name, Namespace: existKv.Namespace},
+							foundResource),
+					).To(BeNil())
+
+					phd := foundResource.Spec.Configuration.PermittedHostDevices
+					Expect(phd).ToNot(BeNil())
+					Expect(phd.PciHostDevices).To(HaveLen(4))
+					Expect(phd.PciHostDevices).To(ContainElements(
+						kubevirtv1.PciHostDevice{
+							PCIVendorSelector:        "other1",
+							ResourceName:             "otherResourceName1",
+							ExternalResourceProvider: true,
+						},
+						kubevirtv1.PciHostDevice{
+							PCIVendorSelector:        "other2",
+							ResourceName:             "otherResourceName2",
+							ExternalResourceProvider: false,
+						},
+						kubevirtv1.PciHostDevice{
+							PCIVendorSelector:        "other3",
+							ResourceName:             "otherResourceName3",
+							ExternalResourceProvider: true,
+						},
+						kubevirtv1.PciHostDevice{
+							PCIVendorSelector:        "other4",
+							ResourceName:             "otherResourceName4",
+							ExternalResourceProvider: true,
+						},
+					))
+
+					Expect(phd.MediatedDevices).To(HaveLen(3))
+					Expect(phd.MediatedDevices).To(ContainElements(
+						kubevirtv1.MediatedHostDevice{
+							MDEVNameSelector:         "otherSelector1",
+							ResourceName:             "otherResource1",
+							ExternalResourceProvider: false,
+						},
+						kubevirtv1.MediatedHostDevice{
+							MDEVNameSelector:         "otherSelector2",
+							ResourceName:             "otherResource2",
+							ExternalResourceProvider: true,
+						},
+						kubevirtv1.MediatedHostDevice{
+							MDEVNameSelector:         "otherSelector3",
+							ResourceName:             "otherResource3",
+							ExternalResourceProvider: true,
+						},
+					))
+
+				})
+
+				handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
+				res := handler.ensure(req)
+
+				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.Updated).To(BeTrue())
+				Expect(res.Err).To(BeNil())
+
+				foundResource := &kubevirtv1.KubeVirt{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existKv.Name, Namespace: existKv.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				By("Check after reconcile")
+				phd := foundResource.Spec.Configuration.PermittedHostDevices
+				Expect(phd).ToNot(BeNil())
+				Expect(phd.PciHostDevices).To(HaveLen(3))
+				Expect(phd.PciHostDevices).To(ContainElements(
+					kubevirtv1.PciHostDevice{
+						PCIVendorSelector:        "vendor1",
+						ResourceName:             "resourceName1",
+						ExternalResourceProvider: true,
+					},
+					kubevirtv1.PciHostDevice{
+						PCIVendorSelector:        "vendor2",
+						ResourceName:             "resourceName2",
+						ExternalResourceProvider: false,
+					},
+					kubevirtv1.PciHostDevice{
+						PCIVendorSelector:        "vendor3",
+						ResourceName:             "resourceName3",
 						ExternalResourceProvider: true,
 					},
 				))
 
+				Expect(phd.MediatedDevices).To(HaveLen(4))
+				Expect(phd.MediatedDevices).To(ContainElements(
+					kubevirtv1.MediatedHostDevice{
+						MDEVNameSelector:         "selector1",
+						ResourceName:             "resource1",
+						ExternalResourceProvider: true,
+					},
+					kubevirtv1.MediatedHostDevice{
+						MDEVNameSelector:         "selector2",
+						ResourceName:             "resource2",
+						ExternalResourceProvider: false,
+					},
+					kubevirtv1.MediatedHostDevice{
+						MDEVNameSelector:         "selector3",
+						ResourceName:             "resource3",
+						ExternalResourceProvider: true,
+					},
+					kubevirtv1.MediatedHostDevice{
+						MDEVNameSelector:         "selector4",
+						ResourceName:             "resource4",
+						ExternalResourceProvider: false,
+					},
+				))
 			})
-
-			handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
-			res := handler.ensure(req)
-
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Updated).To(BeTrue())
-			Expect(res.Err).To(BeNil())
-
-			foundResource := &kubevirtv1.KubeVirt{}
-			Expect(
-				cl.Get(context.TODO(),
-					types.NamespacedName{Name: existKv.Name, Namespace: existKv.Namespace},
-					foundResource),
-			).To(BeNil())
-
-			By("Check after reconcile")
-			phd := foundResource.Spec.Configuration.PermittedHostDevices
-			Expect(phd).ToNot(BeNil())
-			Expect(phd.PciHostDevices).To(HaveLen(3))
-			Expect(phd.PciHostDevices).To(ContainElements(
-				kubevirtv1.PciHostDevice{
-					PCIVendorSelector:        "vendor1",
-					ResourceName:             "resourceName1",
-					ExternalResourceProvider: true,
-				},
-				kubevirtv1.PciHostDevice{
-					PCIVendorSelector:        "vendor2",
-					ResourceName:             "resourceName2",
-					ExternalResourceProvider: false,
-				},
-				kubevirtv1.PciHostDevice{
-					PCIVendorSelector:        "vendor3",
-					ResourceName:             "resourceName3",
-					ExternalResourceProvider: true,
-				},
-			))
-
-			Expect(phd.MediatedDevices).To(HaveLen(4))
-			Expect(phd.MediatedDevices).To(ContainElements(
-				kubevirtv1.MediatedHostDevice{
-					MDEVNameSelector:         "selector1",
-					ResourceName:             "resource1",
-					ExternalResourceProvider: true,
-				},
-				kubevirtv1.MediatedHostDevice{
-					MDEVNameSelector:         "selector2",
-					ResourceName:             "resource2",
-					ExternalResourceProvider: false,
-				},
-				kubevirtv1.MediatedHostDevice{
-					MDEVNameSelector:         "selector3",
-					ResourceName:             "resource3",
-					ExternalResourceProvider: true,
-				},
-				kubevirtv1.MediatedHostDevice{
-					MDEVNameSelector:         "selector4",
-					ResourceName:             "resource4",
-					ExternalResourceProvider: false,
-				},
-			))
 		})
 
 		Context("Test node placement", func() {
@@ -1656,19 +1686,19 @@ Version: 1.2.3`)
 			Expect(err).ToNot(HaveOccurred())
 			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
 			expectedResource.Status.Conditions = []kubevirtv1.KubeVirtCondition{
-				kubevirtv1.KubeVirtCondition{
+				{
 					Type:    kubevirtv1.KubeVirtConditionAvailable,
 					Status:  corev1.ConditionFalse,
 					Reason:  "Foo",
 					Message: "Bar",
 				},
-				kubevirtv1.KubeVirtCondition{
+				{
 					Type:    kubevirtv1.KubeVirtConditionProgressing,
 					Status:  corev1.ConditionTrue,
 					Reason:  "Foo",
 					Message: "Bar",
 				},
-				kubevirtv1.KubeVirtCondition{
+				{
 					Type:    kubevirtv1.KubeVirtConditionDegraded,
 					Status:  corev1.ConditionTrue,
 					Reason:  "Foo",
@@ -2054,6 +2084,13 @@ Version: 1.2.3`)
 						PCIVendorSelector:        "vendor3",
 						ResourceName:             "resourceName3",
 						ExternalResourceProvider: true,
+						Disabled:                 false,
+					},
+					{
+						PCIVendorSelector:        "disabledSelector",
+						ResourceName:             "disabledName",
+						ExternalResourceProvider: true,
+						Disabled:                 true,
 					},
 				},
 				MediatedDevices: []hcov1beta1.MediatedHostDevice{
@@ -2076,6 +2113,13 @@ Version: 1.2.3`)
 						MDEVNameSelector:         "selector4",
 						ResourceName:             "resource4",
 						ExternalResourceProvider: false,
+						Disabled:                 false,
+					},
+					{
+						MDEVNameSelector:         "disabledSelector",
+						ResourceName:             "disabledName",
+						ExternalResourceProvider: false,
+						Disabled:                 true,
 					},
 				},
 			}

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -17,6 +17,7 @@ const (
 	VMImportEnvV           = "VM_IMPORT_VERSION"
 	HcoValidatingWebhook   = "validate-hco.kubevirt.io"
 	HcoMutatingWebhookNS   = "mutate-ns-hco.kubevirt.io"
+	HcoDefaulterWebhookNS  = "defualter-hco.kubevirt.io"
 	AppLabel               = "app"
 	UndefinedNamespace     = ""
 	OpenshiftNamespace     = "openshift"
@@ -50,6 +51,7 @@ const (
 	LivenessEndpointName        = "/livez"
 	HCOWebhookPath              = "/validate-hco-kubevirt-io-v1beta1-hyperconverged"
 	HCONSWebhookPath            = "/mutate-ns-hco-kubevirt-io"
+	DefaulterWebhookPath        = "/mutate-hco-kubevirt-io-v1beta1-hyperconverged"
 	WebhookPort                 = 4343
 )
 

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -17,7 +17,7 @@ const (
 	VMImportEnvV           = "VM_IMPORT_VERSION"
 	HcoValidatingWebhook   = "validate-hco.kubevirt.io"
 	HcoMutatingWebhookNS   = "mutate-ns-hco.kubevirt.io"
-	HcoDefaulterWebhookNS  = "defualter-hco.kubevirt.io"
+	HcoDefaulterWebhookNS  = "defaulter-hco.kubevirt.io"
 	AppLabel               = "app"
 	UndefinedNamespace     = ""
 	OpenshiftNamespace     = "openshift"

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -53,10 +53,6 @@ func (wh WebhookHandler) ValidateCreate(hc *v1beta1.HyperConverged) error {
 		return fmt.Errorf("invalid namespace for v1beta1.HyperConverged - please use the %s namespace", wh.namespace)
 	}
 
-	if err := validatePermittedHostDevices(hc.Spec.PermittedHostDevices); err != nil {
-		return err
-	}
-
 	if _, err := operands.NewKubeVirt(hc); err != nil {
 		return err
 	}
@@ -83,10 +79,6 @@ func (wh WebhookHandler) ValidateUpdate(requested *v1beta1.HyperConverged, exist
 	if reflect.DeepEqual(exists.Spec, requested.Spec) &&
 		reflect.DeepEqual(exists.Annotations, requested.Annotations) {
 		return nil
-	}
-
-	if err := validatePermittedHostDevices(requested.Spec.PermittedHostDevices); err != nil {
-		return err
 	}
 
 	if err := wh.validateCertConfig(requested); err != nil {
@@ -289,48 +281,6 @@ func (wh WebhookHandler) validateCertConfig(hc *v1beta1.HyperConverged) error {
 
 	if hc.Spec.CertConfig.CA.Duration.Duration < hc.Spec.CertConfig.Server.Duration.Duration {
 		return errors.New("spec.certConfig: ca.duration is smaller than server.duration")
-	}
-
-	return nil
-}
-
-func validatePermittedHostDevices(phds *v1beta1.PermittedHostDevices) error {
-	if phds == nil {
-		return nil
-	}
-
-	if err := validatePciHostDevices(phds.PciHostDevices); err != nil {
-		return err
-	}
-
-	if err := validateMediatedHostDevices(phds.MediatedDevices); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Allow only one instance from each PCI host device
-func validatePciHostDevices(list []v1beta1.PciHostDevice) error {
-	found := make(map[string]bool)
-	for _, device := range list {
-		if found[device.PCIVendorSelector] {
-			return fmt.Errorf("%s pci host device is already exist", device.PCIVendorSelector)
-		}
-		found[device.PCIVendorSelector] = true
-	}
-
-	return nil
-}
-
-// Allow only one instance from each Mediated host device
-func validateMediatedHostDevices(list []v1beta1.MediatedHostDevice) error {
-	found := make(map[string]bool)
-	for _, device := range list {
-		if found[device.MDEVNameSelector] {
-			return fmt.Errorf("%s mediate host device is already exist", device.MDEVNameSelector)
-		}
-		found[device.MDEVNameSelector] = true
 	}
 
 	return nil

--- a/pkg/webhooks/webhooks_test.go
+++ b/pkg/webhooks/webhooks_test.go
@@ -173,15 +173,15 @@ var _ = Describe("webhooks handler", func() {
 				cr.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
 					PciHostDevices: []v1beta1.PciHostDevice{
 						{
-							PCIVendorSelector: "111",
+							PCIDeviceSelector: "111",
 							ResourceName:      "name",
 						},
 						{
-							PCIVendorSelector: "222",
+							PCIDeviceSelector: "222",
 							ResourceName:      "name",
 						},
 						{
-							PCIVendorSelector: "333",
+							PCIDeviceSelector: "333",
 							ResourceName:      "name",
 						},
 					},
@@ -466,15 +466,15 @@ var _ = Describe("webhooks handler", func() {
 				newHco.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
 					PciHostDevices: []v1beta1.PciHostDevice{
 						{
-							PCIVendorSelector: "111",
+							PCIDeviceSelector: "111",
 							ResourceName:      "name",
 						},
 						{
-							PCIVendorSelector: "222",
+							PCIDeviceSelector: "222",
 							ResourceName:      "name",
 						},
 						{
-							PCIVendorSelector: "333",
+							PCIDeviceSelector: "333",
 							ResourceName:      "name",
 						},
 					},

--- a/pkg/webhooks/webhooks_test.go
+++ b/pkg/webhooks/webhooks_test.go
@@ -190,27 +190,6 @@ var _ = Describe("webhooks handler", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("should reject non-unique PCI Host Device", func() {
-				cr.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
-					PciHostDevices: []v1beta1.PciHostDevice{
-						{
-							PCIVendorSelector: "non-unique",
-							ResourceName:      "name",
-						},
-						{
-							PCIVendorSelector: "222",
-							ResourceName:      "name",
-						},
-						{
-							PCIVendorSelector: "non-unique",
-							ResourceName:      "name",
-						},
-					},
-				}
-				err := wh.ValidateCreate(cr)
-				Expect(err).To(HaveOccurred())
-			})
-
 			It("should allow unique Mediate Host Device", func() {
 				cr.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
 					MediatedDevices: []v1beta1.MediatedHostDevice{
@@ -230,27 +209,6 @@ var _ = Describe("webhooks handler", func() {
 				}
 				err := wh.ValidateCreate(cr)
 				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("should reject non-unique Mediate Host Device", func() {
-				cr.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
-					MediatedDevices: []v1beta1.MediatedHostDevice{
-						{
-							MDEVNameSelector: "non-unique",
-							ResourceName:     "name",
-						},
-						{
-							MDEVNameSelector: "222",
-							ResourceName:     "name",
-						},
-						{
-							MDEVNameSelector: "non-unique",
-							ResourceName:     "name",
-						},
-					},
-				}
-				err := wh.ValidateCreate(cr)
-				Expect(err).To(HaveOccurred())
 			})
 		})
 	})
@@ -524,32 +482,6 @@ var _ = Describe("webhooks handler", func() {
 				Expect(wh.ValidateUpdate(newHco, hco)).ToNot(HaveOccurred())
 			})
 
-			It("should reject non-unique PCI Host Device", func() {
-				cli := getFakeClient(hco)
-				wh := &WebhookHandler{}
-				wh.Init(logger, cli, HcoValidNamespace, true)
-
-				newHco := &v1beta1.HyperConverged{}
-				hco.DeepCopyInto(newHco)
-				newHco.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
-					PciHostDevices: []v1beta1.PciHostDevice{
-						{
-							PCIVendorSelector: "non-unique",
-							ResourceName:      "name",
-						},
-						{
-							PCIVendorSelector: "222",
-							ResourceName:      "name",
-						},
-						{
-							PCIVendorSelector: "non-unique",
-							ResourceName:      "name",
-						},
-					},
-				}
-				Expect(wh.ValidateUpdate(newHco, hco)).To(HaveOccurred())
-			})
-
 			It("should allow unique Mediate Host Device", func() {
 				cli := getFakeClient(hco)
 				wh := &WebhookHandler{}
@@ -574,32 +506,6 @@ var _ = Describe("webhooks handler", func() {
 					},
 				}
 				Expect(wh.ValidateUpdate(newHco, hco)).ToNot(HaveOccurred())
-			})
-
-			It("should reject non-unique Mediate Host Device", func() {
-				cli := getFakeClient(hco)
-				wh := &WebhookHandler{}
-				wh.Init(logger, cli, HcoValidNamespace, true)
-
-				newHco := &v1beta1.HyperConverged{}
-				hco.DeepCopyInto(newHco)
-				newHco.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
-					MediatedDevices: []v1beta1.MediatedHostDevice{
-						{
-							MDEVNameSelector: "non-unique",
-							ResourceName:     "name",
-						},
-						{
-							MDEVNameSelector: "222",
-							ResourceName:     "name",
-						},
-						{
-							MDEVNameSelector: "non-unique",
-							ResourceName:     "name",
-						},
-					},
-				}
-				Expect(wh.ValidateUpdate(newHco, hco)).To(HaveOccurred())
 			})
 		})
 

--- a/pkg/webhooks/webhooks_test.go
+++ b/pkg/webhooks/webhooks_test.go
@@ -167,6 +167,92 @@ var _ = Describe("webhooks handler", func() {
 			err := wh.ValidateCreate(cr)
 			Expect(err).To(HaveOccurred())
 		})
+
+		Context("test permitted host devices validation", func() {
+			It("should allow unique PCI Host Device", func() {
+				cr.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
+					PciHostDevices: []v1beta1.PciHostDevice{
+						{
+							PCIVendorSelector: "111",
+							ResourceName:      "name",
+						},
+						{
+							PCIVendorSelector: "222",
+							ResourceName:      "name",
+						},
+						{
+							PCIVendorSelector: "333",
+							ResourceName:      "name",
+						},
+					},
+				}
+				err := wh.ValidateCreate(cr)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should reject non-unique PCI Host Device", func() {
+				cr.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
+					PciHostDevices: []v1beta1.PciHostDevice{
+						{
+							PCIVendorSelector: "non-unique",
+							ResourceName:      "name",
+						},
+						{
+							PCIVendorSelector: "222",
+							ResourceName:      "name",
+						},
+						{
+							PCIVendorSelector: "non-unique",
+							ResourceName:      "name",
+						},
+					},
+				}
+				err := wh.ValidateCreate(cr)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow unique Mediate Host Device", func() {
+				cr.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
+					MediatedDevices: []v1beta1.MediatedHostDevice{
+						{
+							MDEVNameSelector: "111",
+							ResourceName:     "name",
+						},
+						{
+							MDEVNameSelector: "222",
+							ResourceName:     "name",
+						},
+						{
+							MDEVNameSelector: "333",
+							ResourceName:     "name",
+						},
+					},
+				}
+				err := wh.ValidateCreate(cr)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should reject non-unique Mediate Host Device", func() {
+				cr.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
+					MediatedDevices: []v1beta1.MediatedHostDevice{
+						{
+							MDEVNameSelector: "non-unique",
+							ResourceName:     "name",
+						},
+						{
+							MDEVNameSelector: "222",
+							ResourceName:     "name",
+						},
+						{
+							MDEVNameSelector: "non-unique",
+							ResourceName:     "name",
+						},
+					},
+				}
+				err := wh.ValidateCreate(cr)
+				Expect(err).To(HaveOccurred())
+			})
+		})
 	})
 
 	Context("validate update validation webhook", func() {
@@ -408,6 +494,113 @@ var _ = Describe("webhooks handler", func() {
 			hco.DeepCopyInto(newHco)
 
 			Expect(wh.ValidateUpdate(newHco, hco)).ToNot(HaveOccurred())
+
+		})
+
+		Context("test permitted host devices update validation", func() {
+			It("should allow unique PCI Host Device", func() {
+				cli := getFakeClient(hco)
+				wh := &WebhookHandler{}
+				wh.Init(logger, cli, HcoValidNamespace, true)
+
+				newHco := &v1beta1.HyperConverged{}
+				hco.DeepCopyInto(newHco)
+				newHco.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
+					PciHostDevices: []v1beta1.PciHostDevice{
+						{
+							PCIVendorSelector: "111",
+							ResourceName:      "name",
+						},
+						{
+							PCIVendorSelector: "222",
+							ResourceName:      "name",
+						},
+						{
+							PCIVendorSelector: "333",
+							ResourceName:      "name",
+						},
+					},
+				}
+				Expect(wh.ValidateUpdate(newHco, hco)).ToNot(HaveOccurred())
+			})
+
+			It("should reject non-unique PCI Host Device", func() {
+				cli := getFakeClient(hco)
+				wh := &WebhookHandler{}
+				wh.Init(logger, cli, HcoValidNamespace, true)
+
+				newHco := &v1beta1.HyperConverged{}
+				hco.DeepCopyInto(newHco)
+				newHco.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
+					PciHostDevices: []v1beta1.PciHostDevice{
+						{
+							PCIVendorSelector: "non-unique",
+							ResourceName:      "name",
+						},
+						{
+							PCIVendorSelector: "222",
+							ResourceName:      "name",
+						},
+						{
+							PCIVendorSelector: "non-unique",
+							ResourceName:      "name",
+						},
+					},
+				}
+				Expect(wh.ValidateUpdate(newHco, hco)).To(HaveOccurred())
+			})
+
+			It("should allow unique Mediate Host Device", func() {
+				cli := getFakeClient(hco)
+				wh := &WebhookHandler{}
+				wh.Init(logger, cli, HcoValidNamespace, true)
+
+				newHco := &v1beta1.HyperConverged{}
+				hco.DeepCopyInto(newHco)
+				newHco.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
+					MediatedDevices: []v1beta1.MediatedHostDevice{
+						{
+							MDEVNameSelector: "111",
+							ResourceName:     "name",
+						},
+						{
+							MDEVNameSelector: "222",
+							ResourceName:     "name",
+						},
+						{
+							MDEVNameSelector: "333",
+							ResourceName:     "name",
+						},
+					},
+				}
+				Expect(wh.ValidateUpdate(newHco, hco)).ToNot(HaveOccurred())
+			})
+
+			It("should reject non-unique Mediate Host Device", func() {
+				cli := getFakeClient(hco)
+				wh := &WebhookHandler{}
+				wh.Init(logger, cli, HcoValidNamespace, true)
+
+				newHco := &v1beta1.HyperConverged{}
+				hco.DeepCopyInto(newHco)
+				newHco.Spec.PermittedHostDevices = &v1beta1.PermittedHostDevices{
+					MediatedDevices: []v1beta1.MediatedHostDevice{
+						{
+							MDEVNameSelector: "non-unique",
+							ResourceName:     "name",
+						},
+						{
+							MDEVNameSelector: "222",
+							ResourceName:     "name",
+						},
+						{
+							MDEVNameSelector: "non-unique",
+							ResourceName:     "name",
+						},
+					},
+				}
+				Expect(wh.ValidateUpdate(newHco, hco)).To(HaveOccurred())
+			})
 		})
 
 		Context("plain-k8s tests", func() {

--- a/tests/build/Dockerfile
+++ b/tests/build/Dockerfile
@@ -6,7 +6,7 @@ RUN echo "diskspacecheck=0" >> /etc/dnf/dnf.conf && dnf update -y && dnf install
 
 RUN pip3 install j2cli && pip3 install operator-courier
 
-ENV GIMME_GO_VERSION=1.15.2 \
+ENV GIMME_GO_VERSION=1.15.11 \
     KUBEBUILDER_VERSION="2.3.1" \
     ARCH="amd64" \
     GOPATH="/go" \


### PR DESCRIPTION
Enforce default values for the `spec.permittedHostDevices` HyperConverged field, by implementing the defaulter webhook.

The default values are:
```yaml
  permittedHostDevices:
    pciHostDevices:
    - pciVendorSelector: 10DE:1DB6
      resourceName: nvidia.com/GV100GL_Tesla_V100
    - pciVendorSelector: 10DE:1EB8
      resourceName: nvidia.com/TU104GL_Tesla_T4
```

In order to support future upgrade, when HCO can't know if a default is missing or removed, especially if the default values are changed, this PR also add the `disabled` boolean field to the `PciHostDevice` type. The defaulter webhook enforces the existence of the above PciHostDevices, but won't change the `disabled` field. If the `disabled` field is true, HCO won't propagate this host device to KubeVirt CR. for example, in this case, only the nvidia.com/TU104GL_Tesla_T4 is propagated to the KubeVirt CR:
```yaml
  permittedHostDevices:
    pciHostDevices:
    - pciVendorSelector: 10DE:1DB6
      resourceName: nvidia.com/GV100GL_Tesla_V100
      disabled: true
    - pciVendorSelector: 10DE:1EB8
      resourceName: nvidia.com/TU104GL_Tesla_T4
```

***NOTE:*** "old" upgrade tests (not index-image tests) can't pass and will fail, because the CSV used to deploy the old version is the new one - with the new webhook definition - that is not implemented in the old version.

This issue is solved in the new (index image) upgrade tests.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enforce the nvidia.com/GV100GL_Tesla_V100 and the nvidia.com/TU104GL_Tesla_T4 PCI host devices. Add the disabled field to the pciHostDevice object, in order to prevent their propagation to the KubeVirt CR.
```

