### PR TITLE
Fix golden images tests

### DIFF
--- a/ci-test-files/dataImportCronTemplatesWithImageStream.yaml
+++ b/ci-test-files/dataImportCronTemplatesWithImageStream.yaml
@@ -1,16 +1,16 @@
 - metadata:
-    name: centos8-image-cron-is
+    name: centos-stream9-image-cron-is
   spec:
     schedule: "0 */12 * * *"
     template:
       spec:
         source:
           registry:
-            imageStream: "centos8"
+            imageStream: "centos-stream9"
             pullMethod: node
         storage:
           resources:
             requests:
               storage: 10Gi
     garbageCollect: Outdated
-    managedDataSource: centos8-is
+    managedDataSource: centos-stream9-is

--- a/hack/check_golden_images.sh
+++ b/hack/check_golden_images.sh
@@ -13,34 +13,34 @@ export -f count_data_import_crons
 if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
 
   # test image streams
-  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
-  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
+  [[ $(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
+  [[ "$(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/containerdisks/centos-stream:9"}' ]]
 
   # check that HCO reconciles the image stream
-  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch imageStream -n ${IMAGES_NS} centos8 --type=json -p '[{\"op\": \"add\", \"path\": \"/metadata/labels/test-label\", \"value\": \"test\"}]'"
+  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch imageStream -n ${IMAGES_NS} centos-stream9 --type=json -p '[{\"op\": \"add\", \"path\": \"/metadata/labels/test-label\", \"value\": \"test\"}]'"
   sleep 10
   # HCO expect to remove the test-label label from the image stream
-  ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o yaml"
+  ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos-stream9 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos-stream9 -o yaml"
 
   ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.featureGates.enableCommonBootImageImport}'
-  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron")'
+  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-stream9-image-cron")'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="fedora-image-cron")'
-  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron-is")'
+  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-stream9-image-cron-is")'
 
   ./hack/retry.sh 10 30 "[[ \$(count_data_import_crons) -eq 3 ]]" "${KUBECTL_BINARY} get DataImportCron -A"
 
-  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos8-image-cron
+  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-stream9-image-cron
   ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} fedora-image-cron
-  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos8-image-cron-is
+  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-stream9-image-cron-is
 
-  [[ $(${KUBECTL_BINARY} get DataImportCron -o json -n ${IMAGES_NS} centos8-image-cron-is | jq -cM '.spec.template.spec.source.registry') == '{"imageStream":"centos8","pullMethod":"node"}' ]]
+  [[ $(${KUBECTL_BINARY} get DataImportCron -o json -n ${IMAGES_NS} centos-stream9-image-cron-is | jq -cM '.spec.template.spec.source.registry') == '{"imageStream":"centos-stream9","pullMethod":"node"}' ]]
 
   # disable the feature
   ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": false }]'"
   sleep 10
 
   # check that the image streams and the DataImportCron were removed
-  ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 0 ]]"
+  ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} --no-headers | wc -l) -eq 0 ]]"
   ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get DataImportCron -A --no-headers | wc -l) -eq 0 ]]"
 
   # enable it back
@@ -48,7 +48,7 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
   sleep 10
 
   # test image streams
-  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
-  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
+  [[ $(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
+  [[ "$(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/containerdisks/centos-stream:9"}' ]]
 
 fi

--- a/pkg/controller/operands/testFiles/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/pkg/controller/operands/testFiles/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -7,10 +7,10 @@
       spec:
         source:
           registry:
-            url: docker://quay.io/kubevirt/fedora
+            url: docker://quay.io/containerdisks/fedora
     managedDataSource: fedora
 - metadata:
-    name: centos8-image-cron
+    name: centos-stream9-image-cron
     namespace: golden-image-namespace
   spec:
     schedule: "* */1 * * *"
@@ -18,5 +18,5 @@
       spec:
         source:
           registry:
-            url: docker://quay.io/kubevirt/centos8
-    managedDataSource: centos8
+            url: docker://quay.io/containerdisks/centos-stream:9
+    managedDataSource: centos-stream9

--- a/pkg/controller/operands/testFiles/dataImportCronTemplates/dataImportCronTemplatesWithImageStream.yaml
+++ b/pkg/controller/operands/testFiles/dataImportCronTemplates/dataImportCronTemplatesWithImageStream.yaml
@@ -6,7 +6,7 @@
       spec:
         source:
           registry:
-            url: docker://quay.io/kubevirt/fedora
+            url: docker://quay.io/containerdisks/fedora
             imageStream: fedora
     managedDataSource: fedora
 - metadata:
@@ -20,12 +20,12 @@
             imageStream: test-is
     managedDataSource: test-is
 - metadata:
-    name: centos8-image-cron
+    name: centos-stream9-image-cron
   spec:
     schedule: "* */1 * * *"
     template:
       spec:
         source:
           registry:
-            url: docker://quay.io/kubevirt/centos8
-    managedDataSource: centos8
+            url: docker://quay.io/containerdisks/centos-stream:9
+    managedDataSource: centos-stream9

--- a/pkg/controller/operands/testFiles/dataImportCronTemplates/wrongDataImportCronTemplates.yaml
+++ b/pkg/controller/operands/testFiles/dataImportCronTemplates/wrongDataImportCronTemplates.yaml
@@ -10,7 +10,7 @@ spec:
           url: docker://quay.io/kubevirt/fedora
   managedDataSource: fedora
 metadata:
-  name: centos8-image-cron
+  name: centos-stream9-image-cron
   namespace: golden-image-namespace
 spec:
   schedule: "* */1 * * *"
@@ -18,5 +18,5 @@ spec:
     spec:
       source:
         registry:
-          url: docker://quay.io/kubevirt/centos8
-  managedDataSource: centos8
+          url: docker://quay.io/kubevirt/centos-stream9
+  managedDataSource: centos-stream9


### PR DESCRIPTION
PR #1690 removed centos 8 dataImportCron, because it's EOL.
Replace it with centos Stream 9 dataImportCron in the tests.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

