### PR TITLE
Expose network on LiveMigrationConfigurations

### DIFF
--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1856,6 +1856,11 @@ spec:
                       in the calculation.
                     format: int64
                     type: integer
+                  network:
+                    description: The migrations will be performed over a dedicated
+                      multus network to minimize disruption to tenant workloads due
+                      to network saturation when VM live migrations are triggered.
+                    type: string
                   parallelMigrationsPerCluster:
                     default: 5
                     description: Number of migrations running in parallel in the cluster.

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -1856,6 +1856,11 @@ spec:
                       in the calculation.
                     format: int64
                     type: integer
+                  network:
+                    description: The migrations will be performed over a dedicated
+                      multus network to minimize disruption to tenant workloads due
+                      to network saturation when VM live migrations are triggered.
+                    type: string
                   parallelMigrationsPerCluster:
                     default: 5
                     description: Number of migrations running in parallel in the cluster.

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/hco00.crd.yaml
@@ -1856,6 +1856,11 @@ spec:
                       in the calculation.
                     format: int64
                     type: integer
+                  network:
+                    description: The migrations will be performed over a dedicated
+                      multus network to minimize disruption to tenant workloads due
+                      to network saturation when VM live migrations are triggered.
+                    type: string
                   parallelMigrationsPerCluster:
                     default: 5
                     description: Number of migrations running in parallel in the cluster.

--- a/docs/api.md
+++ b/docs/api.md
@@ -178,6 +178,7 @@ LiveMigrationConfigurations - Live migration limits and timeouts are applied so 
 | bandwidthPerMigration | Bandwidth limit of each migration, in MiB/s. | *string |  | false |
 | completionTimeoutPerGiB | The migration will be canceled if it has not completed in this time, in seconds per GiB of memory. For example, a virtual machine instance with 6GiB memory will timeout if it has not completed migration in 4800 seconds. If the Migration Method is BlockMigration, the size of the migrating disks is included in the calculation. | *int64 | 800 | false |
 | progressTimeout | The migration will be canceled if memory copy fails to make progress in this time, in seconds. | *int64 | 150 | false |
+| network | The migrations will be performed over a dedicated multus network to minimize disruption to tenant workloads due to network saturation when VM live migrations are triggered. | *string |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -212,6 +212,12 @@ The migration will be canceled if memory copy fails to make progress in this tim
 
 **default**: 150
 
+### network
+
+The name of a [Multus](https://github.com/k8snetworkplumbingwg/multus-cni) network attachment definition to be dedicated to live migrations to minimize disruption to tenant workloads due to network saturation when VM live migrations are triggered. The format is a string.
+
+**default**: unset
+
 ### Example
 
 ```yaml
@@ -222,6 +228,7 @@ metadata:
 spec:
   liveMigrationConfig:
     completionTimeoutPerGiB: 800
+    network: migration-network
     parallelMigrationsPerCluster: 5
     parallelOutboundMigrationsPerNode: 2
     progressTimeout: 150

--- a/pkg/apis/hco/v1beta1/hyperconverged_types.go
+++ b/pkg/apis/hco/v1beta1/hyperconverged_types.go
@@ -209,6 +209,10 @@ type LiveMigrationConfigurations struct {
 	// +kubebuilder:default=150
 	// +optional
 	ProgressTimeout *int64 `json:"progressTimeout,omitempty"`
+
+	// The migrations will be performed over a dedicated multus network to minimize disruption to tenant workloads due to network saturation when VM live migrations are triggered.
+	// +optional
+	Network *string `json:"network,omitempty"`
 }
 
 // HyperConvergedFeatureGates is a set of optional feature gates to enable or disable new features that are not enabled

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -424,6 +424,7 @@ func hcLiveMigrationToKv(lm hcov1beta1.LiveMigrationConfigurations) (*kubevirtco
 		ParallelOutboundMigrationsPerNode: lm.ParallelOutboundMigrationsPerNode,
 		ParallelMigrationsPerCluster:      lm.ParallelMigrationsPerCluster,
 		ProgressTimeout:                   lm.ProgressTimeout,
+		Network:                           lm.Network,
 	}, nil
 }
 

--- a/pkg/controller/operands/kubevirt_test.go
+++ b/pkg/controller/operands/kubevirt_test.go
@@ -248,6 +248,7 @@ Version: 1.2.3`)
 			Expect(*mc.ParallelMigrationsPerCluster).Should(Equal(uint32(5)))
 			Expect(*mc.ParallelOutboundMigrationsPerNode).Should(Equal(uint32(2)))
 			Expect(*mc.ProgressTimeout).Should(Equal(int64(150)))
