### PR TITLE
Enable (again) default workloadUpdates strategies

### DIFF
--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -23,6 +23,20 @@
           "path": "/spec/liveMigrationConfig/bandwidthPerMigration"
         }
       ]
+    },
+    {
+      "semverRange": ">=1.4.0 <1.6.0",
+      "jsonPatch": [
+        {
+          "op": "replace",
+          "path": "/spec/workloadUpdateStrategy",
+          "value": {
+            "batchEvictionInterval": "1m0s",
+            "batchEvictionSize": 10,
+            "workloadUpdateMethods": ["LiveMigrate"]
+          }
+        }
+      ]
     }
   ]
 }

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1394,18 +1394,27 @@ spec:
                   providers
                 type: string
               workloadUpdateStrategy:
+                default:
+                  batchEvictionInterval: 1m0s
+                  batchEvictionSize: 10
+                  workloadUpdateMethods:
+                  - LiveMigrate
                 description: WorkloadUpdateStrategy defines at the cluster level how
                   to handle automated workload updates
                 properties:
                   batchEvictionInterval:
+                    default: 1m0s
                     description: BatchEvictionInterval Represents the interval to
                       wait before issuing the next batch of shutdowns
                     type: string
                   batchEvictionSize:
+                    default: 10
                     description: BatchEvictionSize Represents the number of VMIs that
                       can be forced updated per the BatchShutdownInteral interval
                     type: integer
                   workloadUpdateMethods:
+                    default:
+                    - LiveMigrate
                     description: WorkloadUpdateMethods defines the methods that can
                       be used to disrupt workloads during automated workload updates.
                       When multiple methods are present, the least disruptive method

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -21,4 +21,9 @@ spec:
     parallelMigrationsPerCluster: 5
     parallelOutboundMigrationsPerNode: 2
     progressTimeout: 150
+  workloadUpdateStrategy:
+    batchEvictionInterval: 1m0s
+    batchEvictionSize: 10
+    workloadUpdateMethods:
+    - LiveMigrate
   workloads: {}

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -1394,18 +1394,27 @@ spec:
                   providers
                 type: string
               workloadUpdateStrategy:
+                default:
+                  batchEvictionInterval: 1m0s
+                  batchEvictionSize: 10
+                  workloadUpdateMethods:
+                  - LiveMigrate
                 description: WorkloadUpdateStrategy defines at the cluster level how
                   to handle automated workload updates
                 properties:
                   batchEvictionInterval:
+                    default: 1m0s
                     description: BatchEvictionInterval Represents the interval to
                       wait before issuing the next batch of shutdowns
                     type: string
                   batchEvictionSize:
+                    default: 10
                     description: BatchEvictionSize Represents the number of VMIs that
                       can be forced updated per the BatchShutdownInteral interval
                     type: integer
                   workloadUpdateMethods:
+                    default:
+                    - LiveMigrate
                     description: WorkloadUpdateMethods defines the methods that can
                       be used to disrupt workloads during automated workload updates.
                       When multiple methods are present, the least disruptive method

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -1394,18 +1394,27 @@ spec:
                   providers
                 type: string
               workloadUpdateStrategy:
+                default:
+                  batchEvictionInterval: 1m0s
+                  batchEvictionSize: 10
+                  workloadUpdateMethods:
+                  - LiveMigrate
                 description: WorkloadUpdateStrategy defines at the cluster level how
                   to handle automated workload updates
                 properties:
                   batchEvictionInterval:
+                    default: 1m0s
                     description: BatchEvictionInterval Represents the interval to
                       wait before issuing the next batch of shutdowns
                     type: string
                   batchEvictionSize:
+                    default: 10
                     description: BatchEvictionSize Represents the number of VMIs that
                       can be forced updated per the BatchShutdownInteral interval
                     type: integer
                   workloadUpdateMethods:
