### PR TITLE
Apply upgrade patches according to a yaml file

### DIFF
--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "replace",
+          "path": "/spec/featureGates/sriovLiveMigration",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/build/Dockerfile.okd
+++ b/build/Dockerfile.okd
@@ -5,6 +5,6 @@ ENV KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
 COPY hyperconverged-cluster-operator /usr/bin/
 COPY hack/testFiles/test_quickstart.yaml quickStart/
 COPY hack/testFiles/test_dashboard_cm.yaml dashboard/
-COPY assets/dataImportCronTemplates dataImportCronTemplates/
+COPY assets/ .
 
 ENTRYPOINT /usr/bin/hyperconverged-cluster-operator

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badJson.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badJson.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch":
+      {
+        "op": "replace",
+        "path": "/spec/featureGates/sriovLiveMigration",
+        "value": true
+      }
+      ]
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches1.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches1.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "badOperation",
+          "path": "/spec/featureGates/sriovLiveMigration",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches2.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches2.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "replace",
+          "path": "/badSpec/featureGates/sriovLiveMigration",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches3.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches3.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "replace",
+          "path": "/spec/badFeatureGates/sriovLiveMigration",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badSemverRange.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badSemverRange.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": "= badvalue < > ",
+      "jsonPatch": [
+        {
+          "op": "replace",
+          "path": "/spec/featureGates/sriovLiveMigration",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/empty.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/empty.json
@@ -1,0 +1,3 @@
+{
+  "hcoCRPatchList": []
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/upgradePatches.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/upgradePatches.json
@@ -1,0 +1,1 @@
+../../../../../assets/upgradePatches.json

--- a/pkg/controller/hyperconverged/upgradePatches.go
+++ b/pkg/controller/hyperconverged/upgradePatches.go
@@ -1,0 +1,103 @@
+package hyperconverged
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/blang/semver/v4"
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+const (
+	upgradeChangesFileLocation = "./upgradePatches.json"
+)
+
+type hcoCRPatch struct {
+	// SemverRange is a set of conditions which specify which versions satisfy the range
+	// (see https://github.com/blang/semver#ranges as a reference).
+	SemverRange string `json:"semverRange"`
+	// JSONPatch contains a sequence of operations to apply to the HCO CR during upgrades
+	// (see: https://datatracker.ietf.org/doc/html/rfc6902 as the format reference).
+	JSONPatch jsonpatch.Patch `json:"jsonPatch"`
+}
+
+type UpgradePatches struct {
+	// hcoCRPatchList is a list of upgrade patches.
+	// Each hcoCRPatch consists in a semver range of affected source versions and a json patch to be applied during the upgrade if relevant.
+	HCOCRPatchList []hcoCRPatch `json:"hcoCRPatchList"`
+}
+
+var (
+	hcoUpgradeChanges     UpgradePatches
+	hcoUpgradeChangesRead = false
+)
+
+var getUpgradeChangesFileLocation = func() string {
+	return upgradeChangesFileLocation
+}
+
+func readUpgradePatchesFromFile(req *common.HcoRequest) error {
+	if hcoUpgradeChangesRead {
+		return nil
+	}
+
+	fileLocation := getUpgradeChangesFileLocation()
+
+	file, err := os.Open(fileLocation)
+	if err != nil {
+		req.Logger.Error(err, "Can't open the upgradeChanges yaml file", "file name", fileLocation)
+		return err
+	}
+
+	jsonBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(jsonBytes, &hcoUpgradeChanges)
+	if err != nil {
+		return err
+	}
+	hcoUpgradeChangesRead = true
+	return nil
+}
+
+func validateUpgradePatches(req *common.HcoRequest) error {
+	err := readUpgradePatchesFromFile(req)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range hcoUpgradeChanges.HCOCRPatchList {
+		return validateUpgradePatch(req, p)
+	}
+	return nil
+}
+
+func validateUpgradePatch(req *common.HcoRequest, p hcoCRPatch) error {
+	_, err := semver.ParseRange(p.SemverRange)
+	if err != nil {
+		return err
+	}
+
+	for _, patch := range p.JSONPatch {
+		path, err := patch.Path()
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(path, "/spec/") {
+			return errors.New("can only modify spec fields")
+		}
+	}
+	specBytes, err := json.Marshal(req.Instance)
+	if err != nil {
+		return err
+	}
+	_, err = p.JSONPatch.Apply(specBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/controller/hyperconverged/upgradePatches_test.go
+++ b/pkg/controller/hyperconverged/upgradePatches_test.go
@@ -1,0 +1,114 @@
+package hyperconverged
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"os"
+	"path"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
+)
+
+var origFile string
+
+var _ = Describe("upgradePatches", func() {
+
+	BeforeEach(func() {
+		wd, _ := os.Getwd()
+		origFile = path.Join(wd, "upgradePatches.json")
+		err := commonTestUtils.CopyFile(origFile+".orig", origFile)
+		Expect(err).ToNot(HaveOccurred())
+		hcoUpgradeChangesRead = false
+	})
+
+	AfterEach(func() {
+		err := os.Remove(origFile + ".orig")
+		Expect(err).ToNot(HaveOccurred())
+		hcoUpgradeChangesRead = false
+	})
+
+	Context("readUpgradeChangesFromFile", func() {
+
+		var hco *hcov1beta1.HyperConverged
+		var req *common.HcoRequest
+
+		BeforeEach(func() {
+			hco = commonTestUtils.NewHco()
+			req = commonTestUtils.NewReq(hco)
+		})
+
+		AfterEach(func() {
+			err := commonTestUtils.CopyFile(origFile, origFile+".orig")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should correctly parse and validate actual upgradePatches.json", func() {
+			err := validateUpgradePatches(req)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should correctly parse and validate empty upgradePatches", func() {
+			err := copyTestFile("empty.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = validateUpgradePatches(req)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should fail parsing upgradePatches with bad json", func() {
+			err := copyTestFile("badJson.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = validateUpgradePatches(req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(HavePrefix("invalid character"))
+		})
+
+		It("should fail validating upgradePatches with bad semver ranges", func() {
+			err := copyTestFile("badSemverRange.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = validateUpgradePatches(req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(HavePrefix("Could not get version from string:"))
+		})
+
+		DescribeTable(
+			"should fail validating upgradePatches with bad patches",
+			func(filename, message string) {
+				err := copyTestFile(filename)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = validateUpgradePatches(req)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).Should(HavePrefix(message))
+			},
+			Entry(
+				"bad operation kind",
+				"badPatches1.json",
+				"Unexpected kind:",
+			),
+			Entry(
+				"not on spec",
+				"badPatches2.json",
+				"can only modify spec fields",
+			),
+			Entry(
+				"unexisting path",
+				"badPatches3.json",
+				"replace operation does not apply: doc is missing path:",
+			),
+		)
+
+	})
+
+})
+
+func copyTestFile(filename string) error {
+	testFilesLocation := getTestFilesLocation() + "/upgradePatches"
+	err := commonTestUtils.CopyFile(origFile, path.Join(testFilesLocation, filename))
+	return err
+}


### PR DESCRIPTION
Apply upgrade patches according to a yaml files
shipped within the container.
The operator will read the yaml file expecting
a fixed struct.

Now it handles only jsonpatches to be applied
on the HCO CR, in the future the same mechanism
could be easily extended to delete leftovers
or patch other objects.

Now it expects something like:
```json
{
  "hcoCRPatchList": [
    {
      "semverRange": ">=1.4.0 <=1.5.0",
      "jsonPatch": [
        {
          "op": "replace",
          "path": "/spec/featureGates/sriovLiveMigration",
          "value": true
        }
      ]
    }
  ]
}
```
where hcoCRPatchList is a list of upgrade patches.
Each hcoCRPatch consists in a semver range
( https://github.com/blang/semver#ranges ) of affected
source versions and a json patch
( https://datatracker.ietf.org/doc/html/rfc6902 )
to be applied during the upgrade if relevant.

Applying it to set
`/spec/featureGates/sriovLiveMigration = true`
when upgrading from 1.4.z and 1.5.0 to the current version.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2018468

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Apply upgrade patches according to a yaml file
```

