### PR TITLE
Remove nmstate from deployed components in networkaddonsconfig

### DIFF
--- a/controllers/operands/networkAddons.go
+++ b/controllers/operands/networkAddons.go
@@ -143,7 +143,6 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged, opts ...string) (*networkad
 	cnaoSpec := networkaddonsshared.NetworkAddonsConfigSpec{
 		Multus:      &networkaddonsshared.Multus{},
 		LinuxBridge: &networkaddonsshared.LinuxBridge{},
-		NMState:     &networkaddonsshared.NMState{},
 		KubeMacPool: &networkaddonsshared.KubeMacPool{},
 	}
 

--- a/controllers/operands/networkAddons_test.go
+++ b/controllers/operands/networkAddons_test.go
@@ -787,8 +787,15 @@ var _ = Describe("CNA Operand", func() {
 				Expect(handler.hooks.(*cnaHooks).cache == crII).To(BeTrue())
 			})
 
-		})
+			Context("Requested components", func() {
+				It("should not request nmstate", func() {
+					expectedResource, err := NewNetworkAddons(hco)
+					Expect(err).ToNot(HaveOccurred())
 
+					Expect(expectedResource.Spec.NMState).To(BeNil())
+				})
+			})
+		})
 	})
 
 	Context("hcoConfig2CnaoPlacement", func() {


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>
This PR removed NMState from the list of components to be deployed by CNAO.
CNAO doesn't support knmstate deployment anymore, users should use Kubernetes-nmstate operator instead.
 
 PR on CNAO that proposes raising Degraded condition when nmstate is present in networkAddonsConfig:
 - https://github.com/kubevirt/cluster-network-addons-operator/pull/1292
 
**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Nmstate is removed from networkAddonsConfig as CNAO doesn't support it's deployment
```

