### PR TITLE
Filter out LiveMigrate workloadUpdateMethod on SNO

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -357,6 +357,7 @@ type HyperConvergedWorkloadUpdateStrategy struct {
 	// precedence over more disruptive methods. For example if both LiveMigrate and Evict
 	// methods are listed, only VMs which are not live migratable will be restarted/shutdown.
 	// An empty list defaults to no automated workload updating.
+	// LiveMigrate is ignored on SNO clusters.
 	//
 	// +listType=atomic
 	// +kubebuilder:default={"LiveMigrate"}

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2148,7 +2148,8 @@ spec:
                       takes precedence over more disruptive methods. For example if
                       both LiveMigrate and Evict methods are listed, only VMs which
                       are not live migratable will be restarted/shutdown. An empty
-                      list defaults to no automated workload updating.
+                      list defaults to no automated workload updating. LiveMigrate
+                      is ignored on SNO clusters.
                     items:
                       type: string
                     type: array

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2148,7 +2148,8 @@ spec:
                       takes precedence over more disruptive methods. For example if
                       both LiveMigrate and Evict methods are listed, only VMs which
                       are not live migratable will be restarted/shutdown. An empty
-                      list defaults to no automated workload updating.
+                      list defaults to no automated workload updating. LiveMigrate
+                      is ignored on SNO clusters.
                     items:
                       type: string
                     type: array

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
@@ -2148,7 +2148,8 @@ spec:
                       takes precedence over more disruptive methods. For example if
                       both LiveMigrate and Evict methods are listed, only VMs which
                       are not live migratable will be restarted/shutdown. An empty
-                      list defaults to no automated workload updating.
+                      list defaults to no automated workload updating. LiveMigrate
+                      is ignored on SNO clusters.
                     items:
                       type: string
                     type: array

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
@@ -2148,7 +2148,8 @@ spec:
                       takes precedence over more disruptive methods. For example if
                       both LiveMigrate and Evict methods are listed, only VMs which
                       are not live migratable will be restarted/shutdown. An empty
-                      list defaults to no automated workload updating.
+                      list defaults to no automated workload updating. LiveMigrate
+                      is ignored on SNO clusters.
                     items:
                       type: string
                     type: array

--- a/docs/api.md
+++ b/docs/api.md
@@ -164,7 +164,7 @@ HyperConvergedWorkloadUpdateStrategy defines options related to updating a KubeV
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| workloadUpdateMethods | WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Evict methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. | []string | {"LiveMigrate"} | false |
+| workloadUpdateMethods | WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Evict methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. LiveMigrate is ignored on SNO clusters. | []string | {"LiveMigrate"} | false |
 | batchEvictionSize | BatchEvictionSize Represents the number of VMIs that can be forced updated per the BatchShutdownInteral interval | *int | 10 | false |
 | batchEvictionInterval | BatchEvictionInterval Represents the interval to wait before issuing the next batch of shutdowns | *metav1.Duration | "1m0s" | false |
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -508,6 +508,7 @@ The `workloadUpdateStrategy` fields are:
   An empty list defaults to no automated workload updating.
 
   The default values is `LiveMigrate`; `Evict` is not enabled by default being potentially disruptive for the existing workloads.
+* `LiveMigrate` is ignored on SNO clusters where LiveMigrate is not supported.
 
 ### workloadUpdateStrategy example
 ```yaml


### PR DESCRIPTION
Explicitly filter out LiveMigrate
workloadUpdateMethod on SNO clusters.
On SNO cluster Live Migration FG is globally
disabled because we have a single worker node
but still we allow the user (and it's
the default) to pass
workloadUpdateMethod=["LiveMigrate"]
and this causes an infinite loop in
the upgrade handler in virt-controller
that currently ignores the LiveMigration FG.
Let's explicitly filter out LiveMigrate
workloadUpdateMethod to prevent the issue.

Bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=2065308

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Filter out LiveMigrate workloadUpdateMethod on SNO
```

