### PR TITLE
fix service port string replacement for the kubevirt console plugin nginx configuration

### DIFF
--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"strings"
 
 	"k8s.io/utils/pointer"
 
@@ -167,8 +166,7 @@ func NewKvUiPluginSvc(hc *hcov1beta1.HyperConverged) *corev1.Service {
 	}
 }
 
-func NewKvUiNginxCm(hc *hcov1beta1.HyperConverged) *corev1.ConfigMap {
-	nginxConfig := `error_log /dev/stdout info;
+var nginxConfig = fmt.Sprintf(`error_log /dev/stdout info;
 events {}
 http {
 	access_log         /dev/stdout;
@@ -176,14 +174,15 @@ http {
 	default_type       application/octet-stream;
 	keepalive_timeout  65;
 		server {
-			listen              $SERVER_PORT ssl;
+			listen              %d ssl;
 			ssl_certificate     /var/serving-cert/tls.crt;
 			ssl_certificate_key /var/serving-cert/tls.key;
 			root                /usr/share/nginx/html;
 		}
 	}
-`
-	nginxConfig = strings.ReplaceAll(nginxConfig, "$SERVER_PORT", string(hcoutil.UiPluginServerPort))
+`, hcoutil.UiPluginServerPort)
+
+func NewKvUiNginxCm(hc *hcov1beta1.HyperConverged) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nginxConfigMapName,


### PR DESCRIPTION
`string(hcoutil.UiPluginServerPort)` isn't the numerical string representation of the service port (int32).
This PR fixes that.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

