### PR TITLE
Support Automatic configuration of mediated devices

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1248,6 +1248,16 @@ spec:
               localStorageClassName:
                 description: LocalStorageClassName the name of the local storage class.
                 type: string
+              mediatedDevicesConfiguration:
+                description: MediatedDevicesConfiguration holds information about
+                  MDEV types to be defined on nodes, if available
+                properties:
+                  mediatedDevicesTypes:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -1248,6 +1248,16 @@ spec:
               localStorageClassName:
                 description: LocalStorageClassName the name of the local storage class.
                 type: string
+              mediatedDevicesConfiguration:
+                description: MediatedDevicesConfiguration holds information about
+                  MDEV types to be defined on nodes, if available
+                properties:
+                  mediatedDevicesTypes:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -1248,6 +1248,16 @@ spec:
               localStorageClassName:
                 description: LocalStorageClassName the name of the local storage class.
                 type: string
+              mediatedDevicesConfiguration:
+                description: MediatedDevicesConfiguration holds information about
+                  MDEV types to be defined on nodes, if available
+                properties:
+                  mediatedDevicesTypes:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,7 @@ This Document documents the types introduced by the hyperconverged-cluster-opera
 * [HyperConvergedStatus](#hyperconvergedstatus)
 * [HyperConvergedWorkloadUpdateStrategy](#hyperconvergedworkloadupdatestrategy)
 * [LiveMigrationConfigurations](#livemigrationconfigurations)
+* [MediatedDevicesConfiguration](#mediateddevicesconfiguration)
 * [MediatedHostDevice](#mediatedhostdevice)
 * [OperandResourceRequirements](#operandresourcerequirements)
 * [PciHostDevice](#pcihostdevice)
@@ -126,6 +127,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false} | false |
 | liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150} | false |
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
+| mediatedDevicesConfiguration | MediatedDevicesConfiguration holds information about MDEV types to be defined on nodes, if available | *[MediatedDevicesConfiguration](#mediateddevicesconfiguration) |  | false |
 | certConfig | certConfig holds the rotation policy for internal, self-signed certificates | [HyperConvergedCertConfig](#hyperconvergedcertconfig) | {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}} | false |
 | resourceRequirements | ResourceRequirements describes the resource requirements for the operand workloads. | *[OperandResourceRequirements](#operandresourcerequirements) |  | false |
 | scratchSpaceStorageClass | Override the storage class used for scratch space during transfer operations. The scratch space storage class is determined in the following order: value of scratchSpaceStorageClass, if that doesn't exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space | *string |  | false |
@@ -175,6 +177,16 @@ LiveMigrationConfigurations - Live migration limits and timeouts are applied so 
 | bandwidthPerMigration | Bandwidth limit of each migration, in MiB/s. | *string |  | false |
 | completionTimeoutPerGiB | The migration will be canceled if it has not completed in this time, in seconds per GiB of memory. For example, a virtual machine instance with 6GiB memory will timeout if it has not completed migration in 4800 seconds. If the Migration Method is BlockMigration, the size of the migrating disks is included in the calculation. | *int64 | 800 | false |
 | progressTimeout | The migration will be canceled if memory copy fails to make progress in this time, in seconds. | *int64 | 150 | false |
+
+[Back to TOC](#table-of-contents)
+
+## MediatedDevicesConfiguration
+
+MediatedDevicesConfiguration holds inforamtion about MDEV types to be defined, if available
+
+| Field | Description | Scheme | Default | Required |
+| ----- | ----------- | ------ | -------- |-------- |
+| mediatedDevicesTypes |  | []string |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -226,6 +226,33 @@ spec:
     progressTimeout: 150
 ```
 
+## Automatic Configuration of Mediated Devices (including vGPUs)
+
+Administrators can provide a list of desired mediated devices (vGPU) types.
+KubeVirt will attempt to automatically create the relevant devices on nodes that can support such configuration.
+Currently, it is possible to configure one type per physical card.
+KubeVirt will configure all `available_instances` for each configurable type.
+
+### Example
+
+```yaml
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  mediatedDevicesConfiguration:
+    mediatedDevicesTypes:
+      - nvidia-222
+      - nvidia-228
+      - i915-GVTg_V5_4
+```
+
+This API will facilitate the creation of mediated devices types on cluster
+nodes. However, administrators are expected to use the PermittedHostDevices API
+to allow these devices in the cluster.
+
+
 ## Listing Permitted Host Devices
 Administrators can control which host devices are exposed and permitted to be used in the cluster. Permitted host
 devices in the cluster will need to be allowlisted in KubeVirt CR by its `vendor:product` selector for PCI devices or

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -53,6 +53,10 @@ type HyperConvergedSpec struct {
 	// +optional
 	PermittedHostDevices *PermittedHostDevices `json:"permittedHostDevices,omitempty"`
 
+	// MediatedDevicesConfiguration holds information about MDEV types to be defined on nodes, if available
+	// +optional
+	MediatedDevicesConfiguration *MediatedDevicesConfiguration `json:"mediatedDevicesConfiguration,omitempty"`
+
 	// certConfig holds the rotation policy for internal, self-signed certificates
 	// +kubebuilder:default={"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}
 	// +optional
@@ -253,6 +257,13 @@ type MediatedHostDevice struct {
 	// these objects.
 	// +optional
 	Disabled bool `json:"disabled,omitempty"`
+}
+
+// MediatedDevicesConfiguration holds inforamtion about MDEV types to be defined, if available
+// +k8s:openapi-gen=true
+type MediatedDevicesConfiguration struct {
+	// +listType=atomic
+	MediatedDevicesTypes []string `json:"mediatedDevicesTypes,omitempty"`
 }
 
 // OperandResourceRequirements is a list of resource requirements for the operand workloads pods

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -298,10 +298,11 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		NetworkConfiguration: &kubevirtcorev1.NetworkConfiguration{
 			NetworkInterface: string(kubevirtcorev1.MasqueradeInterface),
 		},
-		MigrationConfiguration: kvLiveMigration,
-		PermittedHostDevices:   toKvPermittedHostDevices(hc.Spec.PermittedHostDevices),
-		ObsoleteCPUModels:      obsoleteCPUs,
-		MinCPUModel:            minCPUModel,
+		MigrationConfiguration:       kvLiveMigration,
+		PermittedHostDevices:         toKvPermittedHostDevices(hc.Spec.PermittedHostDevices),
+		MediatedDevicesConfiguration: toKvMediatedDevicesConfiguration(hc.Spec.MediatedDevicesConfiguration),
+		ObsoleteCPUModels:            obsoleteCPUs,
+		MinCPUModel:                  minCPUModel,
 	}
 
 	if smbiosConfig, ok := os.LookupEnv(smbiosEnvName); ok {
@@ -339,6 +340,16 @@ func getObsoleteCPUConfig(hcObsoleteCPUConf *hcov1beta1.HyperConvergedObsoleteCP
 	}
 
 	return obsoleteCPUModels, minCPUModel
+}
+
+func toKvMediatedDevicesConfiguration(mdevsConfig *hcov1beta1.MediatedDevicesConfiguration) *kubevirtcorev1.MediatedDevicesConfiguration {
+	if mdevsConfig == nil {
+		return nil
+	}
+
+	return &kubevirtcorev1.MediatedDevicesConfiguration{
+		MediatedDevicesTypes: mdevsConfig.MediatedDevicesTypes,
+	}
 }
 
 func toKvPermittedHostDevices(permittedDevices *hcov1beta1.PermittedHostDevices) *kubevirtcorev1.PermittedHostDevices {


### PR DESCRIPTION
This PR will allow the administrators to provide a list of desired mediated devices to be automatically configured by KubeVirt on cluster nodes that can support it.
For example:
```
apiVersion: hco.kubevirt.io/v1beta1
kind: HyperConverged
metadata:
  name: kubevirt-hyperconverged
spec:
  mediatedDevicesConfiguration:
    mediatedDevicesTypes:
      - nvidia-222
      - nvidia-228
      - i915-GVTg_V5_4
```
This follows KubeVirts' PR: https://github.com/kubevirt/kubevirt/pull/5974
```release-note
Support automatic configuration of mediated devices (vGPUs)
```

