### PR TITLE
doc: add another jsonpatch annotation example

### DIFF
--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -541,6 +541,50 @@ $ kubectl get hco -n kubevirt-hyperconverged  kubevirt-hyperconverged -o json \
 }
 ```
 
+* The user wants to configure kubevirt pods to log more verbosely
+```yaml
+metadata:
+  annotations:
+    kubevirt.kubevirt.io/jsonpatch: |-
+      [
+        {
+          "op":"add",
+          "path":"/spec/configuration/developerConfiguration/logVerbosity",
+          "value":{
+            "virtAPI":4,
+            "virtController":4,
+            "virtHandler":4,
+            "virtLauncher":4,
+            "virtOperator":4
+          }
+        }
+      ]
+```
+
+From CLI it will be:
+```bash
+$ patch hco kubevirt-hyperconverged --type=merge -p='{"metadata":{"annotations":{"kubevirt.kubevirt.io/jsonpatch":"[{\"op\":\"add\",\"path\":\"/spec/configuration/developerConfiguration/logVerbosity\",\"value\":{\"virtAPI\":4,\"virtController\":4,\"virtHandler\":4,\"virtLauncher\":4,\"virtOperator\":4}}]"}}}'
+```
+
+* The user wants to forcefully customize virt-handler configuration by setting custom values under `/spec/customizeComponents/patches` or the KV CR. In order to do that, the following annotation should be added to the HyperConverged CR:
+```yaml
+metadata:
+  annotations:
+    kubevirt.kubevirt.io/jsonpatch: |-
+      [
+        {
+          "op": "add",
+          "path": "/spec/customizeComponents/patches",
+          "value": [{
+              "patch": "[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/command/-\",\"value\":\"--max-devices=250\"}]",
+              "resourceName": "virt-handler",
+              "resourceType": "Daemonset",
+              "type": "json"
+          }]
+        }
+      ]
+```
+
 * The user wants to override the default URL used when uploading to a DataVolume, by setting the CDI CR's `spec.config.uploadProxyURLOverride` to `myproxy.example.com`. In order to do that, the following annotation should be added to the HyperConverged CR:
 ```yaml
 metadata:


### PR DESCRIPTION
Add an example about how to use
kubevirt.kubevirt.io/jsonpatch annotation to customize
the configuration of virt-handler via
/spec/customizeComponents/patches
on the kubevirt CR.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
NONE
```

