### PR TITLE
Document why we don't have a race condition removing v2v

### DIFF
--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -284,12 +284,18 @@ if [[ -n ${KV_CM_FOUND} ]]; then
   ${CMD} get cm kubevirt-config-backup -n ${HCO_NAMESPACE}
 fi
 
-Msg "Check that the v2v CRDs were removed"
+Msg "Check that the v2v CRDs and deployments were removed"
 if ${CMD} get crd | grep -q v2v.kubevirt.io; then
     echo "The v2v CRDs should not be found; they had to be removed."
     exit 1
 else
     echo "v2v CRDs removed"
+fi
+if ${CMD} get deployments -n ${HCO_NAMESPACE} | grep -q vm-import; then
+    echo "v2v deployments should not be found; they had to be removed."
+    exit 1
+else
+    echo "v2v deployments removed"
 fi
 
 Msg "Check that the v2v references were removed from .status.relatedObjects"

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -382,7 +382,20 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 			}
 		}
 
-		// Attempt to remove old CRDs and related objects
+		// Attempt to remove old CRDs and related objects:
+		// Directly removing v2v CRDs will be enough to trigger the
+		// removal of the corresponding CRs.
+		// vmimportconfigs CR is protected by "vm-import-finalizer"
+		// which is managed by vm-import-operator that should remove
+		// all of its operands before removing the finalizer so that the
+		// CR and then the CRD can be really deleted.
+		// We don't have any race condition here because the CRD will be
+		// deleted without blocking the caller.
+		// vm-import-operator pod on the other side is not deleted during the
+		// upgrade process, but only at the end of it as a consequence of
+		// the removal of the old CSV (vm-import-operator deployment has
+		// an owner reference on it) once the upgrade successfully completed.
+
 		cdrRemover := newCRDremover(r.client)
 		err = cdrRemover.Remove(req)
 		if err != nil {


### PR DESCRIPTION
The removal of vm-import-operator is tricky
with its deployment removed just as a consequence
of the removal of the old CSV.
Let's document it to prevent introducing regressions
in the future.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
NONE
```

