### PR TITLE
[release-1.5] Avoid setting a default for bandwidthPerMigration

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -55,7 +55,6 @@ spec:
                 sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
-                bandwidthPerMigration: 64Mi
                 completionTimeoutPerGiB: 800
                 parallelMigrationsPerCluster: 5
                 parallelOutboundMigrationsPerNode: 2
@@ -1110,7 +1109,6 @@ spec:
                 type: object
               liveMigrationConfig:
                 default:
-                  bandwidthPerMigration: 64Mi
                   completionTimeoutPerGiB: 800
                   parallelMigrationsPerCluster: 5
                   parallelOutboundMigrationsPerNode: 2
@@ -1119,7 +1117,6 @@ spec:
                   migration processes do not overwhelm the cluster.
                 properties:
                   bandwidthPerMigration:
-                    default: 64Mi
                     description: Bandwidth limit of each migration, in MiB/s.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     type: string

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -16,7 +16,6 @@ spec:
     withHostPassthroughCPU: false
   infra: {}
   liveMigrationConfig:
-    bandwidthPerMigration: 64Mi
     completionTimeoutPerGiB: 800
     parallelMigrationsPerCluster: 5
     parallelOutboundMigrationsPerNode: 2

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -55,7 +55,6 @@ spec:
                 sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
-                bandwidthPerMigration: 64Mi
                 completionTimeoutPerGiB: 800
                 parallelMigrationsPerCluster: 5
                 parallelOutboundMigrationsPerNode: 2
@@ -1110,7 +1109,6 @@ spec:
                 type: object
               liveMigrationConfig:
                 default:
-                  bandwidthPerMigration: 64Mi
                   completionTimeoutPerGiB: 800
                   parallelMigrationsPerCluster: 5
                   parallelOutboundMigrationsPerNode: 2
@@ -1119,7 +1117,6 @@ spec:
                   migration processes do not overwhelm the cluster.
                 properties:
                   bandwidthPerMigration:
-                    default: 64Mi
                     description: Bandwidth limit of each migration, in MiB/s.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     type: string

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.5.0/manifests/hco00.crd.yaml
@@ -55,7 +55,6 @@ spec:
                 sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
-                bandwidthPerMigration: 64Mi
                 completionTimeoutPerGiB: 800
                 parallelMigrationsPerCluster: 5
                 parallelOutboundMigrationsPerNode: 2
@@ -1110,7 +1109,6 @@ spec:
                 type: object
               liveMigrationConfig:
                 default:
-                  bandwidthPerMigration: 64Mi
                   completionTimeoutPerGiB: 800
                   parallelMigrationsPerCluster: 5
                   parallelOutboundMigrationsPerNode: 2
@@ -1119,7 +1117,6 @@ spec:
                   migration processes do not overwhelm the cluster.
                 properties:
                   bandwidthPerMigration:
-                    default: 64Mi
                     description: Bandwidth limit of each migration, in MiB/s.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     type: string

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,7 +54,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true}, "liveMigrationConfig": {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -123,7 +123,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
 | workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
 | featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "sriovLiveMigration": true} | false |
-| liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150} | false |
+| liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150} | false |
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
 | certConfig | certConfig holds the rotation policy for internal, self-signed certificates | [HyperConvergedCertConfig](#hyperconvergedcertconfig) | {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}} | false |
 | resourceRequirements | ResourceRequirements describes the resource requirements for the operand workloads. | *[OperandResourceRequirements](#operandresourcerequirements) |  | false |
@@ -169,7 +169,7 @@ LiveMigrationConfigurations - Live migration limits and timeouts are applied so 
 | ----- | ----------- | ------ | -------- |-------- |
 | parallelMigrationsPerCluster | Number of migrations running in parallel in the cluster. | *uint32 | 5 | false |
 | parallelOutboundMigrationsPerNode | Maximum number of outbound migrations per node. | *uint32 | 2 | false |
-| bandwidthPerMigration | Bandwidth limit of each migration, in MiB/s. | *string | "64Mi" | false |
+| bandwidthPerMigration | Bandwidth limit of each migration, in MiB/s. | *string |  | false |
 | completionTimeoutPerGiB | The migration will be canceled if it has not completed in this time, in seconds per GiB of memory. For example, a virtual machine instance with 6GiB memory will timeout if it has not completed migration in 4800 seconds. If the Migration Method is BlockMigration, the size of the migrating disks is included in the calculation. | *int64 | 800 | false |
 | progressTimeout | The migration will be canceled if memory copy fails to make progress in this time, in seconds. | *int64 | 150 | false |
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -166,9 +166,9 @@ Set the live migration configurations by modifying the fields in the `liveMigrat
 
 ### bandwidthPerMigration
 
-Bandwidth limit of each migration, in MiB/s. The format is a number and with the `Mi` suffix, e.g. `64Mi`.
+Bandwidth limit of each migration, in MiB/s. The format is a number and with the `Mi` suffix, e.g. `2048Mi`.
 
-**default**: 64Mi
+**default**: unset
 
 ### completionTimeoutPerGiB
 
@@ -206,7 +206,6 @@ metadata:
   name: kubevirt-hyperconverged
 spec:
   liveMigrationConfig:
-    bandwidthPerMigration: 64Mi
     completionTimeoutPerGiB: 800
     parallelMigrationsPerCluster: 5
     parallelOutboundMigrationsPerNode: 2

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -23,7 +23,7 @@ ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o
 
 CERTCONFIGDEFAULTS='{"ca":{"duration":"48h0m0s","renewBefore":"24h0m0s"},"server":{"duration":"24h0m0s","renewBefore":"12h0m0s"}}'
 FGDEFAULTS='{"sriovLiveMigration":true,"withHostPassthroughCPU":false}'
-LMDEFAULTS='{"bandwidthPerMigration":"64Mi","completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
+LMDEFAULTS='{"completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'
 WORKLOAD_UPDATE_STRATEGY_DEFAULT='{"batchEvictionInterval":"1m0s","batchEvictionSize":10,"workloadUpdateMethods":["LiveMigrate"]}'

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -43,7 +43,7 @@ type HyperConvergedSpec struct {
 
 	// Live migration limits and timeouts are applied so that migration processes do not
 	// overwhelm the cluster.
-	// +kubebuilder:default={"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}
+	// +kubebuilder:default={"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}
 	// +optional
 	LiveMigrationConfig LiveMigrationConfigurations `json:"liveMigrationConfig,omitempty"`
 
@@ -164,7 +164,6 @@ type LiveMigrationConfigurations struct {
 
 	// Bandwidth limit of each migration, in MiB/s.
 	// +optional
-	// +kubebuilder:default="64Mi"
 	// +kubebuilder:validation:Pattern=^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
 	BandwidthPerMigration *string `json:"bandwidthPerMigration,omitempty"`
 
@@ -415,7 +414,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true}, "liveMigrationConfig": {"bandwidthPerMigration": "64Mi", "completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -792,7 +792,6 @@ func GetV2VOvirtProviderCRD() *extv1.CustomResourceDefinition {
 }
 
 func GetOperatorCR() *hcov1beta1.HyperConverged {
-	bandwidthPerMigration := "64Mi"
 	completionTimeoutPerGiB := int64(800)
 	parallelMigrationsPerCluster := uint32(5)
 	parallelOutboundMigrationsPerNode := uint32(2)
@@ -825,7 +824,6 @@ func GetOperatorCR() *hcov1beta1.HyperConverged {
 				SRIOVLiveMigration:     true,
 			},
 			LiveMigrationConfig: hcov1beta1.LiveMigrationConfigurations{
-				BandwidthPerMigration:             &bandwidthPerMigration,
 				CompletionTimeoutPerGiB:           &completionTimeoutPerGiB,
 				ParallelMigrationsPerCluster:      &parallelMigrationsPerCluster,
 				ParallelOutboundMigrationsPerNode: &parallelOutboundMigrationsPerNode,

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -192,7 +192,7 @@ Version: 1.2.3`)
 			// LiveMigration Configurations
 			mc := foundResource.Spec.Configuration.MigrationConfiguration
 			Expect(mc).ToNot(BeNil())
-			Expect(*mc.BandwidthPerMigration).Should(Equal(resource.MustParse("64Mi")))
+			Expect(mc.BandwidthPerMigration).Should(BeNil())
 			Expect(*mc.CompletionTimeoutPerGiB).Should(Equal(int64(800)))
 			Expect(*mc.ParallelMigrationsPerCluster).Should(Equal(uint32(5)))
 			Expect(*mc.ParallelOutboundMigrationsPerNode).Should(Equal(uint32(2)))
@@ -328,7 +328,7 @@ Version: 1.2.3`)
 			// LiveMigration Configurations
 			mc := foundResource.Spec.Configuration.MigrationConfiguration
 			Expect(mc).ToNot(BeNil())
-			Expect(*mc.BandwidthPerMigration).Should(Equal(resource.MustParse("64Mi")))
+			Expect(mc.BandwidthPerMigration).Should(BeNil())
 			Expect(*mc.CompletionTimeoutPerGiB).Should(Equal(int64(800)))
 			Expect(*mc.ParallelMigrationsPerCluster).Should(Equal(uint32(5)))
 			Expect(*mc.ParallelOutboundMigrationsPerNode).Should(Equal(uint32(2)))


### PR DESCRIPTION
In the past we were setting a default of 64Mi for
spec.livemigrationconfig.bandwidthpermigration but
the value was simply ignored by kubevirt due to
an ancient bug.
Now the bug on kubevirt/kubevirt got fixed and
unfortunately we discover that the default that
kubevirt and then HCO set in the past doesn't
fit production use cases.

Let's avoid setting a default for
spec.livemigrationconfig.bandwidthpermigration
and let's explicitly delete it on upgrades
if set to "64Mi" which is not acceptable.

This is a manual cherry-pick of #1567

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2011179

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
Avoid setting a default for bandwidthPerMigration and dropping it if == 64Mi
```

