### PR TITLE
Fix a bug in quickstart and upgrade

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -2030,6 +2030,10 @@ progressTimeout: 150`,
 						},
 					}
 
+					kvRef, err := reference.GetReference(commonTestUtils.GetScheme(), expected.kv)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(v1.SetObjectReference(&expected.hco.Status.RelatedObjects, *kvRef)).ToNot(HaveOccurred())
+
 					oldQsRef, err := reference.GetReference(commonTestUtils.GetScheme(), oldQs)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(v1.SetObjectReference(&expected.hco.Status.RelatedObjects, *oldQsRef)).ToNot(HaveOccurred())


### PR DESCRIPTION
When removing an old quickstart guide during upgrade, we should also remove it from the related object list in the HyperConverged status field.

The previous implementation failed to do that (because the status is updated later, and we lost track on the old guide, because we removed it).

This PR fixes this issue by checking the related object regrdless if the deletion was done or not.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

