### PR TITLE
Amend 'bandwidthPerMigration' config using 'upgradePatches'

### DIFF
--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -9,6 +9,20 @@
           "value": true
         }
       ]
+    },
+    {
+      "semverRange": ">=1.5.0 <=1.6.0",
+      "jsonPatch": [
+        {
+          "op": "test",
+          "path": "/spec/liveMigrationConfig/bandwidthPerMigration",
+          "value": "64Mi"
+        },
+        {
+          "op": "remove",
+          "path": "/spec/liveMigrationConfig/bandwidthPerMigration"
+        }
+      ]
     }
   ]
 }

--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -11,7 +11,7 @@
       ]
     },
     {
-      "semverRange": ">=1.5.0 <=1.6.0",
+      "semverRange": ">=1.4.0 <1.5.0",
       "jsonPatch": [
         {
           "op": "test",

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/openshift/custom-resource-status v1.1.0
 	github.com/operator-framework/api v0.10.7
 	github.com/operator-framework/operator-lib v0.8.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.51.2
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
@@ -63,7 +64,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -2000,8 +2000,8 @@ progressTimeout: 150`,
 				badBandwidthPerMigration := "64Mi"
 				customBandwidthPerMigration := "32Mi"
 
-				It("should drop spec.livemigrationconfig.bandwidthpermigration if == 64Mi", func() {
-					expected.hco.Status.UpdateVersion(hcoVersionName, oldVersion)
+				It("should drop spec.livemigrationconfig.bandwidthpermigration if == 64Mi when upgrading from <= 1.6.0", func() {
+					expected.hco.Status.UpdateVersion(hcoVersionName, "1.5.99")
 					expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &badBandwidthPerMigration
 
 					cl := expected.initClient()
@@ -2014,8 +2014,8 @@ progressTimeout: 150`,
 					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(BeNil())
 				})
 
-				It("should preserve spec.livemigrationconfig.bandwidthpermigration if != 64Mi", func() {
-					expected.hco.Status.UpdateVersion(hcoVersionName, oldVersion)
+				It("should preserve spec.livemigrationconfig.bandwidthpermigration if != 64Mi when upgrading from <= 1.6.0", func() {
+					expected.hco.Status.UpdateVersion(hcoVersionName, "1.5.99")
 					expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &customBandwidthPerMigration
 
 					cl := expected.initClient()
@@ -2025,6 +2025,19 @@ progressTimeout: 150`,
 					Expect(requeue).To(BeFalse())
 					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(Not(BeNil()))
 					Expect(*foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(Equal(customBandwidthPerMigration))
+				})
+
+				It("should preserve spec.livemigrationconfig.bandwidthpermigration even if == 64Mi when upgrading from >= 1.6.1", func() {
+					expected.hco.Status.UpdateVersion(hcoVersionName, "1.6.1")
+					expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &badBandwidthPerMigration
+
+					cl := expected.initClient()
+					_, reconciler, requeue := doReconcile(cl, expected.hco, nil)
+					Expect(requeue).To(BeTrue())
+					foundResource, _, requeue := doReconcile(cl, expected.hco, reconciler)
+					Expect(requeue).To(BeFalse())
+					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(Not(BeNil()))
+					Expect(*foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(Equal(badBandwidthPerMigration))
 				})
 
 				It("should amend spec.featureGates.sriovLiveMigration upgrading from <= 1.5.0", func() {

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -2000,8 +2000,8 @@ progressTimeout: 150`,
 				badBandwidthPerMigration := "64Mi"
 				customBandwidthPerMigration := "32Mi"
 
-				It("should drop spec.livemigrationconfig.bandwidthpermigration if == 64Mi when upgrading from <= 1.6.0", func() {
-					expected.hco.Status.UpdateVersion(hcoVersionName, "1.5.99")
+				It("should drop spec.livemigrationconfig.bandwidthpermigration if == 64Mi when upgrading from < 1.5.0", func() {
+					expected.hco.Status.UpdateVersion(hcoVersionName, "1.4.99")
 					expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &badBandwidthPerMigration
 
 					cl := expected.initClient()
@@ -2014,21 +2014,23 @@ progressTimeout: 150`,
 					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(BeNil())
 				})
 
-				It("should preserve spec.livemigrationconfig.bandwidthpermigration if != 64Mi when upgrading from <= 1.6.0", func() {
-					expected.hco.Status.UpdateVersion(hcoVersionName, "1.5.99")
+				It("should preserve spec.livemigrationconfig.bandwidthpermigration if != 64Mi when upgrading from < 1.5.0", func() {
+					expected.hco.Status.UpdateVersion(hcoVersionName, "1.4.99")
 					expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &customBandwidthPerMigration
 
 					cl := expected.initClient()
 					_, reconciler, requeue := doReconcile(cl, expected.hco, nil)
 					Expect(requeue).To(BeTrue())
 					foundResource, _, requeue := doReconcile(cl, expected.hco, reconciler)
+					Expect(requeue).To(BeTrue())
+					_, _, requeue = doReconcile(cl, expected.hco, reconciler)
 					Expect(requeue).To(BeFalse())
 					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(Not(BeNil()))
 					Expect(*foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(Equal(customBandwidthPerMigration))
 				})
 
-				It("should preserve spec.livemigrationconfig.bandwidthpermigration even if == 64Mi when upgrading from >= 1.6.1", func() {
-					expected.hco.Status.UpdateVersion(hcoVersionName, "1.6.1")
+				It("should preserve spec.livemigrationconfig.bandwidthpermigration even if == 64Mi when upgrading from >= 1.5.1", func() {
+					expected.hco.Status.UpdateVersion(hcoVersionName, "1.5.1")
 					expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &badBandwidthPerMigration
 
 					cl := expected.initClient()


### PR DESCRIPTION
Signed-off-by: João Vilaça <jvilaca@redhat.com>

Amend bad `bandwidthPerMigration` default using `upgradePatches`, which are executed in specific version upgrades, instead of running amend code in every upgrade.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

