### PR TITLE
Add support for different branches in release-bumper

### DIFF
--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -1,7 +1,7 @@
 name: Auto-Bump Component's Versions
 on:
   schedule:
-    - cron:  '0 5 * * *'
+    - cron:  '5 17 30 12 *'
   workflow_dispatch:
     inputs:
       component:
@@ -11,20 +11,47 @@ on:
         description: 'Component version'
         required: false
 jobs:
-  build:
-    name: HCO Release Bump Job
-    if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')
+  set_bump_branches:
+    name: Get Branches to Bump Components Versions
+    if: (github.repository == 'machadovilaca/hyperconverged-cluster-operator')
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set_branches.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
         with:
           ref: main
+          fetch-depth: 0
+
+      - id: set_branches
+        run: |
+          matrix=$(git for-each-ref --format='%(refname:short)' refs/remotes/origin | grep -e "origin/main" -e "origin/release-[[:digit:]]\+.[[:digit:]]\+" | sed -r 's/origin\/(.*)/{"branch": "\1"}/g' | jq -s)                
+          echo "::set-output name=matrix::{\"branches\":$(echo $matrix)}"
+
+  bump_components_version:
+    name: Bump Components Versions
+    if: (github.repository == 'machadovilaca/hyperconverged-cluster-operator')
+    runs-on: ubuntu-latest
+    needs: set_bump_branches
+    strategy:
+      matrix: ${{fromJson(needs.set_bump_branches.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branches.branch }}
 
       - uses: actions/setup-go@v2
         with:
           go-version: '1.17' # The Go version to download (if necessary) and use.
 
+      - name: Check file existence
+        id: check_release_bumper
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "automation/release-bumper/release-bumper.sh"
+
       - name: Check for new releases and update
+        if: steps.check_release_bumper.outputs.files_exists == 'true'
         env:
           UPDATED_COMPONENT: ${{ github.event.inputs.component }}
           UPDATED_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -1,7 +1,7 @@
 name: Auto-Bump Component's Versions
 on:
   schedule:
-    - cron:  '5 17 30 12 *'
+    - cron:  '0 5 * * *'
   workflow_dispatch:
     inputs:
       component:
@@ -13,7 +13,7 @@ on:
 jobs:
   set_bump_branches:
     name: Get Branches to Bump Components Versions
-    if: (github.repository == 'machadovilaca/hyperconverged-cluster-operator')
+    if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set_branches.outputs.matrix }}
@@ -30,7 +30,7 @@ jobs:
 
   bump_components_version:
     name: Bump Components Versions
-    if: (github.repository == 'machadovilaca/hyperconverged-cluster-operator')
+    if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')
     runs-on: ubuntu-latest
     needs: set_bump_branches
     strategy:

