### PR TITLE
Enable DownwardMetrics FeatureGate

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -172,7 +172,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(kvList.Items).Should(HaveLen(1))
 				kv := kvList.Items[0]
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(12))
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(13))
 
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(
 					"DataVolumes",
@@ -185,7 +185,9 @@ var _ = Describe("HyperconvergedController", func() {
 					"GPU",
 					"HostDevices",
 					"WithHostModelCPU",
-					"HypervStrictCheck"),
+					"HypervStrictCheck",
+					"DownwardMetrics",
+				),
 				)
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement("WithHostPassthroughCPU"))
 			})

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -82,6 +82,9 @@ const (
 
 	// Allow assigning host devices to virtual machines
 	kvHostDevicesGate = "HostDevices"
+
+	// Add downwardMetrics volume to expose a limited set of host metrics to guests
+	kvDownwardMetricsGate = "DownwardMetrics"
 )
 
 var (
@@ -95,6 +98,7 @@ var (
 		kvHotplugVolumesGate,
 		kvGPUGate,
 		kvHostDevicesGate,
+		kvDownwardMetricsGate,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of


### PR DESCRIPTION
github.com/kubevirt/kubevirt/pull/5502
introduced a new Kubevirt feature named
downwardMetrics to expose host metrics
to guests.
The feature is controlled by a feature
gate named "DownwardMetrics".
Enable it in the list of HCO
opinionated feature gates.

Fixes: https://bugzilla.redhat.com/1991691

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
Enable DownwardMetrics FeatureGate on Kubevirt
```

