### PR TITLE
Start replacing Docker with Podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,21 +87,21 @@ container-build-webhook:
 	source "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile.webhook -t $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-build-operator-courier:
-	docker build -f tools/operator-courier/Dockerfile -t hco-courier .
+	podman build -f tools/operator-courier/Dockerfile -t hco-courier .
 
 container-build-validate-bundles:
-	docker build -f tools/operator-sdk-validate/Dockerfile -t operator-sdk-validate-hco .
+	podman build -f tools/operator-sdk-validate/Dockerfile -t operator-sdk-validate-hco .
 
 container-build-functest:
-	docker build -f build/Dockerfile.functest -t $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	podman build -f build/Dockerfile.functest -t $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-build-artifacts-server:
-	docker build -f build/Dockerfile.artifacts -t $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	podman build -f build/Dockerfile.artifacts -t $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-push: quay-login container-push-operator container-push-webhook container-push-functest container-push-artifacts-server
 
 quay-login:
-	docker login $(IMAGE_REGISTRY) -u $(QUAY_USERNAME) -p $(QUAY_PASSWORD)
+	podman login $(IMAGE_REGISTRY) -u $(QUAY_USERNAME) -p $(QUAY_PASSWORD)
 
 container-push-operator:
 	source "hack/cri-bin.sh" && $$CRI_BIN push $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG)
@@ -110,10 +110,10 @@ container-push-webhook:
 	source "hack/cri-bin.sh" && $$CRI_BIN push $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
 
 container-push-functest:
-	docker push $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)
+	podman push $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)
 
 container-push-artifacts-server:
-	docker push $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG)
+	podman push $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG)
 
 cluster-up:
 	./cluster/up.sh

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ VIRT_ARTIFACTS_SERVER ?= $(REGISTRY_NAMESPACE)/virt-artifacts-server
 
 # Prow doesn't have docker command
 DO=./hack/in-docker.sh
-ifeq (, $(shell which docker))
+ifeq (, $(shell (which docker 2> /dev/null || which podman 2> /dev/null)))
 DO=eval
 export JOB_TYPE=prow
 endif

--- a/Makefile
+++ b/Makefile
@@ -81,12 +81,10 @@ hack-clean: ## Run ./hack/clean.sh
 container-build: container-build-operator container-build-webhook container-build-operator-courier container-build-functest container-build-artifacts-server
 
 container-build-operator:
-	source "hack/cri-bin.sh"
-	$CRI_BIN build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	source "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-build-webhook:
-	source "hack/cri-bin.sh"
-	$CRI_BIN build -f build/Dockerfile.webhook -t $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	source "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile.webhook -t $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-build-operator-courier:
 	docker build -f tools/operator-courier/Dockerfile -t hco-courier .
@@ -106,12 +104,10 @@ quay-login:
 	docker login $(IMAGE_REGISTRY) -u $(QUAY_USERNAME) -p $(QUAY_PASSWORD)
 
 container-push-operator:
-	source "hack/cri-bin.sh"
-    $CRI_BIN push $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG)
+	source "hack/cri-bin.sh" && $$CRI_BIN push $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG)
 
 container-push-webhook:
-	source "hack/cri-bin.sh"
-    $CRI_BIN push $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
+	source "hack/cri-bin.sh" && $$CRI_BIN push $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
 
 container-push-functest:
 	docker push $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,10 @@ hack-clean: ## Run ./hack/clean.sh
 container-build: container-build-operator container-build-webhook container-build-operator-courier container-build-functest container-build-artifacts-server
 
 container-build-operator:
-	source "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	. "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-build-webhook:
-	source "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile.webhook -t $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	. "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile.webhook -t $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-build-operator-courier:
 	podman build -f tools/operator-courier/Dockerfile -t hco-courier .
@@ -104,10 +104,10 @@ quay-login:
 	podman login $(IMAGE_REGISTRY) -u $(QUAY_USERNAME) -p $(QUAY_PASSWORD)
 
 container-push-operator:
