### PR TITLE
Avoid special handling for liveMigration FG on SNO

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -252,7 +252,7 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=false
 	WithHostPassthroughCPU bool `json:"withHostPassthroughCPU"`
 
-	// Allow migrating a virtual machine with SRIOV interfaces. Ignored on single node clusters.
+	// Allow migrating a virtual machine with SRIOV interfaces.
 	// +optional
 	// +kubebuilder:default=true
 	SRIOVLiveMigration bool `json:"sriovLiveMigration"`
@@ -382,7 +382,6 @@ type HyperConvergedWorkloadUpdateStrategy struct {
 	// precedence over more disruptive methods. For example if both LiveMigrate and Evict
 	// methods are listed, only VMs which are not live migratable will be restarted/shutdown.
 	// An empty list defaults to no automated workload updating.
-	// LiveMigrate is ignored on SNO clusters.
 	//
 	// +listType=atomic
 	// +kubebuilder:default={"LiveMigrate"}

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -201,7 +201,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 					},
 					"sriovLiveMigration": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Allow migrating a virtual machine with SRIOV interfaces. Ignored on single node clusters.",
+							Description: "Allow migrating a virtual machine with SRIOV interfaces.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
@@ -278,14 +278,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 				Properties: map[string]spec.Schema{
 					"localStorageClassName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "LocalStorageClassName the name of the local storage class.",
+							Description: "Deprecated: LocalStorageClassName the name of the local storage class.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"infra": {
 						SchemaProps: spec.SchemaProps{
-							Description: "infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs.",
+							Description: "infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarily directly on each node running VMs/VMIs.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedConfig"),
 						},
@@ -402,7 +402,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 					},
 					"uninstallStrategy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "UninstallStrategy defines how to proceed on uninstall when workloads (VirtualMachines, DataVolumes) still exist. BlockUninstallIfWorkloadsExist will prevent the CR from being removed when workloads still exist. BlockUninstallIfWorkloadsExist is the safest choice to protect your workloads from accidental data loss, so it's strongly advised. RemoveWorkloads will cause all the workloads to be cascading deleted on uninstall. WARNING: please notice that RemoveWorkloads will cause your workloads to be deleted as soon as this CR will be, even accidentally, deleted. Please correctly consider the implications of this option before setting it. BlockUninstallIfWorkloadsExist is the default behaviour.",
