### PR TITLE
Release bumper: ignore obsolete branches

### DIFF
--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -25,7 +25,7 @@ jobs:
 
       - id: set_branches
         run: |
-          matrix=$(git for-each-ref --format='%(refname:short)' refs/remotes/origin | grep -e "origin/main" -e "origin/release-1.[0-9]\+$" | sed -r 's/origin\/(.*)/{"branch": "\1"}/g' | jq -s)
+          matrix=$(git for-each-ref --format='%(refname:short)' refs/remotes/origin | grep -e "origin/main" -e "origin/release-1.[0-9]\+$" | grep -v "release-1\.[0,1,2,3]$" | sed -r 's/origin\/(.*)/{"branch": "\1"}/g' | jq -s)
           echo "::set-output name=matrix::{\"branches\":$(echo $matrix)}"
 
   bump_components_version:


### PR DESCRIPTION
Avoid processing:
- release-1.0
- release-1.1
- release-1.2
- release-1.3

that are considered obsolete

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

