### PR TITLE
Move rbacs for config reader to a separate handler

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -165,6 +165,14 @@ func getNewManagerCache(operatorNamespace string) cache.NewCacheFunc {
 					Label: labelSelector,
 					Field: namespaceSelector,
 				},
+				&rbacv1.Role{}: {
+					Label: labelSelector,
+					Field: namespaceSelector,
+				},
+				&rbacv1.RoleBinding{}: {
+					Label: labelSelector,
+					Field: namespaceSelector,
+				},
 			},
 		},
 	)

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/metrics"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"os"
 	"reflect"
 	"strings"
@@ -136,6 +137,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo) er
 		&schedulingv1.PriorityClass{},
 		&vmimportv1beta1.VMImportConfig{},
 		&corev1.ConfigMap{},
+		&rbacv1.Role{},
+		&rbacv1.RoleBinding{},
 	}
 	if ci.IsOpenshift() {
 		secondaryResources = append(secondaryResources, []client.Object{

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -144,11 +144,11 @@ func getBasicDeployment() *BasicExpected {
 	expectedKVStorageConfig := operands.NewKubeVirtStorageConfigForCR(hco, namespace)
 	expectedKVStorageConfig.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/configmaps/%s", expectedKVStorageConfig.Namespace, expectedKVStorageConfig.Name)
 	res.kvStorageConfig = expectedKVStorageConfig
-	expectedKVStorageRole := operands.NewKubeVirtStorageRoleForCR(hco, namespace, commonTestUtils.GetScheme())
+	expectedKVStorageRole := operands.NewConfigReaderRoleForCR(hco, namespace)
 	expectedKVStorageRole.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/roles/%s", expectedKVStorageConfig.Namespace, expectedKVStorageConfig.Name)
 	res.kvStorageRole = expectedKVStorageRole
 
-	expectedKVStorageRoleBinding := operands.NewKubeVirtStorageRoleBindingForCR(hco, namespace, commonTestUtils.GetScheme())
+	expectedKVStorageRoleBinding := operands.NewConfigReaderRoleBindingForCR(hco, namespace)
 	expectedKVStorageRoleBinding.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/rolebindings/%s", expectedKVStorageConfig.Namespace, expectedKVStorageConfig.Name)
 	res.kvStorageRoleBinding = expectedKVStorageRoleBinding
 

--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -99,8 +99,6 @@ func getDefaultFeatureGates() []string {
 	return []string{HonorWaitForFirstConsumerGate}
 }
 
-func (h *cdiHooks) postFound(req *common.HcoRequest, exists runtime.Object) error { return nil }
-
 func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, error) {
 	uninstallStrategy := cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist
 
@@ -188,8 +186,7 @@ type storageConfigHooks struct{}
 func (h storageConfigHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewKubeVirtStorageConfigForCR(hc, hc.Namespace), nil
 }
-func (h storageConfigHooks) getEmptyCr() client.Object                              { return &corev1.ConfigMap{} }
-func (h storageConfigHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
+func (h storageConfigHooks) getEmptyCr() client.Object { return &corev1.ConfigMap{} }
 func (h storageConfigHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*corev1.ConfigMap).ObjectMeta
 }
@@ -271,8 +268,7 @@ type configReaderRoleHooks struct{}
 func (h configReaderRoleHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewConfigReaderRoleForCR(hc, hc.Namespace), nil
 }
-func (h configReaderRoleHooks) getEmptyCr() client.Object                              { return &rbacv1.Role{} }
-func (h configReaderRoleHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
+func (h configReaderRoleHooks) getEmptyCr() client.Object { return &rbacv1.Role{} }
 func (h configReaderRoleHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*rbacv1.Role).ObjectMeta
 }
@@ -342,9 +338,6 @@ func (h configReaderRoleBindingHooks) getFullCr(hc *hcov1beta1.HyperConverged) (
 	return NewConfigReaderRoleBindingForCR(hc, hc.Namespace), nil
 }
 func (h configReaderRoleBindingHooks) getEmptyCr() client.Object { return &rbacv1.RoleBinding{} }
-func (h configReaderRoleBindingHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error {
-	return nil
-}
 func (h configReaderRoleBindingHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*rbacv1.RoleBinding).ObjectMeta
 }

--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -4,21 +4,16 @@ import (
 	"errors"
 	"reflect"
 
-	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/reference"
-	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -104,19 +99,7 @@ func getDefaultFeatureGates() []string {
 	return []string{HonorWaitForFirstConsumerGate}
 }
 
-func (h *cdiHooks) postFound(req *common.HcoRequest, exists runtime.Object) error {
-	err := h.ensureKubeVirtStorageRole(req)
-	if err != nil {
-		return err
-	}
-
-	err = h.ensureKubeVirtStorageRoleBinding(req)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
+func (h *cdiHooks) postFound(req *common.HcoRequest, exists runtime.Object) error { return nil }
 
 func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, error) {
 	uninstallStrategy := cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist
@@ -184,120 +167,6 @@ func NewCDIWithNameOnly(hc *hcov1beta1.HyperConverged, opts ...string) *cdiv1bet
 			Annotations: map[string]string{cdiConfigAuthorityAnnotation: ""},
 		},
 	}
-}
-
-func (h *cdiHooks) ensureKubeVirtStorageRole(req *common.HcoRequest) error {
-	kubevirtStorageRole := NewKubeVirtStorageRoleForCR(req.Instance, req.Namespace, h.Scheme)
-
-	found := &rbacv1.Role{}
-	err := h.Client.Get(req.Ctx, client.ObjectKeyFromObject(kubevirtStorageRole), found)
-	if apierrors.IsNotFound(err) {
-		req.Logger.Info("Creating kubevirt storage role")
-		return h.Client.Create(req.Ctx, kubevirtStorageRole)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	if !reflect.DeepEqual(found.Labels, kubevirtStorageRole.Labels) {
-		req.Logger.Info("Updating KubeVirt storage role for labels")
-		util.DeepCopyLabels(&kubevirtStorageRole.ObjectMeta, &found.ObjectMeta)
-		return h.Client.Update(req.Ctx, found)
-	}
-
-	req.Logger.Info("KubeVirt storage role already exists", "KubeVirtConfig.Namespace", found.Namespace, "KubeVirtConfig.Name", found.Name)
-	// Add it to the list of RelatedObjects if found
-	objectRef, err := reference.GetReference(h.Scheme, found)
-	if err != nil {
-		return err
-	}
-	if err = objectreferencesv1.SetObjectReference(&req.Instance.Status.RelatedObjects, *objectRef); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (h *cdiHooks) ensureKubeVirtStorageRoleBinding(req *common.HcoRequest) error {
-	kubevirtStorageRoleBinding := NewKubeVirtStorageRoleBindingForCR(req.Instance, req.Namespace, h.Scheme)
-
-	found := &rbacv1.RoleBinding{}
-	err := h.Client.Get(req.Ctx, client.ObjectKeyFromObject(kubevirtStorageRoleBinding), found)
-	if err != nil && apierrors.IsNotFound(err) {
-		req.Logger.Info("Creating kubevirt storage rolebinding")
-		return h.Client.Create(req.Ctx, kubevirtStorageRoleBinding)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	if !reflect.DeepEqual(found.Labels, kubevirtStorageRoleBinding.Labels) {
-		req.Logger.Info("Updating KubeVirt storage rolebinding for labels")
-		util.DeepCopyLabels(&kubevirtStorageRoleBinding.ObjectMeta, &found.ObjectMeta)
-		return h.Client.Update(req.Ctx, found)
-	}
-
-	req.Logger.Info("KubeVirt storage rolebinding already exists", "KubeVirtConfig.Namespace", found.Namespace, "KubeVirtConfig.Name", found.Name)
-	// Add it to the list of RelatedObjects if found
-	objectRef, err := reference.GetReference(h.Scheme, found)
-	if err != nil {
-		return err
-	}
-	err = objectreferencesv1.SetObjectReference(&req.Instance.Status.RelatedObjects, *objectRef)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func NewKubeVirtStorageRoleForCR(cr *hcov1beta1.HyperConverged, namespace string, scheme *runtime.Scheme) *rbacv1.Role {
-	role := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cdiRoleName,
-			Labels:    getLabels(cr, hcoutil.AppComponentStorage),
-			Namespace: namespace,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups:     []string{""},
-				Resources:     []string{"configmaps"},
-				ResourceNames: []string{"kubevirt-storage-class-defaults"},
-				Verbs:         []string{"get", "watch", "list"},
-			},
-		},
-	}
-
-	_ = controllerutil.SetControllerReference(cr, role, scheme)
-	return role
-}
-
-func NewKubeVirtStorageRoleBindingForCR(cr *hcov1beta1.HyperConverged, namespace string, scheme *runtime.Scheme) *rbacv1.RoleBinding {
-	roleBinding := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cdiRoleName,
-			Labels:    getLabels(cr, hcoutil.AppComponentStorage),
-			Namespace: namespace,
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     cdiRoleName,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Group",
-				Name:     "system:authenticated",
-			},
-		},
-	}
-
-	_ = controllerutil.SetControllerReference(cr, roleBinding, scheme)
-
-	return roleBinding
 }
 
 // ************** CDI Storage Config Handler **************
@@ -379,6 +248,151 @@ func NewKubeVirtStorageConfigForCR(cr *hcov1beta1.HyperConverged, namespace stri
 			localSC + ".volumeMode": "Filesystem",
 			ocsRBD + ".accessMode":  "ReadWriteMany",
 			ocsRBD + ".volumeMode":  "Block",
+		},
+	}
+}
+
+// ************** Config Reader Role Handler **************
+type configReaderRoleHandler genericOperand
+
+func newConfigReaderRoleHandler(Client client.Client, Scheme *runtime.Scheme) *configReaderRoleHandler {
+	return &configReaderRoleHandler{
+		Client:                 Client,
+		Scheme:                 Scheme,
+		crType:                 "Role",
+		removeExistingOwner:    false,
+		setControllerReference: true,
+		hooks:                  &configReaderRoleHooks{},
+	}
+}
+
+type configReaderRoleHooks struct{}
+
+func (h configReaderRoleHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+	return NewConfigReaderRoleForCR(hc, hc.Namespace), nil
+}
+func (h configReaderRoleHooks) getEmptyCr() client.Object                              { return &rbacv1.Role{} }
+func (h configReaderRoleHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
+func (h configReaderRoleHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
+	return &cr.(*rbacv1.Role).ObjectMeta
+}
+func (h *configReaderRoleHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+	configReaderRole, ok1 := required.(*rbacv1.Role)
+	found, ok2 := exists.(*rbacv1.Role)
+	if !ok1 || !ok2 {
+		return false, false, errors.New("can't convert to a Role")
+	}
+
+	if !reflect.DeepEqual(found.Labels, configReaderRole.Labels) ||
+		!reflect.DeepEqual(found.Rules, configReaderRole.Rules) {
+
+		req.Logger.Info("Updating existing Config Reader Role to its default values")
+
+		found.Rules = make([]rbacv1.PolicyRule, len(configReaderRole.Rules))
+		for i := range configReaderRole.Rules {
+			configReaderRole.Rules[i].DeepCopyInto(&found.Rules[i])
+		}
+		util.DeepCopyLabels(&configReaderRole.ObjectMeta, &found.ObjectMeta)
+
+		err := Client.Update(req.Ctx, found)
+		if err != nil {
+			return false, false, err
+		}
+		return true, !req.HCOTriggered, nil
+	}
+
+	return false, false, nil
+}
+
+func NewConfigReaderRoleForCR(cr *hcov1beta1.HyperConverged, namespace string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cdiRoleName,
+			Labels:    getLabels(cr, hcoutil.AppComponentStorage),
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"configmaps"},
+				ResourceNames: []string{"kubevirt-storage-class-defaults"},
+				Verbs:         []string{"get", "watch", "list"},
+			},
+		},
+	}
+}
+
+// ************** Config Reader Role Binding Handler **************
+type configReaderRoleBindingHandler genericOperand
+
+func newConfigReaderRoleBindingHandler(Client client.Client, Scheme *runtime.Scheme) *configReaderRoleBindingHandler {
+	return &configReaderRoleBindingHandler{
+		Client:                 Client,
+		Scheme:                 Scheme,
+		crType:                 "RoleBinding",
+		removeExistingOwner:    false,
+		setControllerReference: true,
+		hooks:                  &configReaderRoleBindingHooks{},
+	}
+}
+
+type configReaderRoleBindingHooks struct{}
+
+func (h configReaderRoleBindingHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+	return NewConfigReaderRoleBindingForCR(hc, hc.Namespace), nil
+}
+func (h configReaderRoleBindingHooks) getEmptyCr() client.Object { return &rbacv1.RoleBinding{} }
+func (h configReaderRoleBindingHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error {
+	return nil
+}
+func (h configReaderRoleBindingHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
+	return &cr.(*rbacv1.RoleBinding).ObjectMeta
+}
+func (h *configReaderRoleBindingHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+	configReaderRoleBinding, ok1 := required.(*rbacv1.RoleBinding)
+	found, ok2 := exists.(*rbacv1.RoleBinding)
+	if !ok1 || !ok2 {
+		return false, false, errors.New("can't convert to a RoleBinding")
+	}
+
+	if !reflect.DeepEqual(found.Labels, configReaderRoleBinding.Labels) ||
+		!reflect.DeepEqual(found.Subjects, configReaderRoleBinding.Subjects) ||
+		!reflect.DeepEqual(found.RoleRef, configReaderRoleBinding.RoleRef) {
+		req.Logger.Info("Updating existing Config Reader RoleBinding to its default values")
+
+		found.Subjects = make([]rbacv1.Subject, len(configReaderRoleBinding.Subjects))
+		copy(found.Subjects, configReaderRoleBinding.Subjects)
+		found.RoleRef = configReaderRoleBinding.RoleRef
+		util.DeepCopyLabels(&configReaderRoleBinding.ObjectMeta, &found.ObjectMeta)
+
+		err := Client.Update(req.Ctx, found)
+		if err != nil {
+			return false, false, err
+		}
+		return true, !req.HCOTriggered, nil
+	}
+
+	return false, false, nil
+}
+
+func NewConfigReaderRoleBindingForCR(cr *hcov1beta1.HyperConverged, namespace string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cdiRoleName,
+			Labels:    getLabels(cr, hcoutil.AppComponentStorage),
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     cdiRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Group",
+				Name:     "system:authenticated",
+			},
 		},
 	}
 }

