### PR TITLE
fix nightly builds

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -4,7 +4,7 @@ set -ex
 
 # Get golang
 docker login --username "$(cat "${QUAY_USER}")" --password-stdin quay.io < "${QUAY_PASSWORD}"
-wget -q https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz
+wget -q https://dl.google.com/go/go1.17.3.linux-amd64.tar.gz
 tar -C /usr/local -xf go*.tar.gz
 export PATH=/usr/local/go/bin:$PATH
 
@@ -23,6 +23,7 @@ rm -rf kubevirt
 git clone https://github.com/kubevirt/kubevirt.git
 (cd kubevirt; git checkout "${latest_kubevirt_commit}")
 go mod edit -replace kubevirt.io/client-go=./kubevirt/staging/src/kubevirt.io/client-go
+go mod edit -replace kubevirt.io/api=./kubevirt/staging/src/kubevirt.io/api
 go mod vendor
 
 # set envs


### PR DESCRIPTION
https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/periodic-hco-push-nightly-build-main?buildId=1463689411110637568
are still red, trying to fix them.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

