### PR TITLE
remove centos 8 dataImportCron, because it is EOL

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -1,18 +1,33 @@
 - metadata:
-    name: centos8-image-cron
+    name: centos-stream8-image-cron
   spec:
     schedule: "0 */12 * * *"
     template:
       spec:
         source:
           registry:
-            url: docker://quay.io/containerdisks/centos:8.4
+            url: docker://quay.io/containerdisks/centos-stream:8
         storage:
           resources:
             requests:
               storage: 10Gi
     garbageCollect: Outdated
-    managedDataSource: centos8
+    managedDataSource: centos-stream8
+- metadata:
+    name: centos-stream9-image-cron
+  spec:
+    schedule: "0 */12 * * *"
+    template:
+      spec:
+        source:
+          registry:
+            url: docker://quay.io/containerdisks/centos-stream:9
+        storage:
+          resources:
+            requests:
+              storage: 10Gi
+    garbageCollect: Outdated
+    managedDataSource: centos-stream9
 - metadata:
     name: fedora-image-cron
   spec:


### PR DESCRIPTION
remove centos 8 dataImportCron, because it is EOL
add centos Stream 8, 9 dataImportCron

This PR https://github.com/kubevirt/containerdisks/pull/12 has to be merged before
/cc @dominikholler 

**Reviewer Checklist**
- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
remove centos 8 dataImportCron, because it is EOL
add centos Stream 8, 9 dataImportCron
```

Signed-off-by: Karel Šimon <ksimon@redhat.com>
