### PR TITLE
Update release-bumper to handle pre-release versions

### DIFF
--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -132,7 +132,9 @@ function get_updated_versions {
 function get_latest_release() {
   repo="${COMPONENTS_REPOS[$1]}"
   current_version="${CURRENT_VERSIONS[$1]}"
-  short_current=${current_version%.*}
+
+  major=$(echo $current_version | cut -d. -f1)
+  minor=$(echo $current_version | cut -d. -f2)
 
   RELEASES=$(curl -s -L "https://api.github.com/repos/$repo/releases" | jq -r '.[].tag_name')
   releases=(${RELEASES})
@@ -141,11 +143,13 @@ function get_latest_release() {
 
   for (( i=${#KEYS_ARR[@]}-1 ; i >= 0 ; i-- )) ; do
     release=${releases[${KEYS_ARR[$i]}]}
-    short_release=${release%.*}
+
+    new_major=$(echo $release | cut -d. -f1)
+    new_minor=$(echo $release | cut -d. -f2)
 
     if [ "$UPDATE_TYPE" = "all" ]; then
       break;
-    elif [ "$UPDATE_TYPE" = "z_release" ] && [ "$short_current" = "$short_release" ]; then
+    elif [ "$UPDATE_TYPE" = "z_release" ] && [ "$major" = "$new_major" ] && [ "$minor" = "$new_minor" ]; then
       break;
     fi
   done


### PR DESCRIPTION
Releases major and minor versions were being parsed using `${variable % pattern}` to remove the patch version, but this operator tests if the pattern matches the end of the variable’s value, deleting the shortest part that matches and returns the rest. When versions contain pre-release versioning such as `v2.0.0-rc.1`, it only removes the pre-release version resulting in `v2.0.0-rc` instead of `v2.0`.

With this PR, we split the version string by the periods and get the first part for the major version and the second part for the minor version, avoiding patch and pre-release versioning complexity.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

