### PR TITLE
Fix golden images tests and enableCommonBootImageImport workaround

### DIFF
--- a/build/Dockerfile.okd
+++ b/build/Dockerfile.okd
@@ -7,6 +7,6 @@ COPY hack/testFiles/test_quickstart.yaml quickStart/
 COPY hack/testFiles/test_dashboard_cm.yaml dashboard/
 COPY assets/ .
 COPY ci-test-files/dataImportCronTemplatesWithImageStream.yaml dataImportCronTemplates/
-COPY ci-test-files/centos8-imagestream.yaml imageStreams/
+COPY ci-test-files/centos-stream9-imagestream.yaml imageStreams/
 
 ENTRYPOINT /usr/bin/hyperconverged-cluster-operator

--- a/ci-test-files/centos-stream9-imagestream.yaml
+++ b/ci-test-files/centos-stream9-imagestream.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: centos8
+  name: centos-stream9
   namespace: kubevirt-os-images
 spec:
   lookupPolicy:
@@ -10,7 +10,7 @@ spec:
   - annotations: null
     from:
       kind: DockerImage
-      name: quay.io/kubevirt/centos8-container-disk-images
+      name: quay.io/containerdisks/centos-stream
     importPolicy:
       scheduled: true
-    name: latest
+    name: 9

--- a/ci-test-files/dataImportCronTemplatesWithImageStream.yaml
+++ b/ci-test-files/dataImportCronTemplatesWithImageStream.yaml
@@ -1,16 +1,16 @@
 - metadata:
-    name: centos8-image-cron-is
+    name: centos-stream9-image-cron-is
   spec:
     schedule: "0 */12 * * *"
     template:
       spec:
         source:
           registry:
-            imageStream: "centos8"
+            imageStream: "centos-stream9"
             pullMethod: node
         storage:
           resources:
             requests:
               storage: 10Gi
     garbageCollect: Outdated
-    managedDataSource: centos8-is
+    managedDataSource: centos-stream9-is

--- a/hack/check_golden_images.sh
+++ b/hack/check_golden_images.sh
@@ -13,34 +13,34 @@ export -f count_data_import_crons
 if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
 
   # test image streams
-  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
-  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
+  [[ $(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
+  [[ "$(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/containerdisks/centos-stream"}' ]]
 
   # check that HCO reconciles the image stream
-  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch imageStream -n ${IMAGES_NS} centos8 --type=json -p '[{\"op\": \"add\", \"path\": \"/metadata/labels/test-label\", \"value\": \"test\"}]'"
+  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch imageStream -n ${IMAGES_NS} centos-stream9 --type=json -p '[{\"op\": \"add\", \"path\": \"/metadata/labels/test-label\", \"value\": \"test\"}]'"
   sleep 10
   # HCO expect to remove the test-label label from the image stream
-  ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o yaml"
+  ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos-stream9 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos-stream9 -o yaml"
 
   ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.featureGates.enableCommonBootImageImport}'
-  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron")'
+  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-stream9-image-cron")'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="fedora-image-cron")'
-  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron-is")'
+  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-stream9-image-cron-is")'
 
   ./hack/retry.sh 10 30 "[[ \$(count_data_import_crons) -eq 3 ]]" "${KUBECTL_BINARY} get DataImportCron -A"
 
-  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos8-image-cron
+  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-stream9-image-cron
   ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} fedora-image-cron
-  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos8-image-cron-is
+  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-stream9-image-cron-is
 
-  [[ $(${KUBECTL_BINARY} get DataImportCron -o json -n ${IMAGES_NS} centos8-image-cron-is | jq -cM '.spec.template.spec.source.registry') == '{"imageStream":"centos8","pullMethod":"node"}' ]]
+  [[ $(${KUBECTL_BINARY} get DataImportCron -o json -n ${IMAGES_NS} centos-stream9-image-cron-is | jq -cM '.spec.template.spec.source.registry') == '{"imageStream":"centos-stream9","pullMethod":"node"}' ]]
 
   # disable the feature
   ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": false }]'"
   sleep 10
 
   # check that the image streams and the DataImportCron were removed
-  ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 0 ]]"
+  ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} --no-headers | wc -l) -eq 0 ]]"
   ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get DataImportCron -A --no-headers | wc -l) -eq 0 ]]"
 
   # enable it back
