### PR TITLE
Remove old HCO metrics services and endpoints when upgrading

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -459,6 +459,14 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.7.0/manifests/kubevirt-hyperconverged-operator.v1.7.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.7.0/manifests/kubevirt-hyperconverged-operator.v1.7.0.clusterserviceversion.yaml
@@ -291,6 +291,14 @@ spec:
           - get
           - list
         - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          verbs:
+          - get
+          - list
+          - delete
+        - apiGroups:
           - apps
           resources:
           - deployments

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.7.0/manifests/kubevirt-hyperconverged-operator.v1.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.7.0/manifests/kubevirt-hyperconverged-operator.v1.7.0.clusterserviceversion.yaml
@@ -291,6 +291,14 @@ spec:
           - get
           - list
         - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          verbs:
+          - get
+          - list
+          - delete
+        - apiGroups:
           - apps
           resources:
           - deployments

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -448,6 +448,11 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 			Verbs:     stringListToSlice("get", "list"),
 		},
 		{
+			APIGroups: emptyAPIGroup,
+			Resources: stringListToSlice("endpoints"),
+			Verbs:     stringListToSlice("get", "list", "delete"),
+		},
+		{
 			APIGroups: stringListToSlice("apps"),
 			Resources: stringListToSlice("deployments", "replicasets"),
 			Verbs:     stringListToSlice("get", "list"),

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -1118,33 +1118,25 @@ var (
 	operatorMetrics = "hyperconverged-cluster-operator-metrics"
 	webhookMetrics  = "hyperconverged-cluster-webhook-metrics"
 
-	oldMetricsServices  map[string]corev1.Service
-	oldMetricsEndpoints map[string]corev1.Endpoints
+	oldMetricsObjects map[string]client.Object
 )
 
-func initOldMetricsServices(req *common.HcoRequest) {
-	if oldMetricsServices == nil {
-		oldMetricsServices = map[string]corev1.Service{
-			operatorMetrics: {
+func initOldMetricsObjects(req *common.HcoRequest) {
+	if oldMetricsObjects == nil {
+		oldMetricsObjects = map[string]client.Object{
+			"operatorService": &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      operatorMetrics,
 					Namespace: req.Namespace,
 				},
 			},
-			webhookMetrics: {
+			"webhookService": &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      webhookMetrics,
 					Namespace: req.Namespace,
 				},
 			},
-		}
-	}
-}
-
-func initOldMetricsEndpoints(req *common.HcoRequest) {
-	if oldMetricsEndpoints == nil {
-		oldMetricsEndpoints = map[string]corev1.Endpoints{
-			operatorMetrics: {
+			"operatorEndpoint": &corev1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      operatorMetrics,
 					Namespace: req.Namespace,
@@ -1155,30 +1147,17 @@ func initOldMetricsEndpoints(req *common.HcoRequest) {
 }
 
 func (r ReconcileHyperConverged) removeOldMetricsObjs(req *common.HcoRequest) error {
-	initOldMetricsServices(req)
-	initOldMetricsEndpoints(req)
+	initOldMetricsObjects(req)
 
-	for name, service := range oldMetricsServices {
-		removed, err := r.deleteObj(req, &service)
-
-		if err != nil {
-			return err
-		}
-
-		if removed {
-			delete(oldMetricsServices, name)
-		}
-	}
-
-	for name, endpoint := range oldMetricsEndpoints {
-		removed, err := r.deleteObj(req, &endpoint)
+	for name, object := range oldMetricsObjects {
+		removed, err := r.deleteObj(req, object)
 
 		if err != nil {
 			return err
 		}
 
 		if removed {
-			delete(oldMetricsEndpoints, name)
+			delete(oldMetricsObjects, name)
 		}
 	}
 

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -1051,7 +1051,7 @@ func (r *ReconcileHyperConverged) migrateBeforeUpgrade(req *common.HcoRequest) (
 
 	removeOldQuickStartGuides(req, r.client, r.operandHandler.GetQuickStartNames())
 
-	return upgradePatched || oldMetricsSVCRemoved, nil
+	return upgradePatched, nil
 }
 
 func (r ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (bool, error) {

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -1044,9 +1044,14 @@ func (r *ReconcileHyperConverged) migrateBeforeUpgrade(req *common.HcoRequest) (
 		return false, err
 	}
 
+	oldMetricsSVCRemoved, err := r.removeOldMetricsObjs(req)
+	if err != nil {
+		return false, err
+	}
+
 	removeOldQuickStartGuides(req, r.client, r.operandHandler.GetQuickStartNames())
 
-	return upgradePatched, nil
+	return upgradePatched || oldMetricsSVCRemoved, nil
 }
 
 func (r ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (bool, error) {
@@ -1107,6 +1112,94 @@ func (r ReconcileHyperConverged) applyUpgradePatch(req *common.HcoRequest, hcoJs
 		return patchedBytes, nil
 	}
 	return hcoJson, nil
+}
+
+func (r ReconcileHyperConverged) removeOldMetricsObjs(req *common.HcoRequest) (bool, error) {
+	anyServiceRemoved, err := r.removeObjs(req, corev1.Service{}, []string{
+		"hyperconverged-cluster-operator-metrics",
+		"hyperconverged-cluster-webhook-metrics",
+	})
+	if err != nil {
+		return false, err
+	}
+
+	anyEndpointRemoved, err := r.removeObjs(req, corev1.Endpoints{}, []string{
+		"hyperconverged-cluster-operator-metrics",
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return anyServiceRemoved || anyEndpointRemoved, nil
+}
+
+func (r ReconcileHyperConverged) removeObjs(req *common.HcoRequest, objType interface{}, objNames []string) (bool, error) {
+	anyRemoved := false
+
+	for _, objName := range objNames {
+		removed, err := r.removeObj(req, objType, objName)
+		if err != nil {
+			return false, err
+		}
+		anyRemoved = anyRemoved || removed
+	}
+
+	return anyRemoved, nil
+}
+
+func (r ReconcileHyperConverged) removeObj(req *common.HcoRequest, objType interface{}, objName string) (bool, error) {
+	obj, err := r.getObj(req, objType, objName)
+	if err != nil {
+		return false, err
+	} else if obj == nil {
+		return false, nil
+	}
+
+	err = r.deleteObj(req, obj)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (r *ReconcileHyperConverged) getObj(req *common.HcoRequest, objType interface{}, objName string) (client.Object, error) {
+	var obj client.Object
+
+	switch objType.(type) {
+	case corev1.Service:
+		obj = &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: objName, Namespace: req.Namespace}}
+	case corev1.Endpoints:
+		obj = &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: objName, Namespace: req.Namespace}}
+	}
+
+	if err := hcoutil.GetRuntimeObject(req.Ctx, r.client, obj, req.Logger); err != nil {
+		if apierrors.IsNotFound(err) {
+			req.Logger.Info(fmt.Sprintf("%s %s already removed", objName, obj.GetObjectKind().GroupVersionKind().Kind))
+			return nil, nil
+		}
+		req.Logger.Info(
+			fmt.Sprintf("failed to get %s %s", objName, obj.GetObjectKind().GroupVersionKind().Kind),
+			"error", err.Error(),
+		)
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (r *ReconcileHyperConverged) deleteObj(req *common.HcoRequest, obj client.Object) error {
+	req.Logger.Info(fmt.Sprintf("removing the %s %s", obj.GetName(), obj.GetObjectKind().GroupVersionKind().Kind))
+	_, err := hcoutil.ComponentResourceRemoval(req.Ctx, r.client, obj, req.Name, req.Logger, false, true)
+	if err != nil {
+		return err
+	}
+
+	r.eventEmitter.EmitEvent(
+		req.Instance, corev1.EventTypeNormal, "Killing",
+		fmt.Sprintf("Removed %s %s", obj.GetName(), obj.GetObjectKind().GroupVersionKind().Kind))
+
+	return nil
 }
 
 func removeOldQuickStartGuides(req *common.HcoRequest, cl client.Client, requiredQSList []string) {

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -1051,7 +1051,7 @@ func (r *ReconcileHyperConverged) migrateBeforeUpgrade(req *common.HcoRequest) (
 
 	removeOldQuickStartGuides(req, r.client, r.operandHandler.GetQuickStartNames())
 
-	return upgradePatched, nil
+	return upgradePatched || oldMetricsSVCRemoved, nil
 }
 
 func (r ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (bool, error) {


### PR DESCRIPTION
There is a bug when updating from v1.2.x to versions later than v1.4.x where services `hyperconverged-cluster-operator-metrics` and `hyperconverged-cluster-webhook-metrics`, and endpoint `hyperconverged-cluster-operator-metrics` are not being deleted. This PR ensures those objects are removed.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove old HCO metrics services and endpoints when upgrading
```

