### PR TITLE
Enable NonRoot feature gate by default

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -196,15 +196,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "Initializing HyperConverged cluster",
 				})))
 
-				// Get the KV
-				kvList := &kubevirtcorev1.KubeVirtList{}
-				Expect(cl.List(context.TODO(), kvList)).To(BeNil())
-				Expect(kvList.Items).Should(HaveLen(1))
-				kv := kvList.Items[0]
-				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(15))
-
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(
+				expectedFeatureGates := []string{
 					"DataVolumes",
 					"SRIOV",
 					"LiveMigration",
@@ -219,9 +211,17 @@ var _ = Describe("HyperconvergedController", func() {
 					"DownwardMetrics",
 					"ExpandDisks",
 					"NUMA",
-				),
-				)
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement("WithHostPassthroughCPU"))
+					"NonRoot",
+					"WithHostPassthroughCPU",
+				}
+				// Get the KV
+				kvList := &kubevirtcorev1.KubeVirtList{}
+				Expect(cl.List(context.TODO(), kvList)).To(BeNil())
+				Expect(kvList.Items).Should(HaveLen(1))
+				kv := kvList.Items[0]
+				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(expectedFeatureGates)))
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(expectedFeatureGates))
 			})
 
 			It("should find all managed resources", func() {

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -92,6 +92,9 @@ const (
 
 	// Allow automatic numa mapping on VMs with dedicated CPUs, if requested
 	kvNUMA = "NUMA"
+
+	// Enables rootless virt-launcher.
+	kvNonRoot = "NonRoot"
 )
 
 var (
@@ -107,6 +110,7 @@ var (
 		kvHostDevicesGate,
 		kvDownwardMetricsGate,
 		kvNUMA,
+		kvNonRoot,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -1251,7 +1251,7 @@ Version: 1.2.3`)
 
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					By("KV CR should contain the HotplugVolumes feature gate", func() {
+					By("KV CR should contain the WithHostPassthroughCPU feature gate", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("WithHostPassthroughCPU"))
 					})
@@ -1265,7 +1265,7 @@ Version: 1.2.3`)
 
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					By("KV CR should contain the HotplugVolumes feature gate", func() {
+					By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvSRIOVLiveMigration))
 					})
@@ -1279,7 +1279,7 @@ Version: 1.2.3`)
 
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					By("KV CR should contain the HotplugVolumes feature gate", func() {
+					By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("SRIOVLiveMigration"))
 					})
@@ -1300,7 +1300,7 @@ Version: 1.2.3`)
 
 						existingResource, err := NewKubeVirt(hco)
 						Expect(err).ToNot(HaveOccurred())
-						By("KV CR should contain the HotplugVolumes feature gate", func() {
+						By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
 							Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 							Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvSRIOVLiveMigration))
 						})
@@ -1314,7 +1314,7 @@ Version: 1.2.3`)
 
 						existingResource, err := NewKubeVirt(hco)
 						Expect(err).ToNot(HaveOccurred())
-						By("KV CR should contain the HotplugVolumes feature gate", func() {
+						By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
 							Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 							Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("SRIOVLiveMigration"))
 						})


### PR DESCRIPTION
This PR enables NonRoot feature gate by default. The feature gate is now fully tested https://github.com/kubevirt/kubevirt/pull/7469. 

HCO should enable this because it is a security feature.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

Needs https://github.com/kubevirt/kubevirt/pull/7469

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NonRoot feature gate is on by default
```

