### PR TITLE
Calculate diff only between tags when generating release notes

### DIFF
--- a/tools/release-notes/git.go
+++ b/tools/release-notes/git.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"os"
 	"os/exec"
@@ -145,10 +146,22 @@ func (p *project) gitGetTypeOfChanges(span string) (string, error) {
 	return strings.TrimSpace(typeOfChanges), nil
 }
 
-func (p *project) switchToBranch(branch string) error {
+func (p *project) gitSwitchToBranch(branch string) error {
 	_, err := gitCommand("-C", p.repoDir, "checkout", branch)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (p *project) gitCheckCurrentTagExists() error {
+	output, err := gitCommand("-C", p.repoDir, "tag", "-l", p.currentTag)
+	if err != nil {
+		return err
+	}
+	if len(output) == 0 {
+		return errors.New("requested tag '" + p.currentTag + "' does not exist")
 	}
 
 	return nil

--- a/tools/release-notes/release-notes.go
+++ b/tools/release-notes/release-notes.go
@@ -91,7 +91,7 @@ func (r *releaseData) writeOtherChanges() error {
 }
 
 func (r *releaseData) getConfig(branch string) (map[string]string, error) {
-	err := r.hco.switchToBranch(branch)
+	err := r.hco.gitSwitchToBranch(branch)
 	if err != nil {
 		return nil, err
 	}
@@ -288,6 +288,10 @@ func parseArguments() *releaseData {
 
 func (r *releaseData) checkoutProjects() {
 	err := r.hco.gitCheckoutUpstream()
+	if err != nil {
+		log.Fatalf("ERROR checking out upstream: %s\n", err)
+	}
+	err = r.hco.gitCheckCurrentTagExists()
 	if err != nil {
 		log.Fatalf("ERROR checking out upstream: %s\n", err)
 	}

--- a/tools/release-notes/release-notes.go
+++ b/tools/release-notes/release-notes.go
@@ -37,8 +37,7 @@ func (r *releaseData) writeHeader(span string) error {
 	return nil
 }
 
-func (r *releaseData) writeHcoChanges() error {
-	span := fmt.Sprintf("%s..origin/%s", r.hco.previousTag, r.hco.tagBranch)
+func (r *releaseData) writeHcoChanges(span string) error {
 	releaseNotes, err := r.hco.gitGetReleaseNotes(span)
 	if err != nil {
 		return err
@@ -58,14 +57,10 @@ func (r *releaseData) writeHcoChanges() error {
 }
 
 func (p *project) writeOtherChangesIfVersionUpdated(f *os.File) error {
-	span := fmt.Sprintf("%s..origin/%s", p.previousTag, p.tagBranch)
+	span := fmt.Sprintf("%s..%s", p.previousTag, p.currentTag)
 	releaseNotes, err := p.gitGetReleaseNotes(span)
 	if err != nil {
-		span = fmt.Sprintf("%s..%s", p.previousTag, p.currentTag)
-		releaseNotes, err = p.gitGetReleaseNotes(span)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 
 	f.WriteString(fmt.Sprintf("### %s: %s -> %s\n", p.name, p.previousTag, p.currentTag))
@@ -110,7 +105,7 @@ func (r *releaseData) getConfig(branch string) (map[string]string, error) {
 }
 
 func (r *releaseData) findProjectsCurrentAndPreviousReleases() error {
-	newConfig, err := r.getConfig(r.hco.tagBranch)
+	newConfig, err := r.getConfig(r.hco.currentTag)
 	if err != nil {
 		return err
 	}
@@ -120,22 +115,18 @@ func (r *releaseData) findProjectsCurrentAndPreviousReleases() error {
 	}
 
 	for _, p := range r.projects {
-		p.currentTag = newConfig[p.short+"_VERSION"]
-		_, p.tagBranch, err = semverGetBranchFromTag(p.currentTag)
-		if err != nil {
-			return err
-		}
-		p.previousTag = oldConfig[p.short+"_VERSION"]
+		p.currentTag = newConfig[p.short + "_VERSION"]
+		p.previousTag = oldConfig[p.short + "_VERSION"]
 	}
 
 	return nil
 }
 
-func (r *releaseData) writeNotableChanges() error {
+func (r *releaseData) writeNotableChanges(span string) error {
 	r.outFile.WriteString("Notable changes\n---------------\n")
 	r.outFile.WriteString("\n")
 
-	err := r.writeHcoChanges()
+	err := r.writeHcoChanges(span)
 	if err != nil {
 		return err
 	}
@@ -220,14 +211,14 @@ func (r *releaseData) generateReleaseNotes() error {
 	}
 	defer r.outFile.Close()
 
-	span := fmt.Sprintf("%s..origin/%s", r.hco.previousTag, r.hco.tagBranch)
+	span := fmt.Sprintf("%s..%s", r.hco.previousTag, r.hco.currentTag)
 
 	err = r.writeHeader(span)
 	if err != nil {
 		return err
 	}
 
-	err = r.writeNotableChanges()
+	err = r.writeNotableChanges(span)
 	if err != nil {
 		return err
 	}

--- a/tools/release-notes/release-notes.go
+++ b/tools/release-notes/release-notes.go
@@ -115,8 +115,8 @@ func (r *releaseData) findProjectsCurrentAndPreviousReleases() error {
 	}
 
 	for _, p := range r.projects {
-		p.currentTag = newConfig[p.short + "_VERSION"]
-		p.previousTag = oldConfig[p.short + "_VERSION"]
+		p.currentTag = newConfig[p.short+"_VERSION"]
+		p.previousTag = oldConfig[p.short+"_VERSION"]
 	}
 
 	return nil

--- a/tools/release-notes/semver.go
+++ b/tools/release-notes/semver.go
@@ -9,15 +9,6 @@ import (
 	"github.com/google/go-github/v32/github"
 )
 
-func semverGetBranchFromTag(tag string) (*semver.Version, string, error) {
-	tagSemver, err := semver.NewVersion(tag)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return tagSemver, fmt.Sprintf("release-%d.%d", tagSemver.Major(), tagSemver.Minor()), nil
-}
-
 func semverGetVersions(releases []*github.RepositoryRelease) []*semver.Version {
 	var vs []*semver.Version
 
@@ -86,7 +77,7 @@ func (r *releaseData) semverVerifyReleaseBranch(expectedBranch string) error {
 }
 
 func (r *releaseData) semverVerifyTag() error {
-	tagSemver, expectedBranch, err := semverGetBranchFromTag(r.hco.currentTag)
+	tagSemver, err := semver.NewVersion(r.hco.currentTag)
 	if err != nil {
 		return err
 	}
@@ -101,13 +92,6 @@ func (r *releaseData) semverVerifyTag() error {
 	} else {
 		log.Printf("Previous Tag [%s]", r.hco.previousTag)
 	}
-
-	err = r.semverVerifyReleaseBranch(expectedBranch)
-	if err != nil {
-		return err
-	}
-
-	r.hco.tagBranch = expectedBranch
 
 	return nil
 }

--- a/tools/release-notes/types.go
+++ b/tools/release-notes/types.go
@@ -29,7 +29,6 @@ type project struct {
 	name        string
 	currentTag  string
 	previousTag string
-	tagBranch   string
 
 	repoDir string
 	repoUrl string


### PR DESCRIPTION
Previously when generating the release notes the notable changes would be calculated through the diff between the previous tag and the release branch. That would cause some extra commits to be shown when generating release notes for older tags. For example, a run for `v1.4.1` and `v1.4.2`, would show the latest commit in the branch `release-1.4` in both documents despite being only related to `v1.4.2`.

This PR changes the code to get the diff between the previous tag and the requested tag eliminating this issue.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

