### PR TITLE
try to fix the hco-test-build image

### DIFF
--- a/tests/build/Dockerfile
+++ b/tests/build/Dockerfile
@@ -6,7 +6,7 @@ RUN echo "diskspacecheck=0" >> /etc/dnf/dnf.conf && dnf update -y && dnf install
 
 RUN pip3 install j2cli && pip3 install operator-courier
 
-ENV GIMME_GO_VERSION=1.17.0 \
+ENV GIMME_GO_VERSION=1.17.3 \
     KUBEBUILDER_VERSION="2.3.1" \
     ARCH="amd64" \
     GOPATH="/go" \


### PR DESCRIPTION
The test image now brings gomega 1.17 when building the test app. this version of gomega is not supported in go.1.15 used in the current hco-test-build image. Trying to build new image.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

