### PR TITLE
Be more tolerant parsing previous version

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -268,7 +268,7 @@ func (r *ReconcileHyperConverged) Reconcile(ctx context.Context, request reconci
 	result, err := r.doReconcile(hcoRequest)
 	if err != nil {
 		r.eventEmitter.EmitEvent(hcoRequest.Instance, corev1.EventTypeWarning, "ReconcileError", err.Error())
-		return reconcile.Result{}, err
+		return result, err
 	}
 
 	if err = r.setOperatorUpgradeableStatus(hcoRequest); err != nil {
@@ -403,7 +403,7 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 
 		modified, err := r.migrateBeforeUpgrade(req)
 		if err != nil {
-			return reconcile.Result{Requeue: init}, err
+			return reconcile.Result{Requeue: true}, err
 		}
 
 		if modified {
@@ -1047,7 +1047,7 @@ func (r ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (bo
 	if knownHcoVersion == "" {
 		knownHcoVersion = "0.0.0"
 	}
-	knownHcoSV, err := semver.Parse(knownHcoVersion)
+	knownHcoSV, err := semver.ParseTolerant(knownHcoVersion)
 	if err != nil {
 		req.Logger.Error(err, "Error!")
 		return false, err


### PR DESCRIPTION
Be more tolerant parsing previous version

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2026198

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Be more tolerant parsing actual version
```

