### PR TITLE
Remove the spec.version field as it's not needed anymore

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1292,9 +1292,6 @@ spec:
                 description: VDDK Init Image eventually used to import VMs from external
                   providers
                 type: string
-              version:
-                description: operator version
-                type: string
               workloadUpdateStrategy:
                 default:
                   batchEvictionInterval: 1m0s

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -1292,9 +1292,6 @@ spec:
                 description: VDDK Init Image eventually used to import VMs from external
                   providers
                 type: string
-              version:
-                description: operator version
-                type: string
               workloadUpdateStrategy:
                 default:
                   batchEvictionInterval: 1m0s

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -1292,9 +1292,6 @@ spec:
                 description: VDDK Init Image eventually used to import VMs from external
                   providers
                 type: string
-              version:
-                description: operator version
-                type: string
               workloadUpdateStrategy:
                 default:
                   batchEvictionInterval: 1m0s

--- a/docs/api.md
+++ b/docs/api.md
@@ -132,7 +132,6 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | obsoleteCPUs | ObsoleteCPUs allows avoiding scheduling of VMs for obsolete CPU models | *[HyperConvergedObsoleteCPUs](#hyperconvergedobsoletecpus) |  | false |
 | storageImport | StorageImport contains configuration for importing containerized data | *[StorageImportConfig](#storageimportconfig) |  | false |
 | workloadUpdateStrategy | WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates | *[HyperConvergedWorkloadUpdateStrategy](#hyperconvergedworkloadupdatestrategy) | {"workloadUpdateMethods": {"LiveMigrate", "Evict"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"} | false |
-| version | operator version | string |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -84,10 +84,6 @@ type HyperConvergedSpec struct {
 	// +kubebuilder:default={"workloadUpdateMethods": {"LiveMigrate", "Evict"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"}
 	// +optional
 	WorkloadUpdateStrategy *HyperConvergedWorkloadUpdateStrategy `json:"workloadUpdateStrategy,omitempty"`
-
-	// operator version
-	// +optional
-	Version string `json:"version,omitempty"`
 }
 
 // CertRotateConfigCA contains the tunables for TLS certificates.

--- a/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types_test.go
@@ -404,7 +404,6 @@ var _ = Describe("HyperconvergedTypes", func() {
 					BatchEvictionInterval: batchEvictionInterval,
 					BatchEvictionSize:     &batchEvictionSize,
 				},
-				Version: "v1.2.3",
 			},
 			Status: HyperConvergedStatus{
 				Conditions: []metav1.Condition{

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -119,9 +119,7 @@ func getBasicDeployment() *BasicExpected {
 			Namespace: namespace,
 			Labels:    map[string]string{hcoutil.AppLabel: name},
 		},
-		Spec: hcov1beta1.HyperConvergedSpec{
-			Version: version.Version,
-		},
+		Spec: hcov1beta1.HyperConvergedSpec{},
 		Status: hcov1beta1.HyperConvergedStatus{
 			Conditions: []metav1.Condition{
 				{


### PR DESCRIPTION
Openshift UI used the spec.version to present the operator version. That feature was removed, so there is no reason for this field anymore.

Placing the version in the spec was problematic for two reasons:
1. the user can get the wrong impression that it is possible to upgrade the HCO version by changing its version, because the spec is for the user to edit.
2. we need to sync the spec.version and the status version, but can't do that as an atomic write, but in two different update operation, and that leads to edge cases.

/hold
@tiraboschi - please review

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
API Change: removed the version field from the HyperConverged's spec
```

