### PR TITLE
Avoid setting Evict workloadUpdates strategy

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1385,7 +1385,6 @@ spec:
                   batchEvictionSize: 10
                   workloadUpdateMethods:
                   - LiveMigrate
-                  - Evict
                 description: WorkloadUpdateStrategy defines at the cluster level how
                   to handle automated workload updates
                 properties:
@@ -1402,7 +1401,6 @@ spec:
                   workloadUpdateMethods:
                     default:
                     - LiveMigrate
-                    - Evict
                     description: WorkloadUpdateMethods defines the methods that can
                       be used to disrupt workloads during automated workload updates.
                       When multiple methods are present, the least disruptive method

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -27,5 +27,4 @@ spec:
     batchEvictionSize: 10
     workloadUpdateMethods:
     - LiveMigrate
-    - Evict
   workloads: {}

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -1385,7 +1385,6 @@ spec:
                   batchEvictionSize: 10
                   workloadUpdateMethods:
                   - LiveMigrate
-                  - Evict
                 description: WorkloadUpdateStrategy defines at the cluster level how
                   to handle automated workload updates
                 properties:
@@ -1402,7 +1401,6 @@ spec:
                   workloadUpdateMethods:
                     default:
                     - LiveMigrate
-                    - Evict
                     description: WorkloadUpdateMethods defines the methods that can
                       be used to disrupt workloads during automated workload updates.
                       When multiple methods are present, the least disruptive method

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -1385,7 +1385,6 @@ spec:
                   batchEvictionSize: 10
                   workloadUpdateMethods:
                   - LiveMigrate
-                  - Evict
                 description: WorkloadUpdateStrategy defines at the cluster level how
                   to handle automated workload updates
                 properties:
@@ -1402,7 +1401,6 @@ spec:
                   workloadUpdateMethods:
                     default:
                     - LiveMigrate
-                    - Evict
                     description: WorkloadUpdateMethods defines the methods that can
                       be used to disrupt workloads during automated workload updates.
                       When multiple methods are present, the least disruptive method

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,7 +133,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | obsoleteCPUs | ObsoleteCPUs allows avoiding scheduling of VMs for obsolete CPU models | *[HyperConvergedObsoleteCPUs](#hyperconvergedobsoletecpus) |  | false |
 | commonTemplatesNamespace | CommonTemplatesNamespace defines namespace in which common templates will be deployed. It overrides the default openshift namespace. | *string |  | false |
 | storageImport | StorageImport contains configuration for importing containerized data | *[StorageImportConfig](#storageimportconfig) |  | false |
-| workloadUpdateStrategy | WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates | *[HyperConvergedWorkloadUpdateStrategy](#hyperconvergedworkloadupdatestrategy) | {"workloadUpdateMethods": {"LiveMigrate", "Evict"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"} | false |
+| workloadUpdateStrategy | WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates | *[HyperConvergedWorkloadUpdateStrategy](#hyperconvergedworkloadupdatestrategy) | {"workloadUpdateMethods": {"LiveMigrate"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"} | false |
 | dataImportCronTemplates | DataImportCronTemplates holds list of data import cron templates (golden images) | []sspv1beta1.DataImportCronTemplate |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -158,7 +158,7 @@ HyperConvergedWorkloadUpdateStrategy defines options related to updating a KubeV
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| workloadUpdateMethods | WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Shutdown methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. | []string | {"LiveMigrate", "Evict"} | false |
+| workloadUpdateMethods | WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Shutdown methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. | []string | {"LiveMigrate"} | false |
 | batchEvictionSize | BatchEvictionSize Represents the number of VMIs that can be forced updated per the BatchShutdownInteral interval | *int | 10 | false |
 | batchEvictionInterval | BatchEvictionInterval Represents the interval to wait before issuing the next batch of shutdowns | *metav1.Duration | "1m0s" | false |
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -444,7 +444,7 @@ The `workloadUpdateStrategy` fields are:
   
   An empty list defaults to no automated workload updating.
 
-  The default values are `LiveMigrate` and `Evict`.
+  The default values is `LiveMigrate`; `Evict` is not enabled by default being potentially disruptive for the existing workloads. 
 
 ### workloadUpdateStrategy example
 ```yaml

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -26,7 +26,7 @@ FGDEFAULTS='{"enableCommonBootImageImport":false,"sriovLiveMigration":true,"with
 LMDEFAULTS='{"bandwidthPerMigration":"64Mi","completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'
-WORKLOAD_UPDATE_STRATEGY_DEFAULT='{"batchEvictionInterval":"1m0s","batchEvictionSize":10,"workloadUpdateMethods":["LiveMigrate","Evict"]}'
+WORKLOAD_UPDATE_STRATEGY_DEFAULT='{"batchEvictionInterval":"1m0s","batchEvictionSize":10,"workloadUpdateMethods":["LiveMigrate"]}'
 
 CERTCONFIGPATHS=(
     "/spec/certConfig/ca/duration"

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -88,7 +88,7 @@ type HyperConvergedSpec struct {
 	StorageImport *StorageImportConfig `json:"storageImport,omitempty"`
 
 	// WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates
-	// +kubebuilder:default={"workloadUpdateMethods": {"LiveMigrate", "Evict"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"}
+	// +kubebuilder:default={"workloadUpdateMethods": {"LiveMigrate"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"}
 	// +optional
 	WorkloadUpdateStrategy *HyperConvergedWorkloadUpdateStrategy `json:"workloadUpdateStrategy,omitempty"`
 
@@ -305,7 +305,7 @@ type HyperConvergedWorkloadUpdateStrategy struct {
 	// An empty list defaults to no automated workload updating.
 	//
 	// +listType=atomic
-	// +kubebuilder:default={"LiveMigrate", "Evict"}
+	// +kubebuilder:default={"LiveMigrate"}
 	// +optional
 	WorkloadUpdateMethods []string `json:"workloadUpdateMethods,omitempty"`
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -643,7 +643,7 @@ func GetOperatorCR() *hcov1beta1.HyperConverged {
 				ProgressTimeout:                   &progressTimeout,
 			},
 			WorkloadUpdateStrategy: &hcov1beta1.HyperConvergedWorkloadUpdateStrategy{
-				WorkloadUpdateMethods: stringListToSlice("LiveMigrate", "Evict"),
+				WorkloadUpdateMethods: stringListToSlice("LiveMigrate"),
 				BatchEvictionSize:     &batchEvictionSize,
 				BatchEvictionInterval: &batchEvictionInterval,
 			},

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -1747,11 +1747,10 @@ Version: 1.2.3`)
 				kvUpdateStrategy := foundResource.Spec.WorkloadUpdateStrategy
 				Expect(kvUpdateStrategy.BatchEvictionInterval.Duration.String()).Should(Equal("1m0s"))
 				Expect(*kvUpdateStrategy.BatchEvictionSize).Should(Equal(defaultBatchEvictionSize))
-				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(HaveLen(2))
+				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(HaveLen(1))
 				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(
 					ContainElements(
 						kubevirtv1.WorkloadUpdateMethodLiveMigrate,
-						kubevirtv1.WorkloadUpdateMethodEvict,
 					),
 				)
 


### PR DESCRIPTION
Evict workloadUpdates strategy can be disruptive
for existing workloads,
avoid setting it by default and let the user
eventually opt-in.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2008900

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
Avoid setting Evict workloadUpdates strategy
```

