### PR TITLE
Expose a knob to tune UninstallStrategy

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -60,6 +60,7 @@ spec:
                 parallelMigrationsPerCluster: 5
                 parallelOutboundMigrationsPerNode: 2
                 progressTimeout: 150
+              uninstallStrategy: BlockUninstallIfWorkloadsExist
             description: HyperConvergedSpec defines the desired state of HyperConverged
             properties:
               certConfig:
@@ -2006,6 +2007,23 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                 type: object
+              uninstallStrategy:
+                default: BlockUninstallIfWorkloadsExist
+                description: 'UninstallStrategy defines how to proceed on uninstall
+                  when workloads (VirtualMachines, DataVolumes) still exist. BlockUninstallIfWorkloadsExist
+                  will prevent the CR from being removed when workloads still exist.
+                  BlockUninstallIfWorkloadsExist is the safest choice to protect your
+                  workloads from accidental data loss, so it''s strongly advised.
+                  RemoveWorkloads will cause all the workloads to be cascading deleted
+                  on uninstall. WARNING: please notice that RemoveWorkloads will cause
+                  your workloads to be deleted as soon as this CR will be, even accidentally,
+                  deleted. Please correctly consider the implications of this option
+                  before setting it. BlockUninstallIfWorkloadsExist is the default
+                  behaviour.'
+                enum:
+                - RemoveWorkloads
+                - BlockUninstallIfWorkloadsExist
+                type: string
               vddkInitImage:
                 description: VDDK Init Image eventually used to import VMs from external
                   providers

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -60,6 +60,7 @@ spec:
                 parallelMigrationsPerCluster: 5
                 parallelOutboundMigrationsPerNode: 2
                 progressTimeout: 150
+              uninstallStrategy: BlockUninstallIfWorkloadsExist
             description: HyperConvergedSpec defines the desired state of HyperConverged
             properties:
               certConfig:
@@ -2006,6 +2007,23 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                 type: object
+              uninstallStrategy:
+                default: BlockUninstallIfWorkloadsExist
+                description: 'UninstallStrategy defines how to proceed on uninstall
+                  when workloads (VirtualMachines, DataVolumes) still exist. BlockUninstallIfWorkloadsExist
+                  will prevent the CR from being removed when workloads still exist.
+                  BlockUninstallIfWorkloadsExist is the safest choice to protect your
+                  workloads from accidental data loss, so it''s strongly advised.
+                  RemoveWorkloads will cause all the workloads to be cascading deleted
+                  on uninstall. WARNING: please notice that RemoveWorkloads will cause
+                  your workloads to be deleted as soon as this CR will be, even accidentally,
+                  deleted. Please correctly consider the implications of this option
+                  before setting it. BlockUninstallIfWorkloadsExist is the default
+                  behaviour.'
+                enum:
+                - RemoveWorkloads
+                - BlockUninstallIfWorkloadsExist
+                type: string
               vddkInitImage:
                 description: VDDK Init Image eventually used to import VMs from external
                   providers

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -60,6 +60,7 @@ spec:
                 parallelMigrationsPerCluster: 5
                 parallelOutboundMigrationsPerNode: 2
                 progressTimeout: 150
+              uninstallStrategy: BlockUninstallIfWorkloadsExist
             description: HyperConvergedSpec defines the desired state of HyperConverged
             properties:
               certConfig:
