### PR TITLE
Fix out of date resource versions of objects in relatedObjects

### DIFF
--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -112,6 +112,8 @@ func (h *genericOperand) handleExistingCr(req *common.HcoRequest, key client.Obj
 	}
 
 	if updated {
+		// update resourceVersions of objects in relatedObjects
+		req.StatusDirty = true
 		return res.SetUpdated().SetOverwritten(overwritten)
 	}
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2010540

Signed-off-by: Erkan Erol <eerol@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix out of date resource versions of objects in relatedObjects
```

