### PR TITLE
Add workflow for dashboard configmaps

### DIFF
--- a/.github/workflows/dashboard-updater.yml
+++ b/.github/workflows/dashboard-updater.yml
@@ -1,0 +1,53 @@
+name: Update Dashboard ConfigMaps
+on: workflow_dispatch
+jobs:
+  build:
+    name: Update Dashboard ConfigMaps
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          path: hco
+
+      - name: Checkout monitoring repository
+        uses: actions/checkout@v2
+        with:
+          repository: kubevirt/monitoring
+          ref: main
+          path: monitoring
+
+
+      - name: Check for update
+        run: |
+          ./hco/automation/dashboard-updater/dashboard-updater.sh "./monitoring/dashboards" "./hco/deploy/dashboards"
+          cd hco
+          git add --all
+          if ! git diff HEAD --quiet --exit-code; then
+            echo "There is an update."
+            echo "UPDATED=true" >> $GITHUB_ENV
+          fi
+
+      - name: Create a PR
+        uses: peter-evans/create-pull-request@v3
+        if: ${{ env.UPDATED }}
+        with:
+          path: hco
+          token: ${{ secrets.HCO_BOT_TOKEN }}
+          commit-message: |
+            Update configmaps of dashboards
+
+            Signed-off-by: HCO Bump Bot <noreply@github.com>
+          committer: HCO Bump Bot <noreply@github.com>
+          title: "Update configmaps of dashboards"
+          body: |
+            Update configmaps of dashboards
+            ```release-note
+            Update configmaps of dashboards
+            ```
+          assignees: erkanerol
+          reviewers: erkanerol
+          team-reviewers: owners, maintainers
+          branch: update_dashboard_configmaps
+          delete-branch: true

--- a/automation/dashboard-updater/dashboard-updater.sh
+++ b/automation/dashboard-updater/dashboard-updater.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+    echo "Illegal number of parameters"
+    echo "Usage: ./dashboard-updater.sh <source-of-json-files> <target-for-configmaps>"
+fi
+
+cat << EOF > /tmp/fake-config
+apiVersion: v1
+clusters:
+- cluster:
+    server: fake:6443
+  name: fake-cluster
+contexts:
+- context:
+    cluster: fake-cluster
+    namespace: no-ns
+  name: fake-context
+current-context: fake-context
+kind: Config
+preferences: {}
+EOF
+
+# See https://github.com/kubernetes/kubernetes/issues/51475
+export KUBECONFIG=/tmp/fake-config
+
+json_files_dir="$1"
+configmaps_files_dir="$2"
+
+rm -Rf "$configmaps_files_dir"
+mkdir -p "$configmaps_files_dir"
+
+echo "Generating configmaps for dashboards"
+
+for file in "${json_files_dir}"/*.json; do
+    echo "Generating configmap for $file"
+    file_name=${file##*/}
+    file_name_without_extension=${file_name::${#file_name}-5}
+
+    configmap_name="grafana-dashboard-$file_name_without_extension"
+    kubectl create configmap "$configmap_name" \
+      --namespace openshift-config-managed \
+      --dry-run=client -o yaml \
+      --from-file="$file_name=$file" | \
+    kubectl label -f - --dry-run=client  -o yaml \
+      --local 'console.openshift.io/dashboard=true' | \
+    grep -v "creationTimestamp" > "${configmaps_files_dir}/${configmap_name}.yaml"
+done


### PR DESCRIPTION
For OCP UI, we need to create configmaps in `openshift-config-managed`
namespace with `console.openshift.io/dashboard: "true"` label.

For visibility, the configmaps are maintained in kubevirt/monitoring
repository in JSON format for grafana. With this workflow, we are
compiling configmaps for OpenShift and put it into our repo. Time to
time, we will run this action and update the content.

Example PR opened by this workflow: https://github.com/erkanerol/hyperconverged-cluster-operator/pull/8

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