-	source "hack/cri-bin.sh" && $$CRI_BIN push $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG)
+	. "hack/cri-bin.sh" && $$CRI_BIN push $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG)
 
 container-push-webhook:
-	source "hack/cri-bin.sh" && $$CRI_BIN push $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
+	. "hack/cri-bin.sh" && $$CRI_BIN push $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
 
 container-push-functest:
 	podman push $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,12 @@ hack-clean: ## Run ./hack/clean.sh
 container-build: container-build-operator container-build-webhook container-build-operator-courier container-build-functest container-build-artifacts-server
 
 container-build-operator:
-	docker build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	source "hack/cri-bin.sh"
+	$CRI_BIN build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-build-webhook:
-	docker build -f build/Dockerfile.webhook -t $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	source "hack/cri-bin.sh"
+	$CRI_BIN build -f build/Dockerfile.webhook -t $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-build-operator-courier:
 	docker build -f tools/operator-courier/Dockerfile -t hco-courier .
@@ -104,10 +106,12 @@ quay-login:
 	docker login $(IMAGE_REGISTRY) -u $(QUAY_USERNAME) -p $(QUAY_PASSWORD)
 
 container-push-operator:
-	docker push $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG)
+	source "hack/cri-bin.sh"
+    $CRI_BIN push $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG)
 
 container-push-webhook:
-	docker push $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
+	source "hack/cri-bin.sh"
+    $CRI_BIN push $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
 
 container-push-functest:
 	docker push $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)

--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -33,9 +33,9 @@ go mod vendor
 build_date="$(date +%Y%m%d)"
 export IMAGE_REGISTRY=quay.io
 export IMAGE_TAG="nb_${build_date}_$(git show -s --format=%h)"
-export CONTAINER_PREFIX=kubevirtci
-TEMP_OPERATOR_IMAGE=${CONTAINER_PREFIX}/hyperconverged-cluster-operator
-TEMP_WEBHOOK_IMAGE=${CONTAINER_PREFIX}/hyperconverged-cluster-webhook
+export IMAGE_PREFIX=kubevirtci
+TEMP_OPERATOR_IMAGE=${IMAGE_PREFIX}/hyperconverged-cluster-operator
+TEMP_WEBHOOK_IMAGE=${IMAGE_PREFIX}/hyperconverged-cluster-webhook
 CSV_OPERATOR_IMAGE=${IMAGE_REGISTRY}/${TEMP_OPERATOR_IMAGE}
 CSV_WEBHOOK_IMAGE=${IMAGE_REGISTRY}/${TEMP_WEBHOOK_IMAGE}
 