+							Description: "UninstallStrategy defines how to proceed on uninstall when workloads (VirtualMachines, DataVolumes) still exist. BlockUninstallIfWorkloadsExist will prevent the CR from being removed when workloads still exist. BlockUninstallIfWorkloadsExist is the safest choice to protect your workloads from accidental data loss, so it's strongly advised. RemoveWorkloads will cause all the workloads to be cascading deleted on uninstallation. WARNING: please notice that RemoveWorkloads will cause your workloads to be deleted as soon as this CR will be, even accidentally, deleted. Please correctly consider the implications of this option before setting it. BlockUninstallIfWorkloadsExist is the default behaviour.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -550,7 +550,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedW
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Evict methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. LiveMigrate is ignored on SNO clusters.",
+							Description: "WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Evict methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -565,7 +565,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedW
 					},
 					"batchEvictionSize": {
 						SchemaProps: spec.SchemaProps{
-							Description: "BatchEvictionSize Represents the number of VMIs that can be forced updated per the BatchShutdownInteral interval",
+							Description: "BatchEvictionSize Represents the number of VMIs that can be forced updated per the BatchShutdownInterval interval",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -663,7 +663,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_MediatedDevices
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "MediatedDevicesConfiguration holds inforamtion about MDEV types to be defined, if available",
+				Description: "MediatedDevicesConfiguration holds information about MDEV types to be defined, if available",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"mediatedDevicesTypes": {
@@ -759,7 +759,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_NodeMediatedDev
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "NodeMediatedDeviceTypesConfig holds inforamtion about MDEV types to be defined in a specifc node that matches the NodeSelector field.",
+				Description: "NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specific node that matches the NodeSelector field.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"nodeSelector": {

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -876,7 +876,6 @@ spec:
                   sriovLiveMigration:
                     default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
-                      Ignored on single node clusters.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false
@@ -2273,8 +2272,7 @@ spec:
                       takes precedence over more disruptive methods. For example if
                       both LiveMigrate and Evict methods are listed, only VMs which
                       are not live migratable will be restarted/shutdown. An empty
-                      list defaults to no automated workload updating. LiveMigrate
-                      is ignored on SNO clusters.
+                      list defaults to no automated workload updating.
                     items:
                       type: string
                     type: array

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -29,7 +29,6 @@ import (
 var _ = Describe("KubeVirt Operand", func() {
 	var (
 		basicNumFgOnOpenshift = len(hardCodeKvFgs) + len(sspConditionKvFgs)
-		deltaFGNotSNO         = 1
 	)
 
 	Context("KubeVirt Priority Classes", func() {
@@ -1284,14 +1283,14 @@ Version: 1.2.3`)
 					})
 				})
 
-				Context("should ignore SRIOVLiveMigration on SNO ", func() {
+				Context("should honor SRIOVLiveMigration on SNO ", func() {
 					BeforeEach(func() {
 						hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
 							return &commonTestUtils.ClusterInfoSNOMock{}
 						}
 					})
 
-					It("should not add the SRIOVLiveMigration feature gate if it's set in HyperConverged on SNO", func() {
+					It("should add the SRIOVLiveMigration feature gate if it's set in HyperConverged on SNO", func() {
 						// one enabled, one disabled and one missing
 						hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
 							SRIOVLiveMigration: true,
@@ -1301,7 +1300,7 @@ Version: 1.2.3`)
 						Expect(err).ToNot(HaveOccurred())
 						By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
 							Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
-							Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvSRIOVLiveMigration))
+							Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvSRIOVLiveMigration))
 						})
 					})
 
@@ -1329,7 +1328,7 @@ Version: 1.2.3`)
 
 					Expect(existingResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 					fgList := getKvFeatureGateList(&hco.Spec.FeatureGates)
-					Expect(fgList).To(HaveLen(basicNumFgOnOpenshift + deltaFGNotSNO))
+					Expect(fgList).To(HaveLen(basicNumFgOnOpenshift))
 					Expect(fgList).Should(ContainElements(hardCodeKvFgs))
 					Expect(fgList).Should(ContainElements(sspConditionKvFgs))
 				})
@@ -1408,7 +1407,7 @@ Version: 1.2.3`)
 						mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
 						Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 						fgList := getKvFeatureGateList(&hco.Spec.FeatureGates)
-						Expect(fgList).To(HaveLen(basicNumFgOnOpenshift + deltaFGNotSNO))
+						Expect(fgList).To(HaveLen(basicNumFgOnOpenshift))
 						Expect(fgList).Should(ContainElements(hardCodeKvFgs))
 						Expect(fgList).Should(ContainElements(sspConditionKvFgs))
 					})
@@ -1439,7 +1438,7 @@ Version: 1.2.3`)
 						mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
 						Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 						fgList := getKvFeatureGateList(&hco.Spec.FeatureGates)
-						Expect(fgList).To(HaveLen(basicNumFgOnOpenshift + deltaFGNotSNO))
+						Expect(fgList).To(HaveLen(basicNumFgOnOpenshift))
 						Expect(fgList).Should(ContainElements(hardCodeKvFgs))
 						Expect(fgList).Should(ContainElements(sspConditionKvFgs))
 					})
@@ -1447,7 +1446,7 @@ Version: 1.2.3`)
 
 				It("should keep FG if already exist", func() {
 					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(true)
-					fgs := append(hardCodeKvFgs, kvWithHostPassthroughCPU, kvSRIOVLiveMigration, kvLiveMigrationGate)
+					fgs := append(hardCodeKvFgs, kvWithHostPassthroughCPU, kvSRIOVLiveMigration)
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 					existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates = fgs
@@ -1482,7 +1481,6 @@ Version: 1.2.3`)
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
 						To(ContainElements(kvWithHostPassthroughCPU, kvSRIOVLiveMigration))
 
-					Expect(res.Updated).To(BeFalse())
 				})
 
 				It("should remove FG if it disabled in HC CR", func() {
@@ -1520,7 +1518,7 @@ Version: 1.2.3`)
 					).ToNot(HaveOccurred())
 
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(basicNumFgOnOpenshift + deltaFGNotSNO))
+					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(basicNumFgOnOpenshift))
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(hardCodeKvFgs))
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(sspConditionKvFgs))
 				})
