### PR TITLE
Fix an issue with setting the dataImportCronTemplates field

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -129,6 +129,23 @@ spec:
                     leaving namespace as optional.
                   properties:
                     metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
                       type: object
                     spec:
                       description: DataImportCronSpec defines specification for DataImportCron

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -129,6 +129,23 @@ spec:
                     leaving namespace as optional.
                   properties:
                     metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
                       type: object
                     spec:
                       description: DataImportCronSpec defines specification for DataImportCron

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -129,6 +129,23 @@ spec:
                     leaving namespace as optional.
                   properties:
                     metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
                       type: object
                     spec:
                       description: DataImportCronSpec defines specification for DataImportCron

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -568,9 +568,11 @@ func GetOperatorCRD(relPath string) *extv1.CustomResourceDefinition {
 	panicOnError(crdmarkers.Register(reg))
 
 	parser := &crdgen.Parser{
-		Collector: &markers.Collector{Registry: reg},
-		Checker:   &loader.TypeChecker{},
+		Collector:                  &markers.Collector{Registry: reg},
+		Checker:                    &loader.TypeChecker{},
+		GenerateEmbeddedObjectMeta: true,
 	}
+
 	crdgen.AddKnownTypes(parser)
 	if len(pkgs) == 0 {
 		panic("Failed identifying packages")


### PR DESCRIPTION
Since the CRD did not contain the field of the dataImportCronTemplate.metadata objects, the API server pruned the name field, and when HCO called to SSP webhook to update SSP with new dataImportCronTemplate, the SSP webhook rejected the request because of the missing name field.

This PR fixes this issue by forcing the metadata filed, by adding the CRD generator crdgen.Parser's `GenerateEmbeddedObjectMeta` to `true`.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix an issue with setting the dataImportCronTemplates field
```

