### PR TITLE
Add new recording rule "cluster:vmi_request_cpu_cores:sum"

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -269,4 +269,64 @@ tests:
           exp_labels:
             severity: "info"
             annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
-
+  # Test recording rule
+  - interval: 1m
+    input_series:
+      # take all containers of running virt-launcher pods
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-x-y", resource="cpu", container="compute"}'
+        # time:  0   1   2   3   4   5
+        values: "0.1 0.1 0.1 0.1 0.1 0.1"
+      # take all containers of running virt-launcher pods
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-x-y", resource="cpu", container="volumecontainerdisk"}'
+        # time:  0    1    2    3    4    5
+        values: "0.01 0.01 0.01 0.01 0.01 0.01"
+      - series: 'kube_pod_labels{label_kubevirt_io="virt-launcher",pod="virt-launcher-x-y"}'
+        # time:  0 1 2 3 4 5
+        values: "1 1 1 1 1 1"
+      - series: 'kube_pod_status_phase{phase="Running", pod="virt-launcher-x-y"}'
+        # time:  0 1 2 3 4 5
+        values: "1 1 1 1 1 1"
+      # do not take containers of other pods
+      - series: 'kube_pod_container_resource_requests{pod="other-pod", resource="cpu", container="volumecontainerdisk"}'
+        # time:  0 1 2 3 4 5
+        values: "5 5 5 5 5 5"
+      - series: 'kube_pod_status_phase{phase="Running", pod="other-pod"}'
+        # time:  0 1 2 3 4 5
+        values: "1 1 1 1 1 1"
+      - series: 'kube_pod_labels{other_label="other-value",pod="other-pod"}'
+        # time:  0 1 2 3 4 5
+        values: "1 1 1 1 1 1"
+      # new VMIs can be created in time
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-new", resource="cpu", container="volumecontainerdisk"}'
+        # time:  0     1     2     3   4    5
+        values: "stale stale stale 0.01 0.01 0.01"
+      - series: 'kube_pod_labels{label_kubevirt_io="virt-launcher",pod="virt-launcher-new"}'
+        # time: 0      1     2     3 4 5
+        values: "stale stale stale 1 1 1"
+      - series: 'kube_pod_status_phase{phase="Running", pod="virt-launcher-new"}'
+        # time:  0     1     2     3 4 5
+        values: "stale stale stale 1 0 1"
+    promql_expr_test:
+      - expr: 'cluster:vmi_request_cpu_cores:sum'
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:vmi_request_cpu_cores:sum{}'
+            value: 0.11
+      # update for new pods
+      - expr: 'cluster:vmi_request_cpu_cores:sum'
+        eval_time: 3m
+        exp_samples:
+          - labels: 'cluster:vmi_request_cpu_cores:sum{}'
+            value: 0.12
+      # virt-launcher-new is not running at 4m. must exclude it
+      - expr: 'cluster:vmi_request_cpu_cores:sum'
+        eval_time: 4m
+        exp_samples:
+          - labels: 'cluster:vmi_request_cpu_cores:sum{}'
+            value: 0.11
+      # virt-launcher-new is back at 5m. must include it
+      - expr: 'cluster:vmi_request_cpu_cores:sum'
+        eval_time: 5m
+        exp_samples:
+          - labels: 'cluster:vmi_request_cpu_cores:sum{}'
+            value: 0.12

--- a/pkg/controller/operands/monitoring.go
+++ b/pkg/controller/operands/monitoring.go
@@ -279,6 +279,11 @@ func NewPrometheusRuleSpec() *monitoringv1.PrometheusRuleSpec {
 						"severity": "info",
 					},
 				},
+				// Recording rules for openshift/cluster-monitoring-operator
+				{
+					Record: "cluster:vmi_request_cpu_cores:sum",
+					Expr:   intstr.FromString(`sum(kube_pod_container_resource_requests{resource="cpu"} and on (pod) kube_pod_status_phase{phase="Running"} * on (pod) group_left kube_pod_labels{ label_kubevirt_io="virt-launcher"} > 0)`),
+				},
 			},
 		}},
 	}


### PR DESCRIPTION
We want to add a new metric into cluster-monitoring-operator to track sum of cpu requests of virt-launcher pods.


"cluster" prefix means that the scope of the metric is cluster-wide like the other metrics in the cluster-monitoring-operator. "cnv" is not used here since it is not related to this upstream project 

Details:
- It relies on cpu requests on pod specs.
- This recording rule only accounts virt-launcher pods and ignores pods of control-plane.
- It only accounts "Running" pods. Other states (Pending, Succeeded, Failed) are ignored.
- It ignores initContainers

Signed-off-by: Erkan Erol <eerol@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add  new recording rule ("cnv:vmi_request_cpu_cores:sum" ) to keep track of sum of allocated CPUs to VMIs.
```