@@ -2006,6 +2007,23 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                 type: object
+              uninstallStrategy:
+                default: BlockUninstallIfWorkloadsExist
+                description: 'UninstallStrategy defines how to proceed on uninstall
+                  when workloads (VirtualMachines, DataVolumes) still exist. BlockUninstallIfWorkloadsExist
+                  will prevent the CR from being removed when workloads still exist.
+                  BlockUninstallIfWorkloadsExist is the safest choice to protect your
+                  workloads from accidental data loss, so it''s strongly advised.
+                  RemoveWorkloads will cause all the workloads to be cascading deleted
+                  on uninstall. WARNING: please notice that RemoveWorkloads will cause
+                  your workloads to be deleted as soon as this CR will be, even accidentally,
+                  deleted. Please correctly consider the implications of this option
+                  before setting it. BlockUninstallIfWorkloadsExist is the default
+                  behaviour.'
+                enum:
+                - RemoveWorkloads
+                - BlockUninstallIfWorkloadsExist
+                type: string
               vddkInitImage:
                 description: VDDK Init Image eventually used to import VMs from external
                   providers

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,7 +55,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -137,6 +137,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | storageImport | StorageImport contains configuration for importing containerized data | *[StorageImportConfig](#storageimportconfig) |  | false |
 | workloadUpdateStrategy | WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates | *[HyperConvergedWorkloadUpdateStrategy](#hyperconvergedworkloadupdatestrategy) | {"workloadUpdateMethods": {"LiveMigrate"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"} | false |
 | dataImportCronTemplates | DataImportCronTemplates holds list of data import cron templates (golden images) | []sspv1beta1.DataImportCronTemplate |  | false |
+| uninstallStrategy | UninstallStrategy defines how to proceed on uninstall when workloads (VirtualMachines, DataVolumes) still exist. BlockUninstallIfWorkloadsExist will prevent the CR from being removed when workloads still exist. BlockUninstallIfWorkloadsExist is the safest choice to protect your workloads from accidental data loss, so it's strongly advised. RemoveWorkloads will cause all the workloads to be cascading deleted on uninstall. WARNING: please notice that RemoveWorkloads will cause your workloads to be deleted as soon as this CR will be, even accidentally, deleted. Please correctly consider the implications of this option before setting it. BlockUninstallIfWorkloadsExist is the default behaviour. | *HyperConvergedUninstallStrategy | BlockUninstallIfWorkloadsExist | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -541,6 +541,17 @@ spec:
       managedDataSource: custom2
 ```
 
+## Workloads protection on uninstall
+
+`UninstallStrategy` defines how to proceed on uninstall when workloads (VirtualMachines, DataVolumes) still exist:
+- `BlockUninstallIfWorkloadsExist` will prevent the CR from being removed when workloads still exist. 
+BlockUninstallIfWorkloadsExist is the safest choice to protect your workloads from accidental data loss, so it's strongly advised.
+- `RemoveWorkloads` will cause all the workloads to be cascading deleted on uninstall.
+**WARNING**: please notice that RemoveWorkloads will cause your workloads to be deleted as soon as this CR will be, even accidentally, deleted.
+Please correctly consider the implications of this option before setting it.
+
+`BlockUninstallIfWorkloadsExist` is the default behaviour.
+
 ## Configurations via Annotations
 
 In addition to `featureGates` field in HyperConverged CR's spec, the user can set annotations in the HyperConverged CR

--- a/pkg/controller/operands/cdi.go
+++ b/pkg/controller/operands/cdi.go
@@ -104,6 +104,9 @@ func getDefaultFeatureGates() []string {
 
 func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, error) {
 	uninstallStrategy := cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist
+	if hc.Spec.UninstallStrategy != nil && *hc.Spec.UninstallStrategy == hcov1beta1.HyperConvergedUninstallStrategyRemoveWorkloads {
+		uninstallStrategy = cdiv1beta1.CDIUninstallStrategyRemoveWorkloads
+	}
 
 	spec := cdiv1beta1.CDISpec{
 		UninstallStrategy: &uninstallStrategy,

--- a/pkg/controller/operands/cdi_test.go
+++ b/pkg/controller/operands/cdi_test.go
@@ -594,6 +594,75 @@ var _ = Describe("CDI Operand", func() {
 			})
 		})
 
+		Context("Test UninstallStrategy", func() {
+
+			It("should set BlockUninstallIfWorkloadsExist if missing HCO CR", func() {
+				existingResource, err := NewCDI(hco)
+				Expect(err).ToNot(HaveOccurred())
+				hco.Spec.UninstallStrategy = nil
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+				handler := (*genericOperand)(newCdiHandler(cl, commonTestUtils.GetScheme()))
+				res := handler.ensure(req)
+				Expect(res.Err).To(BeNil())
+
+				foundCdi := &cdiv1beta1.CDI{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+						foundCdi),
+				).To(BeNil())
+
+				Expect(foundCdi.Spec.UninstallStrategy).ToNot(BeNil())
+				Expect(*foundCdi.Spec.UninstallStrategy).To(Equal(cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist))
+			})
+
+			It("should set BlockUninstallIfWorkloadsExist if set on HCO CR", func() {
+				existingResource, err := NewCDI(hco)
+				Expect(err).ToNot(HaveOccurred())
+				uninstallStrategy := hcov1beta1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
+				hco.Spec.UninstallStrategy = &uninstallStrategy
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+				handler := (*genericOperand)(newCdiHandler(cl, commonTestUtils.GetScheme()))
+				res := handler.ensure(req)
+				Expect(res.Err).To(BeNil())
+
+				foundCdi := &cdiv1beta1.CDI{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+						foundCdi),
+				).To(BeNil())
+
+				Expect(foundCdi.Spec.UninstallStrategy).ToNot(BeNil())
+				Expect(*foundCdi.Spec.UninstallStrategy).To(Equal(cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist))
+			})
+
+			It("should set BlockUninstallIfRemoveWorkloads if set on HCO CR", func() {
+				existingResource, err := NewCDI(hco)
+				Expect(err).ToNot(HaveOccurred())
+				uninstallStrategy := hcov1beta1.HyperConvergedUninstallStrategyRemoveWorkloads
+				hco.Spec.UninstallStrategy = &uninstallStrategy
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+				handler := (*genericOperand)(newCdiHandler(cl, commonTestUtils.GetScheme()))
+				res := handler.ensure(req)
+				Expect(res.Err).To(BeNil())
+
+				foundCdi := &cdiv1beta1.CDI{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+						foundCdi),
+				).To(BeNil())
+
+				Expect(foundCdi.Spec.UninstallStrategy).ToNot(BeNil())
+				Expect(*foundCdi.Spec.UninstallStrategy).To(Equal(cdiv1beta1.CDIUninstallStrategyRemoveWorkloads))
+			})
+
+		})
+
 		It("should override CDI config field", func() {
 			expectedResource, err := NewCDI(hco)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -240,8 +240,13 @@ func NewKubeVirt(hc *hcov1beta1.HyperConverged, opts ...string) (*kubevirtcorev1
 
 	infrastructureHighlyAvailable := hcoutil.GetClusterInfo().IsInfrastructureHighlyAvailable()
 
+	uninstallStrategy := kubevirtcorev1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist
+	if hc.Spec.UninstallStrategy != nil && *hc.Spec.UninstallStrategy == hcov1beta1.HyperConvergedUninstallStrategyRemoveWorkloads {
+		uninstallStrategy = kubevirtcorev1.KubeVirtUninstallStrategyRemoveWorkloads
+	}
+
 	spec := kubevirtcorev1.KubeVirtSpec{
-		UninstallStrategy:           kubevirtcorev1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist,
+		UninstallStrategy:           uninstallStrategy,
 		Infra:                       hcoConfig2KvConfig(hc.Spec.Infra, infrastructureHighlyAvailable),
 		Workloads:                   hcoConfig2KvConfig(hc.Spec.Workloads, true),
 		Configuration:               *config,

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -431,6 +431,75 @@ Version: 1.2.3`)
 			Expect(foundResource.Spec.UninstallStrategy).To(Equal(expectedResource.Spec.UninstallStrategy))
 		})
 
