### PR TITLE
Fix nightly build automation

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -24,6 +24,7 @@ git clone https://github.com/kubevirt/kubevirt.git
 (cd kubevirt; git checkout "${latest_kubevirt_commit}")
 go mod edit -replace kubevirt.io/client-go=./kubevirt/staging/src/kubevirt.io/client-go
 go mod edit -replace kubevirt.io/api=./kubevirt/staging/src/kubevirt.io/api
+go mod edit -replace kubevirt.io/containerized-data-importer-api=$(grep "kubevirt.io/containerized-data-importer-api v" go.mod | xargs | sed "s/ /@/g")
 go mod vendor
 
 # set envs


### PR DESCRIPTION
With recent kubevirt commits,
nightly builds are failing on:

```
+ go mod vendor
go: kubevirt.io/kubevirt@v0.49.1-0.20220112004052-acd4af2ac679 requires
	kubevirt.io/containerized-data-importer@v1.41.0 requires
	kubevirt.io/containerized-data-importer-api@v0.0.0: reading kubevirt.io/containerized-data-importer-api/go.mod at revision v0.0.0: unknown revision v0.0.0
```
See:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-hco-push-nightly-build-main/1481084127066198016

Force a replacement to make go mod happy

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

