### PR TITLE
Add alert for unsafe modifications

### DIFF
--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -656,3 +656,14 @@ FIELDS:
 Using the jsonpatch annotation feature incorrectly might lead to unexpected results and could potentially render the Kubevirt-Hyperconverged system unstable.  
 The jsonpatch annotation feature is particularly dangerous when upgrading Kubevirt-Hyperconverged, as the structure or the semantics of the underlying components' CR might be changed. Please remove any jsonpatch annotation usage prior the upgrade, to avoid any potential issues.
 **USE WITH CAUTION!**
+
+As the usage of the jsonpatch annotation is not safe, the HyperConverged Cluster Operator will count the number of these
+modifications in a metric named kubevirt_hco_unsafe_modification_count.
+if the counter is not zero, an alert named
+`KubevirtHyperconvergedClusterOperatorUSModification will` be eventually fired:
+```
+Labels
+    alertname=KubevirtHyperconvergedClusterOperatorUSModification
+    annotation_name="kubevirt.kubevirt.io/jsonpatch"
+    severity=info
+```

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -6,6 +6,7 @@ group_eval_order:
   - kubevirt.hyperconverged.rules
 
 tests:
+  # Test out-of-bound modification counter
   - interval: 1m
     input_series:
       - series: 'kubevirt_hco_out_of_band_modifications_count{component_name="kubevirt/kubevirt-kubevirt-hyperconverged"}'
@@ -23,7 +24,7 @@ tests:
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts:
           - exp_annotations:
-              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged ."
+              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
             exp_labels:
               severity: "warning"
@@ -34,18 +35,18 @@ tests:
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts:
           - exp_annotations:
-              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged ."
+              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "3 out-of-band CR modifications were detected in the last 10 minutes."
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
-      # Old increases must be ignored.
+    # Old increases must be ignored.
       - eval_time: 13m
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts:
           - exp_annotations:
-              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged ."
+              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
             exp_labels:
               severity: "warning"
@@ -66,20 +67,184 @@ tests:
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts:
           - exp_annotations:
-              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged ."
+              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
-
 
       # After restart, new increases must be detected
       - eval_time: 30m
         alertname: KubevirtHyperconvergedClusterOperatorCRModification
         exp_alerts:
           - exp_annotations:
