### PR TITLE
Expose part-of,component and version labels to kubevirtCR

### DIFF
--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -252,6 +252,9 @@ func NewKubeVirt(hc *hcov1beta1.HyperConverged, opts ...string) (*kubevirtcorev1
 		Configuration:               *config,
 		CertificateRotationStrategy: *kvCertConfig,
 		WorkloadUpdateStrategy:      hcWorkloadUpdateStrategyToKv(hc.Spec.WorkloadUpdateStrategy),
+		ProductName:                 hcoutil.HyperConvergedCluster,
+		ProductVersion:              os.Getenv(hcoutil.HcoKvIoVersionName),
+		ProductComponent:            string(hcoutil.AppComponentCompute),
 	}
 
 	kv := NewKubeVirtWithNameOnly(hc, opts...)


### PR DESCRIPTION
for unique labels values and exposure across kubevirt's components.
kubevirt's operator set it's components labels by kubevirtCR:
https://github.com/kubevirt/kubevirt/blob/9a9080b8a387b4a23d641353b3e22d3e9cc614ff/pkg/virt-operator/resource/apply/reconcile.go#L85

currently KubeVirt's components don't expose `version` and `part-of` labels,
`component` label isn't unique because KubeVirt's components that are managed by
virt-operator and virt-operator set these label to the default value ("kubevirt").
```
Steps to Reproduce **missing labels**:
1.deploy latest 4.10 cluster
2.check labels of virt components
virt-api
$ oc describe deployment virt-api -n openshift-cnv | head
Labels:                 app.kubernetes.io/component=kubevirt
                        app.kubernetes.io/managed-by=virt-operator
                        app.kubernetes.io/name=virt-api
                        kubevirt.io=virt-api

virt-handler
labels:
                        app.kubernetes.io/component: kubevirt
                        app.kubernetes.io/managed-by: virt-operator

virt-controller
Labels:                 app.kubernetes.io/component=kubevirt
                        app.kubernetes.io/managed-by=virt-operator
                        app.kubernetes.io/name=virt-controller
                        kubevirt.io=virt-controller

only Virt-operator have "part-of" and "version"
Labels:                 app.kubernetes.io/component=compute
                        app.kubernetes.io/managed-by=olm
                        app.kubernetes.io/part-of=hyperconverged-cluster
                        app.kubernetes.io/version=4.10.0
                        olm.deployment-spec-hash=7c7c9f8c59
                        olm.owner=kubevirt-hyperconverged-operator.v4.10.0
                        olm.owner.kind=ClusterServiceVersion


Expected results:
all virt components have label "part-of" and "version"

-----------------------------------------------------------------------------------------------------------------------------------------------
Steps to Reproduce **Inconsistent  comonent's label value**:
1.get labels of all virt component
virt-operator is "compute"
$ oc describe deployment virt-operator -n openshift-cnv | head
Labels:                 app.kubernetes.io/component=compute
                        app.kubernetes.io/managed-by=olm
                        app.kubernetes.io/part-of=hyperconverged-cluster
                        app.kubernetes.io/version=4.10.0
                        olm.deployment-spec-hash=7c7c9f8c59
                        olm.owner=kubevirt-hyperconverged-operator.v4.10.0
                        olm.owner.kind=ClusterServiceVersion

Virt-api, Virt-controller and virt-handler, the label is "kubevirt"
Labels:                 app.kubernetes.io/component=kubevirt
                        app.kubernetes.io/managed-by=virt-operator
                        app.kubernetes.io/name=virt-api
                        kubevirt.io=virt-api


Expected results:
all virt parts should have same label of component ,
Component values for Storage, network match, but it does NOT match for Virt.
```
**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add unique part-of,component and version labels values across KubeVirt's components.
```

