### PR TITLE
[release-1.4] Fix a bug in adopting the kubevirt-config CM

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_suite_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_suite_test.go
@@ -1,13 +1,30 @@
-package hyperconverged_test
+package hyperconverged
 
 import (
+	"os"
+	"path"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
+const (
+	pkgDirectory = "pkg/controller/hyperconverged"
+	testFilesLoc = "test-files"
+)
+
 func TestHyperconverged(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Hyperconverged Suite")
+}
+
+func getTestFilesLocation() string {
+	wd, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred())
+	if strings.HasSuffix(wd, pkgDirectory) {
+		return testFilesLoc
+	}
+	return path.Join(pkgDirectory, testFilesLoc)
 }

--- a/pkg/controller/hyperconverged/test-files/kubevirt-config.yaml
+++ b/pkg/controller/hyperconverged/test-files/kubevirt-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+data:
+  default-network-interface: masquerade
+  feature-gates: DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Snapshot,dummy,dummy
+  machine-type: pc-q35-rhel8.3.0
+  migrations: |-
+    parallelMigrationsPerCluster: 3
+    bandwidthPerMigration: 32Mi
+    completionTimeoutPerGiB: 444
+  selinuxLauncherType: virt_launcher.process
+  smbios: |-
+    Family: Red Hat
+    Product: Container-native virtualization
+    Manufacturer: Red Hat
+    Sku: 2.6.2
+    Version: 2.6.2
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2021-05-18T21:31:20Z"
+  labels:
+    app: kubevirt-hyperconverged
+  name: kubevirt-config
+  namespace: kubevirt-hyperconverged
+  resourceVersion: "307882"
+  uid: 660c2339-e981-496a-8527-7a621e82bcd3


### PR DESCRIPTION
The current code removes the configMap after one try, and if there was a problem to update HCO CR, HCO can't try again.

In this PR, HCO only removes the CM if the update was actually done.

Cherry-picked from #1349 and #1350 (added also 1349 mostly to avoid conflict by picking only 1350, but also because it adds good unit tests).

Fixes: https://bugzilla.redhat.com/1962135

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [x] PR Message
- [x] Commit Messages
- [x] How to test
- [x] Unit Tests
- [x] Functional Tests
- [x] User Documentation
- [x] Developer Documentation
- [x] Upgrade Scenario
- [x] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes: https://bugzilla.redhat.com/1962135
```

