### PR TITLE
Do not allow adding a custom DataImportCronTemplate with  the same name as one of the common ones

### DIFF
--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -233,7 +233,8 @@ func getBasicDeployment() *BasicExpected {
 	expectedCNA.Status.Conditions = getGenericCompletedConditions()
 	res.cna = expectedCNA
 
-	expectedSSP := operands.NewSSP(hco)
+	expectedSSP, err := operands.NewSSP(hco)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	expectedSSP.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/ctbs/%s", expectedSSP.Namespace, expectedSSP.Name)
 	expectedSSP.Status.Conditions = getGenericCompletedConditions()
 	res.ssp = expectedSSP

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -176,7 +176,7 @@ func (h OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 		NewKubeVirtWithNameOnly(req.Instance),
 		NewCDIWithNameOnly(req.Instance),
 		NewNetworkAddonsWithNameOnly(req.Instance),
-		NewSSP(req.Instance),
+		NewSSPWithNameOnly(req.Instance),
 		NewConsoleCLIDownload(req.Instance),
 	}
 

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -115,9 +115,11 @@ func (wh WebhookHandler) ValidateUpdate(requested *v1beta1.HyperConverged, exist
 	}
 
 	if wh.isOpenshift {
-		resources = append(resources,
-			operands.NewSSP(requested),
-		)
+		ssp, err := operands.NewSSP(requested)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, ssp)
 	}
 
 	wg.Add(len(resources))
@@ -182,7 +184,10 @@ func (wh WebhookHandler) updateOperatorCr(ctx context.Context, hc *v1beta1.Hyper
 		required.Spec.DeepCopyInto(&existing.Spec)
 
 	case *sspv1beta1.SSP:
-		required := operands.NewSSP(hc)
+		required, err := operands.NewSSP(hc)
+		if err != nil {
+			return err
+		}
 		required.Spec.DeepCopyInto(&existing.Spec)
 
 	}

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -349,7 +349,8 @@ var _ = Describe("webhooks validator", func() {
 		It("should return error if SSP CR is missing", func() {
 			ctx := context.TODO()
 			cli := getFakeClient(hco)
-			Expect(cli.Delete(ctx, operands.NewSSP(hco))).To(BeNil())
+
+			Expect(cli.Delete(ctx, operands.NewSSPWithNameOnly(hco))).To(BeNil())
 			wh := NewWebhookHandler(logger, cli, HcoValidNamespace, true)
 
 			newHco := &v1beta1.HyperConverged{}
@@ -967,7 +968,10 @@ func getFakeClient(hco *v1beta1.HyperConverged) *commonTestUtils.HcoTestClient {
 	cna, err := operands.NewNetworkAddons(hco)
 	Expect(err).ToNot(HaveOccurred())
 
-	return commonTestUtils.InitClient([]runtime.Object{hco, kv, cdi, cna, operands.NewSSP(hco)})
+	ssp, err := operands.NewSSP(hco)
+	Expect(err).ToNot(HaveOccurred())
+
+	return commonTestUtils.InitClient([]runtime.Object{hco, kv, cdi, cna, ssp})
 }
 
 type fakeFailure int


### PR DESCRIPTION
This PR fixes the BZ 2041519 bug.

It does not allow to create a custom DataImportCronTemplate with the same name as one of the common DataImportCronTemplates.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix BZ 2041519
```

