### PR TITLE
[release-1.4] Update .status.storedVersions on the CRD

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -323,6 +323,16 @@ rules:
   - patch
   - update
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions/status
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/manifests/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.4.0/manifests/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -305,6 +305,16 @@ spec:
           - patch
           - update
         - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions/status
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
           - security.openshift.io
           resources:
           - securitycontextconstraints

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/manifests/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.4.0/manifests/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.4.0-unstable
-    createdAt: "2021-07-26 11:28:22"
+    createdAt: "2021-07-31 11:30:48"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -302,6 +302,16 @@ spec:
           - watch
           - create
           - delete
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions/status
+          verbs:
+          - get
+          - list
+          - watch
           - patch
           - update
         - apiGroups:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -598,6 +598,21 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
+				"apiextensions.k8s.io",
+			},
+			Resources: []string{
+				"customresourcedefinitions/status",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"patch",
+				"update",
+			},
+		},
+		{
+			APIGroups: []string{
 				"security.openshift.io",
 			},
 			Resources: []string{

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -3,6 +3,7 @@ package hyperconverged
 import (
 	"context"
 	"fmt"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"os"
 	"reflect"
 	"strings"
@@ -302,6 +303,15 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 	req.SetUpgradeMode(r.upgradeMode)
 
 	if r.upgradeMode {
+		crdStatusUpdated, err := r.updateCrdStoredVersions(req)
+		if err != nil {
+			return reconcile.Result{Requeue: true}, err
+		} else {
+			if crdStatusUpdated {
+				return reconcile.Result{Requeue: true}, nil
+			}
+		}
+
 		modified, err := r.migrateBeforeUpgrade(req)
 		if err != nil {
 			return reconcile.Result{Requeue: init}, err
@@ -873,7 +883,44 @@ const (
 	imsCmName        = "v2v-vmware"
 	liveMigrationKey = "migrations"
 	vddkInitImakeKey = "vddk-init-image"
+	crdName          = "hyperconvergeds.hco.kubevirt.io"
 )
+
+func (r *ReconcileHyperConverged) updateCrdStoredVersions(req *common.HcoRequest) (bool, error) {
+	versionsToBeRemoved := []string{"v1alpha1"}
+
+	found := &apiextensionsv1.CustomResourceDefinition{}
+	key := client.ObjectKey{Namespace: hcoutil.UndefinedNamespace, Name: crdName}
+	err := r.client.Get(req.Ctx, key, found)
+	if err != nil {
+		req.Logger.Error(err, fmt.Sprintf("failed to read the %s CRD; %s", crdName, err.Error()))
+		return false, err
+	}
+
+	needsUpdate := false
+	newStoredVersions := []string{}
+	for _, vToBeRemoved := range versionsToBeRemoved {
+		for _, sVersion := range found.Status.StoredVersions {
+			if vToBeRemoved != sVersion {
+				newStoredVersions = append(newStoredVersions, sVersion)
+			} else {
+				needsUpdate = true
+			}
+		}
+	}
+	if needsUpdate {
+		found.Status.StoredVersions = newStoredVersions
+		err = r.client.Status().Update(req.Ctx, found)
+		if err != nil {
+			req.Logger.Error(err, fmt.Sprintf("failed updating the %s CRD status: %s", crdName, err.Error()))
+			return false, err
+		}
+		req.Logger.Info("successfully updated status.storedVersions on HCO CRD", "CRD Name", crdName)
+		return true, nil
+	}
+
+	return false, nil
+}
 
 func (r *ReconcileHyperConverged) migrateBeforeUpgrade(req *common.HcoRequest) (bool, error) {
 	kvConfigModified, err := r.migrateKvConfigurations(req)

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	consolev1 "github.com/openshift/api/console/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"os"
 
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
@@ -75,6 +76,7 @@ type BasicExpected struct {
 	serviceMonitor       *monitoringv1.ServiceMonitor
 	promRule             *monitoringv1.PrometheusRule
 	cliDownload          *consolev1.ConsoleCLIDownload
+	hcoCRD               *apiextensionsv1.CustomResourceDefinition
 }
 
 func (be BasicExpected) toArray() []runtime.Object {
@@ -94,6 +96,7 @@ func (be BasicExpected) toArray() []runtime.Object {
 		be.serviceMonitor,
 		be.promRule,
 		be.cliDownload,
+		be.hcoCRD,
 	}
 }
 
@@ -193,6 +196,13 @@ func getBasicDeployment() *BasicExpected {
 	expectedCliDownload := operands.NewConsoleCLIDownload(hco)
 	expectedCliDownload.SelfLink = fmt.Sprintf("/apis/console.openshift.io/v1/consoleclidownloads/%s", expectedCliDownload.Name)
 	res.cliDownload = expectedCliDownload
+
+	hcoCrd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hyperconvergeds.hco.kubevirt.io",
+		},
+	}
+	res.hcoCRD = hcoCrd
 
 	return res
 }


### PR DESCRIPTION
.status.storedVersions is not automatically
updated by any CRD controller when all the
CRs get migrated to the next stored version.
So in clusters initially deployed when
v1alpha1 was the stored version,
.status.storedVersions is going to contain
["v1alpha1", "v1beta1"] and this is
enough to prevent the upgrade to 1.4.0 where
we dropped v1alpha1.

This is a manual cherry pick of
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1457

Fixes: https://bugzilla.redhat.com/1986989

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update .status.storedVersions on the CRD on upgrades
```

