### PR TITLE
Handle two todo comments to reduce sonarCloud warnings

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -1957,6 +1957,10 @@ spec:
             type: Recreate
           template:
             metadata:
+              annotations:
+                description: cluster-network-addons-operator manages the lifecycle
+                  of different Kubernetes network components on top of Kubernetes
+                  cluster
               labels:
                 app.kubernetes.io/component: network
                 app.kubernetes.io/managed-by: olm

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
-    createdAt: "2021-07-06 18:00:25"
+    createdAt: "2021-07-08 09:40:45"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -1957,6 +1957,10 @@ spec:
             type: Recreate
           template:
             metadata:
+              annotations:
+                description: cluster-network-addons-operator manages the lifecycle
+                  of different Kubernetes network components on top of Kubernetes
+                  cluster
               labels:
                 app.kubernetes.io/component: network
                 app.kubernetes.io/managed-by: olm

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -280,9 +280,6 @@ func getLabels(name, hcoKvIoVersion string) map[string]string {
 // in the meanwhile a quick (but dirty!) solution is to expose the same hco binary on two distinct pods:
 // the first one will run only the controller and the second one (almost always ready) just the validating
 // webhook one.
-// A deeper code refactor to produce two distinct binaries is not worth now because we are going to
-// use OLM operator conditions soon.
-// TODO: remove this once we will move to OLM operator conditions
 func GetDeploymentSpecWebhook(namespace, image, imagePullPolicy, hcoKvIoVersion string, env []corev1.EnvVar) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
 		Replicas: int32Ptr(1),

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -360,13 +360,6 @@ func processOneCsv(c util.CsvWithComponent, i int, installStrategyBase *csvv1alp
 
 	strategySpec := csvStruct.Spec.InstallStrategy.StrategySpec
 
-	// temporary workaround for https://bugzilla.redhat.com/1907381
-	// a custom .spec.template.annotations["description"] it's causing a failure on OLM
-	// TODO: remove this once fixed on OLM side
-	for _, deployment := range strategySpec.DeploymentSpecs {
-		delete(deployment.Spec.Template.Annotations, "description")
-	}
-
 	overwriteDeploymentSpecLabels(strategySpec.DeploymentSpecs, c.Component)
 	installStrategyBase.DeploymentSpecs = append(installStrategyBase.DeploymentSpecs, strategySpec.DeploymentSpecs...)
 


### PR DESCRIPTION
The "TODO" in tools/csv-merger/csv-merger.go line 365 was removed because the OLM bug was fixed. Removed also the relevant temporary code.

The "TODO" in pkg/components/components.go line 285 was removed because it became wrong. We do want a separate API (webhook) pod, and it's here to stay.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

