### PR TITLE
check uptime of a test VM before and after the upgrade

### DIFF
--- a/deploy/Dockerfile.src.ci
+++ b/deploy/Dockerfile.src.ci
@@ -1,3 +1,4 @@
 FROM src
 
+RUN yum install -y expect
 COPY oc /usr/bin/oc

--- a/hack/vmuptime.ext
+++ b/hack/vmuptime.ext
@@ -1,0 +1,20 @@
+#!/usr/bin/expect -f
+
+# Wait enough (forever) until a long-time boot
+set timeout -1
+
+# Start the guest VM
+spawn ~/virtctl console testvm -n vmsns
+
+send "\n"
+expect "login: "
+send "cirros\n"
+
+expect "Password: "
+send "gocubsgo\n"
+
+expect "$ "
+send "echo BOOTTIME=\$((\$(date +%s) - \$(awk '{print int(\$1)}' /proc/uptime)))\n"
+
+expect "$ "
+send "exit"


### PR DESCRIPTION
check uptime on a VM during the upgrade process

Use expect tool over virtctl console
to check the boot time of the test VM
at guest level.
Doing it before and after the upgrade
to ensure that the test VM does not reboot
during the upgrade process.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
NONE
```

