### PR TITLE
Replace EOL CentOS base images in Dockefiles with CentOS Stream 9

### DIFF
--- a/build/Dockerfile.okd
+++ b/build/Dockerfile.okd
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM quay.io/centos/centos:stream9
 
 ENV KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
 

--- a/build/Dockerfile.wh.okd
+++ b/build/Dockerfile.wh.okd
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM quay.io/centos/centos:stream9
 
 ENV KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
 

--- a/deploy/nightly-bundle/Dockerfile
+++ b/deploy/nightly-bundle/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos8.1.1911
+FROM quay.io/centos/centos:stream9
 
 COPY deploy/nightly-bundle/deploy.sh /deploy.sh
 COPY deploy/nightly-bundle/create_docker_config.sh /create_docker_config.sh

--- a/tests/travis-tests/Dockerfile
+++ b/tests/travis-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.6.1810
+FROM quay.io/centos/centos:stream9
 
 COPY tests/travis-tests/kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 


### PR DESCRIPTION
Both CentOS 7 and CentOS 8 are scheduled for EOL as stated in https://wiki.centos.org/About/Product, and already exited the Full Updates phase.
Therefore this PR updates the CentOS versions in some Dockerfiles for new builds to use CentOS Stream 9, which is in the full support phase (https://www.centos.org/centos-stream/).

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace EOL CentOS base images in Dockefiles with CentOS Stream 9
```

