### PR TITLE
[release-1.5] Revert an hack on upgrade lanes

### DIFF
--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -146,12 +146,6 @@ HCO_SUBSCRIPTION=$(${CMD} get subscription -n ${HCO_NAMESPACE} -o name)
 OLD_INSTALL_PLAN=$(oc -n "${HCO_NAMESPACE}" get "${HCO_SUBSCRIPTION}" -o jsonpath='{.status.installplan.name}')
 ${CMD} patch ${HCO_SUBSCRIPTION} -n ${HCO_NAMESPACE} -p "{\"spec\": {\"channel\": \"${TARGET_CHANNEL}\"}}"  --type merge
 
-# TEMP HACK TO UNLOCK UPGRADE
-sleep 15
-for OLM_APP_LABEL in olm-operator catalog-operator
-do
-  ${CMD} delete -n openshift-operator-lifecycle-manager "$(${CMD} get pod -n openshift-operator-lifecycle-manager -l app=${OLM_APP_LABEL} -o name)"
-done
 Msg "Wait up to 5 minutes for the new installPlan to appear, and approve it to begin upgrade"
 INSTALL_PLAN_APPROVED=false
 for _ in $(seq 1 60); do


### PR DESCRIPTION
Revert an hack on upgrade lanes introduced in #1552
to bypass a possible upgrade bug on the OLM side.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

