### PR TITLE
graphs updater: abort when fetching wrong data

### DIFF
--- a/automation/graphs-updater/graphs-updater.sh
+++ b/automation/graphs-updater/graphs-updater.sh
@@ -20,4 +20,8 @@ ARTIFACTS_FOLDER=${PREFIX}/${JOB_NAME}/${LATEST_BUILD}/${SUFFIX}
 for f in "${filelist[@]}"
 do
    curl "${ARTIFACTS_FOLDER}/${f}" -f -s -o "${graphs_files_dir}/${f}"
+   if [ "$(grep -c "<\!doctype html>" "${graphs_files_dir}/${f}" )" -ge 1 ]; then
+	echo "Got a placeholder HTML file from a failed nightly execution, aborting..."
+	exit 1
+   fi
 done


### PR DESCRIPTION
The bot is daily trying to fetch up to date
graphs from the output of a nightly job.
Unfortunately, if for any reason the nightly
job has failed, we are not going to get any HTTP
error fetching the data but just a placeholder
HTML page.
Let's explicitly detect it to avoid opening
meaningless PRs.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

