### PR TITLE
Bug 2030660: Fix bug where imageStream are not get reconciled

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -216,6 +216,9 @@ func getNewManagerCache(operatorNamespace string) cache.NewCacheFunc {
 				&openshiftroutev1.Route{}: {
 					Field: namespaceSelector,
 				},
+				&imagev1.ImageStream{}: {
+					Label: labelSelector,
+				},
 			},
 		},
 	)

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -598,6 +598,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
   - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
@@ -428,6 +428,8 @@ spec:
           verbs:
           - get
           - list
+          - watch
+          - update
           - create
         serviceAccountName: hyperconverged-cluster-operator
       - rules:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.6.0-unstable
-    createdAt: "2021-12-08 05:13:13"
+    createdAt: "2021-12-13 08:52:28"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -428,6 +428,8 @@ spec:
           verbs:
           - get
           - list
+          - watch
+          - update
           - create
         serviceAccountName: hyperconverged-cluster-operator
       - rules:

--- a/hack/check_golden_images.sh
+++ b/hack/check_golden_images.sh
@@ -5,6 +5,17 @@ set -ex
 IMAGES_NS=${IMAGES_NS:-kubevirt-os-images}
 
 if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
+  # Test image streams
+  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
+  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
+
+  #check that HCO reconciles the image stream
+  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch imageStream -n ${IMAGES_NS} centos8 --type=json -p '[{\"op\": \"add\", \"path\": \"/metadata/labels/test-label\", \"value\": \"test\"}]'"
+  sleep 10
+  # HCO expect to remove the test-label label from the image stream
+  ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o yaml"
+
+  # Test DataImportCronTemplates
   ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": true }]'"
   sleep 10
 
@@ -20,9 +31,6 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
   ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos8-image-cron-is
 
   [[ $(${KUBECTL_BINARY} get DataImportCron -o json -n ${IMAGES_NS} centos8-image-cron-is | jq -cM '.spec.template.spec.source.registry') == '{"imageStream":"centos8","pullMethod":"node"}' ]]
-
-  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
-  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
 
   ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": false }]'"
   sleep 10

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -495,7 +495,7 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		{
 			APIGroups: stringListToSlice("image.openshift.io"),
 			Resources: stringListToSlice("imagestreams"),
-			Verbs:     stringListToSlice("get", "list", "create"),
+			Verbs:     stringListToSlice("get", "list", "watch", "update", "create"),
 		},
 	}
 }

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -7,15 +7,14 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/pkg/errors"
-
 	"github.com/blang/semver/v4"
-
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/google/uuid"
 	consolev1 "github.com/openshift/api/console/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	operatorhandler "github.com/operator-framework/operator-lib/handler"
+	"github.com/pkg/errors"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -178,6 +177,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo) er
 			&monitoringv1.PrometheusRule{},
 			&routev1.Route{},
 			&consolev1.ConsoleCLIDownload{},
+			&imagev1.ImageStream{},
 		}...)
 	}
 

--- a/pkg/controller/operands/imageStream.go
+++ b/pkg/controller/operands/imageStream.go
@@ -99,7 +99,7 @@ func (h isHooks) updateCr(req *common.HcoRequest, Client client.Client, exists r
 
 func (h *isHooks) compareAndUpgradeImageStream(found *imagev1.ImageStream) bool {
 	modified := false
-	if reflect.DeepEqual(h.required.ObjectMeta, found.ObjectMeta) {
+	if !reflect.DeepEqual(h.required.Labels, found.Labels) {
 		util.DeepCopyLabels(&h.required.ObjectMeta, &found.ObjectMeta)
 		modified = true
 	}


### PR DESCRIPTION
Fix by start watching imageStreams. Add an E2E test to validate.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bugzilla bug #2030660
```

