### PR TITLE
Increase the initialDelay for the liveness probe

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -1853,12 +1853,12 @@ spec:
                 image: +IMAGE_TO_REPLACE+
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
-                  failureThreshold: 1
+                  failureThreshold: 3
                   httpGet:
                     path: /livez
                     port: 6060
                     scheme: HTTP
-                  initialDelaySeconds: 5
+                  initialDelaySeconds: 10
                   periodSeconds: 5
                 name: hyperconverged-cluster-operator
                 readinessProbe:
@@ -1916,12 +1916,12 @@ spec:
                 image: +WEBHOOK_IMAGE_TO_REPLACE+
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
-                  failureThreshold: 1
+                  failureThreshold: 3
                   httpGet:
                     path: /livez
                     port: 6060
                     scheme: HTTP
-                  initialDelaySeconds: 5
+                  initialDelaySeconds: 10
                   periodSeconds: 5
                 name: hyperconverged-cluster-webhook
                 readinessProbe:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
-    createdAt: "2021-05-04 09:24:56"
+    createdAt: "2021-05-06 14:09:31"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -1853,12 +1853,12 @@ spec:
                 image: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
-                  failureThreshold: 1
+                  failureThreshold: 3
                   httpGet:
                     path: /livez
                     port: 6060
                     scheme: HTTP
-                  initialDelaySeconds: 5
+                  initialDelaySeconds: 10
                   periodSeconds: 5
                 name: hyperconverged-cluster-operator
                 readinessProbe:
@@ -1916,12 +1916,12 @@ spec:
                 image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.5.0-unstable
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
-                  failureThreshold: 1
+                  failureThreshold: 3
                   httpGet:
                     path: /livez
                     port: 6060
                     scheme: HTTP
-                  initialDelaySeconds: 5
+                  initialDelaySeconds: 10
                   periodSeconds: 5
                 name: hyperconverged-cluster-webhook
                 readinessProbe:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -74,12 +74,12 @@ spec:
         image: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 1
+          failureThreshold: 3
           httpGet:
             path: /livez
             port: 6060
             scheme: HTTP
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
         name: hyperconverged-cluster-operator
         readinessProbe:
@@ -139,12 +139,12 @@ spec:
         image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.5.0-unstable
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 1
+          failureThreshold: 3
           httpGet:
             path: /livez
             port: 6060
             scheme: HTTP
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
         name: hyperconverged-cluster-webhook
         readinessProbe:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -178,9 +178,9 @@ func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.Deployme
 									Scheme: corev1.URISchemeHTTP,
 								},
 							},
-							InitialDelaySeconds: 5,
+							InitialDelaySeconds: 10,
 							PeriodSeconds:       5,
-							FailureThreshold:    1,
+							FailureThreshold:    3,
 						},
 						Env: append([]corev1.EnvVar{
 							{
@@ -354,9 +354,9 @@ func GetDeploymentSpecWebhook(namespace, image, imagePullPolicy, hcoKvIoVersion 
 									Scheme: corev1.URISchemeHTTP,
 								},
 							},
-							InitialDelaySeconds: 5,
+							InitialDelaySeconds: 10,
 							PeriodSeconds:       5,
-							FailureThreshold:    1,
+							FailureThreshold:    3,
 						},
 						Env: append([]corev1.EnvVar{
 							{


### PR DESCRIPTION
The current value for initialDelaySeconds is 5
seconds for both the readiness and liveness probes
so the first checks are going to be executed 5
seconds after the containers (operator and webhook)
have started.
failureThreshold is currently set to 1 so the first
failure will restart the container and this can
potentially cause an endless loop on really overloaded
clusters where our containers are consantly not able
to become live withing 5 seconds.

I'm increasing the initialDelaySeconds for the
livenessProbe to 10 seconds to maintain a certain
responsiveness but raising failureThreshold to 3
so that the pod will not be restarted
during its first 30 seconds.

I'm not going to touch the parameters for the
readinessProbe because it's the mechanism that
we are currently using to report back our status
to the OLM and this can potentially have
side effects.

Fixes: https://bugzilla.redhat.com/1956993

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increase the initialDelay for the liveness probe
```

