### PR TITLE
Fix out-of-date resource-version

### DIFF
--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
@@ -143,6 +144,14 @@ func (h *genericOperand) addCrToTheRelatedObjectList(req *common.HcoRequest, fou
 	objectRef, err := reference.GetReference(h.Scheme, found)
 	if err != nil {
 		return err
+	}
+
+	existingRef, err := objectreferencesv1.FindObjectReference(req.Instance.Status.RelatedObjects, *objectRef)
+	if err != nil {
+		return err
+	}
+	if existingRef != nil && !reflect.DeepEqual(existingRef, *objectRef) {
+		req.StatusDirty = true
 	}
 
 	err = objectreferencesv1.SetObjectReference(&req.Instance.Status.RelatedObjects, *objectRef)

--- a/pkg/controller/operands/operand_test.go
+++ b/pkg/controller/operands/operand_test.go
@@ -3,6 +3,12 @@ package operands
 import (
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/reference"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -81,4 +87,76 @@ var _ = Describe("Test operator.go", func() {
 			Expect(obj.Spec.Config.FilesystemOverhead.Global).Should(BeEquivalentTo("55"))
 		})
 	})
+
+	Context("Test addCrToTheRelatedObjectList", func() {
+		It("Should return error when apiVersion, kind and name missing", func() {
+			hco := commonTestUtils.NewHco()
+			req := commonTestUtils.NewReq(hco)
+			found := &cdiv1beta1.CDI{}
+
+			operand := genericOperand{Scheme: scheme.Scheme}
+			err := operand.addCrToTheRelatedObjectList(req, found)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("object reference must have, at a minimum: apiVersion, kind, and name"))
+		})
+
+		It("Should add into the list when it is missing", func() {
+			hco := commonTestUtils.NewHco()
+			req := commonTestUtils.NewReq(hco)
+			found := &cdiv1beta1.CDI{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CDI",
+					APIVersion: "cdi.kubevirt.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cdi-kubevirt-hyperconverged",
+				},
+			}
+
+			operand := genericOperand{Scheme: scheme.Scheme}
+			err := operand.addCrToTheRelatedObjectList(req, found)
+			Expect(err).ToNot(HaveOccurred())
+
+			foundRef, err := reference.GetReference(operand.Scheme, found)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*foundRef))
+		})
+
+		It("Should update the list and set StatusDirty=true when the resourceVersion is different", func() {
+			const oldVersion = "111"
+			const newVersion = "112"
+			hco := commonTestUtils.NewHco()
+			req := commonTestUtils.NewReq(hco)
+			found := &cdiv1beta1.CDI{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CDI",
+					APIVersion: "cdi.kubevirt.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "cdi-kubevirt-hyperconverged",
+					ResourceVersion: oldVersion,
+				},
+			}
+
+			operand := genericOperand{Scheme: scheme.Scheme}
+			err := operand.addCrToTheRelatedObjectList(req, found)
+			Expect(err).ToNot(HaveOccurred())
+
+			oldRef, err := reference.GetReference(operand.Scheme, found)
+			Expect(err).ToNot(HaveOccurred())
+
+			// update resource version
+			found.ResourceVersion = newVersion
+			err = operand.addCrToTheRelatedObjectList(req, found)
+			Expect(err).ToNot(HaveOccurred())
+
+			newRef, err := reference.GetReference(operand.Scheme, found)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*newRef))
+			Expect(hco.Status.RelatedObjects).ToNot(ContainElement(*oldRef))
+			Expect(req.StatusDirty).To(BeTrue())
+		})
+	})
+
 })


### PR DESCRIPTION
hco-operator is triggered when there is a resourceVersion change in one of the secondary CRs but it doesn't update status part if there is nothing to update in status other than resourceVersion. That leads observation of out-of-date versions in status section. This change forces status update if there is a new version of the secondary CR. 

Signed-off-by: Erkan Erol <eerol@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
NONE
```

