### PR TITLE
Avoid an explicit cast in operands/cdi.go

### DIFF
--- a/controllers/operands/cdi.go
+++ b/controllers/operands/cdi.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"reflect"
 
-	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -133,14 +131,12 @@ func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, err
 		}
 	}
 
-	// TODO: remove this cast once CDI will also consume kubevirt.io/controller-lifecycle-operator-sdk v2.0.4
 	if hc.Spec.Infra.NodePlacement != nil {
-		hc.Spec.Infra.NodePlacement.DeepCopyInto((*sdkapi.NodePlacement)(&spec.Infra))
+		hc.Spec.Infra.NodePlacement.DeepCopyInto(&spec.Infra)
 	}
 
-	// TODO: remove this cast once CDI will also consume kubevirt.io/controller-lifecycle-operator-sdk v2.0.4
 	if hc.Spec.Workloads.NodePlacement != nil {
-		hc.Spec.Workloads.NodePlacement.DeepCopyInto((*sdkapi.NodePlacement)(&spec.Workloads))
+		hc.Spec.Workloads.NodePlacement.DeepCopyInto(&spec.Workloads)
 	}
 
 	certConfig := hc.Spec.CertConfig


### PR DESCRIPTION
Avoid an explicit cast in operands/cdi.go now
that CDI v1.47.0 imports
kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

