### PR TITLE
Clean code smells as reported in sonarCloud

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -87,8 +87,6 @@ func main() {
 	cfg, err := config.GetConfig()
 	cmdHelper.ExitOnError(err, "can't load configuration")
 
-	// a lock is not needed in webhook mode
-	// TODO: remove this once we will move to OLM operator conditions
 	ci := hcoutil.GetClusterInfo()
 	needLeaderElection := !ci.IsRunningLocally()
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -94,7 +94,7 @@ func (hm *hcoMetrics) GetMetricValue(metricName string, label prometheus.Labels)
 	var res = &dto.Metric{}
 	metric, found := hm.metricList[metricName]
 	if !found {
-		return 0, fmt.Errorf("unknown metric name %s", metricName)
+		return 0, unknownMetricNameError(metricName)
 	}
 	switch m := metric.(type) {
 	case *prometheus.CounterVec:
@@ -110,14 +110,14 @@ func (hm *hcoMetrics) GetMetricValue(metricName string, label prometheus.Labels)
 		}
 		return res.Gauge.GetValue(), nil
 	default:
-		return 0, fmt.Errorf("%s is with unknown metric type", metricName)
+		return 0, unknownMetricTypeError(metricName)
 	}
 }
 
 func (hm *hcoMetrics) IncMetric(metricName string, label prometheus.Labels) error {
 	metric, found := hm.metricList[metricName]
 	if !found {
-		return fmt.Errorf("unknown metric name %s", metricName)
+		return unknownMetricNameError(metricName)
 	}
 	switch m := metric.(type) {
 	case *prometheus.CounterVec:
@@ -127,21 +127,21 @@ func (hm *hcoMetrics) IncMetric(metricName string, label prometheus.Labels) erro
 		m.With(label).Inc()
 		return nil
 	default:
-		return fmt.Errorf("%s is with unknown metric type", metricName)
+		return unknownMetricTypeError(metricName)
 	}
 }
 
 func (hm *hcoMetrics) SetMetric(metricName string, label prometheus.Labels, value float64) error {
 	metric, found := hm.metricList[metricName]
 	if !found {
-		return fmt.Errorf("unknown metric name %s", metricName)
+		return unknownMetricNameError(metricName)
 	}
 
 	if m, ok := metric.(*prometheus.GaugeVec); ok {
 		m.With(label).Set(value)
 		return nil
 	}
-	return fmt.Errorf("%s is with unknown metric type", metricName)
+	return unknownMetricTypeError(metricName)
 }
 
 // IncOverwrittenModifications increments counter by 1
@@ -186,4 +186,12 @@ func (hm hcoMetrics) GetMetricDesc() []MetricDescription {
 	}
 
 	return res
+}
+
+func unknownMetricNameError(metricName string) error {
+	return fmt.Errorf("unknown metric name %s", metricName)
+}
+
+func unknownMetricTypeError(metricName string) error {
+	return fmt.Errorf("%s is with unknown metric type", metricName)
 }

--- a/tools/release-notes/release-notes.go
+++ b/tools/release-notes/release-notes.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (r *releaseData) writeHeader(span string) error {
-	tagUrl := fmt.Sprintf("https://github.com/kubevirt/%s/releases/tag/%s", "hyperconverged-cluster-operator", r.hco.currentTag)
+	tagUrl := fmt.Sprintf("https://github.com/kubevirt/hyperconverged-cluster-operator/releases/tag/%s", r.hco.currentTag)
 
 	numChanges, err := r.hco.gitGetNumChanges(span)
 	if err != nil {
@@ -183,8 +183,7 @@ func (r *releaseData) writeContributors(span string) error {
 	return nil
 }
 
-func (r *releaseData) writeAdditionalResources() {
-	additionalResources := fmt.Sprintf(`Additional Resources
+const additionalResources = `Additional Resources
 --------------------
 - Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
 - Slack: <https://kubernetes.slack.com/messages/virtualization>
@@ -193,13 +192,10 @@ func (r *releaseData) writeAdditionalResources() {
 - [License][license]
 
 
-[contributing]: https://github.com/kubevirt/%s/blob/main/CONTRIBUTING.md
-[license]: https://github.com/kubevirt/%s/blob/main/LICENSE
+[contributing]: https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/LICENSE
 ---
-`, "hyperconverged-cluster-operator", "hyperconverged-cluster-operator")
-
-	r.outFile.WriteString(additionalResources)
-}
+`
 
 func (r *releaseData) generateReleaseNotes() error {
 	releaseNotesFile := fmt.Sprintf("%s-release-notes.md", r.hco.currentTag)
@@ -228,7 +224,7 @@ func (r *releaseData) generateReleaseNotes() error {
 		return err
 	}
 
-	r.writeAdditionalResources()
+	r.outFile.WriteString(additionalResources)
 
 	return nil
 }


### PR DESCRIPTION
The sonar cloud reports 11 code smells. This PR clean 10 of them:

* Reduce its Cognitive Complexity in pkg/controller/operands/operandHandler.go, pkg/util/cluster.go and pkg/controller/hyperconverged/hyperconverged_controller.go
* Remove a TODO comment in cmd/hyperconverged-cluster-operator/main.go
* Remove string duplication in pkg/metrics/metrics.go, tools/release-notes/release-notes.go and pkg/util/cluster.go

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

