### PR TITLE
Only update the conditions if they are actually modified

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2377,6 +2377,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the HyperConverged resource
+                  generation. If the ObservedGeneration is less than the resource
+                  generation in metadata, the status is out of date
+                format: int64
+                type: integer
               relatedObjects:
                 description: RelatedObjects is a list of objects created and maintained
                   by this operator. Object references will be added to this list after

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -2377,6 +2377,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the HyperConverged resource
+                  generation. If the ObservedGeneration is less than the resource
+                  generation in metadata, the status is out of date
+                format: int64
+                type: integer
               relatedObjects:
                 description: RelatedObjects is a list of objects created and maintained
                   by this operator. Object references will be added to this list after

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -2377,6 +2377,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the HyperConverged resource
+                  generation. If the ObservedGeneration is less than the resource
+                  generation in metadata, the status is out of date
+                format: int64
+                type: integer
               relatedObjects:
                 description: RelatedObjects is a list of objects created and maintained
                   by this operator. Object references will be added to this list after

--- a/docs/api.md
+++ b/docs/api.md
@@ -145,6 +145,7 @@ HyperConvergedStatus defines the observed state of HyperConverged
 | conditions | Conditions describes the state of the HyperConverged resource. | []metav1.Condition |  | false |
 | relatedObjects | RelatedObjects is a list of objects created and maintained by this operator. Object references will be added to this list after they have been created AND found in the cluster. | []corev1.ObjectReference |  | false |
 | versions | Versions is a list of HCO component versions, as name/version pairs. The version with a name of \"operator\" is the HCO version itself, as described here: https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version | Versions |  | false |
+| observedGeneration | ObservedGeneration reflects the HyperConverged resource generation. If the ObservedGeneration is less than the resource generation in metadata, the status is out of date | int64 |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -326,6 +326,11 @@ type HyperConvergedStatus struct {
 	// https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version
 	// +optional
 	Versions Versions `json:"versions,omitempty"`
+
+	// ObservedGeneration reflects the HyperConverged resource generation. If the ObservedGeneration is less than the
+	// resource generation in metadata, the status is out of date
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 func (hcs *HyperConvergedStatus) UpdateVersion(name, version string) {

--- a/pkg/apis/hco/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.openapi.go
@@ -188,7 +188,7 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedFeatureGates(ref common.Reference
 					},
 					"sriovLiveMigration": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Allow migrating a virtual machine with SRIOV interfaces. When enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability. This may degrade virt-launcher security.",
+							Description: "Allow migrating a virtual machine with SRIOV interfaces.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -386,6 +386,13 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedStatus(ref common.ReferenceCallba
 									},
 								},
 							},
+						},
+					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObservedGeneration reflects the HyperConverged resource generation. If the ObservedGeneration is less than the resource generation in metadata, the status is out of date",
+							Type:        []string{"integer"},
+							Format:      "int64",
 						},
 					},
 				},

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -723,6 +723,15 @@ var _ = Describe("HyperconvergedController", func() {
 
 				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			})