+                    default:
+                    - LiveMigrate
                     description: WorkloadUpdateMethods defines the methods that can
                       be used to disrupt workloads during automated workload updates.
                       When multiple methods are present, the least disruptive method

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,7 +133,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | obsoleteCPUs | ObsoleteCPUs allows avoiding scheduling of VMs for obsolete CPU models | *[HyperConvergedObsoleteCPUs](#hyperconvergedobsoletecpus) |  | false |
 | commonTemplatesNamespace | CommonTemplatesNamespace defines namespace in which common templates will be deployed. It overrides the default openshift namespace. | *string |  | false |
 | storageImport | StorageImport contains configuration for importing containerized data | *[StorageImportConfig](#storageimportconfig) |  | false |
-| workloadUpdateStrategy | WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates | *[HyperConvergedWorkloadUpdateStrategy](#hyperconvergedworkloadupdatestrategy) |  | false |
+| workloadUpdateStrategy | WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates | *[HyperConvergedWorkloadUpdateStrategy](#hyperconvergedworkloadupdatestrategy) | {"workloadUpdateMethods": {"LiveMigrate"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"} | false |
 | dataImportCronTemplates | DataImportCronTemplates holds list of data import cron templates (golden images) | []sspv1beta1.DataImportCronTemplate |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -158,9 +158,9 @@ HyperConvergedWorkloadUpdateStrategy defines options related to updating a KubeV
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| workloadUpdateMethods | WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Evict methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. | []string |  | false |
-| batchEvictionSize | BatchEvictionSize Represents the number of VMIs that can be forced updated per the BatchShutdownInteral interval | *int |  | false |
-| batchEvictionInterval | BatchEvictionInterval Represents the interval to wait before issuing the next batch of shutdowns | *metav1.Duration |  | false |
+| workloadUpdateMethods | WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Evict methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. | []string | {"LiveMigrate"} | false |
+| batchEvictionSize | BatchEvictionSize Represents the number of VMIs that can be forced updated per the BatchShutdownInteral interval | *int | 10 | false |
+| batchEvictionInterval | BatchEvictionInterval Represents the interval to wait before issuing the next batch of shutdowns | *metav1.Duration | "1m0s" | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -420,15 +420,19 @@ spec:
   commonTemplatesNamespace: kubevirt
 ```
 
-## Optionally enable launcher updates
-The HyperConverged `spec.workloadUpdateStrategy` defines how to handle automated workload updates at the cluster
+## Enable eventual launcher updates by default
+us the HyperConverged `spec.workloadUpdateStrategy` object to define how to handle automated workload updates at the cluster
 level.
 
 The `workloadUpdateStrategy` fields are:
 * `batchEvictionInterval` - BatchEvictionInterval Represents the interval to wait before issuing the next batch of
   shutdowns. 
+
+  The Default value is `1m`
   
 * `batchEvictionSize` - Represents the number of VMIs that can be forced updated per the BatchShutdownInteral interval
+
+  The default value is `10`
 
 * `workloadUpdateMethods` - defines the methods that can be used to disrupt workloads
   during automated workload updates.
@@ -439,7 +443,7 @@ The `workloadUpdateStrategy` fields are:
   
   An empty list defaults to no automated workload updating.
 
-The feature is not enabled by default being potentially disruptive for the existing workloads. 
+  The default values is `LiveMigrate`; `Evict` is not enabled by default being potentially disruptive for the existing workloads.
 
 ### workloadUpdateStrategy example
 ```yaml

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -26,6 +26,7 @@ FGDEFAULTS='{"enableCommonBootImageImport":false,"sriovLiveMigration":true,"with
 LMDEFAULTS='{"completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'
+WORKLOAD_UPDATE_STRATEGY_DEFAULT='{"batchEvictionInterval":"1m0s","batchEvictionSize":10,"workloadUpdateMethods":["LiveMigrate"]}'
 
 CERTCONFIGPATHS=(
     "/spec/certConfig/ca/duration"
@@ -53,6 +54,14 @@ LMPATHS=(
     "/spec/liveMigrationConfig/completionTimeoutPerGiB"
     "/spec/liveMigrationConfig/progressTimeout"
     "/spec/liveMigrationConfig"
+    "/spec"
+)
+
+WORKLOAD_UPDATE_STRATEGY_PATHS=(
+    "/spec/workloadUpdateStrategy/workloadUpdateMethods"
+    "/spec/workloadUpdateStrategy/batchEvictionSize"
+    "/spec/workloadUpdateStrategy/batchEvictionInterval"
+    "/spec/workloadUpdateStrategy"
     "/spec"
 )
 
@@ -90,6 +99,19 @@ for JPATH in "${LMPATHS[@]}"; do
     LM=$(${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.liveMigrationConfig}')
     if [[ $LMDEFAULTS != $LM ]]; then
         echo "Failed checking CR defaults for liveMigrationConfig"
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "Check that workloadUpdateStrategy defaults are behaving as expected"
+
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": /spec, \"value\": {} }]'"
+for JPATH in "${WORKLOAD_UPDATE_STRATEGY_PATHS[@]}"; do
+    ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type='json' kubevirt-hyperconverged -p '[{ \"op\": \"remove\", \"path\": '\"${JPATH}\"' }]'"
+    WORKLOAD_UPDATE_STRATEGY=$(${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.workloadUpdateStrategy}')
+    if [[ "${WORKLOAD_UPDATE_STRATEGY_DEFAULT}" != "${WORKLOAD_UPDATE_STRATEGY}" ]]; then
+        echo "Failed checking CR defaults for workloadUpdateStrategy"
         exit 1
     fi
     sleep 2

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -88,6 +88,7 @@ type HyperConvergedSpec struct {
 	StorageImport *StorageImportConfig `json:"storageImport,omitempty"`
 
 	// WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates
+	// +kubebuilder:default={"workloadUpdateMethods": {"LiveMigrate"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"}
 	// +optional
 	WorkloadUpdateStrategy *HyperConvergedWorkloadUpdateStrategy `json:"workloadUpdateStrategy,omitempty"`
 
@@ -303,18 +304,21 @@ type HyperConvergedWorkloadUpdateStrategy struct {
 	// An empty list defaults to no automated workload updating.
 	//
 	// +listType=atomic
+	// +kubebuilder:default={"LiveMigrate"}
 	// +optional
 	WorkloadUpdateMethods []string `json:"workloadUpdateMethods,omitempty"`
 
 	// BatchEvictionSize Represents the number of VMIs that can be forced updated per
 	// the BatchShutdownInteral interval
 	//
+	// +kubebuilder:default=10
 	// +optional
 	BatchEvictionSize *int `json:"batchEvictionSize,omitempty"`
 
 	// BatchEvictionInterval Represents the interval to wait before issuing the next
 	// batch of shutdowns
 	//
+	// +kubebuilder:default="1m0s"
 	// +optional
 	BatchEvictionInterval *metav1.Duration `json:"batchEvictionInterval,omitempty"`
 }

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -611,6 +611,9 @@ func GetOperatorCR() *hcov1beta1.HyperConverged {
 	parallelOutboundMigrationsPerNode := uint32(2)
 	progressTimeout := int64(150)
 
+	batchEvictionSize := 10
+	batchEvictionInterval := metav1.Duration{Duration: 1 * time.Minute}
+
 	return &hcov1beta1.HyperConverged{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: util.APIVersion,
@@ -639,6 +642,11 @@ func GetOperatorCR() *hcov1beta1.HyperConverged {
 				ParallelMigrationsPerCluster:      &parallelMigrationsPerCluster,
 				ParallelOutboundMigrationsPerNode: &parallelOutboundMigrationsPerNode,
 				ProgressTimeout:                   &progressTimeout,
+			},
+			WorkloadUpdateStrategy: &hcov1beta1.HyperConvergedWorkloadUpdateStrategy{
+				WorkloadUpdateMethods: stringListToSlice("LiveMigrate"),
+				BatchEvictionSize:     &batchEvictionSize,
+				BatchEvictionInterval: &batchEvictionInterval,
 			},
 			LocalStorageClassName: "",
 		},

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"reflect"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/blang/semver/v4"
 

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -890,9 +890,7 @@ var _ = Describe("HyperconvergedController", func() {
 				expected = getBasicDeployment()
 				origConditions = expected.hco.Status.Conditions
 				okConds = expected.hco.Status.Conditions
-			})
 
-			BeforeEach(func() {
 				_ = os.Setenv("VIRTIOWIN_CONTAINER", commonTestUtils.VirtioWinImage)
 				_ = os.Setenv("OPERATOR_NAMESPACE", namespace)
 
@@ -909,12 +907,11 @@ var _ = Describe("HyperconvergedController", func() {
 				expected.ssp.Status.ObservedVersion = newComponentVersion
 
 				expected.hco.Status.Conditions = origConditions
+
 			})
 
 			It("Should update OperatorCondition Upgradeable to False", func() {
 				_ = commonTestUtils.GetScheme() // ensure the scheme is loaded so this test can be focused
-
-				expected := getBasicDeployment()
 
 				// old HCO Version is set
 				expected.hco.Status.UpdateVersion(hcoVersionName, oldVersion)
@@ -1177,9 +1174,15 @@ var _ = Describe("HyperconvergedController", func() {
 				parallelOutboundMigrationsPerNode := uint32(2)
 				progressTimeout := int64(150)
 
-				It("should drop KubeVirt configMap and create backup", func() {
-					expected.hco.Status.UpdateVersion(hcoVersionName, oldVersion)
+				var oldKVCMVersion = "1.3.1"
 
+				BeforeEach(func() {
+					expected.hco.Status.UpdateVersion(hcoVersionName, oldKVCMVersion)
+					expected.hco.Spec = hcov1beta1.HyperConvergedSpec{}
+					expected.kv, _ = operands.NewKubeVirt(expected.hco, namespace)
+				})
+
+				It("should drop KubeVirt configMap and create backup", func() {
 					kvCM := &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      kvCmName,
@@ -1196,9 +1199,10 @@ var _ = Describe("HyperconvergedController", func() {
 					resources := append(expected.toArray(), kvCM)
 
 					cl := commonTestUtils.InitClient(resources)
-					foundResource, _, requeue := doReconcile(cl, expected.hco, nil)
+					foundResource, reconciler, requeue := doReconcile(cl, expected.hco, nil)
 					Expect(requeue).To(BeTrue())
-					checkAvailability(foundResource, metav1.ConditionTrue)
+					foundResource, _, requeue = doReconcile(cl, foundResource, reconciler)
+					Expect(requeue).To(BeFalse())
 
 					foundKvCm, foundBackup := searchKvConfigMaps(cl)
 					Expect(foundKvCm).To(BeFalse())
@@ -1208,8 +1212,6 @@ var _ = Describe("HyperconvergedController", func() {
 				})
 
 				It("should adopt KubeVirt configMap into HC CR, drop it and create backup", func() {
-					expected.hco.Status.UpdateVersion(hcoVersionName, oldVersion)
-
 					kvCM := &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      kvCmName,
@@ -1283,7 +1285,6 @@ progressTimeout: 150`,
 				})
 
 				It("should adopt KubeVirt configMap into HC CR if the values are different, drop the cm and create backup", func() {
-					expected.hco.Status.UpdateVersion(hcoVersionName, oldVersion)
 					expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &bandwidthPerMigration
 					expected.hco.Spec.LiveMigrationConfig.CompletionTimeoutPerGiB = &completionTimeoutPerGiB
 					expected.hco.Spec.LiveMigrationConfig.ParallelOutboundMigrationsPerNode = &parallelOutboundMigrationsPerNode
@@ -1363,7 +1364,6 @@ progressTimeout: 300`,
 				})
 
 				It("should adopt real KubeVirt configMap into HC CR if the values are different, drop the cm and create backup", func() {
-					expected.hco.Status.UpdateVersion(hcoVersionName, oldVersion)
 					expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &bandwidthPerMigration
 					expected.hco.Spec.LiveMigrationConfig.CompletionTimeoutPerGiB = &completionTimeoutPerGiB
 					expected.hco.Spec.LiveMigrationConfig.ParallelOutboundMigrationsPerNode = &parallelOutboundMigrationsPerNode
@@ -1435,7 +1435,6 @@ progressTimeout: 300`,
 				})
 
 				It("should ignore KubeVirt configMap into HC CR if there is no change, drop the cm and create backup", func() {
-					expected.hco.Status.UpdateVersion(hcoVersionName, oldVersion)
 					expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &bandwidthPerMigration
 					expected.hco.Spec.LiveMigrationConfig.CompletionTimeoutPerGiB = &completionTimeoutPerGiB
 					expected.hco.Spec.LiveMigrationConfig.ParallelOutboundMigrationsPerNode = &parallelOutboundMigrationsPerNode
@@ -2022,8 +2021,6 @@ progressTimeout: 150`,
 					_, reconciler, requeue := doReconcile(cl, expected.hco, nil)
 					Expect(requeue).To(BeTrue())
 					foundResource, _, requeue := doReconcile(cl, expected.hco, reconciler)
-					Expect(requeue).To(BeTrue())
-					_, _, requeue = doReconcile(cl, expected.hco, reconciler)
 					Expect(requeue).To(BeFalse())
 					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(Not(BeNil()))
 					Expect(*foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(Equal(customBandwidthPerMigration))
@@ -3059,6 +3056,13 @@ progressTimeout: 150`,
 			}
 
 			Context("Positive Tests - KV Config", func() {
+
+				BeforeEach(func() {
+					expected.hco.Status.UpdateVersion(hcoVersionName, "1.3.99")
+					expected.hco.Spec = hcov1beta1.HyperConvergedSpec{}
+					expected.kv, _ = operands.NewKubeVirt(expected.hco, namespace)
+				})
+
 				It("Should delete the CM and create a backup", func() {
 					resources := append(expected.toArray(), &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -25,6 +25,7 @@ import (
 
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	components "github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/operands"
@@ -173,6 +174,8 @@ func getBasicDeployment() *BasicExpected {
 		},
 	}
 	res.hco = hco
+
+	components.GetOperatorCR().Spec.DeepCopyInto(&res.hco.Spec)
 
 	res.pc = operands.NewKubeVirtPriorityClass(hco)
 	res.mService = operands.NewMetricsService(hco, namespace)


### PR DESCRIPTION
Prepare a PR to enable again default workloadUpdates
strategies for the next release.

The feature got temporary disabled with #1577
being still not so mature.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable (again) default workloadUpdates strategies
```

