### PR TITLE
Always update objectReferences in a single pass

### DIFF
--- a/pkg/controller/operands/cdi_test.go
+++ b/pkg/controller/operands/cdi_test.go
@@ -767,6 +767,15 @@ var _ = Describe("CDI Operand", func() {
 			Expect(foundResource.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("7h0m0s"))
 			Expect(foundResource.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("8h0m0s"))
 			Expect(req.Conditions).To(BeEmpty())
+
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, existingResource)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
 		})
 
 		It("should handle conditions", func() {
@@ -1227,6 +1236,15 @@ var _ = Describe("CDI Operand", func() {
 				Expect(foundResource.Data).To(HaveKey(k))
 				Expect(foundResource.Data[k]).To(Equal(expectedResource.Data[k]))
 			}
+
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, outdatedResource)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
 		})
 
 		It("local storage class name should be available when specified", func() {

--- a/pkg/controller/operands/cliDownload_test.go
+++ b/pkg/controller/operands/cliDownload_test.go
@@ -91,6 +91,16 @@ var _ = Describe("CLI Download", func() {
 			Expect(cl.Get(context.TODO(), key, foundResource))
 			Expect(foundResource.Spec.Links[0].Href).To(Equal(expectedResource.Spec.Links[0].Href))
 			Expect(foundResource.Spec.Links[0].Text).To(Equal(expectedResource.Spec.Links[0].Text))
+
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, modifiedResource)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
+
 		},
 			Entry("with modified download link",
 				&consolev1.ConsoleCLIDownload{

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -418,6 +418,16 @@ Version: 1.2.3`)
 			Expect(*mc.ParallelOutboundMigrationsPerNode).To(Equal(parallelOutboundMigrationsPerNode))
 			Expect(*mc.ParallelMigrationsPerCluster).To(Equal(parallelMigrationsPerCluster))
 			Expect(*mc.ProgressTimeout).To(Equal(progressTimeout))
+
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, existKv)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
+
 		})
 
 		Context("test permitted host devices", func() {

--- a/pkg/controller/operands/monitoring_test.go
+++ b/pkg/controller/operands/monitoring_test.go
@@ -92,6 +92,16 @@ var _ = Describe("Monitoring Operand", func() {
 			).To(BeNil())
 			Expect(foundResource.Spec.Ports[0].Name).To(BeIdenticalTo(operatorPortName))
 			Expect(foundResource.Spec.Ports[0].Port).To(BeIdenticalTo(hcoutil.MetricsPort))
+
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, existingResource)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
+
 		})
 
 	})
@@ -167,6 +177,15 @@ var _ = Describe("Monitoring Operand", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Spec.Endpoints[0].Port).To(BeIdenticalTo(operatorPortName))
+
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, existingResource)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
 		})
 
 	})
@@ -244,6 +263,15 @@ var _ = Describe("Monitoring Operand", func() {
 			).To(BeNil())
 			Expect(foundResource.Spec.Groups[0].Name).To(BeIdenticalTo(alertRuleGroup))
 			Expect(foundResource.Spec.Groups[0].Rules[0].Alert).To(BeIdenticalTo(outOfBandUpdateAlert))
+
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, existingResource)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
 		})
 
 	})

--- a/pkg/controller/operands/networkAddons_test.go
+++ b/pkg/controller/operands/networkAddons_test.go
@@ -117,6 +117,16 @@ var _ = Describe("CNA Operand", func() {
 			Expect(foundResource.Spec.ImagePullPolicy).To(BeEmpty())
 
 			Expect(req.Conditions).To(BeEmpty())
+
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, existingResource)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
+
 		})
 
 		It("should add node placement if missing in CNAO", func() {

--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -114,12 +114,12 @@ func (h *genericOperand) handleExistingCr(req *common.HcoRequest, key client.Obj
 		return res.Error(err)
 	}
 
-	if updated {
-		return res.SetUpdated().SetOverwritten(overwritten)
-	}
-
 	if err = h.addCrToTheRelatedObjectList(req, found); err != nil {
 		return res.Error(err)
+	}
+
+	if updated {
+		return res.SetUpdated().SetOverwritten(overwritten)
 	}
 
 	if opr, ok := h.hooks.(hcoOperandHooks); ok { // for operands, perform some more checks

--- a/pkg/controller/operands/quickStart_test.go
+++ b/pkg/controller/operands/quickStart_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"k8s.io/client-go/tools/reference"
 	"os"
 	"path"
 	"strings"
@@ -194,6 +195,15 @@ var _ = Describe("QuickStart tests", func() {
 				Expect(quickstartObjects.Items[0].Name).Should(Equal("test-quick-start"))
 				// check that the existing object was reconciled
 				Expect(quickstartObjects.Items[0].Spec.DurationMinutes).Should(Equal(20))
+
+				// ObjectReference should have been updated
+				Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+				objectRefOutdated, err := reference.GetReference(schemeForTest, exists)
+				Expect(err).To(BeNil())
+				objectRefFound, err := reference.GetReference(schemeForTest, &quickstartObjects.Items[0])
+				Expect(err).To(BeNil())
+				Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+				Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
 			})
 		})
 	})

--- a/pkg/controller/operands/ssp_test.go
+++ b/pkg/controller/operands/ssp_test.go
@@ -108,6 +108,15 @@ var _ = Describe("SSP Operands", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Spec).To(Equal(expectedResource.Spec))
+
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, existingResource)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
 		})
 
 		Context("Node placement", func() {

--- a/pkg/controller/operands/vmImport_test.go
+++ b/pkg/controller/operands/vmImport_test.go
@@ -96,6 +96,15 @@ var _ = Describe("VM-Import", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Spec.ImagePullPolicy).To(BeEmpty())
+
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, existingResource)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
 		})
 
 		It("should add node placement if missing in VM-Import", func() {
@@ -437,6 +446,14 @@ var _ = Describe("VM-Import", func() {
 			Expect(foundResource.Data).To(Not(HaveKey(toBeRemovedKey)))
 			Expect(foundResource.Data).To(HaveKeyWithValue(vddkk, vddkInitImageValue))
 
+			// ObjectReference should have been updated
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRefOutdated, err := reference.GetReference(handler.Scheme, outdatedResource)
+			Expect(err).To(BeNil())
+			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+			Expect(err).To(BeNil())
+			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
 		})
 
 	})


### PR DESCRIPTION
On updates to manage objects,
always update objectReferences on the
status of HCO CR in a single pass to
correctly report the expected resourceVersion of
the managed objects.

Bug-Url: https://bugzilla.redhat.com/1968196

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Always update objectReferences in a single pass
```

