### PR TITLE
Rename the golden images feature gate to enableCommonBootImageImport

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -52,7 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
-                commonDataImportCronEnabled: false
+                enableCommonBootImageImport: false
                 sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
@@ -185,14 +185,14 @@ spec:
                 x-kubernetes-list-type: atomic
               featureGates:
                 default:
-                  commonDataImportCronEnabled: false
+                  enableCommonBootImageImport: false
                   sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
-                  commonDataImportCronEnabled:
+                  enableCommonBootImageImport:
                     default: false
                     description: 'Opt-in to automatic delivery/updates of the common
                       data import cron templates. There are two sources for the data

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -12,7 +12,7 @@ spec:
       duration: 24h0m0s
       renewBefore: 12h0m0s
   featureGates:
-    commonDataImportCronEnabled: false
+    enableCommonBootImageImport: false
     sriovLiveMigration: true
     withHostPassthroughCPU: false
   infra: {}

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -52,7 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
-                commonDataImportCronEnabled: false
+                enableCommonBootImageImport: false
                 sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
@@ -185,14 +185,14 @@ spec:
                 x-kubernetes-list-type: atomic
               featureGates:
                 default:
-                  commonDataImportCronEnabled: false
+                  enableCommonBootImageImport: false
                   sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
-                  commonDataImportCronEnabled:
+                  enableCommonBootImageImport:
                     default: false
                     description: 'Opt-in to automatic delivery/updates of the common
                       data import cron templates. There are two sources for the data

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -52,7 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
-                commonDataImportCronEnabled: false
+                enableCommonBootImageImport: false
                 sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
@@ -185,14 +185,14 @@ spec:
                 x-kubernetes-list-type: atomic
               featureGates:
                 default:
-                  commonDataImportCronEnabled: false
+                  enableCommonBootImageImport: false
                   sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
