### PR TITLE
Remove the IMAGE_FORMAT env var from the E2E test

### DIFF
--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -17,8 +17,7 @@ fi
 
 if [[ ${JOB_TYPE} = "prow" ]]; then
     KUBECTL_BINARY="oc"
-    component=hyperconverged-cluster-functest
-    computed_test_image=`eval echo ${IMAGE_FORMAT}`
+    computed_test_image=${FUNCTEST_IMAGE}
 else
     operator_image="$($KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" get pod -l name=hyperconverged-cluster-operator -o jsonpath='{.items[0] .spec .containers[?(@.name=="hyperconverged-cluster-operator")] .image}')"
     computed_test_image="${operator_image//hyperconverged-cluster-operator/hyperconverged-cluster-functest}"


### PR DESCRIPTION
openshift ci is deprecating the `IMAGE_FORMAT` env var for tests. this PR changes the e2e test to stop using it.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

