### PR TITLE
Enable ExpandDisks FeatureGate

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -198,7 +198,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(kvList.Items).Should(HaveLen(1))
 				kv := kvList.Items[0]
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(13))
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(14))
 
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(
 					"DataVolumes",
@@ -213,6 +213,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"WithHostModelCPU",
 					"HypervStrictCheck",
 					"DownwardMetrics",
+					"ExpandDisks",
 				),
 				)
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement("WithHostPassthroughCPU"))

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -87,6 +87,9 @@ const (
 
 	// Add downwardMetrics volume to expose a limited set of host metrics to guests
 	kvDownwardMetricsGate = "DownwardMetrics"
+
+	// Expand disks to the largest size
+	kvExpandDisksGate = "ExpandDisks"
 )
 
 var (
@@ -98,6 +101,7 @@ var (
 		kvCPUNodeDiscoveryGate,
 		kvSnapshotGate,
 		kvHotplugVolumesGate,
+		kvExpandDisksGate,
 		kvGPUGate,
 		kvHostDevicesGate,
 		kvDownwardMetricsGate,


### PR DESCRIPTION
https://github.com/kubevirt/kubevirt/pull/5981
introduced a new KubeVirt feature named ExpandDisks to expand
the PVC-backed disks to the largest possible size.

The feature is controlled by a feature gate named "ExpandDisks".
Enable it in the list of HCO opinionated feature gates.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable kubevirt ExpandDisks FeatureGate by default
```

