### PR TITLE
[release-1.6] Remove leftovers during upgrades (#1824)

### DIFF
--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -38,5 +38,31 @@
         }
       ]
     }
+  ],
+  "objectsToBeRemoved": [
+    {
+      "semverRange": "<=1.6.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "v1",
+        "kind": "ConfigMap"
+      },
+      "objectKey": {
+        "name": "v2v-vmware",
+        "namespace": "kubevirt-hyperconverged"
+      }
+    },
+    {
+      "semverRange": "<=1.6.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "v1",
+        "kind": "ConfigMap"
+      },
+      "objectKey": {
+        "name": "vm-import-controller-config",
+        "namespace": "kubevirt-hyperconverged"
+      }
+    }
   ]
 }

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/blang/semver/v4"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/google/uuid"
@@ -264,6 +266,11 @@ func (r *ReconcileHyperConverged) Reconcile(ctx context.Context, request reconci
 
 	if r.firstLoop {
 		r.firstLoopInitialization(hcoRequest)
+		if err := validateUpgradePatches(hcoRequest); err != nil {
+			logger.Error(err, "Failed validating upgrade patches file")
+			r.eventEmitter.EmitEvent(hcoRequest.Instance, corev1.EventTypeWarning, "Failed validating upgrade patches file", err.Error())
+			os.Exit(1)
+		}
 	}
 
 	result, err := r.doReconcile(hcoRequest)
@@ -355,7 +362,6 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 		// get into upgrade mode
 
 		r.upgradeMode = true
-
 		r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "UpgradeHCO", "Upgrading the HyperConverged to version "+r.ownVersion)
 		req.Logger.Info(fmt.Sprintf("Start upgrading from version %s to version %s", knownHcoVersion, r.ownVersion))
 	}
@@ -1074,6 +1080,13 @@ func (r ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (bo
 		}
 	}
 
