### PR TITLE
Fix golden images tests and enableCommonBootImageImport workaround

### DIFF
--- a/hack/check_golden_images.sh
+++ b/hack/check_golden_images.sh
@@ -23,13 +23,15 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
   ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o yaml"
 
   ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.featureGates.enableCommonBootImageImport}'
-  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron")'
+  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-stream8-image-cron")'
+  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-stream9-image-cron")'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="fedora-image-cron")'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron-is")'
 
-  ./hack/retry.sh 10 30 "[[ \$(count_data_import_crons) -eq 3 ]]" "${KUBECTL_BINARY} get DataImportCron -A"
+  ./hack/retry.sh 10 30 "[[ \$(count_data_import_crons) -eq 4 ]]" "${KUBECTL_BINARY} get DataImportCron -A"
 
-  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos8-image-cron
+  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-stream8-image-cron
+  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-stream9-image-cron
   ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} fedora-image-cron
   ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos8-image-cron-is
 

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -50,5 +50,13 @@ KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_defaults.sh
 # check golden images
 KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_golden_images.sh
 
+# TODO: workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2037312
+# remove once fixed
+echo "Explictly disabling CommonBootImageImport to be able to safely remove the product"
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n kubevirt-hyperconverged kubevirt-hyperconverged --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": false }]'"
+sleep 10
+./hack/retry.sh 10 30 "[[ $(${KUBECTL_BINARY} get DataImportCron -A --no-headers | wc -l) -eq 0 ]]"
+# ---
+
 # Check the webhook, to see if it allow deleteing of the HyperConverged CR
 ./hack/retry.sh 10 30 "${KUBECTL_BINARY} delete hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged"

--- a/hack/test_delete_ns.sh
+++ b/hack/test_delete_ns.sh
@@ -47,6 +47,14 @@ function test_delete_ns(){
         echo "Ignoring webhook on k8s where we don't have OLM based validating webhooks"
     fi
 
+    # TODO: workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2037312
+    # remove once fixed
+    echo "Explictly disabling CommonBootImageImport to be able to safely remove the product"
+    ./hack/retry.sh 10 3 "${CMD} patch hco -n kubevirt-hyperconverged kubevirt-hyperconverged --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": false }]'"
+    sleep 10
+    ./hack/retry.sh 10 30 "[[ $(${CMD} get DataImportCron -A --no-headers | wc -l) -eq 0 ]]"
+    # ---
+
     echo "Delete the hyperconverged CR to remove the product"
     timeout 10m ${CMD} delete hyperconverged -n kubevirt-hyperconverged kubevirt-hyperconverged
 


### PR DESCRIPTION
1. PR #1690 removed centos 8 dataImportCron, because it's EOL.
Fix the e2e tests accordingly.

2. enableCommonBootImageImport is often preventing
the product from being correctly uninstalled
and this is making CI pretty flaky.
Let's explicitly disable it before trying to
uninstall on CI until we get a proper fix.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2037312

Combine the two fixes in a single PR to unlock CI

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