--- a/pkg/controller/operands/cdi_test.go
+++ b/pkg/controller/operands/cdi_test.go
@@ -1067,15 +1067,12 @@ var _ = Describe("CDI Operand", func() {
 			})
 		})
 
-		Context("KubeVirt Storage Role", func() {
+		Context("Config Reader Role", func() {
 			It("should do nothing if exists", func() {
-				existsCdi, err := NewCDI(hco)
-				expectedRole := NewKubeVirtStorageRoleForCR(hco, hco.Namespace, commonTestUtils.GetScheme())
-				Expect(err).ToNot(HaveOccurred())
+				expectedRole := NewConfigReaderRoleForCR(hco, hco.Namespace)
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedRole})
 
-				cl := commonTestUtils.InitClient([]runtime.Object{hco, existsCdi, expectedRole})
-
-				handler := (*genericOperand)(newCdiHandler(cl, commonTestUtils.GetScheme()))
+				handler := (*genericOperand)(newConfigReaderRoleHandler(cl, commonTestUtils.GetScheme()))
 				res := handler.ensure(req)
 				Expect(res.Err).ToNot(HaveOccurred())
 
@@ -1091,15 +1088,13 @@ var _ = Describe("CDI Operand", func() {
 			})
 
 			It("should update if labels are missing", func() {
-				existsCdi, err := NewCDI(hco)
-				expectedRole := NewKubeVirtStorageRoleForCR(hco, hco.Namespace, commonTestUtils.GetScheme())
+				expectedRole := NewConfigReaderRoleForCR(hco, hco.Namespace)
 				expectedLabels := expectedRole.Labels
 				expectedRole.Labels = nil
-				Expect(err).ToNot(HaveOccurred())
 
-				cl := commonTestUtils.InitClient([]runtime.Object{hco, existsCdi, expectedRole})
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedRole})
 
-				handler := (*genericOperand)(newCdiHandler(cl, commonTestUtils.GetScheme()))
+				handler := (*genericOperand)(newConfigReaderRoleHandler(cl, commonTestUtils.GetScheme()))
 				res := handler.ensure(req)
 				Expect(res.Err).ToNot(HaveOccurred())
 
@@ -1114,16 +1109,13 @@ var _ = Describe("CDI Operand", func() {
 			})
 		})
 
-		Context("KubeVirt Storage Role Binding", func() {
-			scheme := commonTestUtils.GetScheme()
+		Context("Config Reader Role Binding", func() {
 			It("should do nothing if exists", func() {
-				existsCdi, err := NewCDI(hco)
-				expectedRoleBinding := NewKubeVirtStorageRoleBindingForCR(hco, hco.Namespace, scheme)
-				Expect(err).ToNot(HaveOccurred())
+				expectedRoleBinding := NewConfigReaderRoleBindingForCR(hco, hco.Namespace)
 
-				cl := commonTestUtils.InitClient([]runtime.Object{hco, existsCdi, expectedRoleBinding})
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedRoleBinding})
 
-				handler := (*genericOperand)(newCdiHandler(cl, commonTestUtils.GetScheme()))
+				handler := (*genericOperand)(newConfigReaderRoleBindingHandler(cl, commonTestUtils.GetScheme()))
 				res := handler.ensure(req)
 				Expect(res.Err).ToNot(HaveOccurred())
 
@@ -1138,15 +1130,13 @@ var _ = Describe("CDI Operand", func() {
 			})
 
 			It("should update if labels are missing", func() {
-				existsCdi, err := NewCDI(hco)
-				expectedRoleBinding := NewKubeVirtStorageRoleBindingForCR(hco, hco.Namespace, scheme)
+				expectedRoleBinding := NewConfigReaderRoleBindingForCR(hco, hco.Namespace)
 				expectedLabels := expectedRoleBinding.Labels
 				expectedRoleBinding.Labels = nil
-				Expect(err).ToNot(HaveOccurred())
 
-				cl := commonTestUtils.InitClient([]runtime.Object{hco, existsCdi, expectedRoleBinding})
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedRoleBinding})
 
-				handler := (*genericOperand)(newCdiHandler(cl, commonTestUtils.GetScheme()))
+				handler := (*genericOperand)(newConfigReaderRoleBindingHandler(cl, commonTestUtils.GetScheme()))
 				res := handler.ensure(req)
 				Expect(res.Err).ToNot(HaveOccurred())
 

--- a/pkg/controller/operands/cliDownload.go
+++ b/pkg/controller/operands/cliDownload.go
@@ -39,8 +39,6 @@ func (h cliDownloadHooks) getEmptyCr() client.Object {
 	return &consolev1.ConsoleCLIDownload{}
 }
 
-func (h cliDownloadHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
-
 func (h cliDownloadHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*consolev1.ConsoleCLIDownload).ObjectMeta
 }

--- a/pkg/controller/operands/dashboard.go
+++ b/pkg/controller/operands/dashboard.go
@@ -54,8 +54,6 @@ func (h dashboardHooks) getEmptyCr() client.Object {
 	}
 }
 
-func (h dashboardHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
-
 func (h dashboardHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*v1.ConfigMap).ObjectMeta
 }

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -174,8 +174,7 @@ func (h *kubevirtHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object,
 	return h.cache, nil
 }
 
-func (h kubevirtHooks) getEmptyCr() client.Object                          { return &kubevirtv1.KubeVirt{} }
-func (h kubevirtHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
+func (h kubevirtHooks) getEmptyCr() client.Object { return &kubevirtv1.KubeVirt{} }
 func (h kubevirtHooks) getConditions(cr runtime.Object) []metav1.Condition {
 	return translateKubeVirtConds(cr.(*kubevirtv1.KubeVirt).Status.Conditions)
 }
@@ -477,8 +476,7 @@ type kvPriorityClassHooks struct{}
 func (h kvPriorityClassHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewKubeVirtPriorityClass(hc), nil
 }
-func (h kvPriorityClassHooks) getEmptyCr() client.Object                              { return &schedulingv1.PriorityClass{} }
-func (h kvPriorityClassHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
+func (h kvPriorityClassHooks) getEmptyCr() client.Object { return &schedulingv1.PriorityClass{} }
 func (h kvPriorityClassHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*schedulingv1.PriorityClass).ObjectMeta
 }

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -47,8 +47,7 @@ type metricsServiceHooks struct{}
 func (h metricsServiceHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewMetricsService(hc, hc.Namespace), nil
 }
-func (h metricsServiceHooks) getEmptyCr() client.Object                          { return &corev1.Service{} }
-func (h metricsServiceHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
+func (h metricsServiceHooks) getEmptyCr() client.Object { return &corev1.Service{} }
 func (h metricsServiceHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*corev1.Service).ObjectMeta
 }
@@ -130,7 +129,6 @@ func (h metricsServiceMonitorHooks) getFullCr(hc *hcov1beta1.HyperConverged) (cl
 func (h metricsServiceMonitorHooks) getEmptyCr() client.Object {
 	return &monitoringv1.ServiceMonitor{}
 }
-func (h metricsServiceMonitorHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
 func (h metricsServiceMonitorHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*monitoringv1.ServiceMonitor).ObjectMeta
 }
@@ -198,8 +196,7 @@ type prometheusRuleHooks struct{}
 func (h prometheusRuleHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewPrometheusRule(hc, hc.Namespace), nil
 }
-func (h prometheusRuleHooks) getEmptyCr() client.Object                          { return &monitoringv1.PrometheusRule{} }
-func (h prometheusRuleHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
+func (h prometheusRuleHooks) getEmptyCr() client.Object { return &monitoringv1.PrometheusRule{} }
 func (h prometheusRuleHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*monitoringv1.PrometheusRule).ObjectMeta
 }

--- a/pkg/controller/operands/networkAddons.go
+++ b/pkg/controller/operands/networkAddons.go
@@ -49,8 +49,7 @@ func (h *cnaHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, erro
 	return h.cache, nil
 }
 
-func (h cnaHooks) getEmptyCr() client.Object                          { return &networkaddonsv1.NetworkAddonsConfig{} }
-func (h cnaHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
+func (h cnaHooks) getEmptyCr() client.Object { return &networkaddonsv1.NetworkAddonsConfig{} }
 func (h cnaHooks) getConditions(cr runtime.Object) []metav1.Condition {
 	return osConditionsToK8s(cr.(*networkaddonsv1.NetworkAddonsConfig).Status.Conditions)
 }

--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -52,8 +52,6 @@ type hcoResourceHooks interface {
 	// Generate an empty resource, to be used as the input of the client.Get method. After calling this method, it will
 	// contains the actual values in K8s.
 	getEmptyCr() client.Object
-	// an optional hook that is called just after getting the resource from K8s
-	postFound(*common.HcoRequest, runtime.Object) error
 	// check if there is a change between the required resource and the resource read from K8s, and update K8s accordingly.
 	updateCr(*common.HcoRequest, client.Client, runtime.Object, runtime.Object) (bool, bool, error)
 	// cast he specific resource to *metav1.ObjectMeta
@@ -101,10 +99,6 @@ func (h *genericOperand) ensure(req *common.HcoRequest) *EnsureResult {
 
 func (h *genericOperand) handleExistingCr(req *common.HcoRequest, key client.ObjectKey, found client.Object, cr client.Object, res *EnsureResult) *EnsureResult {
 	req.Logger.Info(h.crType+" already exists", h.crType+".Namespace", key.Namespace, h.crType+".Name", key.Name)
-
-	if err := h.hooks.postFound(req, found); err != nil {
-		return res.Error(err)
-	}
 
 	h.doRemoveExistingOwners(req, found)
 

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -50,6 +50,8 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, isOpenshift
 		(*genericOperand)(newKubevirtHandler(client, scheme)),
 		(*genericOperand)(newCdiHandler(client, scheme)),
 		(*genericOperand)(newStorageConfigHandler(client, scheme)),
+		(*genericOperand)(newConfigReaderRoleHandler(client, scheme)),
+		(*genericOperand)(newConfigReaderRoleBindingHandler(client, scheme)),
 		(*genericOperand)(newCnaHandler(client, scheme)),
 		(*genericOperand)(newVmImportHandler(client, scheme)),
 		(*genericOperand)(newImsConfigHandler(client, scheme)),

--- a/pkg/controller/operands/quickStart.go
+++ b/pkg/controller/operands/quickStart.go
@@ -59,8 +59,6 @@ func (h qsHooks) getEmptyCr() client.Object {
 	}
 }
 
-func (h qsHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
-
 func (h qsHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*consolev1.ConsoleQuickStart).ObjectMeta
 }

--- a/pkg/controller/operands/ssp.go
+++ b/pkg/controller/operands/ssp.go
@@ -126,8 +126,7 @@ func (h *sspHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, erro
 	}
 	return h.cache, nil
 }
-func (h sspHooks) getEmptyCr() client.Object                          { return &sspv1beta1.SSP{} }
-func (h sspHooks) postFound(*common.HcoRequest, runtime.Object) error { return nil }
+func (h sspHooks) getEmptyCr() client.Object { return &sspv1beta1.SSP{} }
 func (h sspHooks) getConditions(cr runtime.Object) []metav1.Condition {
 	return osConditionsToK8s(cr.(*sspv1beta1.SSP).Status.Conditions)
 }

--- a/pkg/controller/operands/vmImport.go
+++ b/pkg/controller/operands/vmImport.go
@@ -43,8 +43,7 @@ func (h *vmImportHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object,
 	}
 	return h.cache, nil
 }
-func (h vmImportHooks) getEmptyCr() client.Object                              { return &vmimportv1beta1.VMImportConfig{} }
-func (h vmImportHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
+func (h vmImportHooks) getEmptyCr() client.Object { return &vmimportv1beta1.VMImportConfig{} }
 func (h vmImportHooks) getConditions(cr runtime.Object) []metav1.Condition {
 	return osConditionsToK8s(cr.(*vmimportv1beta1.VMImportConfig).Status.Conditions)
 }
@@ -122,7 +121,6 @@ func (h imsConfigHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object,
 }
 func (h imsConfigHooks) getEmptyCr() client.Object { return &corev1.ConfigMap{} }
 
-func (h imsConfigHooks) postFound(_ *common.HcoRequest, _ runtime.Object) error { return nil }
 func (h imsConfigHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
 	return &cr.(*corev1.ConfigMap).ObjectMeta
 }


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

With this PR, hco operator w,ill start reconciling `hco.kubevirt.io:config-reader` Role&RoleBinding strictly like other operands. After this PR, changes on these operands will be overwritten immediately without requiring any change on CDI or HCO CRs. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1963963

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