+	for _, p := range hcoUpgradeChanges.ObjectsToBeRemoved {
+		removed, err := r.removeLeftover(req, knownHcoSV, p)
+		if err != nil {
+			return removed, err
+		}
+	}
+
 	tmpInstance := &hcov1beta1.HyperConverged{}
 	err = json.Unmarshal(hcoJson, tmpInstance)
 	if err != nil {
@@ -1107,6 +1120,31 @@ func (r ReconcileHyperConverged) applyUpgradePatch(req *common.HcoRequest, hcoJs
 		return patchedBytes, nil
 	}
 	return hcoJson, nil
+}
+
+func (r ReconcileHyperConverged) removeLeftover(req *common.HcoRequest, knownHcoSV semver.Version, p objectToBeRemoved) (bool, error) {
+
+	affectedRange, err := semver.ParseRange(p.SemverRange)
+	if err != nil {
+		return false, err
+	}
+	if affectedRange(knownHcoSV) {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(p.GroupVersionKind)
+		gerr := r.client.Get(req.Ctx, p.ObjectKey, u)
+		if gerr != nil {
+			if apierrors.IsNotFound(gerr) {
+				return false, nil
+			} else {
+				req.Logger.Error(gerr, "failed looking for leftovers", "objectToBeRemoved", p)
+				return false, gerr
+			}
+		}
+		removeRelatedObject(req, p.GroupVersionKind, p.ObjectKey)
+		return r.deleteObj(req, u, false)
+
+	}
+	return false, nil
 }
 
 var (
@@ -1145,7 +1183,7 @@ func (r ReconcileHyperConverged) removeOldMetricsObjs(req *common.HcoRequest) er
 	initOldMetricsObjects(req)
 
 	for name, object := range oldMetricsObjects {
-		removed, err := r.deleteObj(req, object)
+		removed, err := r.deleteObj(req, object, true)
 
 		if err != nil {
 			return err
@@ -1159,8 +1197,8 @@ func (r ReconcileHyperConverged) removeOldMetricsObjs(req *common.HcoRequest) er
 	return nil
 }
 
-func (r *ReconcileHyperConverged) deleteObj(req *common.HcoRequest, obj client.Object) (bool, error) {
-	removed, err := hcoutil.EnsureDeleted(req.Ctx, r.client, obj, req.Instance.Name, req.Logger, false, false)
+func (r *ReconcileHyperConverged) deleteObj(req *common.HcoRequest, obj client.Object, protectNonHCOObjects bool) (bool, error) {
+	removed, err := hcoutil.EnsureDeleted(req.Ctx, r.client, obj, req.Instance.Name, req.Logger, false, false, protectNonHCOObjects)
 
 	if err != nil {
 		req.Logger.Error(
@@ -1200,7 +1238,7 @@ func removeOldQuickStartGuides(req *common.HcoRequest, cl client.Client, require
 		for name, existQs := range existingQSNames {
 			if !hcoutil.ContainsString(requiredQSList, name) {
 				req.Logger.Info("deleting ConsoleQuickStart", "name", name)
-				if _, err = hcoutil.EnsureDeleted(req.Ctx, cl, &existQs, req.Instance.Name, req.Logger, false, false); err != nil {
+				if _, err = hcoutil.EnsureDeleted(req.Ctx, cl, &existQs, req.Instance.Name, req.Logger, false, false, true); err != nil {
 					req.Logger.Error(err, "failed to delete ConsoleQuickStart", "name", name)
 				}
 			}
@@ -1226,6 +1264,25 @@ func removeRelatedQSObjects(req *common.HcoRequest, requiredNames []string) {
 	}
 
 	if foundOldQs {
+		req.Instance.Status.RelatedObjects = refs
+		req.StatusDirty = true
+	}
+
+}
+
+func removeRelatedObject(req *common.HcoRequest, gvk schema.GroupVersionKind, objectKey types.NamespacedName) {
+	refs := make([]corev1.ObjectReference, 0, len(req.Instance.Status.RelatedObjects))
+	foundRO := false
+
+	for _, obj := range req.Instance.Status.RelatedObjects {
+		if obj.GroupVersionKind() == gvk && obj.Namespace == objectKey.Namespace && obj.Name == objectKey.Name {
+			foundRO = true
+			continue
+		}
+		refs = append(refs, obj)
+	}
+
+	if foundRO {
 		req.Instance.Status.RelatedObjects = refs
 		req.StatusDirty = true
 	}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badObject1.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badObject1.json
@@ -1,0 +1,16 @@
+{
+  "objectsToBeRemoved": [
+    {
+      "semverRange": "<=1.6.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "v1",
+        "kind": ""
+      },
+      "objectKey": {
+        "name": "v2v-vmware",
+        "namespace": "kubevirt-hyperconverged"
+      }
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badObject1m.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badObject1m.json
@@ -1,0 +1,15 @@
+{
+  "objectsToBeRemoved": [
+    {
+      "semverRange": "<=1.6.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "v1"
+      },
+      "objectKey": {
+        "name": "v2v-vmware",
+        "namespace": "kubevirt-hyperconverged"
+      }
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badObject2.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badObject2.json
@@ -1,0 +1,16 @@
+{
+  "objectsToBeRemoved": [
+    {
+      "semverRange": "<=1.6.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "",
+        "kind": "ConfigMap"
+      },
+      "objectKey": {
+        "name": "v2v-vmware",
+        "namespace": "kubevirt-hyperconverged"
+      }
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badObject2m.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badObject2m.json
@@ -1,0 +1,15 @@
+{
+  "objectsToBeRemoved": [
+    {
+      "semverRange": "<=1.6.0",
+      "groupVersionKind": {
+        "group": "",
+        "kind": "ConfigMap"
+      },
+      "objectKey": {
+        "name": "v2v-vmware",
+        "namespace": "kubevirt-hyperconverged"
+      }
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badObject3.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badObject3.json
@@ -1,0 +1,16 @@
+{
+  "objectsToBeRemoved": [
+    {
+      "semverRange": "<=1.6.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "v1",
+        "kind": "ConfigMap"
+      },
+      "objectKey": {
+        "name": "",
+        "namespace": "kubevirt-hyperconverged"
+      }
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badObject3m.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badObject3m.json
@@ -1,0 +1,15 @@
+{
+  "objectsToBeRemoved": [
+    {
+      "semverRange": "<=1.6.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "v1",
+        "kind": "ConfigMap"
+      },
+      "objectKey": {
+        "namespace": "kubevirt-hyperconverged"
+      }
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/test-files/upgradePatches/badSemverRangeOR.json
+++ b/pkg/controller/hyperconverged/test-files/upgradePatches/badSemverRangeOR.json
@@ -1,0 +1,16 @@
+{
+  "objectsToBeRemoved": [
+    {
+      "semverRange": "= badvalue < > ",
+      "groupVersionKind": {
+        "group": "",
+        "version": "v1",
+        "kind": "ConfigMap"
+      },
+      "objectKey": {
+        "name": "v2v-vmware",
+        "namespace": "kubevirt-hyperconverged"
+      }
+    }
+  ]
+}

--- a/pkg/controller/hyperconverged/upgradePatches_test.go
+++ b/pkg/controller/hyperconverged/upgradePatches_test.go
@@ -68,41 +68,100 @@ var _ = Describe("upgradePatches", func() {
 			Expect(err.Error()).Should(HavePrefix("invalid character"))
 		})
 
-		It("should fail validating upgradePatches with bad semver ranges", func() {
-			err := copyTestFile("badSemverRange.json")
-			Expect(err).ToNot(HaveOccurred())
+		Context("hcoCRPatchList", func() {
 
-			err = validateUpgradePatches(req)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(HavePrefix("Could not get version from string:"))
-		})
-
-		DescribeTable(
-			"should fail validating upgradePatches with bad patches",
-			func(filename, message string) {
-				err := copyTestFile(filename)
+			It("should fail validating upgradePatches with bad semver ranges", func() {
+				err := copyTestFile("badSemverRange.json")
 				Expect(err).ToNot(HaveOccurred())
 
 				err = validateUpgradePatches(req)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).Should(HavePrefix(message))
-			},
-			Entry(
-				"bad operation kind",
-				"badPatches1.json",
-				"Unexpected kind:",
-			),
-			Entry(
-				"not on spec",
-				"badPatches2.json",
-				"can only modify spec fields",
-			),
-			Entry(
-				"unexisting path",
-				"badPatches3.json",
-				"replace operation does not apply: doc is missing path:",
-			),
-		)
+				Expect(err.Error()).Should(HavePrefix("Could not get version from string:"))
+			})
+
+			DescribeTable(
+				"should fail validating upgradePatches with bad patches",
+				func(filename, message string) {
+					err := copyTestFile(filename)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = validateUpgradePatches(req)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(HavePrefix(message))
+				},
+				Entry(
+					"bad operation kind",
+					"badPatches1.json",
+					"Unexpected kind:",
+				),
+				Entry(
+					"not on spec",
+					"badPatches2.json",
+					"can only modify spec fields",
+				),
+				Entry(
+					"unexisting path",
+					"badPatches3.json",
+					"replace operation does not apply: doc is missing path:",
+				),
+			)
+
+		})
+
+		Context("objectsToBeRemoved", func() {
+
+			It("should fail validating upgradePatches with bad semver ranges", func() {
+				err := copyTestFile("badSemverRangeOR.json")
+				Expect(err).ToNot(HaveOccurred())
+
+				err = validateUpgradePatches(req)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).Should(HavePrefix("Could not get version from string:"))
+			})
+
+			DescribeTable(
+				"should fail validating upgradePatches with bad patches",
+				func(filename, message string) {
+					err := copyTestFile(filename)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = validateUpgradePatches(req)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(HavePrefix(message))
+				},
+				Entry(
+					"empty object kind",
+					"badObject1.json",
+					"missing object kind",
+				),
+				Entry(
+					"missing object kind",
+					"badObject1m.json",
+					"missing object kind",
+				),
+				Entry(
+					"empty object API version",
+					"badObject2.json",
+					"missing object API version",
+				),
+				Entry(
+					"missing object API version",
+					"badObject2m.json",
+					"missing object API version",
+				),
+				Entry(
+					"empty object name",
+					"badObject3.json",
+					"missing object name",
+				),
+				Entry(
+					"missing object name",
+					"badObject3m.json",
+					"missing object name",
+				),
+			)
+
+		})
 
 	})
 

--- a/pkg/controller/operands/imageStream.go
+++ b/pkg/controller/operands/imageStream.go
@@ -49,7 +49,7 @@ func (iso imageStreamOperand) ensure(req *common.HcoRequest) *EnsureResult {
 	cr := iso.operand.hooks.getEmptyCr()
 	res := NewEnsureResult(cr)
 	res.SetName(cr.GetName())
-	deleted, err := util.EnsureDeleted(req.Ctx, iso.operand.Client, cr, req.Instance.Name, req.Logger, false, false)
+	deleted, err := util.EnsureDeleted(req.Ctx, iso.operand.Client, cr, req.Instance.Name, req.Logger, false, false, true)
 	if err != nil {
 		return res.Error(err)
 	}

--- a/pkg/controller/operands/operandHandler.go
+++ b/pkg/controller/operands/operandHandler.go
@@ -196,7 +196,7 @@ func (h OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 	for _, res := range resources {
 		go func(o client.Object, wgr *sync.WaitGroup) {
 			defer wgr.Done()
-			deleted, err := hcoutil.EnsureDeleted(tCtx, h.client, o, req.Instance.Name, req.Logger, false, true)
+			deleted, err := hcoutil.EnsureDeleted(tCtx, h.client, o, req.Instance.Name, req.Logger, false, true, true)
 			if err != nil {
 				req.Logger.Error(err, "Failed to manually delete objects")
 				errT := ErrHCOUninstall

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -210,7 +210,7 @@ func GetRuntimeObject(ctx context.Context, c client.Client, obj client.Object, l
 
 // ComponentResourceRemoval removes the resource `obj` if it exists and belongs to the HCO
 // with wait=true it will wait, (util ctx timeout, please set it!) for the resource to be effectively deleted
-func ComponentResourceRemoval(ctx context.Context, c client.Client, obj interface{}, hcoName string, logger logr.Logger, dryRun bool, wait bool) (bool, error) {
+func ComponentResourceRemoval(ctx context.Context, c client.Client, obj interface{}, hcoName string, logger logr.Logger, dryRun bool, wait bool, protectNonHCOObjects bool) (bool, error) {
 	resource, err := ToUnstructured(obj)
 	if err != nil {
 		logger.Error(err, "Failed to convert object to Unstructured")
@@ -224,7 +224,7 @@ func ComponentResourceRemoval(ctx context.Context, c client.Client, obj interfac
 		return false, err
 	}
 
-	if !shouldDeleteResource(resource, hcoName, logger) {
+	if protectNonHCOObjects && !shouldDeleteResource(resource, hcoName, logger) {
 		return false, nil
 	}
 
@@ -307,7 +307,7 @@ func validateDeletion(ctx context.Context, c client.Client, resource *unstructur
 
 // EnsureDeleted calls ComponentResourceRemoval if the runtime object exists
 // with wait=true it will wait, (util ctx timeout, please set it!) for the resource to be effectively deleted
-func EnsureDeleted(ctx context.Context, c client.Client, obj client.Object, hcoName string, logger logr.Logger, dryRun bool, wait bool) (bool, error) {
+func EnsureDeleted(ctx context.Context, c client.Client, obj client.Object, hcoName string, logger logr.Logger, dryRun bool, wait bool, protectNonHCOObjects bool) (bool, error) {
 	err := GetRuntimeObject(ctx, c, obj, logger)
 
 	if err != nil {
@@ -320,7 +320,7 @@ func EnsureDeleted(ctx context.Context, c client.Client, obj client.Object, hcoN
 		return false, err
 	}
 
-	return ComponentResourceRemoval(ctx, c, obj, hcoName, logger, dryRun, wait)
+	return ComponentResourceRemoval(ctx, c, obj, hcoName, logger, dryRun, wait, protectNonHCOObjects)
 }
 
 func ContainsString(s []string, word string) bool {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Test general utilities", func() {
 				WithRuntimeObjects(pod).
 				Build()
 
-			deleted, err := EnsureDeleted(ctx, cl, pod, appName, logger, false, true)
+			deleted, err := EnsureDeleted(ctx, cl, pod, appName, logger, false, true, true)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(deleted).To(BeTrue())
 
@@ -116,7 +116,7 @@ var _ = Describe("Test general utilities", func() {
 				WithScheme(testScheme).
 				Build()
 
-			deleted, err := EnsureDeleted(ctx, cl, pod, appName, logger, false, true)
+			deleted, err := EnsureDeleted(ctx, cl, pod, appName, logger, false, true, true)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(deleted).To(BeFalse())
 

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -213,7 +213,7 @@ func (wh WebhookHandler) ValidateDelete(hc *v1beta1.HyperConverged) error {
 		kv,
 		cdi,
 	} {
-		_, err := hcoutil.EnsureDeleted(ctx, wh.cli, obj, hc.Name, wh.logger, true, false)
+		_, err := hcoutil.EnsureDeleted(ctx, wh.cli, obj, hc.Name, wh.logger, true, false, true)
 		if err != nil {
 			wh.logger.Error(err, "Delete validation failed", "GVK", obj.GetObjectKind().GroupVersionKind())
 			return err


### PR DESCRIPTION
Extend the UpgradePatches mechanism
to be able to remove leftovers during
upgrades according to a json configuration
file.
Start consuming it by removing v2v-vmware and
vm-import-controller-config (not owned by HCO)
ConfigMap when upgrading from versions <=1.6.0

In a future PR, other pieces of current code
(removal of old SSP CRDs, old metrics,
old quickstarts...) can be migrated to
this generic mechanism.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2063991

This is a manual cherry-pick of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1824

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove leftovers during upgrades
```

