### PR TITLE
Add container for virt-artifacts-server

### DIFF
--- a/build/Dockerfile.artifacts
+++ b/build/Dockerfile.artifacts
@@ -1,0 +1,26 @@
+FROM registry.access.redhat.com/ubi8/nginx-118
+
+COPY hack/config /tmp/config
+
+USER 0
+RUN dnf -y install zip
+USER 1001
+
+ARG download_url=https://github.com/kubevirt/kubevirt/releases/download
+
+RUN source /tmp/config && \
+    curl -L -o virtctl "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-amd64" && \
+    mkdir -p ./amd64/linux && tar -zhcf ./amd64/linux/virtctl.tar virtctl && rm virtctl && \
+    curl -L -o virtctl "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-darwin-amd64" && \
+    mkdir -p ./amd64/mac && zip -r -q ./amd64/mac/virtctl.zip virtctl && rm virtctl && \
+    curl -L -o virtctl.exe "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-windows-amd64.exe" && \
+    mkdir -p ./amd64/windows && zip -r -q ./amd64/windows/virtctl.zip virtctl.exe && rm virtctl.exe
+
+
+ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git
+ARG git_sha=NONE
+
+LABEL multi.GIT_URL=${git_url} \
+      multi.GIT_SHA=${git_sha}
+
+CMD nginx -g "daemon off;"


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

To be able to merge #1466, we need to adapt openshift/release configuration. The change is here https://github.com/openshift/release/pull/20950. To be able to merge that PR, we need to merge this PR initially. 

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

