### PR TITLE
k8s-label-visualizer: try KUBECONFIG first

### DIFF
--- a/tools/k8s-label-visualizer/k8s_fetcher.py
+++ b/tools/k8s-label-visualizer/k8s_fetcher.py
@@ -12,10 +12,10 @@ class ObjectFetcher(object):
     def fetch(self, ns):
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         try:
-            config.load_incluster_config()
+            config.load_kube_config()
         except config.ConfigException:
             try:
-                config.load_kube_config()
+                config.load_incluster_config()
             except config.ConfigException:
                 raise Exception("Could not configure kubernetes python client")
         api = client.CustomObjectsApi()


### PR DESCRIPTION
try to load KUBECONFIG first and eventaully
failback to incluster config only if the
first failed to mimic kubectl behaviour

See: https://github.com/kubernetes-client/python/issues/1005

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

