### PR TITLE
Cancel 2-phase init of some reources

### DIFF
--- a/cmd/cmdcommon/cmdcommon.go
+++ b/cmd/cmdcommon/cmdcommon.go
@@ -109,10 +109,6 @@ func (h HcCmdHelper) ExitOnError(err error, message string, keysAndValues ...int
 	}
 }
 
-func (h HcCmdHelper) IsRunInLocal() bool {
-	return h.runInLocal
-}
-
 func (h HcCmdHelper) AddToScheme(scheme *apiruntime.Scheme, addToSchemeFuncs []func(*apiruntime.Scheme) error) {
 	for _, f := range addToSchemeFuncs {
 		err := f(scheme)

--- a/pkg/controller/commonTestUtils/eventEmitterMock.go
+++ b/pkg/controller/commonTestUtils/eventEmitterMock.go
@@ -3,10 +3,9 @@ package commonTestUtils
 import (
 	"context"
 	"github.com/go-logr/logr"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sync"
 )
 
@@ -35,7 +34,7 @@ func (eem *EventEmitterMock) Reset() {
 	eem.storedEvents = make([]MockEvent, 0)
 }
 
-func (EventEmitterMock) Init(_ context.Context, _ manager.Manager, _ hcoutil.ClusterInfo, _ logr.Logger) {
+func (EventEmitterMock) Init(_ context.Context, _ client.Client, _ record.EventRecorder, _ logr.Logger) {
 	/* not implemented; mock only */
 }
 

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -884,10 +884,6 @@ func getNumOfChangesJsonPatch(jsonPatch string) int {
 }
 
 func (r *ReconcileHyperConverged) firstLoopInitialization(request *common.HcoRequest) {
-	// Reload eventEmitter.
-	// The client should now find all the required resources.
-	r.eventEmitter.UpdateClient(request.Ctx, r.client, request.Logger)
-
 	// Initialize operand handler.
 	r.operandHandler.FirstUseInitiation(r.scheme, hcoutil.GetClusterInfo().IsOpenshift(), request.Instance)
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -88,7 +88,8 @@ func GetWatchNamespace() (string, error) {
 	return ns, nil
 }
 
-func GetPod(ctx context.Context, c client.Reader, logger logr.Logger, ci ClusterInfo) (*corev1.Pod, error) {
+func GetPod(ctx context.Context, c client.Reader, logger logr.Logger) (*corev1.Pod, error) {
+	ci := GetClusterInfo()
 	operatorNs, err := GetOperatorNamespace(logger)
 	if err != nil {
 		logger.Error(err, "Failed to get HCO namespace")


### PR DESCRIPTION
The client from the manager can't be used before its cache is populated. That prevents some initialization operation, like setting up the `clientInfo` and the event emitter. The solution so far was to perform the initialization in two phases - one on boot up and the second on the first reconciliation loop.

But it is possible to get a client without cache that will work on boot up. This PR uses such a client to remove the late initialization and perform everything on boot time.

This is mostly preparation for the operator-condition implementation, that must setup the operator condition on boot up.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

