### PR TITLE
Split writing HyperConverged's status and body

### DIFF
--- a/hack/generate_local_env.py
+++ b/hack/generate_local_env.py
@@ -33,7 +33,7 @@ def get_env_file(outdir, file_format='txt'):
         for row in reader:
             if row['image_var'] in ['VMWARE_IMAGE', 'CONVERSION_IMAGE', 'KUBEVIRT_VIRTIO_IMAGE']:
                 image = f"{row['name']}@sha256:{row['digest']}"
-                env = 'VIRTIOWIN_CONTAINER' if row['image_var'] == 'KUBEVIRT_VIRTIO_IMAGE' else row['image_var']
+                env = 'VIRTIOWIN_CONTAINER' if row['image_var'] == 'KUBEVIRT_VIRTIO_IMAGE' else row['image_var'].replace("_IMAGE", "_CONTAINER")
                 vars_list.append(f"{env}={image}")
 
     vars_list.extend([


### PR DESCRIPTION
split writing HyperConverged's status and body (spec/metadata)

Since writing to the HyperConverged status must be a separate write and we can't write the whole custom resource as an atomic operation, it caused several instabilities and conflicts.

This PR split the right to two calls - if the code modified something in the body (should be with very low frequency, except for during upgrade), HCO will write only the body, and exit with requeue = true to force additional call, then we expect the body not to be modified again, letting HCO write only the status this time.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