@@ -55,9 +55,9 @@ HCO_WEBHOOK_IMAGE_DIGEST=$(tools/digester/digester --image ${CSV_WEBHOOK_IMAGE}:
 # Build the CSV
 HCO_OPERATOR_IMAGE=${HCO_OPERATOR_IMAGE_DIGEST} HCO_WEBHOOK_IMAGE=${HCO_WEBHOOK_IMAGE_DIGEST} ./hack/build-manifests.sh
 
-REGISTRY_NAMESPACE=${CONTAINER_PREFIX} CONTAINER_TAG=${IMAGE_TAG} make bundleRegistry
+REGISTRY_NAMESPACE=${IMAGE_PREFIX} CONTAINER_TAG=${IMAGE_TAG} make bundleRegistry
 hco_bucket="kubevirt-prow/devel/nightly/release/kubevirt/hyperconverged-cluster-operator"
 echo "${build_date}" > build-date
-echo "${IMAGE_REGISTRY}/${CONTAINER_PREFIX}/hco-container-registry:${IMAGE_TAG}" > hco-bundle
+echo "${IMAGE_REGISTRY}/${IMAGE_PREFIX}/hco-container-registry:${IMAGE_TAG}" > hco-bundle
 gsutil cp ./hco-bundle "gs://${hco_bucket}/${build_date}/hco-bundle-image"
 gsutil cp ./build-date gs://${hco_bucket}/latest

--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -2,8 +2,10 @@
 
 set -ex
 
+source "hack/cri-bin.sh"
+
 # Get golang
-docker login --username "$(cat "${QUAY_USER}")" --password-stdin quay.io < "${QUAY_PASSWORD}"
+$CRI_BIN login --username "$(cat "${QUAY_USER}")" --password-stdin quay.io < "${QUAY_PASSWORD}"
 wget -q https://dl.google.com/go/go1.17.3.linux-amd64.tar.gz
 tar -C /usr/local -xf go*.tar.gz
 export PATH=/usr/local/go/bin:$PATH
@@ -31,9 +33,9 @@ go mod vendor
 build_date="$(date +%Y%m%d)"
 export IMAGE_REGISTRY=quay.io
 export IMAGE_TAG="nb_${build_date}_$(git show -s --format=%h)"
-export DOCKER_PREFIX=kubevirtci
-TEMP_OPERATOR_IMAGE=${DOCKER_PREFIX}/hyperconverged-cluster-operator
-TEMP_WEBHOOK_IMAGE=${DOCKER_PREFIX}/hyperconverged-cluster-webhook
+export CONTAINER_PREFIX=kubevirtci
+TEMP_OPERATOR_IMAGE=${CONTAINER_PREFIX}/hyperconverged-cluster-operator
+TEMP_WEBHOOK_IMAGE=${CONTAINER_PREFIX}/hyperconverged-cluster-webhook
 CSV_OPERATOR_IMAGE=${IMAGE_REGISTRY}/${TEMP_OPERATOR_IMAGE}
 CSV_WEBHOOK_IMAGE=${IMAGE_REGISTRY}/${TEMP_WEBHOOK_IMAGE}
 
@@ -45,7 +47,6 @@ sed -i "s#quay.io/kubevirt/virt-#${kv_image/-*/-}#" deploy/images.csv
 sed -i "s#^KUBEVIRT_VERSION=.*#KUBEVIRT_VERSION=\"${kv_tag}\"#" hack/config
 (cd ./tools/digester && go build .)
 export HCO_VERSION="${IMAGE_TAG}"
-export DOCKER_API_VERSION=1.40
 ./automation/digester/update_images.sh
 
 HCO_OPERATOR_IMAGE_DIGEST=$(tools/digester/digester --image ${CSV_OPERATOR_IMAGE}:${IMAGE_TAG})
@@ -54,9 +55,9 @@ HCO_WEBHOOK_IMAGE_DIGEST=$(tools/digester/digester --image ${CSV_WEBHOOK_IMAGE}:
 # Build the CSV
 HCO_OPERATOR_IMAGE=${HCO_OPERATOR_IMAGE_DIGEST} HCO_WEBHOOK_IMAGE=${HCO_WEBHOOK_IMAGE_DIGEST} ./hack/build-manifests.sh
 
-REGISTRY_NAMESPACE=${DOCKER_PREFIX} CONTAINER_TAG=${IMAGE_TAG} make bundleRegistry
+REGISTRY_NAMESPACE=${CONTAINER_PREFIX} CONTAINER_TAG=${IMAGE_TAG} make bundleRegistry
 hco_bucket="kubevirt-prow/devel/nightly/release/kubevirt/hyperconverged-cluster-operator"
 echo "${build_date}" > build-date
-echo "${IMAGE_REGISTRY}/${DOCKER_PREFIX}/hco-container-registry:${IMAGE_TAG}" > hco-bundle
+echo "${IMAGE_REGISTRY}/${CONTAINER_PREFIX}/hco-container-registry:${IMAGE_TAG}" > hco-bundle
 gsutil cp ./hco-bundle "gs://${hco_bucket}/${build_date}/hco-bundle-image"
 gsutil cp ./build-date gs://${hco_bucket}/latest

--- a/hack/build-in-docker.sh
+++ b/hack/build-in-docker.sh
@@ -15,13 +15,13 @@ main() {
   local TEST_BUILD_TAG="${REGISTRY}/${BUILD_TAG}:${TAG}"
 
   # Build the encapsulated compile and test container
-  (cd "${BUILD_DIR}" && docker build --tag "${TEST_BUILD_TAG}" .)
+  (cd "${BUILD_DIR}" && $CRI_BIN build --tag "${TEST_BUILD_TAG}" .)
 
   if [[ ${PUSH_IMAGE} == "false" ]]; then
     exit 0
   fi
 
-  docker push "${TEST_BUILD_TAG}"
+  $CRI_BIN push "${TEST_BUILD_TAG}"
 
   echo "Successfully created and pushed new test utils image: ${TEST_BUILD_TAG}"
 
@@ -43,4 +43,6 @@ update_tag_in_pull_request() {
 }
 
 source hack/common.sh
+source hack/cri-bin.sh
+
 main "$@"

--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -40,16 +40,16 @@ function create_index_image() {
     INDEX_IMAGE_PARAM=--from-index="${PREV_INDEX_IMAGE}"
   fi
 
-  docker build -t "${BUNDLE_IMAGE_NAME}" -f bundle.Dockerfile --build-arg "VERSION=${CURRENT_VERSION}" .
-  docker push "${BUNDLE_IMAGE_NAME}"
+  podman build -t "${BUNDLE_IMAGE_NAME}" -f bundle.Dockerfile --build-arg "VERSION=${CURRENT_VERSION}" .
+  podman push "${BUNDLE_IMAGE_NAME}"
 
   # Referencing the unstable bundle digest in the index image, rather than the floating tag, to avoid
   # unalignment between cached index image and fetched bundle image.
   BUNDLE_IMAGE_NAME=$("${PROJECT_ROOT}/tools/digester/digester" --image "${BUNDLE_IMAGE_NAME}")
 
   # shellcheck disable=SC2086
-  ${OPM} index add --bundles "${BUNDLE_IMAGE_NAME}" ${INDEX_IMAGE_PARAM} --tag "${INDEX_IMAGE_NAME}" -u docker --mode semver
-  docker push "${INDEX_IMAGE_NAME}"
+  ${OPM} index add --bundles "${BUNDLE_IMAGE_NAME}" ${INDEX_IMAGE_PARAM} --tag "${INDEX_IMAGE_NAME}" -u podman --mode semver
+  podman push "${INDEX_IMAGE_NAME}"
 }
 
 function create_all_versions() {

--- a/hack/cri-bin.sh
+++ b/hack/cri-bin.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if podman ps >/dev/null; then
+    _cri_bin=podman
+    >&2 echo "selecting podman as container runtime"
+elif docker ps >/dev/null; then
+    _cri_bin=docker
+    >&2 echo "selecting docker as container runtime"
+else
+    >&2 echo "no working container runtime found. Neither docker nor podman seems to work."
+    exit 1
+fi
+
+CRI_BIN=${_cri_bin}

--- a/hack/in-docker.sh
+++ b/hack/in-docker.sh
@@ -3,6 +3,7 @@
 set -e
 
 source hack/common.sh
+source hack/cri-bin.sh
 
 HCO_DIR="$(readlink -f $(dirname $0)/../)"
 WORK_DIR="/go/src/github.com/kubevirt/hyperconverged-cluster-operator"
@@ -13,7 +14,7 @@ BUILD_TAG="${REGISTRY}/${REPOSITORY}:${TAG}"
 
 # Execute the build
 [ -t 1 ] && USE_TTY="-it"
-docker run ${USE_TTY} \
+$CRI_BIN run ${USE_TTY} \
     --rm \
     -v ${HCO_DIR}:${WORK_DIR}:rw,Z \
     -e RUN_UID=$(id -u) \

--- a/hack/kubevirt-nightly-build-images.sh
+++ b/hack/kubevirt-nightly-build-images.sh
@@ -28,8 +28,8 @@ go mod edit -require kubevirt.io/kubevirt@${LATEST_KUBEVIRT_COMMIT}
 go mod vendor
 KUBEVIRT_IMAGE=${LATEST_KUBEVIRT_IMAGE} hack/build-manifests.sh
 
-container_id=$(docker ps | grep kubevirtci | cut -d ' ' -f 1)
-registry_port=$(docker port $container_id | grep 5000 | cut -d ':' -f 2)
+container_id=$(podman ps | grep kubevirtci | cut -d ' ' -f 1)
+registry_port=$(podman port $container_id | grep 5000 | cut -d ':' -f 2)
 registry=localhost:$registry_port
 
 echo "INFO: registry: $registry"

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -11,7 +11,7 @@ function cleanup() {
 
 function lint() {
     local target_file="${1:?}"
-    docker run --rm --entrypoint=/bin/promtool \
+    podman run --rm --entrypoint=/bin/promtool \
         -v "$target_file":/tmp/rules.verify:ro "$PROM_IMAGE" \
         check rules /tmp/rules.verify
 }
@@ -19,7 +19,7 @@ function lint() {
 function unit_test() {
     local target_file="${1:?}"
     local tests_file="${2:?}"
-    docker run --rm --entrypoint=/bin/promtool \
+    podman run --rm --entrypoint=/bin/promtool \
         -v "$tests_file":/tmp/rules.test:ro \
         -v "$target_file":/tmp/rules.verify:ro \
         "$PROM_IMAGE" \

--- a/hack/upgrade-test-build-images.sh
+++ b/hack/upgrade-test-build-images.sh
@@ -19,8 +19,10 @@
 # Used only with the STDCI
 # Builds operator and registry images.
 
-container_id=$(docker ps | grep kubevirtci | cut -d ' ' -f 1)
-registry_port=$(docker port $container_id | grep 5000 | cut -d ':' -f 2)
+source hack/cri-bin.sh
+
+container_id=$($CRI_BIN ps | grep kubevirtci | cut -d ' ' -f 1)
+registry_port=$($CRI_BIN port $container_id | grep 5000 | cut -d ':' -f 2)
 registry=localhost:$registry_port
 
 echo "INFO: registry: $registry"

--- a/hack/upgrade-test-clusterserviceversion.sh
+++ b/hack/upgrade-test-clusterserviceversion.sh
@@ -12,9 +12,11 @@ CLUSTER_FILE=${CLUSTER_DIR}/kubevirt-hyperconverged-operator.v${UPGRADE_VERSION}
 
 echo ${CLUSTER_FILE}
 
-docker run --entrypoint ls  ${IMAGE_REGISTRY}/kubevirt/hco-registry-upgrade:${IMAGE_TAG} ${CLUSTER_DIR} || true
+source hack/cri-bin.sh
 
-docker run --entrypoint cat  ${IMAGE_REGISTRY}/kubevirt/hco-registry-upgrade:${IMAGE_TAG} ${CLUSTER_FILE} > ./test-out/clusterserviceversion.yaml
+$CRI_BIN run --entrypoint ls  ${IMAGE_REGISTRY}/kubevirt/hco-registry-upgrade:${IMAGE_TAG} ${CLUSTER_DIR} || true
+
+$CRI_BIN run --entrypoint cat  ${IMAGE_REGISTRY}/kubevirt/hco-registry-upgrade:${IMAGE_TAG} ${CLUSTER_FILE} > ./test-out/clusterserviceversion.yaml
 
 ls -al test-out
 

--- a/tools/operator-courier/push.sh
+++ b/tools/operator-courier/push.sh
@@ -32,7 +32,7 @@ echo "getting auth token from Quay"
 AUTH_TOKEN=$(/"${PROJECT_ROOT}"/tools/token.sh $QUAY_USERNAME $QUAY_PASSWORD)
 
 echo "pushing bundle"
-docker run \
+podman run \
 	-e QUAY_USERNAME="${QUAY_USERNAME}" \
 	-e QUAY_PASSWORD="${QUAY_PASSWORD}" \
 	-e QUAY_REPOSITORY="${REPO_DIR}" \


### PR DESCRIPTION
Docker updated its terms of use to require paid subscriptions for almost all users. We still require Docker tools for building and testing. This PR starts replacing the usage of Docker for Podman, a free open-source alternative, in order to reduce unnecessary subscription costs.

Right now, since some testing lanes use images that do not support podman usage yet, we are keeping Docker compatibility in some scripts.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace Docker commands with Podman
```

