### PR TITLE
test upgrade with a real config map

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_suite_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_suite_test.go
@@ -1,13 +1,30 @@
-package hyperconverged_test
+package hyperconverged
 
 import (
+	"os"
+	"path"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
+const (
+	pkgDirectory = "pkg/controller/hyperconverged"
+	testFilesLoc = "test-files"
+)
+
 func TestHyperconverged(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Hyperconverged Suite")
+}
+
+func getTestFilesLocation() string {
+	wd, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred())
+	if strings.HasSuffix(wd, pkgDirectory) {
+		return testFilesLoc
+	}
+	return path.Join(pkgDirectory, testFilesLoc)
 }

--- a/pkg/controller/hyperconverged/test-files/kubevirt-config.yaml
+++ b/pkg/controller/hyperconverged/test-files/kubevirt-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+data:
+  default-network-interface: masquerade
+  feature-gates: DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Snapshot,dummy,dummy
+  machine-type: pc-q35-rhel8.3.0
+  migrations: |-
+    parallelMigrationsPerCluster: 3
+    bandwidthPerMigration: 32Mi
+    completionTimeoutPerGiB: 444
+  selinuxLauncherType: virt_launcher.process
+  smbios: |-
+    Family: Red Hat
+    Product: Container-native virtualization
+    Manufacturer: Red Hat
+    Sku: 2.6.2
+    Version: 2.6.2
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2021-05-18T21:31:20Z"
+  labels:
+    app: kubevirt-hyperconverged
+  name: kubevirt-config
+  namespace: kubevirt-hyperconverged
+  resourceVersion: "307882"
+  uid: 660c2339-e981-496a-8527-7a621e82bcd3


### PR DESCRIPTION
Add unit test to check the kubevirt-config configMap adoption with a real yaml file.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [x] PR Message
- [x] Commit Messages
- [x] How to test
- [x] Unit Tests
- [x] Functional Tests
- [x] User Documentation
- [x] Developer Documentation
- [x] Upgrade Scenario
- [x] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

