### PR TITLE
[release-1.6] Opt-out from cluster-wide default node selector (#1799)

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -180,6 +180,7 @@ func main() {
 func getNewManagerCache(operatorNamespace string) cache.NewCacheFunc {
 	namespaceSelector := fields.Set{"metadata.namespace": operatorNamespace}.AsSelector()
 	labelSelector := labels.Set{hcoutil.AppLabel: hcoutil.HyperConvergedName}.AsSelector()
+	labelSelectorForNamespace := labels.Set{hcoutil.KubernetesMetadataName: operatorNamespace}.AsSelector()
 	return cache.BuilderWithOptions(
 		cache.Options{
 			SelectorsByObject: cache.SelectorsByObject{
@@ -218,6 +219,9 @@ func getNewManagerCache(operatorNamespace string) cache.NewCacheFunc {
 				},
 				&imagev1.ImageStream{}: {
 					Label: labelSelector,
+				},
+				&corev1.Namespace{}: {
+					Label: labelSelectorForNamespace,
 				},
 			},
 		},

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -467,6 +467,16 @@ rules:
   - list
   - delete
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
@@ -299,6 +299,16 @@ spec:
           - list
           - delete
         - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
           - apps
           resources:
           - deployments
@@ -3270,7 +3280,7 @@ spec:
     generateName: mutate-ns-hco.kubevirt.io
     objectSelector:
       matchLabels:
-        name: kubevirt-hyperconverged
+        kubernetes.io/metadata.name: kubevirt-hyperconverged
     rules:
     - apiGroups:
       - ""

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.6.0-unstable
-    createdAt: "2022-02-16 10:12:22"
+    createdAt: "2022-03-13 21:00:31"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -298,6 +298,16 @@ spec:
           - get
           - list
           - delete
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
         - apiGroups:
           - apps
           resources:
@@ -3270,7 +3280,7 @@ spec:
     generateName: mutate-ns-hco.kubevirt.io
     objectSelector:
       matchLabels:
-        name: kubevirt-hyperconverged
+        kubernetes.io/metadata.name: kubevirt-hyperconverged
     rules:
     - apiGroups:
       - ""

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -453,6 +453,11 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 			Verbs:     stringListToSlice("get", "list", "delete"),
 		},
 		{
+			APIGroups: emptyAPIGroup,
+			Resources: stringListToSlice("namespaces"),
+			Verbs:     stringListToSlice("get", "list", "watch", "patch", "update"),
+		},
+		{
 			APIGroups: stringListToSlice("apps"),
 			Resources: stringListToSlice("deployments", "replicasets"),
 			Verbs:     stringListToSlice("get", "list"),
@@ -776,7 +781,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 		FailurePolicy:           &failurePolicy,
 		TimeoutSeconds:          &webhookTimeout,
 		ObjectSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{"name": params.Namespace},
+			MatchLabels: map[string]string{util.KubernetesMetadataName: params.Namespace},
 		},
 		Rules: []admissionregistrationv1.RuleWithOperations{
 			{

--- a/pkg/controller/commonTestUtils/testUtils.go
+++ b/pkg/controller/commonTestUtils/testUtils.go
@@ -57,6 +57,14 @@ func NewHco() *hcov1beta1.HyperConverged {
 	return hco
 }
 
+func NewHcoNamespace() *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: Namespace,
+		},
+	}
+}
+
 func NewReq(inst *hcov1beta1.HyperConverged) *common.HcoRequest {
 	return &common.HcoRequest{
 		Request:      TestRequest,

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -178,6 +178,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo) er
 			&routev1.Route{},
 			&consolev1.ConsoleCLIDownload{},
 			&imagev1.ImageStream{},
+			&corev1.Namespace{},
 		}...)
 	}
 

