### PR TITLE
Make deploy/kustomize compatible with kustomize v3

### DIFF
--- a/deploy/kustomize/base/hco_cr.yaml
+++ b/deploy/kustomize/base/hco_cr.yaml
@@ -2,5 +2,4 @@ apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: kubevirt-hyperconverged
 spec: {}

--- a/deploy/kustomize/base/kustomization.yaml
+++ b/deploy/kustomize/base/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kubevirt-hyperconverged
 
 resources:
   - operator_group.yaml

--- a/deploy/kustomize/base/operator_group.yaml
+++ b/deploy/kustomize/base/operator_group.yaml
@@ -2,5 +2,4 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: kubevirt-hyperconverged-group
-  namespace: kubevirt-hyperconverged
 spec: {}

--- a/deploy/kustomize/base/subscription.yaml
+++ b/deploy/kustomize/base/subscription.yaml
@@ -2,7 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: hco-operatorhub
-  namespace: kubevirt-hyperconverged
 spec:
   source: kubevirt-hyperconverged
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Specify the namespace in the base kustomization.yml
but not in the base resources so that can be kustomized
by patches that don't specify the same namespace.

The kustomize version shipped with kubectl has been
recently updated, see: https://github.com/kubernetes/kubectl/issues/818

This introduces an incompatibility when we try to apply
a patch that doesn't specify a namespace to a base
obejct that instead specifies it.

The simplest option to have it working at the same time
with kustomize 2.y and 3.y seems to set the namespace
only on the base kustomization.yml but not on the
base resources.
See:
https://github.com/kubernetes-sigs/kustomize/issues/1351

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make deploy/kustomize compatible with kustomize v3
```

