### PR TITLE
Update .status.storedVersions on the CRD on upgrades

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -339,6 +339,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions/status
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -339,6 +339,16 @@ spec:
           - list
           - watch
         - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions/status
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - servicemonitors

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/kubevirt-hyperconverged-operator.v1.5.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.5.0-unstable
-    createdAt: "2021-07-24 05:10:48"
+    createdAt: "2021-07-30 17:56:58"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -338,6 +338,16 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions/status
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -416,6 +416,13 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 			Resources: stringListToSilce("customresourcedefinitions"),
 			Verbs:     stringListToSilce("get", "list", "watch"),
 		},
+		{
+			APIGroups: []string{
+				"apiextensions.k8s.io",
+			},
+			Resources: stringListToSilce("customresourcedefinitions/status"),
+			Verbs:     stringListToSilce("get", "list", "watch", "patch", "update"),
+		},
 		roleWithAllPermissions("monitoring.coreos.com", stringListToSilce("servicemonitors", "prometheusrules")),
 		{
 			APIGroups: []string{

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	consolev1 "github.com/openshift/api/console/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"os"
 
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
@@ -83,6 +84,7 @@ type BasicExpected struct {
 	serviceMonitor       *monitoringv1.ServiceMonitor
 	promRule             *monitoringv1.PrometheusRule
 	cliDownload          *consolev1.ConsoleCLIDownload
+	hcoCRD               *apiextensionsv1.CustomResourceDefinition
 }
 
 func (be BasicExpected) toArray() []runtime.Object {
@@ -102,6 +104,7 @@ func (be BasicExpected) toArray() []runtime.Object {
 		be.serviceMonitor,
 		be.promRule,
 		be.cliDownload,
+		be.hcoCRD,
 	}
 }
 
@@ -202,6 +205,13 @@ func getBasicDeployment() *BasicExpected {
 	expectedCliDownload := operands.NewConsoleCLIDownload(hco)
 	expectedCliDownload.SelfLink = fmt.Sprintf("/apis/console.openshift.io/v1/consoleclidownloads/%s", expectedCliDownload.Name)
 	res.cliDownload = expectedCliDownload
+
+	hcoCrd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hyperconvergeds.hco.kubevirt.io",
+		},
+	}
+	res.hcoCRD = hcoCrd
 
 	return res
 }


### PR DESCRIPTION
Update .status.storedVersions on the CRD on upgrades

.status.storedVersions is not automatically
updated by any CRD controller when all the
CRs get migrated to the next stored version.
So in clusters initially deployed when
v1alpha1 was the stored version,
.status.storedVersions is going to contain
["v1alpha1", "v1beta1"] and this is
enough to prevent the upgrade to 1.4.0 where
we dropped v1alpha1.

Fixes: https://bugzilla.redhat.com/1986989

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update .status.storedVersions on the CRD on upgrades
```

