### PR TITLE
Fix calculation to convert upstream HCO version to OCP index image version

### DIFF
--- a/automation/publisher/publisher.sh
+++ b/automation/publisher/publisher.sh
@@ -34,7 +34,10 @@ function main() {
   sed -r -i "s/(.*channel.*: ).+/\1\stable/g" hco_bundle/metadata/annotations.yaml
 
   echo "Add annotation for community-operators index image"
-  INDEX_IMAGE_VERSION=$(echo "${BASE_TAGGED_VERSION%.*}+3.4" | bc)
+  IFS='.' read -r -a SPLITTED_BASE_VERSION <<< "${BASE_TAGGED_VERSION%.*}"
+  SPLITTED_BASE_VERSION[0]=$((SPLITTED_BASE_VERSION[0]+3))
+  SPLITTED_BASE_VERSION[1]=$((SPLITTED_BASE_VERSION[1]+4))
+  INDEX_IMAGE_VERSION=$(IFS=. ; echo "${SPLITTED_BASE_VERSION[*]}")
   echo "  com.redhat.openshift.versions: \"v${INDEX_IMAGE_VERSION}\"" >> hco_bundle/metadata/annotations.yaml
 
   echo "Bump version to ${TAGGED_VERSION}"


### PR DESCRIPTION
The calculation from HCO to OCP index image is broken in 1.6.0 and upwards.
This PR fixes the calculation so, e.g. 1.6.0 resolves to 4.10, 1.7.0 to 4.11 and so on.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

