### PR TITLE
Allow manually bump a specific component to a specific version

### DIFF
--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -3,6 +3,13 @@ on:
   schedule:
     - cron:  '0 5 * * *'
   workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component to bump'
+        required: false
+      version:
+        description: 'Component version'
+        required: false
 jobs:
   build:
     name: HCO Release Bump Job
@@ -18,6 +25,9 @@ jobs:
           go-version: '1.16' # The Go version to download (if necessary) and use.
 
       - name: Check for new releases and update
+        env:
+          UPDATED_COMPONENT: ${{ github.event.inputs.component }}"
+          UPDATED_VERSION: ${{ github.event.inputs.version }}"
         run: |
           ./automation/release-bumper/release-bumper.sh
           if [[ -f updated_component.txt ]]; then


### PR DESCRIPTION
When running the release bumper, it is now possible to specify the component to bump. It is also possible to specify the target component version. The script does not allow downgrade, so specifying a previous version will do nothing.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [x] PR Message
- [x] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [x] Upgrade Scenario
- [ ] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