--- a/pkg/controller/hyperconverged/testUtils_test.go
+++ b/pkg/controller/hyperconverged/testUtils_test.go
@@ -104,6 +104,7 @@ func validateOperatorCondition(r *ReconcileHyperConverged, status metav1.Conditi
 }
 
 type BasicExpected struct {
+	namespace            *corev1.Namespace
 	hco                  *hcov1beta1.HyperConverged
 	pc                   *schedulingv1.PriorityClass
 	kvStorageConfig      *corev1.ConfigMap
@@ -127,6 +128,7 @@ type BasicExpected struct {
 
 func (be BasicExpected) toArray() []runtime.Object {
 	return []runtime.Object{
+		be.namespace,
 		be.hco,
 		be.pc,
 		be.kvStorageConfig,
@@ -184,6 +186,15 @@ func getBasicDeployment() *BasicExpected {
 	res.hco = hco
 
 	components.GetOperatorCR().Spec.DeepCopyInto(&res.hco.Spec)
+
+	res.namespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hco.Namespace,
+			Annotations: map[string]string{
+				hcoutil.OpenshiftNodeSelectorAnn: "",
+			},
+		},
+	}
 
 	res.pc = operands.NewKubeVirtPriorityClass(hco)
 	res.mService = operands.NewMetricsService(hco, namespace)

--- a/pkg/controller/operands/imageStream_test.go
+++ b/pkg/controller/operands/imageStream_test.go
@@ -119,10 +119,11 @@ var _ = Describe("imageStream tests", func() {
 				return testFilesLocation
 			}
 
+			hcoNamespace := commonTestUtils.NewHcoNamespace()
 			hco := commonTestUtils.NewHco()
 			hco.Spec.FeatureGates.EnableCommonBootImageImport = true
 			eventEmitter := commonTestUtils.NewEventEmitterMock()
-			cli := commonTestUtils.InitClient([]runtime.Object{hco})
+			cli := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), true, hco)
 
@@ -183,8 +184,9 @@ var _ = Describe("imageStream tests", func() {
 				return testFilesLocation
 			}
 
+			hcoNamespace := commonTestUtils.NewHcoNamespace()
 			hco := commonTestUtils.NewHco()
-			cli := commonTestUtils.InitClient([]runtime.Object{hco})
+			cli := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 
 			eventEmitter := commonTestUtils.NewEventEmitterMock()
 			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)

--- a/pkg/controller/operands/namespace.go
+++ b/pkg/controller/operands/namespace.go
@@ -1,0 +1,78 @@
+package operands
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+)
+
+// Handles a specific resource (a CR, a configMap and so on), to be run during reconciliation
+type namespaceHandler struct {
+	// K8s client
+	Client client.Client
+	Scheme *runtime.Scheme
+}
+
+func newNamespaceHandler(Client client.Client, Scheme *runtime.Scheme) *namespaceHandler {
+	return &namespaceHandler{
+		Client: Client,
+		Scheme: Scheme,
+	}
+}
+
+func (h *namespaceHandler) ensure(req *common.HcoRequest) *EnsureResult {
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: req.Instance.Namespace,
+		},
+	}
+	key := client.ObjectKeyFromObject(namespace)
+	found := &corev1.Namespace{}
+	err := h.Client.Get(req.Ctx, key, found)
+	if err != nil {
+		req.Logger.Error(err, "failed fetching namespace")
+		return &EnsureResult{
+			Err: err,
+		}
+	}
+	res := NewEnsureResult(found)
+	res.SetName(key.Name)
+
+	needUpdate := false
+	if found.Annotations == nil {
+		found.Annotations = make(map[string]string)
+	}
+	if found_v, hasKey := found.Annotations[hcoutil.OpenshiftNodeSelectorAnn]; !hasKey || found_v != "" {
+		found.Annotations[hcoutil.OpenshiftNodeSelectorAnn] = ""
+		needUpdate = true
+	}
+
+	if needUpdate {
+		if req.HCOTriggered {
+			req.Logger.Info("Updating existing namespace to new opinionated values")
+		} else {
+			req.Logger.Info("Reconciling an externally updated namespace to its opinionated values")
+		}
+		err := h.Client.Update(req.Ctx, found)
+		if err != nil {
+			if err != nil {
+				req.Logger.Error(err, "failed updating the namespace")
+				return &EnsureResult{
+					Err: err,
+				}
+			}
+		}
+		res.SetUpdated()
+		res.SetOverwritten(!req.HCOTriggered)
+		return res
+	}
+
+	return res.SetUpgradeDone(req.ComponentUpgradeInProgress)
+}
+
+func (h namespaceHandler) reset( /* No implementation */ ) {}

