### PR TITLE
Enable the KubeVirt NUMA featuregate

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -196,7 +196,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(kvList.Items).Should(HaveLen(1))
 				kv := kvList.Items[0]
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(14))
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(15))
 
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(
 					"DataVolumes",
@@ -212,6 +212,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"HypervStrictCheck",
 					"DownwardMetrics",
 					"ExpandDisks",
+					"NUMA",
 				),
 				)
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement("WithHostPassthroughCPU"))

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -90,6 +90,9 @@ const (
 
 	// Expand disks to the largest size
 	kvExpandDisksGate = "ExpandDisks"
+
+	// Allow automatic numa mapping on VMs with dedicated CPUs, if requested
+	kvNUMA = "NUMA"
 )
 
 var (
@@ -105,6 +108,7 @@ var (
 		kvGPUGate,
 		kvHostDevicesGate,
 		kvDownwardMetricsGate,
+		kvNUMA,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of


### PR DESCRIPTION
Enable the NUMA feature gate for kubevirt. It allows using additional tuning options like `guestMappingPassthrough{}` on VMs with dedicated CPUs.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
Enable the NUMA feature gate for kubevirt
```