-              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged ."
+              description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "2 out-of-band CR modifications were detected in the last 10 minutes."
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
+  # Test unsafe modification counter
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_hco_unsafe_modification_count{annotation_name="kubevirt.kubevirt.io/jsonpatch"}'
+        # time:      0     1 2 3 4 5 6 7 8     9    10 11
+        values: "stale stale 1 2 3 3 3 0 1 stale stale  2"
+      - series: 'kubevirt_hco_unsafe_modification_count{annotation_name="containerizeddataimporter.kubevirt.io/jsonpatch"}'
+        # time:      0     1 2 3 4 5 6 7 8     9    10 11
+        values: "stale stale 1 2 3 1 3 0 2 stale stale  3"
+      - series: 'kubevirt_hco_unsafe_modification_count{annotation_name="networkaddonsconfigs.kubevirt.io/jsonpatch"}'
+        # time:      0     1 2 3 4 5 6 7 8     9    10 11
+        values: "stale stale 5 1 1 1 0 0 3 stale stale  1"
+
+    alert_rule_test:
+      # No metric, no alert
+      - eval_time: 1m
+        alertname: KubevirtHyperconvergedClusterOperatorUSModification
+        exp_alerts: [ ]
+
+      # First increase must trigger an alert
+      - eval_time: 2m
+        alertname: KubevirtHyperconvergedClusterOperatorUSModification
+        exp_alerts:
+        - exp_annotations:
+            description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+            summary: "1 unsafe modifications were detected in the HyperConverged resource."
+          exp_labels:
+            severity: "info"
+            annotation_name: "kubevirt.kubevirt.io/jsonpatch"
+        - exp_annotations:
+            description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+            summary: "1 unsafe modifications were detected in the HyperConverged resource."
+          exp_labels:
+            severity: "info"
+            annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
+        - exp_annotations:
+            description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+            summary: "5 unsafe modifications were detected in the HyperConverged resource."
+          exp_labels:
+            severity: "info"
+            annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+
+      # New increases must be detected
+      - eval_time: 4m
+        alertname: KubevirtHyperconvergedClusterOperatorUSModification
+        exp_alerts:
+          - exp_annotations:
+              description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+              summary: "3 unsafe modifications were detected in the HyperConverged resource."
+            exp_labels:
+              severity: "info"
+              annotation_name: "kubevirt.kubevirt.io/jsonpatch"
+          - exp_annotations:
+              description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+              summary: "3 unsafe modifications were detected in the HyperConverged resource."
+            exp_labels:
+              severity: "info"
+              annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
+          # still using the 10 minutes max
+          - exp_annotations:
+              description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+              summary: "1 unsafe modifications were detected in the HyperConverged resource."
+            exp_labels:
+              severity: "info"
+              annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+
+      # counter can be reduced
+      - eval_time: 5m
+        alertname: KubevirtHyperconvergedClusterOperatorUSModification
+        exp_alerts:
+          - exp_annotations:
+              description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+              summary: "3 unsafe modifications were detected in the HyperConverged resource."
+            exp_labels:
+              severity: "info"
+              annotation_name: "kubevirt.kubevirt.io/jsonpatch"
+          # Reduced
+          - exp_annotations:
+              description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+              summary: "1 unsafe modifications were detected in the HyperConverged resource."
+            exp_labels:
+              severity: "info"
+              annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
+          - exp_annotations:
+              description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+              summary: "1 unsafe modifications were detected in the HyperConverged resource."
+            exp_labels:
+              severity: "info"
+              annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+
+      # no alert if the value is 0
+      - eval_time: 6m
+        alertname: KubevirtHyperconvergedClusterOperatorUSModification
+        exp_alerts:
+          - exp_annotations:
+              description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+              summary: "3 unsafe modifications were detected in the HyperConverged resource."
+            exp_labels:
+              severity: "info"
+              annotation_name: "kubevirt.kubevirt.io/jsonpatch"
+          - exp_annotations:
+              description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+              summary: "3 unsafe modifications were detected in the HyperConverged resource."
+            exp_labels:
+              severity: "info"
+              annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
+
+      # no alert if the value is 0 for all of the annotations
+      - eval_time: 7m
+        alertname: KubevirtHyperconvergedClusterOperatorUSModification
+        exp_alerts: []
+
+      # recover after all-zero
+      - eval_time: 8m
+        alertname: KubevirtHyperconvergedClusterOperatorUSModification
+        exp_alerts:
+        - exp_annotations:
+            description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+            summary: "1 unsafe modifications were detected in the HyperConverged resource."
+          exp_labels:
+            severity: "info"
+            annotation_name: "kubevirt.kubevirt.io/jsonpatch"
+        # Reduced
+        - exp_annotations:
+            description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+            summary: "2 unsafe modifications were detected in the HyperConverged resource."
+          exp_labels:
+            severity: "info"
+            annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
+        - exp_annotations:
+            description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+            summary: "3 unsafe modifications were detected in the HyperConverged resource."
+          exp_labels:
+            severity: "info"
+            annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+
+      # no data
+      - eval_time: 9m
+        alertname: KubevirtHyperconvergedClusterOperatorUSModification
+        exp_alerts: []
+
+    # recover after reset
+      - eval_time: 11m
+        alertname: KubevirtHyperconvergedClusterOperatorUSModification
+        exp_alerts:
+        - exp_annotations:
+            description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+            summary: "2 unsafe modifications were detected in the HyperConverged resource."
+          exp_labels:
+            severity: "info"
+            annotation_name: "kubevirt.kubevirt.io/jsonpatch"
+        # Reduced
+        - exp_annotations:
+            description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+            summary: "3 unsafe modifications were detected in the HyperConverged resource."
+          exp_labels:
+            severity: "info"
+            annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
+        - exp_annotations:
+            description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+            summary: "1 unsafe modifications were detected in the HyperConverged resource."
+          exp_labels:
+            severity: "info"
+            annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -7,19 +7,36 @@ import (
 	"strings"
 )
 
