### PR TITLE
Disable VM upgrade tests when 'workloadUpdateMethods' is empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ cluster-clean:
 
 ci-functest: build-functest test-functional
 
-functest: build-functest test-functional-in-container
+functest: test-functional-in-container
 
 build-functest:
 	${DO} ./hack/build-tests.sh

--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -265,10 +265,13 @@ fi
 Msg "make sure that we don't have outdated VMs"
 
 INFRASTRUCTURETOPOLOGY=$(${CMD} get infrastructure.config.openshift.io cluster -o json | jq -j '.status.infrastructureTopology')
+UPDATE_METHODS=$(${CMD} get hco ${HCO_RESOURCE_NAME} -n ${HCO_NAMESPACE} -o jsonpath='{.spec .workloadUpdateStrategy .workloadUpdateMethods}')
 
 if [[ "${INFRASTRUCTURETOPOLOGY}" == "SingleReplica" ]]; then
   echo "Skipping the check on SNO clusters"
-else 
+elif [[ "${UPDATE_METHODS}" == "" || "${UPDATE_METHODS}" == "[]" ]]; then
+  echo "Skipping while workloadUpdateMethods methods are empty "
+else
   OUTDATEDVMI=$(${CMD} get vmi -l kubevirt.io/outdatedLauncherImage -A -o json | jq -j '.items | length')
   if [[ $OUTDATEDVMI -ne 0 ]]; then
     echo "Not all the running VMs got upgraded"


### PR DESCRIPTION
When workloadUpdateMethods is empty, VMs are not updated
after upgrade. We should disable this test accordingly.

Signed-off-by: Erkan Erol <eerol@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
NONE
```