--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -59,8 +59,6 @@ function get_current_branch() {
     exit 1
   fi
 
-  TARGET_BRANCH="main"
-
   if [ "$TARGET_BRANCH" == "main" ]
   then
     UPDATE_TYPE="all"

--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -157,21 +157,21 @@ function version_weight() {
 function update_versions() {
   PR=$(curl -s -L https://api.github.com/repos/kubevirt/hyperconverged-cluster-operator/pulls | jq "[.[] | {title: .title, ref: .base.ref}]" )
 
+  if [ -n "$TARGET_BRANCH" ]
+  then
+    target_branch=$TARGET_BRANCH
+  elif [ -n "$GITHUB_REF" ]
+  then
+    target_branch=${GITHUB_REF#refs/heads/}
+  else
+    target_branch=main
+  fi
+
   for component in "${SHOULD_UPDATED[@]}"; do
     echo INFO: Checking update for "$component";
 
     # Check if pull request for that component and version already exists
     search_pattern=$(echo "$component.*${UPDATED_VERSIONS[$component]}" | tr -d '"')
-
-    if [ -n "$TARGET_BRANCH" ]
-    then
-      target_branch=$TARGET_BRANCH
-    elif [ -n "$GITHUB_REF" ]
-    then
-      target_branch=${GITHUB_REF#refs/heads/}
-    else
-      target_branch=main
-    fi
 
     search_pr=$(jq "[.[] | select((.title | test(\"${search_pattern}\")) and (.ref == \"${target_branch}\"))] | length" <<< "$PR")
 

--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -10,6 +10,10 @@ function main {
   declare -A COMPONENTS_REPOS
   declare -A IMPORT_REPOS
   declare SHOULD_UPDATED
+  declare TARGET_BRANCH
+  declare UPDATE_TYPE
+
+  get_current_branch
 
   echo "INFO: Checking go version"
   go version
@@ -44,6 +48,25 @@ function main {
 
   echo INFO: Executing "build-manifests.sh"...
   ./hack/build-manifests.sh
+}
+
+function get_current_branch() {
+  if TARGET_BRANCH=$(git symbolic-ref --short -q HEAD)
+  then
+    echo on branch "$TARGET_BRANCH"
+  else
+    echo no branch is checked out
+    exit 1
+  fi
+
+  TARGET_BRANCH="main"
+
+  if [ "$TARGET_BRANCH" == "main" ]
+  then
+    UPDATE_TYPE="all"
+  else
+    UPDATE_TYPE="z_release"
+  fi
 }
 
 function get_current_versions {
@@ -83,7 +106,7 @@ function get_updated_versions {
   UPDATED_VERSIONS=()
   if [[ -n ${UPDATED_COMPONENT} ]]; then
     if [[ -z ${UPDATED_VERSION} ]]; then
-      UPDATED_VERSION=$(get_latest_release "${COMPONENTS_REPOS[$UPDATED_COMPONENT]}")
+      UPDATED_VERSION=$(get_latest_release "$UPDATED_COMPONENT")
     fi
     if [[ -v COMPONENTS_REPOS[${UPDATED_COMPONENT}] ]]; then
       HTTP_CODE=$(curl "https://api.github.com/repos/${COMPONENTS_REPOS[$UPDATED_COMPONENT]}/releases/tags/${UPDATED_VERSION}" --write-out '%{http_code}' --silent --output /dev/null)
@@ -99,7 +122,7 @@ function get_updated_versions {
     fi
   else
     for component in "${!COMPONENTS_REPOS[@]}"; do
-      UPDATED_VERSIONS[$component]=$(get_latest_release "${COMPONENTS_REPOS[$component]}");
+      UPDATED_VERSIONS[$component]=$(get_latest_release "$component");
       if [ -z "${UPDATED_VERSIONS[$component]}" ]; then
         echo "ERROR: Unable to get an updated version of $component, aborting..."
         exit 1
@@ -109,16 +132,37 @@ function get_updated_versions {
 }
 
 function get_latest_release() {
-  RELEASES=$(curl -s -L "https://api.github.com/repos/$1/releases" | jq -r '.[].tag_name')
-  semversort "${RELEASES[*]}"
+  repo="${COMPONENTS_REPOS[$1]}"
+  current_version="${CURRENT_VERSIONS[$1]}"
+  short_current=${current_version%.*}
+
+  RELEASES=$(curl -s -L "https://api.github.com/repos/$repo/releases" | jq -r '.[].tag_name')
+  releases=(${RELEASES})
+
+  semversort "${releases[*]}"
+
+  for (( i=${#KEYS_ARR[@]}-1 ; i >= 0 ; i-- )) ; do
+    release=${releases[${KEYS_ARR[$i]}]}
+    short_release=${release%.*}
+
+    if [ "$UPDATE_TYPE" = "all" ]; then
+      break;
+    elif [ "$UPDATE_TYPE" = "z_release" ] && [ "$short_current" = "$short_release" ]; then
+      break;
+    fi
+  done
+
+  echo "${release}"
 }
 
 function compare_versions() {
   # comparing between current (local) components versions and their counterparts in the remote repositories.
   for component in "${!UPDATED_VERSIONS[@]}"; do
-    higher_version=$(semversort ${CURRENT_VERSIONS[$component]} ${UPDATED_VERSIONS[$component]});
+    versions=("${CURRENT_VERSIONS[$component]}" "${UPDATED_VERSIONS[$component]}")
+    semversort "${versions[*]}"
+
     if [ ${CURRENT_VERSIONS[$component]} != ${UPDATED_VERSIONS[$component]} ] \
-     && [ ${higher_version} == ${UPDATED_VERSIONS[$component]} ]; then
+     && [ "${versions[${KEYS_ARR[-1]}]}" == ${UPDATED_VERSIONS[$component]} ]; then
       echo "INFO: $component" is outdated. Current: "${CURRENT_VERSIONS[$component]}", Updated: "${UPDATED_VERSIONS[$component]}"
       SHOULD_UPDATED+=( "$component" )
     fi
@@ -135,8 +179,7 @@ function semversort() {
     printf "%s+%s\n" "${tags_weight[${ix}]}" ${ix}
   done | sort -V | cut -d+ -f2)
 
-  keys_arr=(${keys})
-  echo ${tags_orig[${keys_arr[-1]}]}
+  KEYS_ARR=(${keys})
 }
 
 function version_weight() {
@@ -156,16 +199,6 @@ function version_weight() {
 
 function update_versions() {
   PR=$(curl -s -L https://api.github.com/repos/kubevirt/hyperconverged-cluster-operator/pulls | jq "[.[] | {title: .title, ref: .base.ref}]" )
-
-  if [ -n "$TARGET_BRANCH" ]
-  then
-    target_branch=$TARGET_BRANCH
-  elif [ -n "$GITHUB_REF" ]
-  then
-    target_branch=${GITHUB_REF#refs/heads/}
-  else
-    target_branch=main
-  fi
 
   for component in "${SHOULD_UPDATED[@]}"; do
     echo INFO: Checking update for "$component";


### PR DESCRIPTION
This PR adds support in release-bumper to automatically bump .z releases of all the components on upstream stabilization branches.

The changes include:
- Support to update components versions in other branches than 'main'
- Limit components versions updates, in other branches than main, to .z releases

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

