### PR TITLE
Fix WORKDIR for virt-artifacts-server

### DIFF
--- a/build/Dockerfile.artifacts
+++ b/build/Dockerfile.artifacts
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi8/nginx-118
 
+WORKDIR /opt/app-root/src
+
 COPY hack/config /tmp/config
 
 USER 0


### PR DESCRIPTION
WORKDIR may be different in different environment and
we should not rely on the default value

Signed-off-by: Erkan Erol <eerol@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

