### PR TITLE
Set enableCommonBootImageImport to true by default

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -52,7 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
-                enableCommonBootImageImport: false
+                enableCommonBootImageImport: true
                 sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
@@ -835,7 +835,7 @@ spec:
                 x-kubernetes-list-type: atomic
               featureGates:
                 default:
-                  enableCommonBootImageImport: false
+                  enableCommonBootImageImport: true
                   sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
@@ -843,7 +843,7 @@ spec:
                   the feature gate, disables the feature.
                 properties:
                   enableCommonBootImageImport:
-                    default: false
+                    default: true
                     description: 'Opt-in to automatic delivery/updates of the common
                       data import cron templates. There are two sources for the data
                       import cron templates: hard coded list of common templates,

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -52,7 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
-                enableCommonBootImageImport: false
+                enableCommonBootImageImport: true
                 sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
@@ -835,7 +835,7 @@ spec:
                 x-kubernetes-list-type: atomic
               featureGates:
                 default:
-                  enableCommonBootImageImport: false
+                  enableCommonBootImageImport: true
                   sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
@@ -843,7 +843,7 @@ spec:
                   the feature gate, disables the feature.
                 properties:
                   enableCommonBootImageImport:
-                    default: false
+                    default: true
                     description: 'Opt-in to automatic delivery/updates of the common
                       data import cron templates. There are two sources for the data
                       import cron templates: hard coded list of common templates,

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -52,7 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
-                enableCommonBootImageImport: false
+                enableCommonBootImageImport: true
                 sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
@@ -835,7 +835,7 @@ spec:
                 x-kubernetes-list-type: atomic
               featureGates:
                 default:
-                  enableCommonBootImageImport: false
+                  enableCommonBootImageImport: true
                   sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
@@ -843,7 +843,7 @@ spec:
                   the feature gate, disables the feature.
                 properties:
                   enableCommonBootImageImport:
-                    default: false
+                    default: true
                     description: 'Opt-in to automatic delivery/updates of the common
                       data import cron templates. There are two sources for the data
                       import cron templates: hard coded list of common templates,

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,7 +55,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -89,7 +89,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | ----- | ----------- | ------ | -------- |-------- |
 | withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here | bool | false | true |
 | sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. | bool | true | true |
-| enableCommonBootImageImport | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | bool | false | true |
+| enableCommonBootImageImport | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | bool | true | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -124,7 +124,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | localStorageClassName | LocalStorageClassName the name of the local storage class. | string |  | false |
 | infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
 | workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
-| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false} | false |
+| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": true} | false |
 | liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150} | false |
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
 | mediatedDevicesConfiguration | MediatedDevicesConfiguration holds information about MDEV types to be defined on nodes, if available | *[MediatedDevicesConfiguration](#mediateddevicesconfiguration) |  | false |

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -149,14 +149,15 @@ degrade virt-launcher security.
 
 ### enableCommonBootImageImport Feature Gate
 
-Set the `enableCommonBootImageImport` feature gate to `true` in order to enable the common golden images in the cluster.
+Set the `enableCommonBootImageImport` feature gate to `false` in order to disable the common golden images in the cluster 
+(for instance to reduce logs noise on disconnected environments).
 For additional information, see
 here: https://github.com/kubevirt/community/blob/master/design-proposals/golden-image-delivery-and-update-pipeline.md
 
 **Note**: Custom golden images are enabled by adding them
 the [dataImportCronTemplates field](#configure-custom-golden-images), even if this feature gate is `false`.
 
-**Default**: `false`
+**Default**: `true`
 
 ### Feature Gates Example
 
@@ -171,7 +172,7 @@ spec:
   featureGates:
     withHostPassthroughCPU: true
     sriovLiveMigration: true
-    enableCommonBootImageImport: false
+    enableCommonBootImageImport: true
 ```
 
 ## Live Migration Configurations

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -22,7 +22,7 @@ echo "Read the CR's spec before starting the test"
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o json | jq '.spec'
 
 CERTCONFIGDEFAULTS='{"ca":{"duration":"48h0m0s","renewBefore":"24h0m0s"},"server":{"duration":"24h0m0s","renewBefore":"12h0m0s"}}'
-FGDEFAULTS='{"enableCommonBootImageImport":false,"sriovLiveMigration":true,"withHostPassthroughCPU":false}'
+FGDEFAULTS='{"enableCommonBootImageImport":true,"sriovLiveMigration":true,"withHostPassthroughCPU":false}'
 LMDEFAULTS='{"completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'

--- a/hack/check_golden_images.sh
+++ b/hack/check_golden_images.sh
@@ -11,22 +11,16 @@ function count_data_import_crons() {
 export -f count_data_import_crons
 
 if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
-  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 0 ]]
 
-  # Test DataImportCronTemplates
-  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": true }]'"
-  sleep 10
-
-  # Test image streams
+  # test image streams
   [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
   [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
 
-  #check that HCO reconciles the image stream
+  # check that HCO reconciles the image stream
   ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch imageStream -n ${IMAGES_NS} centos8 --type=json -p '[{\"op\": \"add\", \"path\": \"/metadata/labels/test-label\", \"value\": \"test\"}]'"
   sleep 10
   # HCO expect to remove the test-label label from the image stream
   ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o yaml"
-
 
   ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.featureGates.enableCommonBootImageImport}'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron")'
@@ -41,10 +35,20 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
 
   [[ $(${KUBECTL_BINARY} get DataImportCron -o json -n ${IMAGES_NS} centos8-image-cron-is | jq -cM '.spec.template.spec.source.registry') == '{"imageStream":"centos8","pullMethod":"node"}' ]]
 
+  # disable the feature
   ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": false }]'"
   sleep 10
 
-  #check that the image streams and the DataImportCron were removed
+  # check that the image streams and the DataImportCron were removed
   ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 0 ]]"
   ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get DataImportCron -A --no-headers | wc -l) -eq 0 ]]"
+
+  # enable it back
+  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": true }]'"
+  sleep 10
+
+  # test image streams
+  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
+  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
+
 fi

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -46,7 +46,7 @@ type HyperConvergedSpec struct {
 
 	// featureGates is a map of feature gate flags. Setting a flag to `true` will enable
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
-	// +kubebuilder:default={"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false}
+	// +kubebuilder:default={"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": true}
 	// +optional
 	FeatureGates HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
@@ -231,7 +231,7 @@ type HyperConvergedFeatureGates struct {
 	// templates that can be added to the dataImportCronTemplates field. This feature gates only control the common
 	// templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.
 	// +optional
-	// +kubebuilder:default=false
+	// +kubebuilder:default=true
 	EnableCommonBootImageImport bool `json:"enableCommonBootImageImport"`
 }
 
@@ -466,7 +466,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`


### PR DESCRIPTION
Enable the common boot image import by default
and let the user eventually opt-out if needed.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set enableCommonBootImageImport to `true` by default
```

