### PR TITLE
DataImportCronTemplates references quay.io/containerdisks

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -6,7 +6,7 @@
       spec:
         source:
           registry:
-            url: docker://quay.io/kubevirt/centos8-container-disk-images
+            url: docker://quay.io/containerdisks/centos:8.4
         storage:
           resources:
             requests:
@@ -21,7 +21,7 @@
       spec:
         source:
           registry:
-            url: docker://quay.io/kubevirt/fedora-container-disk-images
+            url: docker://quay.io/containerdisks/fedora:35
         storage:
           resources:
             requests:

--- a/ci-test-files/centos8-imagestream.yaml
+++ b/ci-test-files/centos8-imagestream.yaml
@@ -10,7 +10,7 @@ spec:
   - annotations: null
     from:
       kind: DockerImage
-      name: quay.io/kubevirt/centos8-container-disk-images
+      name: quay.io/containerdisks/centos
     importPolicy:
       scheduled: true
-    name: latest
+    name: 8.4

--- a/hack/check_golden_images.sh
+++ b/hack/check_golden_images.sh
@@ -7,7 +7,7 @@ IMAGES_NS=${IMAGES_NS:-kubevirt-os-images}
 if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
   # Test image streams
   [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
-  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
+  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/containerdisks/centos:8.4"}' ]]
 
   #check that HCO reconciles the image stream
   ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch imageStream -n ${IMAGES_NS} centos8 --type=json -p '[{\"op\": \"add\", \"path\": \"/metadata/labels/test-label\", \"value\": \"test\"}]'"


### PR DESCRIPTION
There are maintained containerdisks in quay.io/containerdisks/ , which
are referenced by the DataImportCronTemplates make them
available to the users in a comfortable way.

@nunnatsa Can you please have a look?

cc @rmohr 

