### PR TITLE
Enable SRIOVLiveMigration feature-gate by default

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -52,7 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
-                sriovLiveMigration: false
+                sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
                 bandwidthPerMigration: 64Mi
@@ -117,18 +117,15 @@ spec:
                 type: object
               featureGates:
                 default:
-                  sriovLiveMigration: false
+                  sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
                   sriovLiveMigration:
-                    default: false
+                    default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
-                      When enabled virt-launcher pods of virtual machines with SRIOV
-                      interfaces run with CAP_SYS_RESOURCE capability. This may degrade
-                      virt-launcher security.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -52,7 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
-                sriovLiveMigration: false
+                sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
                 bandwidthPerMigration: 64Mi
@@ -117,18 +117,15 @@ spec:
                 type: object
               featureGates:
                 default:
-                  sriovLiveMigration: false
+                  sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
                   sriovLiveMigration:
-                    default: false
+                    default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
-                      When enabled virt-launcher pods of virtual machines with SRIOV
-                      interfaces run with CAP_SYS_RESOURCE capability. This may degrade
-                      virt-launcher security.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -52,7 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
-                sriovLiveMigration: false
+                sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
                 bandwidthPerMigration: 64Mi
@@ -117,18 +117,15 @@ spec:
                 type: object
               featureGates:
                 default:
-                  sriovLiveMigration: false
+                  sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
                   sriovLiveMigration:
-                    default: false
+                    default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
-                      When enabled virt-launcher pods of virtual machines with SRIOV
-                      interfaces run with CAP_SYS_RESOURCE capability. This may degrade
-                      virt-launcher security.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,7 +54,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": false}, "liveMigrationConfig": {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true}, "liveMigrationConfig": {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -87,7 +87,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here | bool | false | true |
-| sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. When enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability. This may degrade virt-launcher security. | bool | false | true |
+| sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. | bool | true | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -122,7 +122,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | localStorageClassName | LocalStorageClassName the name of the local storage class. | string |  | false |
 | infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
 | workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
-| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "sriovLiveMigration": false} | false |
+| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "sriovLiveMigration": true} | false |
 | liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150} | false |
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
 | certConfig | certConfig holds the rotation policy for internal, self-signed certificates | [HyperConvergedCertConfig](#hyperconvergedcertconfig) | {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}} | false |

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -141,10 +141,8 @@ Additional information: [LibvirtXMLCPUModel](https://wiki.openstack.org/wiki/Lib
 
 ### sriovLiveMigration Feature Gate
 Set the `sriovLiveMigration` feature gate in order to allow migrating a virtual machine with SRIOV interfaces.
-When enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability.
-This may degrade virt-launcher security.
 
-**Default**: `false`
+**Default**: `true`
 
 ### Feature Gates Example
 ```yaml

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -22,7 +22,7 @@ echo "Read the CR's spec before starting the test"
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o json | jq '.spec'
 
 CERTCONFIGDEFAULTS='{"ca":{"duration":"48h0m0s","renewBefore":"24h0m0s"},"server":{"duration":"24h0m0s","renewBefore":"12h0m0s"}}'
-FGDEFAULTS='{"sriovLiveMigration":false,"withHostPassthroughCPU":false}'
+FGDEFAULTS='{"sriovLiveMigration":true,"withHostPassthroughCPU":false}'
 LMDEFAULTS='{"bandwidthPerMigration":"64Mi","completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -38,7 +38,7 @@ type HyperConvergedSpec struct {
 
 	// featureGates is a map of feature gate flags. Setting a flag to `true` will enable
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
-	// +kubebuilder:default={"withHostPassthroughCPU": false, "sriovLiveMigration": false}
+	// +kubebuilder:default={"withHostPassthroughCPU": false, "sriovLiveMigration": true}
 	// +optional
 	FeatureGates HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
@@ -193,11 +193,8 @@ type HyperConvergedFeatureGates struct {
 	WithHostPassthroughCPU bool `json:"withHostPassthroughCPU"`
 
 	// Allow migrating a virtual machine with SRIOV interfaces.
-	// When enabled virt-launcher pods of virtual machines with SRIOV
-	// interfaces run with CAP_SYS_RESOURCE capability.
-	// This may degrade virt-launcher security.
 	// +optional
-	// +kubebuilder:default=false
+	// +kubebuilder:default=true
 	SRIOVLiveMigration bool `json:"sriovLiveMigration"`
 }
 
@@ -397,7 +394,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": false}, "liveMigrationConfig": {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true}, "liveMigrationConfig": {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`


### PR DESCRIPTION
Following kubevirt/kubevirt#5558 
Kubevirt is not longer requires SYS_RESOURCE capability in order to enable SRIOV VM's migration.

We still want this feature-gate to enable the user to choose whether to enable SRIOV VM migration or not
until this feature is maturated.

Signed-off-by: Or Mergi <ormergi@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable SRIOVLiveMigration feature-gate by default
```

