### PR TITLE
Set PriorityClass for the two deployments

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -1873,6 +1873,7 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 96Mi
+              priorityClassName: system-cluster-critical
               serviceAccountName: hyperconverged-cluster-operator
       - label:
           app.kubernetes.io/component: deployment
@@ -1939,6 +1940,7 @@ spec:
                   requests:
                     cpu: 5m
                     memory: 48Mi
+              priorityClassName: system-node-critical
               serviceAccountName: hyperconverged-cluster-operator
       - label:
           app.kubernetes.io/component: network

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
-    createdAt: "2021-07-03 05:11:19"
+    createdAt: "2021-07-06 18:00:25"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -1873,6 +1873,7 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 96Mi
+              priorityClassName: system-cluster-critical
               serviceAccountName: hyperconverged-cluster-operator
       - label:
           app.kubernetes.io/component: deployment
@@ -1939,6 +1940,7 @@ spec:
                   requests:
                     cpu: 5m
                     memory: 48Mi
+              priorityClassName: system-node-critical
               serviceAccountName: hyperconverged-cluster-operator
       - label:
           app.kubernetes.io/component: network

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -94,6 +94,7 @@ spec:
           requests:
             cpu: 10m
             memory: 96Mi
+      priorityClassName: system-cluster-critical
       serviceAccountName: hyperconverged-cluster-operator
 ---
 apiVersion: apps/v1
@@ -165,6 +166,7 @@ spec:
         volumeMounts:
         - mountPath: /apiserver.local.config/certificates
           name: apiservice-cert
+      priorityClassName: system-node-critical
       serviceAccountName: hyperconverged-cluster-operator
       volumes:
       - name: apiservice-cert

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -253,6 +253,7 @@ func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.Deployme
 						},
 					},
 				},
+				PriorityClassName: "system-cluster-critical",
 			},
 		},
 	}
@@ -351,6 +352,7 @@ func GetDeploymentSpecWebhook(namespace, image, imagePullPolicy, hcoKvIoVersion 
 						},
 					},
 				},
+				PriorityClassName: "system-node-critical",
 			},
 		},
 	}


### PR DESCRIPTION
Setting PriorityClass for the operator
and the webhook deployment according to:
https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#priority-classes

Setting system-node-critical on the validating webhook
because it's quite small and it can affect user ability
of removing the product.

Fixes: https://bugzilla.redhat.com/1953481

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
Set PriorityClass for the two deployments
```

