### PR TITLE
Reference unstable bundle in unstable index by digests

### DIFF
--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -43,11 +43,9 @@ function create_index_image() {
   docker build -t "${BUNDLE_IMAGE_NAME}" -f bundle.Dockerfile --build-arg "VERSION=${CURRENT_VERSION}" .
   docker push "${BUNDLE_IMAGE_NAME}"
 
-  # In case of stable version, extract the digest of the bundle image, to be added to the index image
-  # Otherwise use a floating tag for the unstable bundle image.
-  if [[ "${UNSTABLE}" != "UNSTABLE" ]]; then
-    BUNDLE_IMAGE_NAME=$("${PROJECT_ROOT}/tools/digester/digester" --image "${BUNDLE_IMAGE_NAME}")
-  fi
+  # Referencing the unstable bundle digest in the index image, rather than the floating tag, to avoid
+  # unalignment between cached index image and fetched bundle image.
+  BUNDLE_IMAGE_NAME=$("${PROJECT_ROOT}/tools/digester/digester" --image "${BUNDLE_IMAGE_NAME}")
 
   # shellcheck disable=SC2086
   ${OPM} index add --bundles "${BUNDLE_IMAGE_NAME}" ${INDEX_IMAGE_PARAM} --tag "${INDEX_IMAGE_NAME}" -u docker --mode semver


### PR DESCRIPTION
This is done to avoid unaligned contents between the csv version/timestamp in the bundle, to the one in the index db.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

