### PR TITLE
[release-1.6] Fix a race condition on object recreation (#1835)

### DIFF
--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -95,16 +95,19 @@ func (h *genericOperand) ensure(req *common.HcoRequest) *EnsureResult {
 	found := h.hooks.getEmptyCr()
 	err = h.Client.Get(req.Ctx, key, found)
 	if err != nil {
-		result := h.createNewCr(req, err, cr, res)
-
-		if apierrors.IsAlreadyExists(result.Err) {
-			// we failed trying to create it due to a caching error
-			// or we neither tried because we know that the object is already there for sure,
-			// but we cannot get it due to a bad cache hit.
-			// Let's try updating it bypassing the client cache mechanism
-			return h.handleExistingCrSkipCache(req, key, found, cr, res)
+		if apierrors.IsNotFound(err) {
+			res = h.createNewCr(req, cr, res)
+			if apierrors.IsAlreadyExists(res.Err) {
+				// we failed trying to create it due to a caching error
+				// or we neither tried because we know that the object is already there for sure,
+				// but we cannot get it due to a bad cache hit.
+				// Let's try updating it bypassing the client cache mechanism
+				return h.handleExistingCrSkipCache(req, key, found, cr, res)
+			}
+		} else {
+			return res.Error(err)
 		}
-		return result
+		return res
 	}
 
 	return h.handleExistingCr(req, key, found, cr, res)
@@ -238,17 +241,17 @@ func (h *genericOperand) doRemoveExistingOwners(req *common.HcoRequest, found cl
 	}
 }
 
-func (h *genericOperand) createNewCr(req *common.HcoRequest, err error, cr client.Object, res *EnsureResult) *EnsureResult {
-	if apierrors.IsNotFound(err) {
-		req.Logger.Info("Creating " + h.crType)
-		err = h.Client.Create(req.Ctx, cr)
-		if err != nil {
-			req.Logger.Error(err, "Failed to create object for "+h.crType)
-			return res.Error(err)
-		}
-		return res.SetCreated()
+func (h *genericOperand) createNewCr(req *common.HcoRequest, cr client.Object, res *EnsureResult) *EnsureResult {
+	req.Logger.Info("Creating " + h.crType)
+	if cr.GetResourceVersion() != "" {
+		cr.SetResourceVersion("")
 	}
-	return res.Error(err)
+	err := h.Client.Create(req.Ctx, cr)
+	if err != nil {
+		req.Logger.Error(err, "Failed to create object for "+h.crType)
+		return res.Error(err)
+	}
+	return res.SetCreated()
 }
 
 func (h *genericOperand) reset() {


### PR DESCRIPTION
If the cluster admin deletes one of the
HCO managed resource, HCO will try to
recreate it but (according to the delete
instant) HCO could potentially consume
a cached in-memory representation
of the object that can include a
resourceVersion. In that case HCO
was going to fail in a loop with:
"resourceVersion should not be set on objects to be created".
Let's ensure we never try to re-create an object
with a value for resourceVersion.

This is a manual cherry-pick of #1835

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2062321

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a race condition on object recreation
```

