### PR TITLE
fix a bug in community operators publish workflow

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -9,6 +9,10 @@ jobs:
     if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')
     name: Publish HCO tagged version to community-operators
     runs-on: ubuntu-latest
+    env:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      REGISTRY_NAMESPACE: kubevirt
     steps:
       - name: resolve the correct branch of the tag
         run: |


### PR DESCRIPTION
`.github/workflows/publish-community-operators.yaml` uses `make container-push`, but lacks the env vars requires for quay login.
This PR fixes this.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