-                  commonDataImportCronEnabled:
+                  enableCommonBootImageImport:
                     default: false
                     description: 'Opt-in to automatic delivery/updates of the common
                       data import cron templates. There are two sources for the data

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,7 +54,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "commonDataImportCronEnabled": false}, "liveMigrationConfig": {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false}, "liveMigrationConfig": {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -88,7 +88,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | ----- | ----------- | ------ | -------- |-------- |
 | withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here | bool | false | true |
 | sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. | bool | true | true |
-| commonDataImportCronEnabled | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | bool | false | true |
+| enableCommonBootImageImport | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | bool | false | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -123,7 +123,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | localStorageClassName | LocalStorageClassName the name of the local storage class. | string |  | false |
 | infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
 | workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
-| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "commonDataImportCronEnabled": false} | false |
+| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false} | false |
 | liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150} | false |
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
 | certConfig | certConfig holds the rotation policy for internal, self-signed certificates | [HyperConvergedCertConfig](#hyperconvergedcertconfig) | {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}} | false |

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -140,22 +140,26 @@ CPU HW perspective.
 Additional information: [LibvirtXMLCPUModel](https://wiki.openstack.org/wiki/LibvirtXMLCPUModel)
 
 ### sriovLiveMigration Feature Gate
-Set the `sriovLiveMigration` feature gate in order to allow migrating a virtual machine with SRIOV interfaces.
-When enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability.
-This may degrade virt-launcher security.
+
+Set the `sriovLiveMigration` feature gate in order to allow migrating a virtual machine with SRIOV interfaces. When
+enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability. This may
+degrade virt-launcher security.
 
 **Default**: `true`
 
-### commonDataImportCronEnabled Feature Gate
-Set the `commonDataImportCronEnabled` feature gate to `true` in order to enable the common golden images in the cluster.
-For additional information, see here: https://github.com/kubevirt/community/blob/master/design-proposals/golden-image-delivery-and-update-pipeline.md 
+### enableCommonBootImageImport Feature Gate
 
-**Note**: Custom golden images are enabled by adding them the [dataImportCronTemplates field](#configure-custom-golden-images),
-even if this feature gate is `false`.
+Set the `enableCommonBootImageImport` feature gate to `true` in order to enable the common golden images in the cluster.
+For additional information, see
+here: https://github.com/kubevirt/community/blob/master/design-proposals/golden-image-delivery-and-update-pipeline.md
+
+**Note**: Custom golden images are enabled by adding them
+the [dataImportCronTemplates field](#configure-custom-golden-images), even if this feature gate is `false`.
 
 **Default**: `false`
 
 ### Feature Gates Example
+
 ```yaml
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
@@ -167,7 +171,7 @@ spec:
   featureGates:
     withHostPassthroughCPU: true
     sriovLiveMigration: true
-    commonDataImportCronEnabled: false
+    enableCommonBootImageImport: false
 ```
 
 ## Live Migration Configurations
@@ -479,10 +483,11 @@ spec:
 Golden images are root disk images for commonly used operating systems. HCO provides several hard coded images, but it 
 is also possible to add custom golden images. For more details, see [the golden image documentation](https://github.com/kubevirt/community/blob/master/design-proposals/golden-image-delivery-and-update-pipeline.md).
 
-To add a custom image, add a `DataImportCronTemplate` object to the `dataImportCronTemplates` under the `HyperConverged`'s
+To add a custom image, add a `DataImportCronTemplate` object to the `dataImportCronTemplates` under
+the `HyperConverged`'s
 `spec` field.
 
-**Note**: the commonDataImportCronEnabled feature does not block the custom golden images, but only the common ones. 
+**Note**: the `enableCommonBootImageImport` feature does not block the custom golden images, but only the common ones.
 
 ### Custom Golden Images example
 ```yaml

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -22,7 +22,7 @@ echo "Read the CR's spec before starting the test"
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o json | jq '.spec'
 
 CERTCONFIGDEFAULTS='{"ca":{"duration":"48h0m0s","renewBefore":"24h0m0s"},"server":{"duration":"24h0m0s","renewBefore":"12h0m0s"}}'
-FGDEFAULTS='{"commonDataImportCronEnabled":false,"sriovLiveMigration":true,"withHostPassthroughCPU":false}'
+FGDEFAULTS='{"enableCommonBootImageImport":false,"sriovLiveMigration":true,"withHostPassthroughCPU":false}'
 LMDEFAULTS='{"bandwidthPerMigration":"64Mi","completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'
@@ -40,7 +40,7 @@ CERTCONFIGPATHS=(
 )
 
 FGPATHS=(
-    "/spec/featureGates/commonDataImportCronEnabled"
+    "/spec/featureGates/enableCommonBootImageImport"
     "/spec/featureGates/withHostPassthroughCPU"
     "/spec/featureGates/sriovLiveMigration"
     "/spec/featureGates"

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -39,7 +39,7 @@ type HyperConvergedSpec struct {
 
 	// featureGates is a map of feature gate flags. Setting a flag to `true` will enable
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
-	// +kubebuilder:default={"withHostPassthroughCPU": false, "sriovLiveMigration": true, "commonDataImportCronEnabled": false}
+	// +kubebuilder:default={"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false}
 	// +optional
 	FeatureGates HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
@@ -210,7 +210,7 @@ type HyperConvergedFeatureGates struct {
 	// templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.
 	// +optional
 	// +kubebuilder:default=false
-	CommonDataImportCronEnabled bool `json:"commonDataImportCronEnabled"`
+	EnableCommonBootImageImport bool `json:"enableCommonBootImageImport"`
 }
 
 // PermittedHostDevices holds information about devices allowed for passthrough
@@ -437,7 +437,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "commonDataImportCronEnabled": false}, "liveMigrationConfig": {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false}, "liveMigrationConfig": {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/pkg/apis/hco/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hco/v1beta1/zz_generated.openapi.go
@@ -205,7 +205,7 @@ func schema_pkg_apis_hco_v1beta1_HyperConvergedFeatureGates(ref common.Reference
 							Format:      "",
 						},
 					},
-					"commonDataImportCronEnabled": {
+					"enableCommonBootImageImport": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.",
 							Default:     false,

--- a/pkg/controller/operands/ssp.go
+++ b/pkg/controller/operands/ssp.go
@@ -193,7 +193,7 @@ func readDataImportCronTemplatesFromFile() error {
 func getDataImportCronTemplates(hc *hcov1beta1.HyperConverged) []sspv1beta1.DataImportCronTemplate {
 	var dataImportCronTemplateList []sspv1beta1.DataImportCronTemplate = nil
 
-	if hc.Spec.FeatureGates.CommonDataImportCronEnabled {
+	if hc.Spec.FeatureGates.EnableCommonBootImageImport {
 		dataImportCronTemplateList = append(dataImportCronTemplateList, dataImportCronTemplateHardCodedList...)
 	}
 	dataImportCronTemplateList = append(dataImportCronTemplateList, hc.Spec.DataImportCronTemplates...)

--- a/pkg/controller/operands/ssp_test.go
+++ b/pkg/controller/operands/ssp_test.go
@@ -445,10 +445,10 @@ var _ = Describe("SSP Operands", func() {
 
 				It("should return an empty list if both the hard-coded list and the list from HC are empty", func() {
 					hcoWithEmptyList := commonTestUtils.NewHco()
-					hcoWithEmptyList.Spec.FeatureGates.CommonDataImportCronEnabled = true
+					hcoWithEmptyList.Spec.FeatureGates.EnableCommonBootImageImport = true
 					hcoWithEmptyList.Spec.DataImportCronTemplates = []sspv1beta1.DataImportCronTemplate{}
 					hcoWithNilList := commonTestUtils.NewHco()
-					hcoWithNilList.Spec.FeatureGates.CommonDataImportCronEnabled = true
+					hcoWithNilList.Spec.FeatureGates.EnableCommonBootImageImport = true
 					hcoWithNilList.Spec.DataImportCronTemplates = nil
 
 					dataImportCronTemplateHardCodedList = nil
@@ -462,7 +462,7 @@ var _ = Describe("SSP Operands", func() {
 				It("Should add the CR list to the hard-coded list", func() {
 					dataImportCronTemplateHardCodedList = []sspv1beta1.DataImportCronTemplate{image1, image2}
 					hco := commonTestUtils.NewHco()
-					hco.Spec.FeatureGates.CommonDataImportCronEnabled = true
+					hco.Spec.FeatureGates.EnableCommonBootImageImport = true
 					hco.Spec.DataImportCronTemplates = []sspv1beta1.DataImportCronTemplate{image3, image4}
 					goldenImageList := getDataImportCronTemplates(hco)
 					Expect(goldenImageList).To(HaveLen(4))
@@ -474,7 +474,7 @@ var _ = Describe("SSP Operands", func() {
 					By("CR list is nil")
 					dataImportCronTemplateHardCodedList = []sspv1beta1.DataImportCronTemplate{image1, image2}
 					hco := commonTestUtils.NewHco()
-					hco.Spec.FeatureGates.CommonDataImportCronEnabled = true
+					hco.Spec.FeatureGates.EnableCommonBootImageImport = true
 					hco.Spec.DataImportCronTemplates = nil
 					goldenImageList := getDataImportCronTemplates(hco)
 					Expect(goldenImageList).To(HaveLen(2))
@@ -490,7 +490,7 @@ var _ = Describe("SSP Operands", func() {
 
 				It("Should return only the CR list, if the hard-coded list is empty", func() {
 					hco := commonTestUtils.NewHco()
-					hco.Spec.FeatureGates.CommonDataImportCronEnabled = true
+					hco.Spec.FeatureGates.EnableCommonBootImageImport = true
 					hco.Spec.DataImportCronTemplates = []sspv1beta1.DataImportCronTemplate{image3, image4}
 
 					By("when dataImportCronTemplateHardCodedList is nil")
@@ -513,7 +513,7 @@ var _ = Describe("SSP Operands", func() {
 
 				It("should return an empty list if there is no file and no list in the HyperConverged CR", func() {
 					hco := commonTestUtils.NewHco()
-					hco.Spec.FeatureGates.CommonDataImportCronEnabled = true
+					hco.Spec.FeatureGates.EnableCommonBootImageImport = true
 					ssp := NewSSP(hco)
 
 					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(BeNil())
@@ -531,7 +531,7 @@ var _ = Describe("SSP Operands", func() {
 					Expect(readDataImportCronTemplatesFromFile()).ToNot(HaveOccurred())
 
 					hco := commonTestUtils.NewHco()
-					hco.Spec.FeatureGates.CommonDataImportCronEnabled = true
+					hco.Spec.FeatureGates.EnableCommonBootImageImport = true
 					ssp := NewSSP(hco)
 
 					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ShouldNot(BeNil())
@@ -550,7 +550,7 @@ var _ = Describe("SSP Operands", func() {
 					Expect(readDataImportCronTemplatesFromFile()).ToNot(HaveOccurred())
 
 					hco := commonTestUtils.NewHco()
-					hco.Spec.FeatureGates.CommonDataImportCronEnabled = true
+					hco.Spec.FeatureGates.EnableCommonBootImageImport = true
 					hco.Spec.DataImportCronTemplates = []sspv1beta1.DataImportCronTemplate{image3, image4}
 					ssp := NewSSP(hco)
 
@@ -564,7 +564,7 @@ var _ = Describe("SSP Operands", func() {
 					Expect(dataImportCronTemplateHardCodedList).Should(BeEmpty())
 
 					hco := commonTestUtils.NewHco()
-					hco.Spec.FeatureGates.CommonDataImportCronEnabled = true
+					hco.Spec.FeatureGates.EnableCommonBootImageImport = true
 					hco.Spec.DataImportCronTemplates = []sspv1beta1.DataImportCronTemplate{image3, image4}
 					ssp := NewSSP(hco)
 
@@ -585,7 +585,7 @@ var _ = Describe("SSP Operands", func() {
 					Expect(readDataImportCronTemplatesFromFile()).ToNot(HaveOccurred())
 
 					hco := commonTestUtils.NewHco()
-					hco.Spec.FeatureGates.CommonDataImportCronEnabled = false
+					hco.Spec.FeatureGates.EnableCommonBootImageImport = false
 					hco.Spec.DataImportCronTemplates = []sspv1beta1.DataImportCronTemplate{image3, image4}
 					ssp := NewSSP(hco)
 


### PR DESCRIPTION
Following @davidvossel [comment](https://github.com/kubevirt/community/pull/132#discussion_r708444013) in the related PR in the community repo (https://github.com/kubevirt/community/pull/132), this PR renames the `commonDataImportCronEnabled` feature gate to `enableCommonBootImageImport`.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Rename the golden images feature gate from commonDataImportCronEnabled to enableCommonBootImageImport
```