--- a/pkg/controller/operands/namespace_test.go
+++ b/pkg/controller/operands/namespace_test.go
@@ -1,0 +1,105 @@
+package operands
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/pkg/apis/hco/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/controller/commonTestUtils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("Namespace Operand", func() {
+	Context("Namespace", func() {
+
+		var hco *hcov1beta1.HyperConverged
+		var req *common.HcoRequest
+		customAnnotation := "customAnnotation"
+		customValue := "customValue"
+
+		BeforeEach(func() {
+			hco = commonTestUtils.NewHco()
+			req = commonTestUtils.NewReq(hco)
+		})
+
+		It("should reconcile selected annotations to default", func() {
+			existingResource := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: hco.Namespace,
+					Annotations: map[string]string{
+						hcoutil.OpenshiftNodeSelectorAnn: "",
+					},
+				},
+			}
+			existingResource.Annotations[hcoutil.OpenshiftNodeSelectorAnn] = customValue
+			existingResource.Annotations[customAnnotation] = customValue
+
+			req.HCOTriggered = false
+
+			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+			handler := newNamespaceHandler(cl, commonTestUtils.GetScheme())
+			res := handler.ensure(req)
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Overwritten).To(BeTrue())
+			Expect(res.UpgradeDone).To(BeFalse())
+			Expect(res.Err).To(BeNil())
+
+			foundResource := &corev1.Namespace{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+					foundResource),
+			).To(BeNil())
+			Expect(foundResource.Annotations[hcoutil.OpenshiftNodeSelectorAnn]).To(Not(BeIdenticalTo(customValue)))
+			Expect(foundResource.Annotations[hcoutil.OpenshiftNodeSelectorAnn]).To(BeIdenticalTo(""))
+			Expect(foundResource.Annotations[customAnnotation]).To(BeIdenticalTo(customValue))
+
+		})
+
+		It("should add 'openshift.io/node-selector' annotation if missing", func() {
+			existingResource := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: hco.Namespace,
+					Annotations: map[string]string{
+						hcoutil.OpenshiftNodeSelectorAnn: "",
+					},
+				},
+			}
+			delete(existingResource.Annotations, hcoutil.OpenshiftNodeSelectorAnn)
+			Expect(existingResource.Annotations).To(Not(HaveKey(hcoutil.OpenshiftNodeSelectorAnn)))
+
+			req.HCOTriggered = true
+
+			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+			handler := newNamespaceHandler(cl, commonTestUtils.GetScheme())
+			res := handler.ensure(req)
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Overwritten).To(BeFalse())
+			Expect(res.UpgradeDone).To(BeFalse())
+			Expect(res.Err).To(BeNil())
+
+			foundResource := &corev1.Namespace{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+					foundResource),
+			).To(BeNil())
+			Expect(foundResource.Annotations).To(HaveKey(hcoutil.OpenshiftNodeSelectorAnn))
+			Expect(foundResource.Annotations[hcoutil.OpenshiftNodeSelectorAnn]).To(BeIdenticalTo(""))
+
+		})
+
+	})
+
+})

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -63,6 +63,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, isOpenshift
 			(*genericOperand)(newCliDownloadHandler(client, scheme)),
 			(*genericOperand)(newCliDownloadsRouteHandler(client, scheme)),
 			(*genericOperand)(newCliDownloadsServiceHandler(client, scheme)),
+			newNamespaceHandler(client, scheme),
 		}...)
 	}
 

