### PR TITLE
Exit the upgrade mode only when nothing is still to be written on the HCO CR

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -714,8 +714,8 @@ func (r *ReconcileHyperConverged) completeReconciliation(req *common.HcoRequest)
 	if allComponentsAreUp {
 		req.Logger.Info("No component operator reported negatively")
 
-		// if in upgrade mode, and all the components are upgraded - upgrade is completed
-		if r.upgradeMode && req.ComponentUpgradeInProgress {
+		// if in upgrade mode, and all the components are upgraded, and nothing pending to be written - upgrade is completed
+		if r.upgradeMode && req.ComponentUpgradeInProgress && !req.Dirty {
 			// update the new version only when upgrade is completed
 			req.Instance.Status.UpdateVersion(hcoVersionName, r.ownVersion)
 			req.StatusDirty = true


### PR DESCRIPTION
Effectively exit the upgrade mode only when we are sure that 
nothing is still to be written on the HCO CR
because we are going to write the status subresource before
really updating the HCO CR and so we don't want to report
a wrong status if the update on the HCO CR is going to fail
for any reason.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Exit the upgrade mode only when nothing is still to be written on the HCO CR
```