@@ -48,7 +48,7 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
   sleep 10
 
   # test image streams
-  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
-  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
+  [[ $(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
+  [[ "$(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/containerdisks/centos-stream"}' ]]
 
 fi

--- a/hack/test_delete_ns.sh
+++ b/hack/test_delete_ns.sh
@@ -47,6 +47,13 @@ function test_delete_ns(){
         echo "Ignoring webhook on k8s where we don't have OLM based validating webhooks"
     fi
 
+    # TODO: workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2037312
+    # remove once fixed
+    echo "Explictly disabling CommonBootImageImport to be able to safely remove the product"
+    ${CMD} patch hco -n kubevirt-hyperconverged kubevirt-hyperconverged --type=json kubevirt-hyperconverged -p '[{ "op": "replace", "path": /spec/enableCommonBootImageImport, "value": false }]'
+    sleep 30
+    # ---
+
     echo "Delete the hyperconverged CR to remove the product"
     timeout 10m ${CMD} delete hyperconverged -n kubevirt-hyperconverged kubevirt-hyperconverged
 

--- a/pkg/controller/operands/testFiles/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/pkg/controller/operands/testFiles/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -7,10 +7,10 @@
       spec:
         source:
           registry:
-            url: docker://quay.io/kubevirt/fedora
+            url: docker://quay.io/containerdisks/fedora
     managedDataSource: fedora
 - metadata:
-    name: centos8-image-cron
+    name: centos-stream9-image-cron
     namespace: golden-image-namespace
   spec:
     schedule: "* */1 * * *"
@@ -18,5 +18,5 @@
       spec:
         source:
           registry:
-            url: docker://quay.io/kubevirt/centos8
-    managedDataSource: centos8
+            url: docker://quay.io/containerdisks/centos-stream:9
+    managedDataSource: centos-stream9

--- a/pkg/controller/operands/testFiles/dataImportCronTemplates/dataImportCronTemplatesWithImageStream.yaml
+++ b/pkg/controller/operands/testFiles/dataImportCronTemplates/dataImportCronTemplatesWithImageStream.yaml
@@ -6,7 +6,7 @@
       spec:
         source:
           registry:
-            url: docker://quay.io/kubevirt/fedora
+            url: docker://quay.io/containerdisks/fedora
             imageStream: fedora
     managedDataSource: fedora
 - metadata:
@@ -20,12 +20,12 @@
             imageStream: test-is
     managedDataSource: test-is
 - metadata:
-    name: centos8-image-cron
+    name: centos-stream9-image-cron
   spec:
     schedule: "* */1 * * *"
     template:
       spec:
         source:
           registry:
-            url: docker://quay.io/kubevirt/centos8
-    managedDataSource: centos8
+            url: docker://quay.io/containerdisks/centos-stream:9
+    managedDataSource: centos-stream9

--- a/pkg/controller/operands/testFiles/dataImportCronTemplates/wrongDataImportCronTemplates.yaml
+++ b/pkg/controller/operands/testFiles/dataImportCronTemplates/wrongDataImportCronTemplates.yaml
@@ -10,7 +10,7 @@ spec:
           url: docker://quay.io/kubevirt/fedora
   managedDataSource: fedora
 metadata:
-  name: centos8-image-cron
+  name: centos-stream9-image-cron
   namespace: golden-image-namespace
 spec:
   schedule: "* */1 * * *"
@@ -18,5 +18,5 @@ spec:
     spec:
       source:
         registry:
-          url: docker://quay.io/kubevirt/centos8
-  managedDataSource: centos8
+          url: docker://quay.io/kubevirt/centos-stream9
+  managedDataSource: centos-stream9


### PR DESCRIPTION
1. PR #1690 removed centos 8 dataImportCron, because it's EOL.
Replace it with centos Stream 9 dataImportCron in the tests.

2. enableCommonBootImageImport is often preventing
the product from being correctly uninstalled
and this is making CI pretty flaky.
Let's explicitly disable it before trying to
uninstall on CI until we get a proper fix.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2037312

Combine the two fixes in a single PR to unlock CI

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

