### PR TITLE
Auto bump kubevirt-ci to the latest release

### DIFF
--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.19'}
-
-KUBEVIRTCI_VERSION="8f48705333a7b9c4c91cf8a0b96b40bb54ef6c8d"
-export KUBEVIRTCI_TAG=2103111738-8f48705
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.20'}
+export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 
 function kubevirtci::install() {
@@ -23,7 +21,7 @@ function kubevirtci::install() {
         git clone https://github.com/kubevirt/kubevirtci.git ${KUBEVIRTCI_PATH}
         (
             cd ${KUBEVIRTCI_PATH}
-            git checkout ${KUBEVIRTCI_VERSION}
+            git checkout tags/${KUBEVIRTCI_TAG} -b ${KUBEVIRTCI_TAG}
         )
     fi
 }

--- a/hack/bump-kubevirtci.sh
+++ b/hack/bump-kubevirtci.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-val=$(git ls-remote https://github.com/kubevirt/kubevirtci | grep HEAD | awk '{print $1}')
-sed -i "/^[[:blank:]]*[KUBEVIRTCI_VERSION[:blank:]]*=/s/=.*/=\"${val}\"/" cluster/kubevirtci.sh
-git --no-pager diff cluster/kubevirtci.sh | grep KUBEVIRTCI_VERSION


### PR DESCRIPTION
This will allow adding the 1.21 lane.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

