### PR TITLE
Set priority class for hyperconverged-cluster-cli-download

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
@@ -2006,6 +2006,7 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 96Mi
+              priorityClassName: system-cluster-critical
       - label:
           app.kubernetes.io/component: network
           app.kubernetes.io/managed-by: olm

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.6.0-unstable
-    createdAt: "2021-10-04 21:12:02"
+    createdAt: "2021-10-05 09:52:07"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -2006,6 +2006,7 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 96Mi
+              priorityClassName: system-cluster-critical
       - label:
           app.kubernetes.io/component: network
           app.kubernetes.io/managed-by: olm

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -208,6 +208,7 @@ spec:
           requests:
             cpu: 10m
             memory: 96Mi
+      priorityClassName: system-cluster-critical
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -292,6 +292,7 @@ func GetDeploymentSpecCliDownloads(params *DeploymentOperatorParams) appsv1.Depl
 						},
 					},
 				},
+				PriorityClassName: "system-cluster-critical",
 			},
 		},
 	}


### PR DESCRIPTION
Set system-cluster-critical priority class on
hyperconverged-cluster-cli-download pod so that
it can be eventually killed by the OOM but
not preempted by user-workload.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2008938

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
Set priority class for hyperconverged-cluster-cli-download
```

