### PR TITLE
Add dashboard configmaps into operator container

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,6 +20,7 @@ RUN mkdir -p ${HOME} && \
 
 COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/_out/hyperconverged-cluster-operator $OPERATOR
 COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/_out/csv-merger $CSV_MERGER
+COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/assets/dashboards/ dashboard/
 ENTRYPOINT $OPERATOR
 USER ${USER_UID}
 


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

Complimentary of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1421


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add dashboards into OpenShift  UI
```

