### PR TITLE
Reconcile ImageStream only if the FG is true

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -601,6 +601,7 @@ rules:
   - watch
   - update
   - create
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
@@ -431,6 +431,7 @@ spec:
           - watch
           - update
           - create
+          - delete
         serviceAccountName: hyperconverged-cluster-operator
       - rules:
         - apiGroups:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.6.0-unstable
-    createdAt: "2021-12-13 08:52:28"
+    createdAt: "2021-12-16 07:25:42"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -431,6 +431,7 @@ spec:
           - watch
           - update
           - create
+          - delete
         serviceAccountName: hyperconverged-cluster-operator
       - rules:
         - apiGroups:

--- a/hack/check_golden_images.sh
+++ b/hack/check_golden_images.sh
@@ -5,6 +5,12 @@ set -ex
 IMAGES_NS=${IMAGES_NS:-kubevirt-os-images}
 
 if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
+  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 0 ]]
+
+  # Test DataImportCronTemplates
+  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": true }]'"
+  sleep 10
+
   # Test image streams
   [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
   [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
@@ -15,9 +21,6 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
   # HCO expect to remove the test-label label from the image stream
   ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o yaml"
 
-  # Test DataImportCronTemplates
-  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": true }]'"
-  sleep 10
 
   ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.featureGates.enableCommonBootImageImport}'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron")'
@@ -35,5 +38,7 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
   ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": false }]'"
   sleep 10
 
+  #check that the image streams and the DataImportCron were removed
+  ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 0 ]]"
   ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get DataImportCron -A --no-headers | wc -l) -eq 0 ]]"
 fi

--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -309,7 +309,7 @@ else
 fi
 
 Msg "check golden images"
-KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} ./hack/check_defaults.sh
+KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} ./hack/check_golden_images.sh
 
 Msg "check virtio-win image is in configmap"
 VIRTIOWIN_IMAGE_CSV=$(${CMD} get ${CSV} -n ${HCO_NAMESPACE} \

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -495,7 +495,7 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		{
 			APIGroups: stringListToSlice("image.openshift.io"),
 			Resources: stringListToSlice("imagestreams"),
-			Verbs:     stringListToSlice("get", "list", "watch", "update", "create"),
+			Verbs:     stringListToSlice("get", "list", "watch", "update", "create", "delete"),
 		},
 	}
 }

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -1119,7 +1119,7 @@ func removeOldQuickStartGuides(req *common.HcoRequest, cl client.Client, require
 		for name, existQs := range existingQSNames {
 			if !hcoutil.ContainsString(requiredQSList, name) {
 				req.Logger.Info("deleting ConsoleQuickStart", "name", name)
-				if err = hcoutil.EnsureDeleted(req.Ctx, cl, &existQs, req.Instance.Name, req.Logger, false, false); err != nil {
+				if _, err = hcoutil.EnsureDeleted(req.Ctx, cl, &existQs, req.Instance.Name, req.Logger, false, false); err != nil {
 					req.Logger.Error(err, "failed to delete ConsoleQuickStart", "name", name)
 				}
 			}

--- a/pkg/controller/operands/ensure_result.go
+++ b/pkg/controller/operands/ensure_result.go
@@ -12,6 +12,7 @@ type EnsureResult struct {
 	Overwritten bool
 	Created     bool
 	UpgradeDone bool
+	Deleted     bool
 	Err         error
 	Type        string
 	Name        string
@@ -50,5 +51,10 @@ func (r *EnsureResult) SetUpgradeDone(upgradeDone bool) *EnsureResult {
 
 func (r *EnsureResult) SetName(name string) *EnsureResult {
 	r.Name = name
+	return r
+}
+
+func (r *EnsureResult) SetDeleted() *EnsureResult {
+	r.Deleted = true
 	return r
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -102,8 +102,9 @@ var _ = Describe("Test general utilities", func() {
 				WithRuntimeObjects(pod).
 				Build()
 
-			err := EnsureDeleted(ctx, cl, pod, appName, logger, false, true)
+			deleted, err := EnsureDeleted(ctx, cl, pod, appName, logger, false, true)
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(deleted).To(BeTrue())
 
 			podToSearch := &corev1.Pod{}
 			err = cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)
@@ -115,8 +116,9 @@ var _ = Describe("Test general utilities", func() {
 				WithScheme(testScheme).
 				Build()
 
-			err := EnsureDeleted(ctx, cl, pod, appName, logger, false, true)
+			deleted, err := EnsureDeleted(ctx, cl, pod, appName, logger, false, true)
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(deleted).To(BeFalse())
 
 			podToSearch := &corev1.Pod{}
 			err = cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -208,7 +208,7 @@ func (wh WebhookHandler) ValidateDelete(hc *v1beta1.HyperConverged) error {
 		kv,
 		cdi,
 	} {
-		err := hcoutil.EnsureDeleted(ctx, wh.cli, obj, hc.Name, wh.logger, true, false)
+		_, err := hcoutil.EnsureDeleted(ctx, wh.cli, obj, hc.Name, wh.logger, true, false)
 		if err != nil {
 			wh.logger.Error(err, "Delete validation failed", "GVK", obj.GetObjectKind().GroupVersionKind())
 			return err


### PR DESCRIPTION
If the enableCommonBootImageImport FG is set, create the imageStreams and reconcile them
If the enableCommonBootImageImport FG is not set, remove the imageStreams

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reconcile the image stream only if the enableCommonBootImageImport featuregate is true
```