+const (
+	counterLabelCompName = "component_name"
+	counterLabelAnnName  = "annotation_name"
+)
+
 // HcoMetrics wrapper for all hco metrics
-var HcoMetrics = hcoMetrics{prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "kubevirt_hco_out_of_band_modifications_count",
-		Help: "Count of out-of-band modifications overwritten by HCO",
-	},
-	[]string{"component_name"},
-)}
+var HcoMetrics = hcoMetrics{
+	overwrittenModifications: prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kubevirt_hco_out_of_band_modifications_count",
+			Help: "Count of out-of-band modifications overwritten by HCO",
+		},
+		[]string{counterLabelCompName},
+	),
+	unsafeModifications: prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kubevirt_hco_unsafe_modification_count",
+			Help: "count of unsafe modifications in the HyperConverged annotations",
+		},
+		[]string{counterLabelAnnName},
+	),
+}
 
 // hcoMetrics holds all HCO metrics
 type hcoMetrics struct {
 	// overwrittenModifications counts out-of-band modifications overwritten by HCO
 	overwrittenModifications *prometheus.CounterVec
+
+	// unsafeModifications counts the modifications done using the jsonpatch annotations
+	unsafeModifications *prometheus.GaugeVec
 }
 
 func init() {
@@ -27,7 +44,7 @@ func init() {
 }
 
 func (hm *hcoMetrics) init() {
-	metrics.Registry.MustRegister(hm.overwrittenModifications)
+	metrics.Registry.MustRegister(hm.overwrittenModifications, hm.unsafeModifications)
 }
 
 // IncOverwrittenModifications increments counter by 1
@@ -42,6 +59,22 @@ func (hm *hcoMetrics) GetOverwrittenModificationsCount(kind, name string) (float
 	return m.Counter.GetValue(), err
 }
 
+// SetUnsafeModificationCount sets the counter to the required number
+func (hm *hcoMetrics) SetUnsafeModificationCount(count int, unsafeAnnotation string) {
+	hm.unsafeModifications.With(getLabelsForUnsafeAnnotation(unsafeAnnotation)).Set(float64(count))
+}
+
+// GetUnsafeModificationsCount returns current value of counter. If error is not nil then value is undefined
+func (hm *hcoMetrics) GetUnsafeModificationsCount(unsafeAnnotation string) (float64, error) {
+	var m = &dto.Metric{}
+	err := hm.unsafeModifications.With(getLabelsForUnsafeAnnotation(unsafeAnnotation)).Write(m)
+	return m.Gauge.GetValue(), err
+}
+
 func getLabelsForObj(kind string, name string) prometheus.Labels {
-	return prometheus.Labels{"component_name": strings.ToLower(kind + "/" + name)}
+	return prometheus.Labels{counterLabelCompName: strings.ToLower(kind + "/" + name)}
+}
+
+func getLabelsForUnsafeAnnotation(unsafeAnnotation string) prometheus.Labels {
+	return prometheus.Labels{counterLabelAnnName: strings.ToLower(unsafeAnnotation)}
 }


### PR DESCRIPTION
This PR adds a new prometheus metrics called `kubevirt_hco_unsafe_modification_count` to count the unsafe modifications - the modifications that are done using the jsonpatch annotation.

The PR also adds a new alert, `KubevirtHyperconvergedClusterOperatorUSModification`, if the number of the unsafe modifications was increased in the last ten minutes.

### Note: 
The counter is set in the webhook as well, even on dry-runs. But we don't care because the webhook does not expose the Prometheus port.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added a new prometheus metrics called `kubevirt_hco_unsafe_modification_count` to count the unsafe modifications - the modifications that are done using the jsonpatch annotation.

Added a new alert, `KubevirtHyperconvergedClusterOperatorUSModification`, if the number of the unsafe modifications was increased in the last ten minutes.
```