+
+			It("Should upgrade the status.observedGeneration field", func() {
+				expected := getBasicDeployment()
+				expected.hco.ObjectMeta.Generation = 10
+				cl := expected.initClient()
+				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+
+				Expect(foundResource.Status.ObservedGeneration).Should(BeEquivalentTo(10))
+			})
 		})
 
 		Context("Validate OLM required fields", func() {

--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -249,10 +249,11 @@ func handleOperandDegradedCond(req *common.HcoRequest, component string, conditi
 	if condition.Status == metav1.ConditionTrue {
 		req.Logger.Info(fmt.Sprintf("%s is 'Degraded'", component))
 		req.Conditions.SetStatusCondition(metav1.Condition{
-			Type:    hcov1beta1.ConditionDegraded,
-			Status:  metav1.ConditionTrue,
-			Reason:  fmt.Sprintf("%sDegraded", component),
-			Message: fmt.Sprintf("%s is degraded: %v", component, condition.Message),
+			Type:               hcov1beta1.ConditionDegraded,
+			Status:             metav1.ConditionTrue,
+			Reason:             fmt.Sprintf("%sDegraded", component),
+			Message:            fmt.Sprintf("%s is degraded: %v", component, condition.Message),
+			ObservedGeneration: req.Instance.Generation,
 		})
 
 		return false
@@ -264,16 +265,18 @@ func handleOperandProgressingCond(req *common.HcoRequest, component string, cond
 	if condition.Status == metav1.ConditionTrue {
 		req.Logger.Info(fmt.Sprintf("%s is 'Progressing'", component))
 		req.Conditions.SetStatusCondition(metav1.Condition{
-			Type:    hcov1beta1.ConditionProgressing,
-			Status:  metav1.ConditionTrue,
-			Reason:  fmt.Sprintf("%sProgressing", component),
-			Message: fmt.Sprintf("%s is progressing: %v", component, condition.Message),
+			Type:               hcov1beta1.ConditionProgressing,
+			Status:             metav1.ConditionTrue,
+			Reason:             fmt.Sprintf("%sProgressing", component),
+			Message:            fmt.Sprintf("%s is progressing: %v", component, condition.Message),
+			ObservedGeneration: req.Instance.Generation,
 		})
 		req.Conditions.SetStatusCondition(metav1.Condition{
-			Type:    hcov1beta1.ConditionUpgradeable,
-			Status:  metav1.ConditionFalse,
-			Reason:  fmt.Sprintf("%sProgressing", component),
-			Message: fmt.Sprintf("%s is progressing: %v", component, condition.Message),
+			Type:               hcov1beta1.ConditionUpgradeable,
+			Status:             metav1.ConditionFalse,
+			Reason:             fmt.Sprintf("%sProgressing", component),
+			Message:            fmt.Sprintf("%s is progressing: %v", component, condition.Message),
+			ObservedGeneration: req.Instance.Generation,
 		})
 
 		return false
@@ -295,32 +298,36 @@ func getConditionsForNewCr(req *common.HcoRequest, component string) {
 	message := fmt.Sprintf("%s resource has no conditions", component)
 	req.Logger.Info(fmt.Sprintf("%s's resource is not reporting Conditions on it's Status", component))
 	req.Conditions.SetStatusCondition(metav1.Condition{
-		Type:    hcov1beta1.ConditionAvailable,
-		Status:  metav1.ConditionFalse,
-		Reason:  reason,
-		Message: message,
+		Type:               hcov1beta1.ConditionAvailable,
+		Status:             metav1.ConditionFalse,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: req.Instance.Generation,
 	})
 	req.Conditions.SetStatusCondition(metav1.Condition{
-		Type:    hcov1beta1.ConditionProgressing,
-		Status:  metav1.ConditionTrue,
-		Reason:  reason,
-		Message: message,
+		Type:               hcov1beta1.ConditionProgressing,
+		Status:             metav1.ConditionTrue,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: req.Instance.Generation,
 	})
 	req.Conditions.SetStatusCondition(metav1.Condition{
-		Type:    hcov1beta1.ConditionUpgradeable,
-		Status:  metav1.ConditionFalse,
-		Reason:  reason,
-		Message: message,
+		Type:               hcov1beta1.ConditionUpgradeable,
+		Status:             metav1.ConditionFalse,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: req.Instance.Generation,
 	})
 }
 
 func componentNotAvailable(req *common.HcoRequest, component string, msg string) {
 	req.Logger.Info(fmt.Sprintf("%s is not 'Available'", component))
 	req.Conditions.SetStatusCondition(metav1.Condition{
-		Type:    hcov1beta1.ConditionAvailable,
-		Status:  metav1.ConditionFalse,
-		Reason:  fmt.Sprintf("%sNotAvailable", component),
-		Message: msg,
+		Type:               hcov1beta1.ConditionAvailable,
+		Status:             metav1.ConditionFalse,
+		Reason:             fmt.Sprintf("%sNotAvailable", component),
+		Message:            msg,
+		ObservedGeneration: req.Instance.Generation,
 	})
 }
 

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -104,10 +104,11 @@ func (h OperandHandler) Ensure(req *common.HcoRequest) error {
 		if res.Err != nil {
 			req.ComponentUpgradeInProgress = false
 			req.Conditions.SetStatusCondition(metav1.Condition{
-				Type:    hcov1beta1.ConditionReconcileComplete,
-				Status:  metav1.ConditionFalse,
-				Reason:  reconcileFailed,
-				Message: fmt.Sprintf("Error while reconciling: %v", res.Err),
+				Type:               hcov1beta1.ConditionReconcileComplete,
+				Status:             metav1.ConditionFalse,
+				Reason:             reconcileFailed,
+				Message:            fmt.Sprintf("Error while reconciling: %v", res.Err),
+				ObservedGeneration: req.Instance.Generation,
 			})
 			return res.Err
 		}


### PR DESCRIPTION
This PR only updates the conditions if they are changed from the existing conditions. That gives a good understanding on when thing happened, because the timestamp is the time of the last change of the condition's state. If the state was not changed, the timestamp wouldn't be changed either.

API Changes:
The status contains a new `observedGeneration` field. This field reflects the HyperConverged resource generation. If the ObservedGeneration is less than the resource generation in metadata, the status is out of date.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [x] PR Message
- [x] Commit Messages
- [ ] How to test
- [x] Unit Tests
- [ ] Functional Tests
- [x] User Documentation
- [ ] Developer Documentation
- [x] Upgrade Scenario
- [x] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

