### PR TITLE
Fix initialDelay for the liveness probe

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -1853,12 +1853,12 @@ spec:
                 image: +IMAGE_TO_REPLACE+
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
-                  failureThreshold: 3
+                  failureThreshold: 1
                   httpGet:
                     path: /livez
                     port: 6060
                     scheme: HTTP
-                  initialDelaySeconds: 10
+                  initialDelaySeconds: 30
                   periodSeconds: 5
                 name: hyperconverged-cluster-operator
                 readinessProbe:
@@ -1916,12 +1916,12 @@ spec:
                 image: +WEBHOOK_IMAGE_TO_REPLACE+
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
-                  failureThreshold: 3
+                  failureThreshold: 1
                   httpGet:
                     path: /livez
                     port: 6060
                     scheme: HTTP
-                  initialDelaySeconds: 10
+                  initialDelaySeconds: 30
                   periodSeconds: 5
                 name: hyperconverged-cluster-webhook
                 readinessProbe:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
-    createdAt: "2021-05-07 09:38:48"
+    createdAt: "2021-05-10 14:30:01"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -1853,12 +1853,12 @@ spec:
                 image: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
-                  failureThreshold: 3
+                  failureThreshold: 1
                   httpGet:
                     path: /livez
                     port: 6060
                     scheme: HTTP
-                  initialDelaySeconds: 10
+                  initialDelaySeconds: 30
                   periodSeconds: 5
                 name: hyperconverged-cluster-operator
                 readinessProbe:
@@ -1916,12 +1916,12 @@ spec:
                 image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.5.0-unstable
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
-                  failureThreshold: 3
+                  failureThreshold: 1
                   httpGet:
                     path: /livez
                     port: 6060
                     scheme: HTTP
-                  initialDelaySeconds: 10
+                  initialDelaySeconds: 30
                   periodSeconds: 5
                 name: hyperconverged-cluster-webhook
                 readinessProbe:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -74,12 +74,12 @@ spec:
         image: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 3
+          failureThreshold: 1
           httpGet:
             path: /livez
             port: 6060
             scheme: HTTP
-          initialDelaySeconds: 10
+          initialDelaySeconds: 30
           periodSeconds: 5
         name: hyperconverged-cluster-operator
         readinessProbe:
@@ -139,12 +139,12 @@ spec:
         image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.5.0-unstable
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 3
+          failureThreshold: 1
           httpGet:
             path: /livez
             port: 6060
             scheme: HTTP
-          initialDelaySeconds: 10
+          initialDelaySeconds: 30
           periodSeconds: 5
         name: hyperconverged-cluster-webhook
         readinessProbe:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -178,9 +178,9 @@ func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.Deployme
 									Scheme: corev1.URISchemeHTTP,
 								},
 							},
-							InitialDelaySeconds: 10,
+							InitialDelaySeconds: 30,
 							PeriodSeconds:       5,
-							FailureThreshold:    3,
+							FailureThreshold:    1,
 						},
 						Env: append([]corev1.EnvVar{
 							{
@@ -354,9 +354,9 @@ func GetDeploymentSpecWebhook(namespace, image, imagePullPolicy, hcoKvIoVersion 
 									Scheme: corev1.URISchemeHTTP,
 								},
 							},
-							InitialDelaySeconds: 10,
+							InitialDelaySeconds: 30,
 							PeriodSeconds:       5,
-							FailureThreshold:    3,
+							FailureThreshold:    1,
 						},
 						Env: append([]corev1.EnvVar{
 							{


### PR DESCRIPTION
We recently merged #1325 but after further
investigation it come out that the exact formula
is:
time = initialDelaySeconds + (failureThreshold - 1)*periodSeconds
+ timeoutSeconds

so let's set now initialDelaySeconds=30 and failureThreshold=1 to
really get the result we aim for.

Fixes: https://bugzilla.redhat.com/1956993

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [x] PR Message
- [x] Commit Messages
- [x] How to test
- [x] Unit Tests
- [x] Functional Tests
- [x] User Documentation
- [x] Developer Documentation
- [x] Upgrade Scenario
- [x] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly
  
**Release note**:
```release-note
Fix initialDelay for the liveness probe
```

