### PR TITLE
Add missing owner references

### DIFF
--- a/pkg/controller/operands/cliDownload.go
+++ b/pkg/controller/operands/cliDownload.go
@@ -117,7 +117,7 @@ func newCliDownloadsServiceHandler(Client client.Client, Scheme *runtime.Scheme)
 		Scheme:                 Scheme,
 		crType:                 "Service",
 		removeExistingOwner:    false,
-		setControllerReference: false,
+		setControllerReference: true,
 		hooks:                  &cliDownloadsServiceHooks{},
 	}
 }
@@ -203,7 +203,7 @@ func newCliDownloadsRouteHandler(Client client.Client, Scheme *runtime.Scheme) *
 		Scheme:                 Scheme,
 		crType:                 "Route",
 		removeExistingOwner:    false,
-		setControllerReference: false,
+		setControllerReference: true,
 		hooks:                  &cliDownloadsRouteHooks{},
 	}
 }


### PR DESCRIPTION
After hco deletion, service and route objects are not deleted by k8s since ownerreferences are missing. This PR fixes that issue.

Signed-off-by: Erkan Erol <eerol@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
NONE
```

