### PR TITLE
Fix the release bumper bot

### DIFF
--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -33,17 +33,17 @@ function main {
   echo INFO: Updating image digest list...
   ./automation/digester/update_images.sh
 
-  echo INFO: Executing "build-manifests.sh"...
-  ./hack/build-manifests.sh
-
   echo INFO: Updating go.mod...
   update_go_mod
+
+  echo INFO: Executing "go mod tidy"
+  go mod tidy -v
 
   echo INFO: Executing "go mod vendor"
   go mod vendor
 
-  echo INFO: Executing "go mod tidy"
-  go mod tidy -v
+  echo INFO: Executing "build-manifests.sh"...
+  ./hack/build-manifests.sh
 }
 
 function get_current_versions {


### PR DESCRIPTION
It seems that the bot misses some changes in new libraries.

This PR fixes it by change the order of call to `go mod vendor` and `go mod tidy`, so the vendor will use the right versions.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

