### PR TITLE
[release-1.5] Apply upgrade patches according to a yaml file (#1586)

### DIFF
--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "replace",
+          "path": "/spec/featureGates/sriovLiveMigration",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/build/Dockerfile.okd
+++ b/build/Dockerfile.okd
@@ -5,5 +5,6 @@ ENV KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
 COPY hyperconverged-cluster-operator /usr/bin/
 COPY hack/testFiles/test_quickstart.yaml quickStart/
 COPY hack/testFiles/test_dashboard_cm.yaml dashboard/
+COPY assets/ .
 
 ENTRYPOINT /usr/bin/hyperconverged-cluster-operator

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/evanphx/json-patch v4.11.0+incompatible
+	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.4.0
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,9 @@ github.com/evanphx/json-patch v4.1.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch v4.11.0+incompatible h1:glyUF9yIYtMHzn8xaKw5rMhdWcwsYV8dZHIq5567/xs=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW64qjjJq8M2u4dxNaBiDfKK+z/3eGDpXEQhc=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -2,6 +2,7 @@ package hyperconverged
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/metrics"
@@ -12,6 +13,8 @@ import (
 	"os"
 	"reflect"
 	"strings"
+
+	"github.com/blang/semver/v4"
 
 	"github.com/google/uuid"
 	operatorhandler "github.com/operator-framework/operator-lib/handler"
@@ -317,6 +320,12 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 	req.SetUpgradeMode(r.upgradeMode)
 
 	if r.upgradeMode {
+
+		err = validateUpgradePatches(req)
+		if err != nil {
+			return reconcile.Result{Requeue: true}, err
+		}
+
 		crdStatusUpdated, err := r.updateCrdStoredVersions(req)
 		if err != nil {
 			return reconcile.Result{Requeue: true}, err
@@ -970,7 +979,12 @@ func (r *ReconcileHyperConverged) migrateBeforeUpgrade(req *common.HcoRequest) (
 		return false, err
 	}
 
-	return kvConfigModified || cdiConfigModified || imsConfigModified || defaultsAmended, nil
+	upgradePatched, err := r.applyUpgradePatches(req)
+	if err != nil {
+		return false, err
+	}
+
+	return kvConfigModified || cdiConfigModified || imsConfigModified || defaultsAmended || upgradePatched, nil
 }
 
 func (r ReconcileHyperConverged) migrateKvConfigurations(req *common.HcoRequest) (bool, error) {
@@ -1051,6 +1065,62 @@ func (r ReconcileHyperConverged) amendBadDefaults(req *common.HcoRequest) (bool,
 		req.Dirty = true
 	}
 	return modified, nil
+}
+
+func (r ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (bool, error) {
+	modified := false
+
+	knownHcoVersion, _ := req.Instance.Status.GetVersion(hcoVersionName)
+	if knownHcoVersion == "" {
+		knownHcoVersion = "0.0.0"
+	}
+	knownHcoSV, err := semver.Parse(knownHcoVersion)
+	if err != nil {
+		req.Logger.Error(err, "Error!")
+		return false, err
+	}
+
+	hcoJson, err := json.Marshal(req.Instance)
+	if err != nil {
+		return false, err
+	}
+
+	for _, p := range hcoUpgradeChanges.HCOCRPatchList {
+		hcoJson, err = r.applyUpgradePatch(req, hcoJson, knownHcoSV, p)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	tmpInstance := &hcov1beta1.HyperConverged{}
+	err = json.Unmarshal(hcoJson, tmpInstance)
+	if err != nil {
+		return false, err
+	}
+	if !reflect.DeepEqual(tmpInstance.Spec, req.Instance.Spec) {
+		req.Logger.Info("updating HCO spec as a result of upgrade patches")
+		tmpInstance.Spec.DeepCopyInto(&req.Instance.Spec)
+		modified = true
+		req.Dirty = true
+	}
+
+	return modified, nil
+}
+
+func (r ReconcileHyperConverged) applyUpgradePatch(req *common.HcoRequest, hcoJson []byte, knownHcoSV semver.Version, p hcoCRPatch) ([]byte, error) {
+	affectedRange, err := semver.ParseRange(p.SemverRange)
+	if err != nil {
+		return hcoJson, err
+	}
+	if affectedRange(knownHcoSV) {
+		req.Logger.Info("applying upgrade patch", "knownHcoSV", knownHcoSV, "affectedRange", p.SemverRange, "patches", p.JSONPatch)
+		patchedBytes, err := p.JSONPatch.Apply(hcoJson)
+		if err != nil {
+			return hcoJson, err
+		}
+		return patchedBytes, nil
+	}
+	return hcoJson, nil
 }
 
 func (r *ReconcileHyperConverged) removeConfigMap(req *common.HcoRequest, cm *corev1.ConfigMap, cmName string) error {

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badJson.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badJson.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch":
+      {
+        "op": "replace",
+        "path": "/spec/featureGates/sriovLiveMigration",
+        "value": true
+      }
+      ]
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches1.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches1.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "badOperation",
+          "path": "/spec/featureGates/sriovLiveMigration",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches2.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches2.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "replace",
+          "path": "/badSpec/featureGates/sriovLiveMigration",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches3.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badPatches3.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "replace",
+          "path": "/spec/badFeatureGates/sriovLiveMigration",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badSemverRange.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badSemverRange.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": "= badvalue < > ",
+      "jsonPatch": [
+        {
+          "op": "replace",
+          "path": "/spec/featureGates/sriovLiveMigration",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/empty.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/empty.json
@@ -1,0 +1,3 @@
+{
+  "hcoCRPatchList": []
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/upgradePatches.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/upgradePatches.json
@@ -1,0 +1,1 @@
+../../../../../assets/upgradePatches.json

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -143,6 +143,8 @@ func getBasicDeployment() *BasicExpected {
 		},
 	}
 	res.hco = hco
+	// avoid an upgrade patch loop
+	res.hco.Spec.FeatureGates.SRIOVLiveMigration = true
 
 	res.pc = operands.NewKubeVirtPriorityClass(hco)
 	res.mService = operands.NewMetricsService(hco, namespace)

--- a/pkg/controller/hyperconverged/upgradePatches.go
+++ b/pkg/controller/hyperconverged/upgradePatches.go
@@ -1,0 +1,103 @@
+package hyperconverged
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/blang/semver/v4"
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+const (
+	upgradeChangesFileLocation = "./upgradePatches.json"
+)
+
+type hcoCRPatch struct {
+	// SemverRange is a set of conditions which specify which versions satisfy the range
+	// (see https://github.com/blang/semver#ranges as a reference).
+	SemverRange string `json:"semverRange"`
+	// JSONPatch contains a sequence of operations to apply to the HCO CR during upgrades
+	// (see: https://datatracker.ietf.org/doc/html/rfc6902 as the format reference).
+	JSONPatch jsonpatch.Patch `json:"jsonPatch"`
+}
+
+type UpgradePatches struct {
+	// hcoCRPatchList is a list of upgrade patches.
+	// Each hcoCRPatch consists in a semver range of affected source versions and a json patch to be applied during the upgrade if relevant.
+	HCOCRPatchList []hcoCRPatch `json:"hcoCRPatchList"`
+}
+
+var (
+	hcoUpgradeChanges     UpgradePatches
+	hcoUpgradeChangesRead = false
+)
+
+var getUpgradeChangesFileLocation = func() string {
+	return upgradeChangesFileLocation
+}
+
+func readUpgradePatchesFromFile(req *common.HcoRequest) error {
+	if hcoUpgradeChangesRead {
+		return nil
+	}
+
+	fileLocation := getUpgradeChangesFileLocation()
+
+	file, err := os.Open(fileLocation)
+	if err != nil {
+		req.Logger.Error(err, "Can't open the upgradeChanges yaml file", "file name", fileLocation)
+		return err
+	}
+
+	jsonBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(jsonBytes, &hcoUpgradeChanges)
+	if err != nil {
+		return err
+	}
+	hcoUpgradeChangesRead = true
+	return nil
+}
+
+func validateUpgradePatches(req *common.HcoRequest) error {
+	err := readUpgradePatchesFromFile(req)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range hcoUpgradeChanges.HCOCRPatchList {
+		return validateUpgradePatch(req, p)
+	}
+	return nil
+}
+
+func validateUpgradePatch(req *common.HcoRequest, p hcoCRPatch) error {
+	_, err := semver.ParseRange(p.SemverRange)
+	if err != nil {
+		return err
+	}
+
+	for _, patch := range p.JSONPatch {
+		path, err := patch.Path()
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(path, "/spec/") {
+			return errors.New("can only modify spec fields")
+		}
+	}
+	specBytes, err := json.Marshal(req.Instance)
+	if err != nil {
+		return err
+	}
+	_, err = p.JSONPatch.Apply(specBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/controller/hyperconverged/upgradePatches_test.go
+++ b/pkg/controller/hyperconverged/upgradePatches_test.go
@@ -1,0 +1,114 @@
+package hyperconverged
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"os"
+	"path"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
+)
+
+var origFile string
+
+var _ = Describe("upgradePatches", func() {
+
+	BeforeEach(func() {
+		wd, _ := os.Getwd()
+		origFile = path.Join(wd, "upgradePatches.json")
+		err := commonTestUtils.CopyFile(origFile+".orig", origFile)
+		Expect(err).ToNot(HaveOccurred())
+		hcoUpgradeChangesRead = false
+	})
+
+	AfterEach(func() {
+		err := os.Remove(origFile + ".orig")
+		Expect(err).ToNot(HaveOccurred())
+		hcoUpgradeChangesRead = false
+	})
+
+	Context("readUpgradeChangesFromFile", func() {
+
+		var hco *hcov1beta1.HyperConverged
+		var req *common.HcoRequest
+
+		BeforeEach(func() {
+			hco = commonTestUtils.NewHco()
+			req = commonTestUtils.NewReq(hco)
+		})
+
+		AfterEach(func() {
+			err := commonTestUtils.CopyFile(origFile, origFile+".orig")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should correctly parse and validate actual upgradePatches.json", func() {
+			err := validateUpgradePatches(req)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should correctly parse and validate empty upgradePatches", func() {
+			err := copyTestFile("empty.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = validateUpgradePatches(req)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should fail parsing upgradePatches with bad json", func() {
+			err := copyTestFile("badJson.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = validateUpgradePatches(req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(HavePrefix("invalid character"))
+		})
+
+		It("should fail validating upgradePatches with bad semver ranges", func() {
+			err := copyTestFile("badSemverRange.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = validateUpgradePatches(req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(HavePrefix("Could not get version from string:"))
+		})
+
+		DescribeTable(
+			"should fail validating upgradePatches with bad patches",
+			func(filename, message string) {
+				err := copyTestFile(filename)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = validateUpgradePatches(req)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).Should(HavePrefix(message))
+			},
+			Entry(
+				"bad operation kind",
+				"badPatches1.json",
+				"Unexpected kind:",
+			),
+			Entry(
+				"not on spec",
+				"badPatches2.json",
+				"can only modify spec fields",
+			),
+			Entry(
+				"unexisting path",
+				"badPatches3.json",
+				"replace operation does not apply: doc is missing path:",
+			),
+		)
+
+	})
+
+})
+
+func copyTestFile(filename string) error {
+	testFilesLocation := getTestFilesLocation() + "/upgradePatches"
+	err := commonTestUtils.CopyFile(origFile, path.Join(testFilesLocation, filename))
+	return err
+}

--- a/vendor/github.com/evanphx/json-patch/.gitignore
+++ b/vendor/github.com/evanphx/json-patch/.gitignore
@@ -1,0 +1,6 @@
+# editor and IDE paraphernalia
+.idea
+.vscode
+
+# macOS paraphernalia
+.DS_Store

--- a/vendor/github.com/evanphx/json-patch/patch.go
+++ b/vendor/github.com/evanphx/json-patch/patch.go
@@ -412,6 +412,17 @@ func (d *partialArray) set(key string, val *lazyNode) error {
 	if err != nil {
 		return err
 	}
+
+	if idx < 0 {
+		if !SupportNegativeIndices {
+			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		}
+		if idx < -len(*d) {
+			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		}
+		idx += len(*d)
+	}
+
 	(*d)[idx] = val
 	return nil
 }
@@ -460,6 +471,16 @@ func (d *partialArray) get(key string) (*lazyNode, error) {
 
 	if err != nil {
 		return nil, err
+	}
+
+	if idx < 0 {
+		if !SupportNegativeIndices {
+			return nil, errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		}
+		if idx < -len(*d) {
+			return nil, errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		}
+		idx += len(*d)
 	}
 
 	if idx >= len(*d) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,7 +16,7 @@ github.com/davecgh/go-spew/spew
 # github.com/emicklei/go-restful v2.10.0+incompatible
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
-# github.com/evanphx/json-patch v4.11.0+incompatible
+# github.com/evanphx/json-patch v5.6.0+incompatible
 ## explicit
 github.com/evanphx/json-patch
 # github.com/fsnotify/fsnotify v1.4.9


### PR DESCRIPTION
Apply upgrade patches according to a yaml files
shipped within the container.
The operator will read the yaml file expecting
a fixed struct.

Now it handles only jsonpatches to be applied
on the HCO CR, in the future the same mechanism
could be easily extended to delete leftovers
or patch other objects.

Now it expects something like:
```json
{
  "hcoCRPatchList": [
    {
      "semverRange": ">=1.4.0 <=1.5.0",
      "jsonPatch": [
        {
          "op": "replace",
          "path": "/spec/featureGates/sriovLiveMigration",
          "value": true
        }
      ]
    }
  ]
}
```
where hcoCRPatchList is a list of upgrade patches.
Each hcoCRPatch consists in a semver range
( https://github.com/blang/semver#ranges ) of affected
source versions and a json patch
( https://datatracker.ietf.org/doc/html/rfc6902 )
to be applied during the upgrade if relevant.

Applying it to set
/spec/featureGates/sriovLiveMigration = true
when upgrading from 1.4.z and 1.5.0 to the current version.

This is a manual cherry-pick of #1586

Bump github.com/evanphx/json-patch => v5.6.0+incompatible
to be aligned with the main branch.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2018468

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Apply upgrade patches according to a yaml file
```