@@ -1557,7 +1555,7 @@ Version: 1.2.3`)
 					).ToNot(HaveOccurred())
 
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(basicNumFgOnOpenshift + deltaFGNotSNO))
+					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(basicNumFgOnOpenshift))
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(hardCodeKvFgs))
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(sspConditionKvFgs))
 				})
@@ -1594,7 +1592,7 @@ Version: 1.2.3`)
 					).ToNot(HaveOccurred())
 
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(hardCodeKvFgs) + deltaFGNotSNO))
+					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(hardCodeKvFgs)))
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(hardCodeKvFgs))
 				})
 			})
@@ -1625,37 +1623,37 @@ Version: 1.2.3`)
 					Entry("When not using kvm-emulation and FG is empty",
 						false,
 						&hcov1beta1.HyperConvergedFeatureGates{},
-						basicNumFgOnOpenshift+deltaFGNotSNO,
+						basicNumFgOnOpenshift,
 						[][]string{hardCodeKvFgs, sspConditionKvFgs},
 					),
 					Entry("When using kvm-emulation and FG is empty",
 						true,
 						&hcov1beta1.HyperConvergedFeatureGates{},
-						len(hardCodeKvFgs)+deltaFGNotSNO,
+						len(hardCodeKvFgs),
 						[][]string{hardCodeKvFgs},
 					),
 					Entry("When not using kvm-emulation and all FGs are disabled",
 						false,
 						&hcov1beta1.HyperConvergedFeatureGates{SRIOVLiveMigration: false, WithHostPassthroughCPU: false},
-						basicNumFgOnOpenshift+deltaFGNotSNO,
+						basicNumFgOnOpenshift,
 						[][]string{hardCodeKvFgs, sspConditionKvFgs},
 					),
 					Entry("When using kvm-emulation all FGs are disabled",
 						true,
 						&hcov1beta1.HyperConvergedFeatureGates{SRIOVLiveMigration: false, WithHostPassthroughCPU: false},
-						len(hardCodeKvFgs)+deltaFGNotSNO,
+						len(hardCodeKvFgs),
 						[][]string{hardCodeKvFgs},
 					),
 					Entry("When not using kvm-emulation and all FGs are enabled",
 						false,
 						&hcov1beta1.HyperConvergedFeatureGates{SRIOVLiveMigration: true, WithHostPassthroughCPU: true},
-						basicNumFgOnOpenshift+deltaFGNotSNO+2,
+						basicNumFgOnOpenshift+2,
 						[][]string{hardCodeKvFgs, sspConditionKvFgs, {kvWithHostPassthroughCPU}},
 					),
 					Entry("When using kvm-emulation all FGs are enabled",
 						true,
 						&hcov1beta1.HyperConvergedFeatureGates{SRIOVLiveMigration: true, WithHostPassthroughCPU: true},
-						len(hardCodeKvFgs)+deltaFGNotSNO+2,
+						len(hardCodeKvFgs)+2,
 						[][]string{hardCodeKvFgs, {kvWithHostPassthroughCPU}},
 					))
 
@@ -1665,7 +1663,7 @@ Version: 1.2.3`)
 					}
 					hco_fg := hcov1beta1.HyperConvergedFeatureGates{}
 					fgs := getKvFeatureGateList(&hco_fg)
-					Expect(fgs).To(HaveLen(len(hardCodeKvFgs) + 1))
+					Expect(fgs).To(HaveLen(len(hardCodeKvFgs)))
 					Expect(fgs).To(ContainElement(kvLiveMigrationGate))
 				})
 
