### PR TITLE
add new API field CommonTemplatesNamespace

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -115,6 +115,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              commonTemplatesNamespace:
+                description: CommonTemplatesNamespace defines namespace in which common
+                  templates will be deployed. It overrides the default openshift namespace.
+                type: string
               featureGates:
                 default:
                   sriovLiveMigration: true

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -115,6 +115,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              commonTemplatesNamespace:
+                description: CommonTemplatesNamespace defines namespace in which common
+                  templates will be deployed. It overrides the default openshift namespace.
+                type: string
               featureGates:
                 default:
                   sriovLiveMigration: true

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -115,6 +115,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              commonTemplatesNamespace:
+                description: CommonTemplatesNamespace defines namespace in which common
+                  templates will be deployed. It overrides the default openshift namespace.
+                type: string
               featureGates:
                 default:
                   sriovLiveMigration: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -130,6 +130,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | scratchSpaceStorageClass | Override the storage class used for scratch space during transfer operations. The scratch space storage class is determined in the following order: value of scratchSpaceStorageClass, if that doesn't exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space | *string |  | false |
 | vddkInitImage | VDDK Init Image eventually used to import VMs from external providers | *string |  | false |
 | obsoleteCPUs | ObsoleteCPUs allows avoiding scheduling of VMs for obsolete CPU models | *[HyperConvergedObsoleteCPUs](#hyperconvergedobsoletecpus) |  | false |
+| commonTemplatesNamespace | CommonTemplatesNamespace defines namespace in which common templates will be deployed. It overrides the default openshift namespace. | *string |  | false |
 | storageImport | StorageImport contains configuration for importing containerized data | *[StorageImportConfig](#storageimportconfig) |  | false |
 | workloadUpdateStrategy | WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates | *[HyperConvergedWorkloadUpdateStrategy](#hyperconvergedworkloadupdatestrategy) | {"workloadUpdateMethods": {"LiveMigrate", "Evict"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"} | false |
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -396,6 +396,17 @@ spec:
     minCPUModel: "Penryn"
 ```
 
+## Common templates namespace
+User can specify namespace in which common templates will be deployed. This will override default `openshift` namespace.
+```yaml
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  commonTemplatesNamespace: kubevirt
+```
+
 ## Enable eventual launcher updates by default
 us the HyperConverged `spec.workloadUpdateStrategy` object to define how to handle automated workload updates at the cluster
 level.

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -76,6 +76,11 @@ type HyperConvergedSpec struct {
 	// +optional
 	ObsoleteCPUs *HyperConvergedObsoleteCPUs `json:"obsoleteCPUs,omitempty"`
 
+	// CommonTemplatesNamespace defines namespace in which common templates will
+	// be deployed. It overrides the default openshift namespace.
+	// +optional
+	CommonTemplatesNamespace *string `json:"commonTemplatesNamespace,omitempty"`
+
 	// StorageImport contains configuration for importing containerized data
 	// +optional
 	StorageImport *StorageImportConfig `json:"storageImport,omitempty"`

--- a/pkg/apis/hco/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.deepcopy.go
@@ -231,6 +231,11 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 		*out = new(HyperConvergedObsoleteCPUs)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CommonTemplatesNamespace != nil {
+		in, out := &in.CommonTemplatesNamespace, &out.CommonTemplatesNamespace
+		*out = new(string)
+		**out = **in
+	}
 	if in.StorageImport != nil {
 		in, out := &in.StorageImport, &out.StorageImport
 		*out = new(StorageImportConfig)

--- a/pkg/apis/hco/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.openapi.go
@@ -57,12 +57,14 @@ func schema_pkg_apis_hco_v1beta1_CertRotateConfigCA(ref common.ReferenceCallback
 					"duration": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The requested 'duration' (i.e. lifetime) of the Certificate. This should comply with golang's ParseDuration format (https://golang.org/pkg/time/#ParseDuration)",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
 					"renewBefore": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The amount of time before the currently issued certificate's `notAfter` time that we will begin to attempt to renew the certificate. This should comply with golang's ParseDuration format (https://golang.org/pkg/time/#ParseDuration)",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
@@ -84,12 +86,14 @@ func schema_pkg_apis_hco_v1beta1_CertRotateConfigServer(ref common.ReferenceCall
 					"duration": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The requested 'duration' (i.e. lifetime) of the Certificate. This should comply with golang's ParseDuration format (https://golang.org/pkg/time/#ParseDuration)",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
 					"renewBefore": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The amount of time before the currently issued certificate's `notAfter` time that we will begin to attempt to renew the certificate. This should comply with golang's ParseDuration format (https://golang.org/pkg/time/#ParseDuration)",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
@@ -124,17 +128,20 @@ func schema_pkg_apis_hco_v1beta1_HyperConverged(ref common.ReferenceCallback) co
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.HyperConvergedSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.HyperConvergedSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.HyperConvergedStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.HyperConvergedStatus"),
 						},
 					},
 				},
@@ -155,12 +162,14 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedCertConfig(ref common.ReferenceCa
 					"ca": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CA configuration - CA certs are kept in the CA bundle as long as they are valid",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.CertRotateConfigCA"),
 						},
 					},
 					"server": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Server configuration - Certs are rotated and discarded",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.CertRotateConfigServer"),
 						},
 					},
@@ -182,6 +191,7 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedFeatureGates(ref common.Reference
 					"withHostPassthroughCPU": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here",
+							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -189,6 +199,7 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedFeatureGates(ref common.Reference
 					"sriovLiveMigration": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Allow migrating a virtual machine with SRIOV interfaces.",
+							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -220,8 +231,9 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedObsoleteCPUs(ref common.Reference
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -250,24 +262,28 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedSpec(ref common.ReferenceCallback
 					"infra": {
 						SchemaProps: spec.SchemaProps{
 							Description: "infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.HyperConvergedConfig"),
 						},
 					},
 					"workloads": {
 						SchemaProps: spec.SchemaProps{
 							Description: "workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.HyperConvergedConfig"),
 						},
 					},
 					"featureGates": {
 						SchemaProps: spec.SchemaProps{
 							Description: "featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.HyperConvergedFeatureGates"),
 						},
 					},
 					"liveMigrationConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.LiveMigrationConfigurations"),
 						},
 					},
@@ -280,6 +296,7 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedSpec(ref common.ReferenceCallback
 					"certConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "certConfig holds the rotation policy for internal, self-signed certificates",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.HyperConvergedCertConfig"),
 						},
 					},
@@ -309,6 +326,13 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedSpec(ref common.ReferenceCallback
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.HyperConvergedObsoleteCPUs"),
 						},
 					},
+					"commonTemplatesNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CommonTemplatesNamespace defines namespace in which common templates will be deployed. It overrides the default openshift namespace.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"storageImport": {
 						SchemaProps: spec.SchemaProps{
 							Description: "StorageImport contains configuration for importing containerized data",
@@ -319,13 +343,6 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedSpec(ref common.ReferenceCallback
 						SchemaProps: spec.SchemaProps{
 							Description: "WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates",
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.HyperConvergedWorkloadUpdateStrategy"),
-						},
-					},
-					"version": {
-						SchemaProps: spec.SchemaProps{
-							Description: "operator version",
-							Type:        []string{"string"},
-							Format:      "",
 						},
 					},
 				},
@@ -356,7 +373,8 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedStatus(ref common.ReferenceCallba
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Condition"),
 									},
 								},
 							},
@@ -369,7 +387,8 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedStatus(ref common.ReferenceCallba
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ObjectReference"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
 									},
 								},
 							},
@@ -382,7 +401,8 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedStatus(ref common.ReferenceCallba
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.Version"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.Version"),
 									},
 								},
 							},
@@ -422,8 +442,9 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedWorkloadUpdateStrategy(ref common
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -508,6 +529,7 @@ func schema_pkg_apis_hco_v1beta1_MediatedHostDevice(ref common.ReferenceCallback
 					"mdevNameSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name of a mediated device type required to identify a mediated device on a host",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -515,6 +537,7 @@ func schema_pkg_apis_hco_v1beta1_MediatedHostDevice(ref common.ReferenceCallback
 					"resourceName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name by which a device is advertised and being requested",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -571,6 +594,7 @@ func schema_pkg_apis_hco_v1beta1_PciHostDevice(ref common.ReferenceCallback) com
 					"pciDeviceSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "a combination of a vendor_id:product_id required to identify a PCI device on a host.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -578,6 +602,7 @@ func schema_pkg_apis_hco_v1beta1_PciHostDevice(ref common.ReferenceCallback) com
 					"resourceName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name by which a device is advertised and being requested",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -624,7 +649,8 @@ func schema_pkg_apis_hco_v1beta1_PermittedHostDevices(ref common.ReferenceCallba
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.PciHostDevice"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.PciHostDevice"),
 									},
 								},
 							},
@@ -644,7 +670,8 @@ func schema_pkg_apis_hco_v1beta1_PermittedHostDevices(ref common.ReferenceCallba
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.MediatedHostDevice"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1.MediatedHostDevice"),
 									},
 								},
 							},
@@ -672,8 +699,9 @@ func schema_pkg_apis_hco_v1beta1_StorageImportConfig(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},

--- a/pkg/controller/operands/ssp.go
+++ b/pkg/controller/operands/ssp.go
@@ -168,13 +168,18 @@ func (h *sspHooks) updateCr(req *common.HcoRequest, client client.Client, exists
 
 func NewSSP(hc *hcov1beta1.HyperConverged, opts ...string) *sspv1beta1.SSP {
 	replicas := int32(defaultTemplateValidatorReplicas)
+	templatesNamespace := defaultCommonTemplatesNamespace
+
+	if hc.Spec.CommonTemplatesNamespace != nil {
+		templatesNamespace = *hc.Spec.CommonTemplatesNamespace
+	}
 
 	spec := sspv1beta1.SSPSpec{
 		TemplateValidator: sspv1beta1.TemplateValidator{
 			Replicas: &replicas,
 		},
 		CommonTemplates: sspv1beta1.CommonTemplates{
-			Namespace: defaultCommonTemplatesNamespace,
+			Namespace: templatesNamespace,
 		},
 		// NodeLabeller field is explicitly initialized to its zero-value,
 		// in order to future-proof from bugs if SSP changes it to pointer-type,

--- a/pkg/controller/operands/ssp_test.go
+++ b/pkg/controller/operands/ssp_test.go
@@ -79,13 +79,14 @@ var _ = Describe("SSP Operands", func() {
 		})
 
 		It("should reconcile to default", func() {
+			cTNamespace := "nonDefault"
+			hco.Spec.CommonTemplatesNamespace = &cTNamespace
 			expectedResource := NewSSP(hco)
 			existingResource := expectedResource.DeepCopy()
 			existingResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", existingResource.Namespace, existingResource.Name)
 
 			replicas := int32(defaultTemplateValidatorReplicas * 2) // non-default value
 			existingResource.Spec.TemplateValidator.Replicas = &replicas
-			existingResource.Spec.CommonTemplates.Namespace = "foobar"
 			existingResource.Spec.NodeLabeller.Placement = &lifecycleapi.NodePlacement{
 				NodeSelector: map[string]string{"foo": "bar"},
 			}
@@ -108,6 +109,7 @@ var _ = Describe("SSP Operands", func() {
 					foundResource),
 			).To(BeNil())
 			Expect(foundResource.Spec).To(Equal(expectedResource.Spec))
+			Expect(foundResource.Spec.CommonTemplates.Namespace).To(Equal(cTNamespace), "common-templates namespace should equal")
 
 			// ObjectReference should have been updated
 			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))


### PR DESCRIPTION
add new API field CommonTemplatesNamespace
This new field defines in which namespace will be templates deployed

/cc @tiraboschi @nunnatsa can you please help me, if these are all the places that need to be updated?

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Reviewer Checklist**
> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:

```
API Change: add commonTemplatesNamespace field to the HyperConverged's spec
```