--- a/pkg/controller/operands/operandHandler_test.go
+++ b/pkg/controller/operands/operandHandler_test.go
@@ -25,13 +25,20 @@ var _ = Describe("Test operandHandler", func() {
 	Context("Test operandHandler", func() {
 		testFileLocation := getTestFilesLocation()
 
-		_ = os.Setenv(quickStartManifestLocationVarName, testFileLocation+"/quickstarts")
-		_ = os.Setenv(dashboardManifestLocationVarName, testFileLocation+"/dashboards")
-		_ = os.Setenv("VIRTIOWIN_CONTAINER", "just-a-value:version")
+		var (
+			hcoNamespace *corev1.Namespace
+		)
+
+		BeforeEach(func() {
+			_ = os.Setenv(quickStartManifestLocationVarName, testFileLocation+"/quickstarts")
+			_ = os.Setenv(dashboardManifestLocationVarName, testFileLocation+"/dashboards")
+			_ = os.Setenv("VIRTIOWIN_CONTAINER", "just-a-value:version")
+			hcoNamespace = commonTestUtils.NewHcoNamespace()
+		})
 
 		It("should create all objects are created", func() {
 			hco := commonTestUtils.NewHco()
-			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+			cli := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, qsCrd, hco})
 
 			eventEmitter := commonTestUtils.NewEventEmitterMock()
 
@@ -153,7 +160,7 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("should handle errors on ensure loop", func() {
 			hco := commonTestUtils.NewHco()
-			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+			cli := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, qsCrd, hco})
 
 			eventEmitter := commonTestUtils.NewEventEmitterMock()
 
@@ -195,7 +202,7 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("make sure the all objects are deleted", func() {
 			hco := commonTestUtils.NewHco()
-			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+			cli := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, qsCrd, hco})
 
 			eventEmitter := commonTestUtils.NewEventEmitterMock()
 			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
@@ -287,7 +294,7 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("delete KV error handling", func() {
 			hco := commonTestUtils.NewHco()
-			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+			cli := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, qsCrd, hco})
 
 			eventEmitter := commonTestUtils.NewEventEmitterMock()
 
@@ -337,7 +344,7 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("delete CDI error handling", func() {
 			hco := commonTestUtils.NewHco()
-			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+			cli := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, qsCrd, hco})
 
 			eventEmitter := commonTestUtils.NewEventEmitterMock()
 			handler := NewOperandHandler(cli, commonTestUtils.GetScheme(), true, eventEmitter)
@@ -387,7 +394,7 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("default delete error handling", func() {
 			hco := commonTestUtils.NewHco()
-			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+			cli := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, qsCrd, hco})
 
 			fakeError := fmt.Errorf("fake CNA deletion error")
 			eventEmitter := commonTestUtils.NewEventEmitterMock()
@@ -438,7 +445,7 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("delete timeout error handling", func() {
 			hco := commonTestUtils.NewHco()
-			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd, hco})
+			cli := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, qsCrd, hco})
 
 			eventEmitter := commonTestUtils.NewEventEmitterMock()
 

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -37,7 +37,9 @@ const (
 	// Operator name for managed-by label
 	OperatorName = "hco-operator"
 	// Value for "part-of" label
-	HyperConvergedCluster = "hyperconverged-cluster"
+	HyperConvergedCluster    = "hyperconverged-cluster"
+	OpenshiftNodeSelectorAnn = "openshift.io/node-selector"
+	KubernetesMetadataName   = "kubernetes.io/metadata.name"
 
 	// HyperConvergedName is the name of the HyperConverged resource that will be reconciled
 	HyperConvergedName          = "kubevirt-hyperconverged"


### PR DESCRIPTION
The hyperconverged cluster operator defines
its own node selectors APIs that schedules
deployments and daemon sets on nodes according to
infra and workload classification.
Opting out from cluster-wide default node selector
on Openshift setting a specific annotation
(openshift.io/node-selector=) to prevent conflicts.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2055950

This is a manual cherry-pick of #1799

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Opt-out from cluster-wide default node selector
```

