### PR TITLE
Update dashboards path to be used by OCP UI

### DIFF
--- a/.github/workflows/dashboard-updater.yml
+++ b/.github/workflows/dashboard-updater.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Check for update
         run: |
-          ./hco/automation/dashboard-updater/dashboard-updater.sh "./monitoring/dashboards" "./hco/assets/dashboards"
+          ./hco/automation/dashboard-updater/dashboard-updater.sh "./monitoring/dashboards/openshift" "./hco/assets/dashboards"
           cd hco
           git add --all
           if ! git diff HEAD --quiet --exit-code; then


### PR DESCRIPTION
OpenShift dashboards can be consumed by the community,
But OpenShift UI can't usually consume community dashboards.

This is why we seperated community and OpenShift dashboards
by createing a dedicated openshift sub-directory
under dashboards folder.

This fix updates the path for the new openshift sub directory.

Related to https://github.com/kubevirt/monitoring/pull/40

Signed-off-by: Shirly Radco <sradco@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

