### PR TITLE
Force an older docker API version

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -44,6 +44,7 @@ sed -i "s#quay.io/kubevirt/virt-#${kv_image/-*/-}#" deploy/images.csv
 sed -i "s#^KUBEVIRT_VERSION=.*#KUBEVIRT_VERSION=\"${kv_tag}\"#" hack/config
 (cd ./tools/digester && go build .)
 export HCO_VERSION="${IMAGE_TAG}"
+export DOCKER_API_VERSION=1.40
 ./automation/digester/update_images.sh
 
 HCO_OPERATOR_IMAGE_DIGEST=$(tools/digester/digester --image ${CSV_OPERATOR_IMAGE}:${IMAGE_TAG})


### PR DESCRIPTION
periodic-hco-push-nightly-build-main job
is still failing with:
`Error response from daemon: client version 1.41 is too new. Maximum
supported API version is 1.40`
(see:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-hco-push-nightly-build-main/1465139095750578176
for an example); forcing DOCKER_API_VERSION=1.40 via an environmental
variable to make it happy.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