@@ -1676,7 +1674,7 @@ Version: 1.2.3`)
 					hco_fg := hcov1beta1.HyperConvergedFeatureGates{}
 					fgs := getKvFeatureGateList(&hco_fg)
 					Expect(fgs).To(HaveLen(len(hardCodeKvFgs)))
-					Expect(fgs).To(Not(ContainElement(kvLiveMigrationGate)))
+					Expect(fgs).To(ContainElement(kvLiveMigrationGate))
 				})
 			})
 
@@ -2231,66 +2229,6 @@ Version: 1.2.3`)
 				Expect(foundUpdateStrategy.BatchEvictionInterval.Duration.String()).Should(Equal("5m0s"))
 			})
 
-			DescribeTable("Should ignore LiveMigrate Workload Update Strategy on SNO",
-				func(hcoWorkloadUpdateMethods []string, expectedKVWorkloadUpdateMethods []kubevirtcorev1.WorkloadUpdateMethod) {
-
-					hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
-						return &commonTestUtils.ClusterInfoSNOMock{}
-					}
-
-					existingKv, err := NewKubeVirt(hco)
-					Expect(err).ToNot(HaveOccurred())
-
-					hcoModifiedBatchEvictionSize := 5
-					hco.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = hcoWorkloadUpdateMethods
-					hco.Spec.WorkloadUpdateStrategy.BatchEvictionInterval = &metav1.Duration{Duration: time.Minute * 5}
-					hco.Spec.WorkloadUpdateStrategy.BatchEvictionSize = &hcoModifiedBatchEvictionSize
-
-					cl := commonTestUtils.InitClient([]runtime.Object{hco, existingKv})
-					handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
-					res := handler.ensure(req)
-					Expect(res.UpgradeDone).To(BeFalse())
-					Expect(res.Updated).To(BeTrue())
-					Expect(res.Err).ToNot(HaveOccurred())
-
-					foundKv := &kubevirtcorev1.KubeVirt{}
-					Expect(
-						cl.Get(context.TODO(),
-							types.NamespacedName{Name: existingKv.Name, Namespace: existingKv.Namespace},
-							foundKv),
-					).ToNot(HaveOccurred())
-
-					Expect(foundKv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods).Should(HaveLen(len(expectedKVWorkloadUpdateMethods)))
-					for _, expected := range expectedKVWorkloadUpdateMethods {
-						Expect(foundKv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods).Should(ContainElements(expected))
-					}
-					Expect(foundKv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods).ShouldNot(ContainElements(kubevirtcorev1.WorkloadUpdateMethod("LiveMigrate")))
-				},
-				Entry("LiveMigrate and others, LiveMigrate first",
-					[]string{"LiveMigrate", "test1", "test2"},
-					[]kubevirtcorev1.WorkloadUpdateMethod{"test1", "test2"},
-				),
-				Entry("LiveMigrate and others, LiveMigrate in the middle",
-					[]string{"test1", "LiveMigrate", "test2"},
-					[]kubevirtcorev1.WorkloadUpdateMethod{"test1", "test2"},
-				),
-				Entry("LiveMigrate and others, LiveMigrate last",
-					[]string{"test1", "test2", "LiveMigrate"},
-					[]kubevirtcorev1.WorkloadUpdateMethod{"test1", "test2"},
-				),
-				Entry("LiveMigrate only",
-					[]string{"LiveMigrate"},
-					[]kubevirtcorev1.WorkloadUpdateMethod{},
-				),
-				Entry("empty",
-					[]string{},
-					[]kubevirtcorev1.WorkloadUpdateMethod{},
-				),
-				Entry("LiveMigrate and Evict",
-					[]string{"LiveMigrate", "Evict"},
-					[]kubevirtcorev1.WorkloadUpdateMethod{"Evict"},
-				))
-
 		})
 
 		Context("SNO replicas", func() {
@@ -2752,7 +2690,7 @@ Version: 1.2.3`)
 				).ToNot(HaveOccurred())
 
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(mandatoryKvFeatureGates) + deltaFGNotSNO + 1))
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(mandatoryKvFeatureGates) + 1))
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(hardCodeKvFgs))
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvSRIOVGate))
 				Expect(kv.Spec.Configuration.CPURequest).To(BeNil())

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -876,7 +876,6 @@ spec:
                   sriovLiveMigration:
                     default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
-                      Ignored on single node clusters.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false
@@ -2273,8 +2272,7 @@ spec:
                       takes precedence over more disruptive methods. For example if
                       both LiveMigrate and Evict methods are listed, only VMs which
                       are not live migratable will be restarted/shutdown. An empty
-                      list defaults to no automated workload updating. LiveMigrate
-                      is ignored on SNO clusters.
+                      list defaults to no automated workload updating.
                     items:
                       type: string
                     type: array

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
@@ -876,7 +876,6 @@ spec:
                   sriovLiveMigration:
                     default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
-                      Ignored on single node clusters.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false
@@ -2273,8 +2272,7 @@ spec:
                       takes precedence over more disruptive methods. For example if
                       both LiveMigrate and Evict methods are listed, only VMs which
                       are not live migratable will be restarted/shutdown. An empty
-                      list defaults to no automated workload updating. LiveMigrate
-                      is ignored on SNO clusters.
+                      list defaults to no automated workload updating.
                     items:
                       type: string
                     type: array

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.7.0/manifests/hco00.crd.yaml
@@ -876,7 +876,6 @@ spec:
                   sriovLiveMigration:
                     default: true
                     description: Allow migrating a virtual machine with SRIOV interfaces.
-                      Ignored on single node clusters.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false
@@ -2273,8 +2272,7 @@ spec:
                       takes precedence over more disruptive methods. For example if
                       both LiveMigrate and Evict methods are listed, only VMs which
                       are not live migratable will be restarted/shutdown. An empty
-                      list defaults to no automated workload updating. LiveMigrate
-                      is ignored on SNO clusters.
+                      list defaults to no automated workload updating.
                     items:
                       type: string
                     type: array

--- a/docs/api.md
+++ b/docs/api.md
@@ -113,7 +113,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here | bool | false | true |
-| sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. Ignored on single node clusters. | bool | true | true |
+| sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. | bool | true | true |
 | enableCommonBootImageImport | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | bool | true | true |
 | deployTektonTaskResources | deploy resources (kubevirt tekton tasks and example pipelines) in Tekton tasks operator | bool | false | true |
 
@@ -192,7 +192,7 @@ HyperConvergedWorkloadUpdateStrategy defines options related to updating a KubeV
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| workloadUpdateMethods | WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Evict methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. LiveMigrate is ignored on SNO clusters. | []string | {"LiveMigrate"} | false |
+| workloadUpdateMethods | WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Evict methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. | []string | {"LiveMigrate"} | false |
 | batchEvictionSize | BatchEvictionSize Represents the number of VMIs that can be forced updated per the BatchShutdownInterval interval | *int | 10 | false |
 | batchEvictionInterval | BatchEvictionInterval Represents the interval to wait before issuing the next batch of shutdowns | *metav1.Duration | "1m0s" | false |
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -143,7 +143,7 @@ Additional information: [LibvirtXMLCPUModel](https://wiki.openstack.org/wiki/Lib
 
 Set the `sriovLiveMigration` feature gate in order to allow migrating a virtual machine with SRIOV interfaces. When
 enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability. This may
-degrade virt-launcher security. `sriovLiveMigration` is ignored on single node clusters.
+degrade virt-launcher security.
 
 **Default**: `true`
 
@@ -567,7 +567,6 @@ The `workloadUpdateStrategy` fields are:
   An empty list defaults to no automated workload updating.
 
   The default values is `LiveMigrate`; `Evict` is not enabled by default being potentially disruptive for the existing workloads.
-* `LiveMigrate` is ignored on SNO clusters where LiveMigrate is not supported.
 
 ### workloadUpdateStrategy example
 ```yaml


### PR DESCRIPTION
Introducing special handling for liveMigration FG
and related (SRIOV livemigration WorkloadUpdateStrategy
LiveMigrated) proved to cause more issues than benefits.
Let's revert it.
HCO will not inject special configuration based on SNO
topology and virt-controller will do the rest.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2073880

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid special handling for liveMigration FG on SNO
```

