### PR TITLE
Add the `runbook_url` annotation to all the alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -26,6 +26,7 @@ tests:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorCRModification.md"
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -37,6 +38,7 @@ tests:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "3 out-of-band CR modifications were detected in the last 10 minutes."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorCRModification.md"
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -48,6 +50,7 @@ tests:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorCRModification.md"
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -69,6 +72,7 @@ tests:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorCRModification.md"
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -80,6 +84,7 @@ tests:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "2 out-of-band CR modifications were detected in the last 10 minutes."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorCRModification.md"
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -109,17 +114,20 @@ tests:
         - exp_annotations:
             description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "1 unsafe modifications were detected in the HyperConverged resource."
+            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
           exp_labels:
             severity: "info"
             annotation_name: "kubevirt.kubevirt.io/jsonpatch"
         - exp_annotations:
             description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "1 unsafe modifications were detected in the HyperConverged resource."
+            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
           exp_labels:
             severity: "info"
             annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
         - exp_annotations:
             description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
             summary: "5 unsafe modifications were detected in the HyperConverged resource."
           exp_labels:
             severity: "info"
@@ -132,12 +140,14 @@ tests:
           - exp_annotations:
               description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "3 unsafe modifications were detected in the HyperConverged resource."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
             exp_labels:
               severity: "info"
               annotation_name: "kubevirt.kubevirt.io/jsonpatch"
           - exp_annotations:
               description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "3 unsafe modifications were detected in the HyperConverged resource."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
             exp_labels:
               severity: "info"
               annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
@@ -145,6 +155,7 @@ tests:
           - exp_annotations:
               description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "1 unsafe modifications were detected in the HyperConverged resource."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
             exp_labels:
               severity: "info"
               annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -156,6 +167,7 @@ tests:
           - exp_annotations:
               description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "3 unsafe modifications were detected in the HyperConverged resource."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
             exp_labels:
               severity: "info"
               annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -163,12 +175,14 @@ tests:
           - exp_annotations:
               description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "1 unsafe modifications were detected in the HyperConverged resource."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
             exp_labels:
               severity: "info"
               annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
           - exp_annotations:
               description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "1 unsafe modifications were detected in the HyperConverged resource."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
             exp_labels:
               severity: "info"
               annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -180,12 +194,14 @@ tests:
           - exp_annotations:
               description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "3 unsafe modifications were detected in the HyperConverged resource."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
             exp_labels:
               severity: "info"
               annotation_name: "kubevirt.kubevirt.io/jsonpatch"
           - exp_annotations:
               description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "3 unsafe modifications were detected in the HyperConverged resource."
+              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
             exp_labels:
               severity: "info"
               annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
@@ -202,6 +218,7 @@ tests:
         - exp_annotations:
             description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "1 unsafe modifications were detected in the HyperConverged resource."
+            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
           exp_labels:
             severity: "info"
             annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -209,12 +226,14 @@ tests:
         - exp_annotations:
             description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "2 unsafe modifications were detected in the HyperConverged resource."
+            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
           exp_labels:
             severity: "info"
             annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
         - exp_annotations:
             description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "3 unsafe modifications were detected in the HyperConverged resource."
+            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
           exp_labels:
             severity: "info"
             annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -231,6 +250,7 @@ tests:
         - exp_annotations:
             description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "2 unsafe modifications were detected in the HyperConverged resource."
+            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
           exp_labels:
             severity: "info"
             annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -238,12 +258,14 @@ tests:
         - exp_annotations:
             description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "3 unsafe modifications were detected in the HyperConverged resource."
+            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
           exp_labels:
             severity: "info"
             annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
         - exp_annotations:
             description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "1 unsafe modifications were detected in the HyperConverged resource."
+            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
           exp_labels:
             severity: "info"
             annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
 
@@ -27,6 +28,12 @@ const (
 	alertRuleGroup          = "kubevirt.hyperconverged.rules"
 	outOfBandUpdateAlert    = "KubevirtHyperconvergedClusterOperatorCRModification"
 	unsafeModificationAlert = "KubevirtHyperconvergedClusterOperatorUSModification"
+	runbookUrlTemplate      = "https://github.com/kubevirt/monitoring/blob/main/runbooks/%s.md"
+)
+
+var (
+	outOfBandUpdateRunbookUrl    = fmt.Sprintf(runbookUrlTemplate, outOfBandUpdateAlert)
+	unsafeModificationRunbookUrl = fmt.Sprintf(runbookUrlTemplate, unsafeModificationAlert)
 )
 
 type metricsServiceHandler genericOperand
@@ -254,6 +261,7 @@ func NewPrometheusRuleSpec() *monitoringv1.PrometheusRuleSpec {
 					Annotations: map[string]string{
 						"description": "Out-of-band modification for {{ $labels.component_name }}.",
 						"summary":     "{{ $value }} out-of-band CR modifications were detected in the last 10 minutes.",
+						"runbook_url": outOfBandUpdateRunbookUrl,
 					},
 					Labels: map[string]string{
 						"severity": "warning",
@@ -265,6 +273,7 @@ func NewPrometheusRuleSpec() *monitoringv1.PrometheusRuleSpec {
 					Annotations: map[string]string{
 						"description": "unsafe modification for the {{ $labels.annotation_name }} annotation in the HyperConverged resource.",
 						"summary":     "{{ $value }} unsafe modifications were detected in the HyperConverged resource.",
+						"runbook_url": unsafeModificationRunbookUrl,
 					},
 					Labels: map[string]string{
 						"severity": "info",


### PR DESCRIPTION
Runbooks are documents that describe alerts and explain what to do when they are triggered. 

This PR adds the missing runbook URLs to the existing alert definitions.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

