### PR TITLE
[release-1.3] Update .status.storedVersions on the CRD

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -314,6 +314,16 @@ rules:
   - patch
   - update
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions/status
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.3.0/manifests/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.3.0/manifests/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -357,6 +357,16 @@ spec:
           - patch
           - update
         - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions/status
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
           - security.openshift.io
           resources:
           - securitycontextconstraints

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.3.0/manifests/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.3.0/manifests/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:46b81b9c5c9ff6be953bddcbf3537258d5f96ade8ddfbf355e67075fbe670368
-    createdAt: "2021-06-09 18:26:08"
+    createdAt: "2021-07-31 12:00:50"
     description: |-
       **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
       Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
@@ -354,6 +354,16 @@ spec:
           - watch
           - create
           - delete
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions/status
+          verbs:
+          - get
+          - list
+          - watch
           - patch
           - update
         - apiGroups:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -535,6 +535,21 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
+				"apiextensions.k8s.io",
+			},
+			Resources: []string{
+				"customresourcedefinitions/status",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"patch",
+				"update",
+			},
+		},
+		{
+			APIGroups: []string{
 				"security.openshift.io",
 			},
 			Resources: []string{

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -2,6 +2,7 @@ package hyperconverged
 
 import (
 	"fmt"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"os"
 
 	"github.com/google/uuid"
@@ -332,6 +333,14 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 		r.upgradeMode = true
 		r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "UpgradeHCO", "Upgrading the HyperConverged to version "+r.ownVersion)
 		req.Logger.Info(fmt.Sprintf("Start upgrading from version %s to version %s", knownHcoVersion, r.ownVersion))
+		crdStatusUpdated, err := r.updateCrdStoredVersions(req)
+		if err != nil {
+			return reconcile.Result{Requeue: true}, err
+		} else {
+			if crdStatusUpdated {
+				return reconcile.Result{Requeue: true}, nil
+			}
+		}
 	}
 
 	req.SetUpgradeMode(r.upgradeMode)
@@ -785,6 +794,43 @@ func (r *ReconcileHyperConverged) detectTaintedConfiguration(req *common.HcoRequ
 			req.StatusDirty = true
 		}
 	}
+}
+
+func (r *ReconcileHyperConverged) updateCrdStoredVersions(req *common.HcoRequest) (bool, error) {
+	const crdName = "hyperconvergeds.hco.kubevirt.io"
+	versionsToBeRemoved := []string{"v1alpha1"}
+
+	found := &apiextensionsv1.CustomResourceDefinition{}
+	key := client.ObjectKey{Namespace: hcoutil.UndefinedNamespace, Name: crdName}
+	err := r.client.Get(req.Ctx, key, found)
+	if err != nil {
+		req.Logger.Error(err, fmt.Sprintf("failed to read the %s CRD; %s", crdName, err.Error()))
+		return false, err
+	}
+
+	needsUpdate := false
+	newStoredVersions := []string{}
+	for _, vToBeRemoved := range versionsToBeRemoved {
+		for _, sVersion := range found.Status.StoredVersions {
+			if vToBeRemoved != sVersion {
+				newStoredVersions = append(newStoredVersions, sVersion)
+			} else {
+				needsUpdate = true
+			}
+		}
+	}
+	if needsUpdate {
+		found.Status.StoredVersions = newStoredVersions
+		err = r.client.Status().Update(req.Ctx, found)
+		if err != nil {
+			req.Logger.Error(err, fmt.Sprintf("failed updating the %s CRD status: %s", crdName, err.Error()))
+			return false, err
+		}
+		req.Logger.Info("successfully updated status.storedVersions on HCO CRD", "CRD Name", crdName)
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // getHyperconverged returns the name/namespace of the HyperConverged resource

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -3,6 +3,7 @@ package hyperconverged
 import (
 	"context"
 	"fmt"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"os"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -72,6 +73,7 @@ type BasicExpected struct {
 	mService             *corev1.Service
 	serviceMonitor       *monitoringv1.ServiceMonitor
 	promRule             *monitoringv1.PrometheusRule
+	hcoCRD               *apiextensionsv1.CustomResourceDefinition
 }
 
 func (be BasicExpected) toArray() []runtime.Object {
@@ -91,6 +93,7 @@ func (be BasicExpected) toArray() []runtime.Object {
 		be.mService,
 		be.serviceMonitor,
 		be.promRule,
+		be.hcoCRD,
 	}
 }
 
@@ -187,6 +190,13 @@ func getBasicDeployment() *BasicExpected {
 	res.imsConfig.Data["v2v-conversion-image"] = commonTestUtils.Conversion_image
 	res.imsConfig.Data["kubevirt-vmware-image"] = commonTestUtils.Vmware_image
 	res.imsConfig.Data["virtio-win-image"] = commonTestUtils.VirtioWinImage
+
+	hcoCrd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hyperconvergeds.hco.kubevirt.io",
+		},
+	}
+	res.hcoCRD = hcoCrd
 
 	return res
 }


### PR DESCRIPTION
.status.storedVersions is not automatically
updated by any CRD controller when all the
CRs get migrated to the next stored version.
So in clusters initially deployed when
v1alpha1 was the stored version,
.status.storedVersions is going to contain
["v1alpha1", "v1beta1"] and this is
enough to prevent the upgrade to 1.4.0 where
we dropped v1alpha1.

This is a manual cherry pick of
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1457

Fixes: https://bugzilla.redhat.com/1986989

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update .status.storedVersions on the CRD on upgrades
```

