### PR TITLE
Add golden images file

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -1,0 +1,16 @@
+- metadata:
+    name: centos8-image-cron
+  spec:
+    schedule: "0 */12 * * *"
+    source:
+      registry:
+        url: docker://quay.io/kubevirt/centos8-container-disk-images
+    managedDataSource: centos8
+- metadata:
+    name: fedora-image-cron
+  spec:
+    schedule: "0 */12 * * *"
+    source:
+      registry:
+        url: docker://quay.io/kubevirt/fedora-container-disk-images
+    managedDataSource: fedora

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p ${HOME} && \
 
 COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/_out/hyperconverged-cluster-operator $OPERATOR
 COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/_out/csv-merger $CSV_MERGER
-COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/assets/dashboards/ dashboard/
+COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/assets/ ./
 ENTRYPOINT $OPERATOR
 USER ${USER_UID}
 

--- a/build/Dockerfile.okd
+++ b/build/Dockerfile.okd
@@ -5,5 +5,6 @@ ENV KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
 COPY hyperconverged-cluster-operator /usr/bin/
 COPY hack/testFiles/test_quickstart.yaml quickStart/
 COPY hack/testFiles/test_dashboard_cm.yaml dashboard/
+COPY assets/dataImportCronTemplates dataImportCronTemplates/
 
 ENTRYPOINT /usr/bin/hyperconverged-cluster-operator

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -18,6 +18,7 @@ RUN mkdir -p ${HOME} && \
     chmod g+rw /etc/passwd
 
 COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/_out/hyperconverged-cluster-webhook $WEBHOOK
+COPY --from=builder /go/src/github.com/kubevirt/hyperconverged-cluster-operator/assets/dataImportCronTemplates/ dataImportCronTemplates/
 ENTRYPOINT $WEBHOOK
 USER ${USER_UID}
 

--- a/build/Dockerfile.wh.okd
+++ b/build/Dockerfile.wh.okd
@@ -3,5 +3,6 @@ FROM centos:7
 ENV KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
 
 COPY hyperconverged-cluster-webhook /usr/bin/
+COPY assets/dataImportCronTemplates dataImportCronTemplates/
 
 ENTRYPOINT /usr/bin/hyperconverged-cluster-webhook

--- a/hack/check_golden_images.sh
+++ b/hack/check_golden_images.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
+  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": true }]'"
+  sleep 10
+
+  ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.featureGates.enableCommonBootImageImport}'
+  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron")'
+  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="fedora-image-cron")'
+fi

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -47,5 +47,8 @@ sleep 60
 # Check the defaulting mechanism
 KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_defaults.sh
 
+# check golden images
+KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_golden_images.sh
+
 # Check the webhook, to see if it allow deleteing of the HyperConverged CR
 ./hack/retry.sh 10 30 "${KUBECTL_BINARY} delete hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged"

--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -306,6 +306,9 @@ else
     echo "v2v references removed from .status.relatedObjects"
 fi
 
+Msg "check golden images"
+KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} ./hack/check_defaults.sh
+
 Msg "Read the HCO operator log before it been deleted"
 HCO_POD=$( ${CMD} get -n ${HCO_NAMESPACE} pods -l "name=hyperconverged-cluster-operator" -o name)
 ${CMD} logs -n ${HCO_NAMESPACE} "${HCO_POD}"


### PR DESCRIPTION
Add file of hard coded list of golden images, and copy this file to the HCO operator and HCO webhook images.

The reason to add this file to the webhook image is for the dry-run update requests sent to the SSP operator, so SSP will validate them.

The file contains the `"0 */12 * * *"` cron expression in the `schedule` fields. This will overrode in the operator. However, this is a mandatory field, so the webhook will use it in the dry-run request, and won't fail for the missing field.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add hard coded list of golden images to the HCO operator and webhook images.
```

