### PR TITLE
Also run build-push-images action on changes in tests/

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -10,7 +10,6 @@ on:
       - 'images/**'
       - 'automation/**'
       - 'cluster/**'
-      - 'tests/**'
 jobs:
   build_push:
     if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')


### PR DESCRIPTION
The build-push-images action is responsible for building a set of images that includes, for example, the `func-tests` image, built from code in the `tests/` directory. But that directory is stated as `paths-ignore` in the action definition, so when tests in that directory are changed, the action is not triggered and the image is not being rebuilt.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

