### PR TITLE
Remove out-of-date quick start guides

### DIFF
--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -22,7 +22,7 @@ fi
 # when the tests are run in a pod, in-cluster config will be used
 KUBECONFIG_FLAG=""
 if [[ -n "${KUBECONFIG-}" ]]; then
-  KUBECONFIG_FLAG="-kubeconfig="${KUBECONFIG}""
+  KUBECONFIG_FLAG="-kubeconfig=${KUBECONFIG}"
 fi
 
 source ./hack/check_operator_condition.sh
@@ -34,8 +34,8 @@ ${TEST_OUT_PATH}/func-tests.test -ginkgo.v -installed-namespace="${INSTALLED_NAM
 sleep 60
 
 # Check the webhook, to see if it allow updating of the HyperConverged CR
-${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -p '{"spec":{"infra":{"nodePlacement":{"tolerations":[{"effect":"NoSchedule","key":"key","operator":"Equal","value":"value"}]}}}}' --type=merge
-${KUBECTL_BINARY} patch hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -p '{"spec":{"workloads":{"nodePlacement":{"tolerations":[{"effect":"NoSchedule","key":"key","operator":"Equal","value":"value"}]}}}}' --type=merge
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged -p '{\"spec\":{\"infra\":{\"nodePlacement\":{\"tolerations\":[{\"effect\":\"NoSchedule\",\"key\":\"key\",\"operator\":\"Equal\",\"value\":\"value\"}]}}}}' --type=merge"
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged -p '{\"spec\":{\"workloads\":{\"nodePlacement\":{\"tolerations\":[{\"effect\":\"NoSchedule\",\"key\":\"key\",\"operator\":\"Equal\",\"value\":\"value\"}]}}}}' --type=merge"
 # Read the HyperConverged CR
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o yaml
 

--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -262,7 +262,7 @@ else
     echo "The test VM survived the upgrade process."
 fi
 
-~/virtctl stop testvm -n ${VMS_NAMESPACE}
+./hack/retry.sh 5 30 "~/virtctl stop testvm -n ${VMS_NAMESPACE}"
 ${CMD} delete vm -n ${VMS_NAMESPACE} testvm
 
 KUBECTL_BINARY=${CMD} ./hack/test_quick_start.sh

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -85,6 +85,10 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, isOpenshiftC
 	}
 }
 
+func (h *OperandHandler) GetQuickStartNames() []string {
+	return quickstartNames
+}
+
 type GetHandler func(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error)
 
 func (h *OperandHandler) addOperands(scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged, getHandler GetHandler) {

--- a/pkg/controller/operands/quickStart.go
+++ b/pkg/controller/operands/quickStart.go
@@ -28,6 +28,8 @@ const (
 	quickStartDefaultManifestLocation = "./quickStart"
 )
 
+var quickstartNames []string
+
 func newQuickStartHandler(Client client.Client, Scheme *runtime.Scheme, required *consolev1.ConsoleQuickStart) Operand {
 	h := &genericOperand{
 		Client: Client,
@@ -133,6 +135,8 @@ func getQuickStartHandlers(logger log.Logger, Client client.Client, Scheme *runt
 
 func createQuickstartHandlersFromFiles(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged, filesLocation string) ([]Operand, error) {
 	var handlers []Operand
+	quickstartNames = []string{}
+
 	err := filepath.Walk(filesLocation, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -167,6 +171,7 @@ func processQuickstartFile(path string, info os.FileInfo, logger log.Logger, hc 
 			logger.Error(err, "Can't generate a ConsoleQuickStart object from yaml file", "file name", path)
 		} else {
 			qs.Labels = getLabels(hc, util.AppComponentCompute)
+			quickstartNames = append(quickstartNames, qs.Name)
 			return newQuickStartHandler(Client, Scheme, qs), nil
 		}
 	}

--- a/pkg/controller/operands/quickStart_test.go
+++ b/pkg/controller/operands/quickStart_test.go
@@ -103,6 +103,7 @@ var _ = Describe("QuickStart tests", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handlers).To(HaveLen(1))
+				Expect(quickstartNames).To(ContainElements("test-quick-start"))
 			})
 		})
 
@@ -138,6 +139,7 @@ var _ = Describe("QuickStart tests", func() {
 			handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(handlers).To(HaveLen(1))
+			Expect(quickstartNames).To(ContainElement("test-quick-start"))
 
 			{ // for the next test
 				handler, ok := handlers[0].(*genericOperand)
@@ -173,6 +175,7 @@ var _ = Describe("QuickStart tests", func() {
 			handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(handlers).To(HaveLen(1))
+			Expect(quickstartNames).To(ContainElement("test-quick-start"))
 
 			hco := commonTestUtils.NewHco()
 			By("apply the quickstart CRs", func() {


### PR DESCRIPTION
On upgrade, HCO compares the list of quick start guides from its image, with the existing list of HCO related quick start guide from the cluster. If there are old quick start guides that are not required anymore, HCO will remove them.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
On upgrade, HCO compares the list of quick start guides from its image, with the existing list of HCO related quick start guide from the cluster. If there are old quick start guides that are not required anymore, HCO will remove them.
```

