### PR TITLE
[release-1.5] grant access for v2v-vmware config map for non-admin users

### DIFF
--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -311,7 +311,7 @@ func NewConfigReaderRoleForCR(cr *hcov1beta1.HyperConverged, namespace string) *
 			{
 				APIGroups:     []string{""},
 				Resources:     []string{"configmaps"},
-				ResourceNames: []string{"kubevirt-storage-class-defaults"},
+				ResourceNames: []string{"kubevirt-storage-class-defaults", "v2v-vmware"},
 				Verbs:         []string{"get", "watch", "list"},
 			},
 		},

--- a/tests/func-tests/unprivileged_test.go
+++ b/tests/func-tests/unprivileged_test.go
@@ -38,4 +38,11 @@ var _ = Describe("[rfe_id:393][crit:medium][vendor:cnv-qe@redhat.com][level:syst
 		Expect(configmap.Data["local-sc.volumeMode"]).To(Equal("Filesystem"))
 		Expect(configmap.Data["local-sc.accessMode"]).To(Equal("ReadWriteOnce"))
 	})
+
+	It("should be able to read v2v-vmware ConfigMap", func() {
+		configmap, err := unprivClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.TODO(), "v2v-vmware", metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(configmap.Data["virtio-win-image"]).NotTo(BeEmpty())
+	})
 })


### PR DESCRIPTION
v2v-vmware ConfigMap contains the virtio-win-image pullspec that is shipped in the bundle. This value is required by the UI when creaing a VirtualMachine using the wizard, also if the user is not a cluster admin.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2032873

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

