### PR TITLE
Ignore sriovLiveMigration FG on SNO

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -232,7 +232,7 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=false
 	WithHostPassthroughCPU bool `json:"withHostPassthroughCPU"`
 
-	// Allow migrating a virtual machine with SRIOV interfaces.
+	// Allow migrating a virtual machine with SRIOV interfaces. Ignored on single node clusters.
 	// +optional
 	// +kubebuilder:default=true
 	SRIOVLiveMigration bool `json:"sriovLiveMigration"`

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -869,6 +869,7 @@ spec:
                   sriovLiveMigration:
                     default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
+                      Ignored on single node clusters.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -520,7 +520,7 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) [
 		fgs = append(fgs, kvWithHostPassthroughCPU)
 	}
 
-	if featureGates.SRIOVLiveMigration {
+	if featureGates.SRIOVLiveMigration && hcoutil.GetClusterInfo().IsInfrastructureHighlyAvailable() {
 		fgs = append(fgs, kvSRIOVLiveMigration)
 	}
 

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -869,6 +869,7 @@ spec:
                   sriovLiveMigration:
                     default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
+                      Ignored on single node clusters.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
@@ -869,6 +869,7 @@ spec:
                   sriovLiveMigration:
                     default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
+                      Ignored on single node clusters.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
@@ -869,6 +869,7 @@ spec:
                   sriovLiveMigration:
                     default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
+                      Ignored on single node clusters.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/docs/api.md
+++ b/docs/api.md
@@ -90,7 +90,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here | bool | false | true |
-| sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. | bool | true | true |
+| sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. Ignored on single node clusters. | bool | true | true |
 | enableCommonBootImageImport | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | bool | true | true |
 
 [Back to TOC](#table-of-contents)

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -143,7 +143,7 @@ Additional information: [LibvirtXMLCPUModel](https://wiki.openstack.org/wiki/Lib
 
 Set the `sriovLiveMigration` feature gate in order to allow migrating a virtual machine with SRIOV interfaces. When
 enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability. This may
-degrade virt-launcher security.
+degrade virt-launcher security. `sriovLiveMigration` is ignored on single node clusters.
 
 **Default**: `true`
 


### PR DESCRIPTION
The default value of sriovLiveMigration is
true but the value is meaningless on SNO
cluster, let's simply ignore it:
the CRD defaulting mechanism on the
APIServer is not so flexible to allow to
specify a default based on the cluster topology.
On the other side, validating it with the webhook is overkilling
for users that simply expect to have the simplest possible
CR always accepted.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2062227

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ignore sriovLiveMigration FG on SNO
```

