### PR TITLE
Deploy kubevirt's serviceMonitor object in our namespace

### DIFF
--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -261,6 +261,7 @@ func NewKubeVirt(hc *hcov1beta1.HyperConverged, opts ...string) (*kubevirtcorev1
 		ProductName:                 hcoutil.HyperConvergedCluster,
 		ProductVersion:              os.Getenv(hcoutil.HcoKvIoVersionName),
 		ProductComponent:            string(hcoutil.AppComponentCompute),
+		MonitorNamespace:            getNamespace(hc.Namespace, opts),
 	}
 
 	kv := NewKubeVirtWithNameOnly(hc, opts...)


### PR DESCRIPTION
Signed-off-by: bmordeha <bmodeha@redhat.com>

https://github.com/kubevirt/kubevirt/pull/7130
it is better to move it to our namespace because keeping components
in our namespace makes management easier.
servicemonitor object namespace `openshift-monitoring`  -> <our_namespace> (the default namespace is `openshift-cnv`)

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
moving the servicemonitor object from the monitoring namespace to our namespace
```

