### PR TITLE
fix the release bump action

### DIFF
--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Check for new releases and update
         env:
-          UPDATED_COMPONENT: ${{ github.event.inputs.component }}"
-          UPDATED_VERSION: ${{ github.event.inputs.version }}"
+          UPDATED_COMPONENT: ${{ github.event.inputs.component }}
+          UPDATED_VERSION: ${{ github.event.inputs.version }}
         run: |
           ./automation/release-bumper/release-bumper.sh
           if [[ -f updated_component.txt ]]; then


### PR DESCRIPTION
Redundant double-quotes caused wrong env var values

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

