### PR TITLE
add DataImportCron reference link to the cluster configuration document

### DIFF
--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -550,6 +550,8 @@ To add a custom image, add a `DataImportCronTemplate` object to the `dataImportC
 the `HyperConverged`'s
 `spec` field.
 
+See the [CDI document](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/os-image-poll-and-update.md) for specific details about the `DataImportCronTemplate` fields.
+
 **Note**: the `enableCommonBootImageImport` feature does not block the custom golden images, but only the common ones.
 
 ### Custom Golden Images example
@@ -568,6 +570,7 @@ spec:
         registry:
           url: docker://myprivateregistry/custom1
       managedDataSource: custom1
+      retentionPolicy: "All" # created DataVolumes and DataSources are retained when their DataImportCron is deleted (default behavior)
   - metadata:
       name: custom-image2
     spec:
@@ -576,6 +579,7 @@ spec:
         registry:
           url: docker://myprivateregistry/custom2
       managedDataSource: custom2
+      retentionPolicy: "None" # created DataVolumes and DataSources are deleted when their DataImportCron is deleted
 ```
 
 ## Log verbosity


### PR DESCRIPTION
Fixes #1767 

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add missing DataImportCron reference in cluster configuration document
```

