### PR TITLE
temporary workaround for uninstalling with enableCommonBootImageImport

### DIFF
--- a/hack/test_delete_ns.sh
+++ b/hack/test_delete_ns.sh
@@ -47,6 +47,13 @@ function test_delete_ns(){
         echo "Ignoring webhook on k8s where we don't have OLM based validating webhooks"
     fi
 
+    # TODO: workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2037312
+    # remove once fixed
+    echo "Explictly disabling CommonBootImageImport to be able to safely remove the product"
+    ${CMD} patch hco -n kubevirt-hyperconverged kubevirt-hyperconverged --type=json kubevirt-hyperconverged -p '[{ "op": "replace", "path": /spec/enableCommonBootImageImport, "value": false }]'
+    sleep 30
+    # ---
+
     echo "Delete the hyperconverged CR to remove the product"
     timeout 10m ${CMD} delete hyperconverged -n kubevirt-hyperconverged kubevirt-hyperconverged
 


### PR DESCRIPTION
enableCommonBootImageImport is often preventing
the product from being correctly uninstalled
and this is making CI pretty flaky.
Let's explicitly disable it before trying to
uninstall on CI until we get a proper fix.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2037312

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

