### PR TITLE
Reorder things in the rebase bot

### DIFF
--- a/automation/rebase-bot/rebase-bot.sh
+++ b/automation/rebase-bot/rebase-bot.sh
@@ -71,14 +71,14 @@ git fetch fork $HEAD_BRANCH
 # checkout the PR branch
 git checkout -b $HEAD_BRANCH fork/$HEAD_BRANCH
 
-# perform build-manifests and commit the changes
-./hack/build-manifests.sh
-git status
-git add .
-git commit -s -m "build-manifests" || true
-
 # do the rebase
 git rebase origin/$BASE_BRANCH
+
+# perform build-manifests and commit the changes
+./hack/build-manifests.sh
+if [[ $(git diff --name-only | wc -l) -gt 0 ]]; then
+  git commit -sam "build-manifests"
+fi
 
 # push back
 git push --force-with-lease fork $HEAD_BRANCH


### PR DESCRIPTION
Try to fix the rebase bot by moving things around.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

