### PR TITLE
unstable index image in deploy_kustomize.sh

### DIFF
--- a/deploy/kustomize/base/subscription.yaml
+++ b/deploy/kustomize/base/subscription.yaml
@@ -6,5 +6,5 @@ spec:
   source: kubevirt-hyperconverged
   sourceNamespace: openshift-marketplace
   name: community-kubevirt-hyperconverged
-  startingCSV: kubevirt-hyperconverged-operator.v1.5.0
+  #startingCSV: kubevirt-hyperconverged-operator.v1.5.0
   channel: "1.5.0"

--- a/deploy/kustomize/deploy_kustomize.sh
+++ b/deploy/kustomize/deploy_kustomize.sh
@@ -3,8 +3,9 @@
 set -x
 
 # Setup Environment Variables
-HCO_VERSION="${HCO_VERSION:-1.5.0}"
+HCO_VERSION="${HCO_VERSION:-}"
 HCO_CHANNEL="${HCO_CHANNEL:-1.5.0}"
+HCO_INDEX_IMAGE="${HCO_INDEX_IMAGE:-quay.io/kubevirt/hyperconverged-cluster-index:1.5.0-unstable}"
 MARKETPLACE_MODE="${MARKETPLACE_MODE:-true}"
 PRIVATE_REPO="${PRIVATE_REPO:-false}"
 QUAY_USERNAME="${QUAY_USERNAME:-}"
@@ -21,8 +22,12 @@ main() {
   sed -i "s/- kubevirt-hyperconverged/- $TARGET_NAMESPACE/" $SCRIPT_DIR/base/operator_group.yaml
 
   # setting appropriate version and channel in the subscription manifest
-  sed -ri "s|(startingCSV.+v)[0-9].+|\1${HCO_VERSION}|" $SCRIPT_DIR/base/subscription.yaml
+  if [ -n "$HCO_VERSION" ]; then
+    sed -ri "s|(startingCSV.+v)[0-9].+|\1${HCO_VERSION}|" $SCRIPT_DIR/base/subscription.yaml
+    sed -ri "s|#startingCSV|startingCSV|" $SCRIPT_DIR/base/subscription.yaml
+  fi
   sed -ri "s|(channel: ).+|\1\"${HCO_CHANNEL}\"|" $SCRIPT_DIR/base/subscription.yaml
+  sed -ri "s|(image: ).+|\1\"${HCO_INDEX_IMAGE}\"|" $SCRIPT_DIR/image_registry/catalog_source.yaml
 
   TMPDIR=$(mktemp -d)
   cp -r $SCRIPT_DIR/* $TMPDIR

--- a/deploy/kustomize/image_registry/catalog_source.yaml
+++ b/deploy/kustomize/image_registry/catalog_source.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: quay.io/kubevirt/hco-container-registry:latest
+  image: quay.io/kubevirt/hyperconverged-cluster-index:1.5.0-unstable
   displayName: KubeVirt HyperConverged
   publisher: KubeVirt Project


### PR DESCRIPTION
unstable index image in deploy_kustomize.sh

Use by default the unstable index image in deploy_kustomize.sh
Set startingCSV only if really needed because
in the unstable index image the CSV name
includes also a timestamp.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
NONE
```

