### PR TITLE
Fix the runbook links in the alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -26,7 +26,7 @@ tests:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorCRModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorCRModification"
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -38,7 +38,7 @@ tests:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "3 out-of-band CR modifications were detected in the last 10 minutes."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorCRModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorCRModification"
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -50,7 +50,7 @@ tests:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorCRModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorCRModification"
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -72,7 +72,7 @@ tests:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "1 out-of-band CR modifications were detected in the last 10 minutes."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorCRModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorCRModification"
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -84,7 +84,7 @@ tests:
           - exp_annotations:
               description: "Out-of-band modification for kubevirt/kubevirt-kubevirt-hyperconverged."
               summary: "2 out-of-band CR modifications were detected in the last 10 minutes."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorCRModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorCRModification"
             exp_labels:
               severity: "warning"
               component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -114,20 +114,20 @@ tests:
         - exp_annotations:
             description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "1 unsafe modifications were detected in the HyperConverged resource."
-            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
           exp_labels:
             severity: "info"
             annotation_name: "kubevirt.kubevirt.io/jsonpatch"
         - exp_annotations:
             description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "1 unsafe modifications were detected in the HyperConverged resource."
-            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
           exp_labels:
             severity: "info"
             annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
         - exp_annotations:
             description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
-            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
             summary: "5 unsafe modifications were detected in the HyperConverged resource."
           exp_labels:
             severity: "info"
@@ -140,14 +140,14 @@ tests:
           - exp_annotations:
               description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "3 unsafe modifications were detected in the HyperConverged resource."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
             exp_labels:
               severity: "info"
               annotation_name: "kubevirt.kubevirt.io/jsonpatch"
           - exp_annotations:
               description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "3 unsafe modifications were detected in the HyperConverged resource."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
             exp_labels:
               severity: "info"
               annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
@@ -155,7 +155,7 @@ tests:
           - exp_annotations:
               description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "1 unsafe modifications were detected in the HyperConverged resource."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
             exp_labels:
               severity: "info"
               annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -167,7 +167,7 @@ tests:
           - exp_annotations:
               description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "3 unsafe modifications were detected in the HyperConverged resource."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
             exp_labels:
               severity: "info"
               annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -175,14 +175,14 @@ tests:
           - exp_annotations:
               description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "1 unsafe modifications were detected in the HyperConverged resource."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
             exp_labels:
               severity: "info"
               annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
           - exp_annotations:
               description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "1 unsafe modifications were detected in the HyperConverged resource."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
             exp_labels:
               severity: "info"
               annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -194,14 +194,14 @@ tests:
           - exp_annotations:
               description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "3 unsafe modifications were detected in the HyperConverged resource."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
             exp_labels:
               severity: "info"
               annotation_name: "kubevirt.kubevirt.io/jsonpatch"
           - exp_annotations:
               description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
               summary: "3 unsafe modifications were detected in the HyperConverged resource."
-              runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
             exp_labels:
               severity: "info"
               annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
@@ -218,7 +218,7 @@ tests:
         - exp_annotations:
             description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "1 unsafe modifications were detected in the HyperConverged resource."
-            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
           exp_labels:
             severity: "info"
             annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -226,14 +226,14 @@ tests:
         - exp_annotations:
             description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "2 unsafe modifications were detected in the HyperConverged resource."
-            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
           exp_labels:
             severity: "info"
             annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
         - exp_annotations:
             description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "3 unsafe modifications were detected in the HyperConverged resource."
-            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
           exp_labels:
             severity: "info"
             annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -250,7 +250,7 @@ tests:
         - exp_annotations:
             description: "unsafe modification for the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "2 unsafe modifications were detected in the HyperConverged resource."
-            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
           exp_labels:
             severity: "info"
             annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -258,14 +258,14 @@ tests:
         - exp_annotations:
             description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "3 unsafe modifications were detected in the HyperConverged resource."
-            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
           exp_labels:
             severity: "info"
             annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
         - exp_annotations:
             description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
             summary: "1 unsafe modifications were detected in the HyperConverged resource."
-            runbook_url: "https://github.com/kubevirt/monitoring/blob/main/runbooks/KubevirtHyperconvergedClusterOperatorUSModification.md"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
           exp_labels:
             severity: "info"
             annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -28,7 +28,7 @@ const (
 	alertRuleGroup          = "kubevirt.hyperconverged.rules"
 	outOfBandUpdateAlert    = "KubevirtHyperconvergedClusterOperatorCRModification"
 	unsafeModificationAlert = "KubevirtHyperconvergedClusterOperatorUSModification"
-	runbookUrlTemplate      = "https://github.com/kubevirt/monitoring/blob/main/runbooks/%s.md"
+	runbookUrlTemplate      = "https://kubevirt.io/monitoring/runbooks/%s"
 )
 
 var (


### PR DESCRIPTION
The monitoring repository now uses github pages to serve the runbooks. Fix the alerts' runbook links to match this change.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [x] PR Message
- [x] Commit Messages
- [x] How to test
- [x] Unit Tests
- [x] Functional Tests
- [x] User Documentation
- [x] Developer Documentation
- [x] Upgrade Scenario
- [x] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

