### PR TITLE
Fix reconcile not updating CR when cache misses when fetching

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -21,8 +21,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -175,48 +173,9 @@ func main() {
 // Restricts the cache's ListWatch to specific fields/labels per GVK at the specified object to control the memory impact
 // this is used to completely overwrite the NewCache function so all the interesting objects should be explicitly listed here
 func getNewManagerCache(operatorNamespace string) cache.NewCacheFunc {
-	namespaceSelector := fields.Set{"metadata.namespace": operatorNamespace}.AsSelector()
-	labelSelector := labels.Set{hcoutil.AppLabel: hcoutil.HyperConvergedName}.AsSelector()
 	return cache.BuilderWithOptions(
 		cache.Options{
-			SelectorsByObject: cache.SelectorsByObject{
-				&hcov1beta1.HyperConverged{}:           {},
-				&kubevirtcorev1.KubeVirt{}:             {},
-				&cdiv1beta1.CDI{}:                      {},
-				&networkaddonsv1.NetworkAddonsConfig{}: {},
-				&sspv1beta1.SSP{}:                      {},
-				&schedulingv1.PriorityClass{}: {
-					Label: labels.SelectorFromSet(labels.Set{hcoutil.AppLabel: hcoutil.HyperConvergedName}),
-				},
-				&corev1.ConfigMap{}: {
-					Label: labelSelector,
-				},
-				&corev1.Service{}: {
-					Field: namespaceSelector,
-				},
-				&monitoringv1.ServiceMonitor{}: {
-					Label: labelSelector,
-					Field: namespaceSelector,
-				},
-				&monitoringv1.PrometheusRule{}: {
-					Label: labelSelector,
-					Field: namespaceSelector,
-				},
-				&rbacv1.Role{}: {
-					Label: labelSelector,
-					Field: namespaceSelector,
-				},
-				&rbacv1.RoleBinding{}: {
-					Label: labelSelector,
-					Field: namespaceSelector,
-				},
-				&openshiftroutev1.Route{}: {
-					Field: namespaceSelector,
-				},
-				&imagev1.ImageStream{}: {
-					Label: labelSelector,
-				},
-			},
+			SelectorsByObject: cmdcommon.GetCacheSelectorsByObject(operatorNamespace),
 		},
 	)
 }


### PR DESCRIPTION
If `app` label is removed in `kubevirt-cluster-critical` PriorityClass, since this label is used as a selector for cache, when the hco reconcile loop tries to revert the change, it is not able to fetch the resource, then it tries to recreate it which is throwing an `already exists` error causing the operator to go into an "Reconcile Failed" condition, and the PriorityClass not being reverted.

In this PR, when recreating a resource to revert a change, if we catch an `already exists` error, we then try to update it even if the previous fetch resource action failed.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix reconcile not updating CR when cache misses when fetching
```

