### PR TITLE
Remove workaround for bug #2031919

### DIFF
--- a/hack/test_delete_ns.sh
+++ b/hack/test_delete_ns.sh
@@ -58,16 +58,6 @@ function test_delete_ns(){
     echo "Delete the hyperconverged CR to remove the product"
     timeout 10m ${CMD} delete hyperconverged -n kubevirt-hyperconverged kubevirt-hyperconverged
 
-    # TODO: workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2031919
-    # remove once fixed
-    INFRASTRUCTURETOPOLOGY=$(${CMD} get infrastructure.config.openshift.io cluster -o json | jq -j '.status.infrastructureTopology')
-    if [[ "${INFRASTRUCTURETOPOLOGY}" == "SingleReplica" ]]; then
-      echo "Explictly deleting kubevirt apiservice leftovers"
-      ${CMD} delete apiservice v1alpha3.subresources.kubevirt.io --ignore-not-found=true
-      ${CMD} delete apiservice v1.subresources.kubevirt.io --ignore-not-found=true
-    fi
-    # ---
-
     echo "Finally delete kubevirt-hyperconverged namespace"
     timeout 10m ${CMD} delete namespace kubevirt-hyperconverged
 }


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=2031919
is supposed to be fixed,
so we can now remove a workaround for that.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

