### PR TITLE
Add a statement to clarify checklist in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 **Reviewer Checklist**
 <!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->
 
+> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 
+
 - [ ] PR Message
 - [ ] Commit Messages
 - [ ] How to test


### PR DESCRIPTION
Signed-off-by: Erkan Erol eerol@redhat.com

Improvement for this feedback: It is not clear whether we should check an item or leave it when the PR is not applicable for an aspect.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

- [x] PR Message
- [x] Commit Messages
- [x] How to test
- [x] Unit Tests
- [x] Functional Tests
- [x] User Documentation
- [x] Developer Documentation
- [x] Upgrade Scenario
- [x] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly
  
**Release note**:
```release-note
NONE
```

