### PR TITLE
Allow setting all the fields of a common DICT spec

### DIFF
--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -259,11 +259,12 @@ func getCommonDicts(list []hcov1beta1.DataImportCronTemplateStatus, crDicts map[
 				continue
 			}
 
-			if crDict.Spec.Template.Spec.Storage != nil {
-				targetDict.Spec.Template.Spec.Storage = crDict.Spec.Template.Spec.Storage.DeepCopy()
-
-				targetDict.Status.Modified = true
+			// if the schedule is missing, copy from the common dict:
+			if len(crDict.Spec.Schedule) == 0 {
+				crDict.Spec.Schedule = targetDict.Spec.Schedule
 			}
+			targetDict.Spec = *crDict.Spec.DeepCopy()
+			targetDict.Status.Modified = true
 		}
 		list = append(list, targetDict)
 	}

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -566,23 +566,33 @@ spec:
 
 There is no need to copy the whole object, but only the relevant fields; i.e. the `metadat.name` field.
 
-### Modifying the storage field
-It is possible to checge the storage configuration of a common golden image by adding the common image to the `dataImportCronTemplates` list in the `spec` field. HCO will replace the existing storage object if it exists, or add it if it is missing; for example, change the storage class for centos8 golden image:
+### Modifying a common dataImportCronTemplate
+It is possible to change the configuration of a common golden image by adding the common image to the
+`dataImportCronTemplates` list in the `spec` field. HCO will replace the existing spec object; The `schedule` 
+field is mandatory, and HCO will copy it from the common template if it is missing. 
+
+Copy the required dtaImportCronTemplate object from the list in the `status` field (not including the `status`
+field), and change or add the desired fields.
+
+for example, set the storage class for centos8 golden image, and modify the source URL:
 
 ```yaml
-apiVersion: hco.kubevirt.io/v1beta1
-kind: HyperConverged
-metadata:
-  name: kubevirt-hyperconverged
-spec:
-  dataImportCronTemplates:
-  - metadata:
-      name: centos-stream8-image-cron
-    spec:
-      template:
-        spec:
-          storage:
-            storageClassName: "some-name"
+- metadata:
+    name: kubevirt-hyperconverged
+  spec:
+    schedule: "0 */12 * * *"
+    template:
+      spec:
+        source:
+          registry:
+            url: docker://my-private-registry/my-own-version-of-centos:8
+        storage:
+          resources:
+            requests:
+              storage: 10Gi
+            storageClassName: "some-non-default-storage-class"
+    garbageCollect: Outdated
+    managedDataSource: centos-stream8
 ```
 
 ## Configure custom golden images


### PR DESCRIPTION
This PR allows modifying all the field a common DataImportCronTemplate
spec. Before this PR, HCO only modified the storage field. and ignored
the rest.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow setting all the fields of a common DICT spec
```

