### PR TITLE
Randomize the DataImportCronTemplate cron's hour

### DIFF
--- a/pkg/controller/hyperconverged/dataimportschedule.go
+++ b/pkg/controller/hyperconverged/dataimportschedule.go
@@ -31,5 +31,6 @@ func generateSchedule() string {
 	s := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(s)
 	randMinute := r.Intn(60)
-	return fmt.Sprintf("%d */12 * * *", randMinute)
+	randHour := r.Intn(12) // not using r.Intn(24) because, for example, 2/12 and 14/12 are exactly the same.
+	return fmt.Sprintf("%d %d/12 * * *", randMinute, randHour)
 }

--- a/pkg/controller/hyperconverged/dataimportschedule_test.go
+++ b/pkg/controller/hyperconverged/dataimportschedule_test.go
@@ -1,6 +1,9 @@
 package hyperconverged
 
 import (
+	"regexp"
+	"strconv"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -8,17 +11,37 @@ import (
 )
 
 var _ = Describe("test data import schedule", func() {
-	const schedule = "42 */12 * * *"
+	const schedule = "42 5/12 * * *"
 
 	It("should update the status and the variable if both are empty", func() {
-		hco := commonTestUtils.NewHco()
-		req := commonTestUtils.NewReq(hco)
+		regex := `(\d+) (\d+)/12 \* \* \*`
 
-		applyDataImportSchedule(req)
+		for i := 0; i < 1000; i++ { // testing random number - need some statistic confidence, so running this 1000 times
+			dataImportSchedule = ""
+			hco := commonTestUtils.NewHco()
+			req := commonTestUtils.NewReq(hco)
 
-		Expect(dataImportSchedule).Should(MatchRegexp(`\d+ \*/12 \* \* \*`))
-		Expect(hco.Status.DataImportSchedule).Should(Equal(dataImportSchedule))
-		Expect(req.StatusDirty).Should(BeTrue())
+			applyDataImportSchedule(req)
+
+			Expect(dataImportSchedule).Should(MatchRegexp(regex))
+
+			rx := regexp.MustCompile(regex)
+			groups := rx.FindStringSubmatch(dataImportSchedule)
+			Expect(groups).To(HaveLen(3))
+			minute, err := strconv.Atoi(groups[1])
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(minute).Should(BeNumerically(">=", 0), "minute should be grater than or equal to 0; cron expression is: %s", dataImportSchedule)
+			Expect(minute).Should(BeNumerically("<", 60), "minute should br less than 60; cron expression is: %s", dataImportSchedule)
+
+			hour, err := strconv.Atoi(groups[2])
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hour).Should(BeNumerically(">=", 0), "hour should be grater than or equal to 0; cron expression is: %s", dataImportSchedule)
+			Expect(hour).Should(BeNumerically("<", 12), "hour should br less than 12; cron expression is: %s", dataImportSchedule)
+
+			Expect(hco.Status.DataImportSchedule).Should(Equal(dataImportSchedule))
+			Expect(req.StatusDirty).Should(BeTrue())
+		}
 	})
 
 	It("should update the status if the variable is set", func() {
@@ -53,7 +76,7 @@ var _ = Describe("test data import schedule", func() {
 		hco.Status.DataImportSchedule = schedule
 		req := commonTestUtils.NewReq(hco)
 
-		dataImportSchedule = "24 */12 * * *"
+		dataImportSchedule = "24 2/12 * * *"
 
 		applyDataImportSchedule(req)
 


### PR DESCRIPTION
Improve the image pull spread by randomize the cron hour in addition to the cron minute.

The new cron expression will be `<rand minute> <rand hour>/12 * * *`, where `0 <= rand hour < 12`.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