+		Context("Test UninstallStrategy", func() {
+
+			It("should set BlockUninstallIfWorkloadsExist if missing HCO CR", func() {
+				expectedResource, err := NewKubeVirt(hco, commonTestUtils.Namespace)
+				Expect(err).ToNot(HaveOccurred())
+				hco.Spec.UninstallStrategy = nil
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
+				handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
+				res := handler.ensure(req)
+				Expect(res.Err).To(BeNil())
+
+				foundResource := &kubevirtcorev1.KubeVirt{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				Expect(foundResource.Spec.UninstallStrategy).ToNot(BeNil())
+				Expect(foundResource.Spec.UninstallStrategy).To(Equal(kubevirtcorev1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist))
+			})
+
+			It("should set BlockUninstallIfWorkloadsExist if set on HCO CR", func() {
+				expectedResource, err := NewKubeVirt(hco, commonTestUtils.Namespace)
+				Expect(err).ToNot(HaveOccurred())
+				uninstallStrategy := hcov1beta1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
+				hco.Spec.UninstallStrategy = &uninstallStrategy
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
+				handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
+				res := handler.ensure(req)
+				Expect(res.Err).To(BeNil())
+
+				foundResource := &kubevirtcorev1.KubeVirt{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				Expect(foundResource.Spec.UninstallStrategy).ToNot(BeNil())
+				Expect(foundResource.Spec.UninstallStrategy).To(Equal(kubevirtcorev1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist))
+			})
+
+			It("should set BlockUninstallIfRemoveWorkloads if set on HCO CR", func() {
+				expectedResource, err := NewKubeVirt(hco, commonTestUtils.Namespace)
+				Expect(err).ToNot(HaveOccurred())
+				uninstallStrategy := hcov1beta1.HyperConvergedUninstallStrategyRemoveWorkloads
+				hco.Spec.UninstallStrategy = &uninstallStrategy
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
+				handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
+				res := handler.ensure(req)
+				Expect(res.Err).To(BeNil())
+
+				foundResource := &kubevirtcorev1.KubeVirt{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
+						foundResource),
+				).To(BeNil())
+
+				Expect(foundResource.Spec.UninstallStrategy).ToNot(BeNil())
+				Expect(foundResource.Spec.UninstallStrategy).To(Equal(kubevirtcorev1.KubeVirtUninstallStrategyRemoveWorkloads))
+			})
+
+		})
+
 		It("should propagate the live migration configuration from the HC", func() {
 			existKv, err := NewKubeVirt(hco)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Kubevirt and CDI operator were already exposing
a knob to tune the uninstall behaviour when
workloads (VirtualMachines and DataVolumes) still
exists.
The two alternatives are:
- BlockUninstallIfWorkloadsExist
- RemoveWorkloads

HCO wasn't exposing it always hardocding BlockUninstallIfWorkloadsExist
but RemoveWorkloads can also be an interesting option
for users that wants to cascading drop all
the workloads on product removal.

The defaut behaviour will remain BlockUninstallIfWorkloadsExist

In the futere we can probably implement a better mechanism
like https://github.com/kubernetes/enhancements/pull/2840
but this is still in the design phase.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose a knob to tune UninstallStrategy

API changes: add the new uninstallStrategy field; the two supported values are "BlockUninstallIfWorkloadsExist" (default) and "RemoveWorkloads"
```

