### PR TITLE
Add cleanup before deletion of the operand CRs

### DIFF
--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -50,13 +50,5 @@ KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_defaults.sh
 # check golden images
 KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_golden_images.sh
 
-# TODO: workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2037312
-# remove once fixed
-echo "Explictly disabling CommonBootImageImport to be able to safely remove the product"
-./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n kubevirt-hyperconverged kubevirt-hyperconverged --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": false }]'"
-sleep 10
-./hack/retry.sh 10 30 "[[ $(${KUBECTL_BINARY} get DataImportCron -A --no-headers | wc -l) -eq 0 ]]"
-# ---
-
 # Check the webhook, to see if it allow deleteing of the HyperConverged CR
 ./hack/retry.sh 10 30 "${KUBECTL_BINARY} delete hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged"

--- a/hack/test_delete_ns.sh
+++ b/hack/test_delete_ns.sh
@@ -47,14 +47,6 @@ function test_delete_ns(){
         echo "Ignoring webhook on k8s where we don't have OLM based validating webhooks"
     fi
 
-    # TODO: workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2037312
-    # remove once fixed
-    echo "Explictly disabling CommonBootImageImport to be able to safely remove the product"
-    ./hack/retry.sh 10 3 "${CMD} patch hco -n kubevirt-hyperconverged kubevirt-hyperconverged --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": false }]'"
-    sleep 10
-    ./hack/retry.sh 10 30 "[[ $(${CMD} get DataImportCron -A --no-headers | wc -l) -eq 0 ]]"
-    # ---
-
     echo "Delete the hyperconverged CR to remove the product"
     timeout 10m ${CMD} delete hyperconverged -n kubevirt-hyperconverged kubevirt-hyperconverged
 

--- a/pkg/controller/commonTestUtils/testUtils.go
+++ b/pkg/controller/commonTestUtils/testUtils.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -20,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -266,5 +265,30 @@ func (ClusterInfoSRCPHAIMock) IsInfrastructureHighlyAvailable() bool {
 	return true
 }
 func (ClusterInfoSRCPHAIMock) GetDomain() string {
+	return "domain"
+}
+
+// ClusterInfoK8sMock mocks K8s cluster, with no OLM
+type ClusterInfoK8sMock struct{}
+
+func (ClusterInfoK8sMock) Init(_ context.Context, _ client.Client, _ logr.Logger) error {
+	return nil
+}
+func (ClusterInfoK8sMock) IsOpenshift() bool {
+	return false
+}
+func (ClusterInfoK8sMock) IsRunningLocally() bool {
+	return false
+}
+func (ClusterInfoK8sMock) IsManagedByOLM() bool {
+	return false
+}
+func (ClusterInfoK8sMock) IsControlPlaneHighlyAvailable() bool {
+	return true
+}
+func (ClusterInfoK8sMock) IsInfrastructureHighlyAvailable() bool {
+	return true
+}
+func (ClusterInfoK8sMock) GetDomain() string {
 	return "domain"
 }


### PR DESCRIPTION
workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2037312

This PR adds a cleanup operation upon deletion of the HyperConverged CR. Before deleting the operands CRs, HCO removes the dataImportCron templates from SSP.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2037312
```