+			Expect(mc.Network).Should(BeNil())
 		})
 
 		It("should find if present", func() {
@@ -326,12 +327,14 @@ Version: 1.2.3`)
 			bandwidthPerMigration := resource.MustParse("16Mi")
 			wrongNumeric64Value := int64(0)
 			wrongNumeric32Value := uint32(0)
+			network := "testNetwork"
 			existKv.Spec.Configuration.MigrationConfiguration = &kubevirtcorev1.MigrationConfiguration{
 				BandwidthPerMigration:             &bandwidthPerMigration,
 				CompletionTimeoutPerGiB:           &wrongNumeric64Value,
 				ParallelMigrationsPerCluster:      &wrongNumeric32Value,
 				ParallelOutboundMigrationsPerNode: &wrongNumeric32Value,
 				ProgressTimeout:                   &wrongNumeric64Value,
+				Network:                           &network,
 			}
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existKv})
@@ -384,6 +387,7 @@ Version: 1.2.3`)
 			Expect(*mc.ParallelMigrationsPerCluster).Should(Equal(uint32(5)))
 			Expect(*mc.ParallelOutboundMigrationsPerNode).Should(Equal(uint32(2)))
 			Expect(*mc.ProgressTimeout).Should(Equal(int64(150)))
+			Expect(mc.Network).Should(BeNil())
 		})
 
 		It("should fail if the SMBIOS is wrongly formatted mandatory configurations", func() {
@@ -509,12 +513,14 @@ Version: 1.2.3`)
 			parallelOutboundMigrationsPerNode := uint32(7)
 			parallelMigrationsPerCluster := uint32(18)
 			progressTimeout := int64(5000)
+			network := "testNetwork"
 
 			hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &bandwidthPerMigration
 			hco.Spec.LiveMigrationConfig.CompletionTimeoutPerGiB = &completionTimeoutPerGiB
 			hco.Spec.LiveMigrationConfig.ParallelOutboundMigrationsPerNode = &parallelOutboundMigrationsPerNode
 			hco.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster = &parallelMigrationsPerCluster
 			hco.Spec.LiveMigrationConfig.ProgressTimeout = &progressTimeout
+			hco.Spec.LiveMigrationConfig.Network = &network
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existKv})
 			handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
@@ -538,6 +544,7 @@ Version: 1.2.3`)
 			Expect(*mc.ParallelOutboundMigrationsPerNode).To(Equal(parallelOutboundMigrationsPerNode))
 			Expect(*mc.ParallelMigrationsPerCluster).To(Equal(parallelMigrationsPerCluster))
 			Expect(*mc.ProgressTimeout).To(Equal(progressTimeout))
+			Expect(*mc.Network).To(Equal(network))
 
 			// ObjectReference should have been updated
 			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
@@ -2603,6 +2610,7 @@ Version: 1.2.3`)
 		parallelMigrationsPerCluster := uint32(100)
 		parallelOutboundMigrationsPerNode := uint32(100)
 		progressTimeout := int64(100)
+		network := "testNetwork"
 
 		It("should create valid KV LM config from a valid HC LM config", func() {
 			lmc := hcov1beta1.LiveMigrationConfigurations{
@@ -2611,6 +2619,7 @@ Version: 1.2.3`)
 				ParallelMigrationsPerCluster:      &parallelMigrationsPerCluster,
 				ParallelOutboundMigrationsPerNode: &parallelOutboundMigrationsPerNode,
 				ProgressTimeout:                   &progressTimeout,
+				Network:                           &network,
 			}
 			mc, err := hcLiveMigrationToKv(lmc)
 			Expect(err).ToNot(HaveOccurred())
@@ -2620,6 +2629,7 @@ Version: 1.2.3`)
 			Expect(*mc.ParallelMigrationsPerCluster).Should(Equal(parallelMigrationsPerCluster))
 			Expect(*mc.ParallelOutboundMigrationsPerNode).Should(Equal(parallelOutboundMigrationsPerNode))
 			Expect(*mc.ProgressTimeout).Should(Equal(progressTimeout))
+			Expect(*mc.Network).Should(Equal(network))
 		})
 
 		It("should create valid empty KV LM config from a valid empty HC LM config", func() {
@@ -2632,6 +2642,7 @@ Version: 1.2.3`)
 			Expect(mc.ParallelMigrationsPerCluster).Should(BeNil())
 			Expect(mc.ParallelOutboundMigrationsPerNode).Should(BeNil())
 			Expect(mc.ProgressTimeout).Should(BeNil())
+			Expect(mc.Network).Should(BeNil())
 		})
 
 		It("should return error if the value of the BandwidthPerMigration field is not valid", func() {
@@ -2642,6 +2653,7 @@ Version: 1.2.3`)
 				ParallelMigrationsPerCluster:      &parallelMigrationsPerCluster,
 				ParallelOutboundMigrationsPerNode: &parallelOutboundMigrationsPerNode,
 				ProgressTimeout:                   &progressTimeout,
+				Network:                           &network,
 			}
 			mc, err := hcLiveMigrationToKv(lmc)
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Expose network on LiveMigrationConfigurations
    
kubevirt v0.49 exposes a new API to let the user
optionally configure a dedicated multus network
for live migrations,
see: https://github.com/kubevirt/kubevirt/pull/6036
    
Let's expose it also on the HCO CR.
    
Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
Migrations can now be done over a dedicated multus network
```

