### PR TITLE
sanity: check for unvedored code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ sanity: generate generate-doc validate-no-offensive-lang
 	go mod tidy -v
 	go mod vendor
 	./hack/build-manifests.sh
+	git add -N vendor
 	git difftool -y --trust-exit-code --extcmd=./hack/diff-csv.sh
 
 lint:


### PR DESCRIPTION
In make sanity we were already checking
for unstaged code changes but this is not
enough if we forget to completely
add a new whole directory under vendor/ .
Let's cover also that case.

Use `git add -N` to record only the fact that the path will be added later so
that `git diff` can correctly process them.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

