### PR TITLE
set supported labels on the CSV (#1881)

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
@@ -18,6 +18,9 @@ metadata:
     operators.operatorframework.io/internal-objects: '["networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","ssps.ssp.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.nodemaintenance.kubevirt.io"]'
     repository: https://github.com/kubevirt/hyperconverged-cluster-operator
     support: "false"
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/os.linux: supported
   name: kubevirt-hyperconverged-operator.v1.6.0
   namespace: placeholder
 spec:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.6.0/manifests/kubevirt-hyperconverged-operator.v1.6.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.6.0-unstable
-    createdAt: "2022-03-24 05:14:51"
+    createdAt: "2022-04-10 17:41:41"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -18,6 +18,9 @@ metadata:
     operators.operatorframework.io/internal-objects: '["networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","ssps.ssp.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.nodemaintenance.kubevirt.io"]'
     repository: https://github.com/kubevirt/hyperconverged-cluster-operator
     support: "false"
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/os.linux: supported
   name: kubevirt-hyperconverged-operator.v1.6.0
   namespace: placeholder
 spec:

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -46,11 +46,18 @@ import (
 )
 
 const (
-	operatorName          = "kubevirt-hyperconverged-operator"
-	CSVMode               = "CSV"
-	CRDMode               = "CRDs"
-	almExamplesAnnotation = "alm-examples"
-	validOutputModes      = CSVMode + "|" + CRDMode
+	operatorName            = "kubevirt-hyperconverged-operator"
+	CSVMode                 = "CSV"
+	CRDMode                 = "CRDs"
+	almExamplesAnnotation   = "alm-examples"
+	validOutputModes        = CSVMode + "|" + CRDMode
+	supported               = "supported"
+	operatorFrameworkPrefix = "operatorframework.io/"
+)
+
+var (
+	supported_archs = []string{"arch.amd64"}
+	supported_os    = []string{"os.linux"}
 )
 
 type EnvVarFlags []corev1.EnvVar
@@ -306,6 +313,8 @@ func getHcoCsv() {
 		csvBase.Spec.DisplayName = *specDisplayName
 	}
 
+	setSupported(csvBase)
+
 	applyOverrides(csvBase)
 
 	csvBase.Spec.RelatedImages = sortRelatedImages(csvBase.Spec.RelatedImages)
@@ -411,6 +420,18 @@ func applyOverrides(csvBase *csvv1alpha1.ClusterServiceVersion) {
 		panicOnError(yaml.Unmarshal(csvOBytes, csvO))
 
 		panicOnError(mergo.Merge(csvBase, csvO, mergo.WithOverride))
+	}
+}
+
+func setSupported(csvBase *csvv1alpha1.ClusterServiceVersion) {
+	if csvBase.Labels == nil {
+		csvBase.Labels = make(map[string]string)
+	}
+	for _, ele := range supported_archs {
+		csvBase.Labels[operatorFrameworkPrefix+ele] = supported
+	}
+	for _, ele := range supported_os {
+		csvBase.Labels[operatorFrameworkPrefix+ele] = supported
 	}
 }
 


### PR DESCRIPTION
Correctly set
```
  labels:
    operatorframework.io/os.linux: supported
    operatorframework.io/arch.amd64: supported
```
on the CSV

This is a manual cherry-pick of #1881

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
set supported labels on the CSV
```

