### PR TITLE
Watch all the CMs in the operator namespace

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -197,7 +197,7 @@ func getNewManagerCache(operatorNamespace string) cache.NewCacheFunc {
 					Label: labels.SelectorFromSet(labels.Set{hcoutil.AppLabel: hcoutil.HyperConvergedName}),
 				},
 				&corev1.ConfigMap{}: {
-					Label: labelSelector,
+					Field: namespaceSelector,
 				},
 				&corev1.Service{}: {
 					Field: namespaceSelector,

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -1221,9 +1221,12 @@ func (r ReconcileHyperConverged) removeLeftover(req *common.HcoRequest, knownHco
 		return false, err
 	}
 	if affectedRange(knownHcoSV) {
+		req.Logger.Info("Removing leftover during upgrade", "GVK", p.GroupVersionKind, "ObjectKey", p.ObjectKey)
 		removeRelatedObject(req, p.GroupVersionKind, p.ObjectKey)
 		u := &unstructured.Unstructured{}
 		u.SetGroupVersionKind(p.GroupVersionKind)
+		u.SetName(p.ObjectKey.Name)
+		u.SetNamespace(p.ObjectKey.Namespace)
 		gerr := r.client.Get(req.Ctx, p.ObjectKey, u)
 		if gerr != nil {
 			if apierrors.IsNotFound(gerr) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -159,7 +159,7 @@ func doDeleteResource(ctx context.Context, c client.Client, resource *unstructur
 func shouldDeleteResource(resource *unstructured.Unstructured, hcoName string, logger logr.Logger) bool {
 	labels := resource.GetLabels()
 	if app, labelExists := labels[AppLabel]; !labelExists || app != hcoName {
-		logger.Info("Existing resource wasn't deployed by HCO, ignoring", "Kind", resource.GetObjectKind())
+		logger.Info("Existing resource wasn't deployed by HCO, ignoring", "GVK", resource.GetObjectKind().GroupVersionKind())
 		return false
 	}
 	return true
@@ -181,7 +181,7 @@ func getResourceForDeletion(ctx context.Context, c client.Client, resource *unst
 	err := c.Get(ctx, types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}, resource)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("Resource doesn't exist, there is nothing to remove", "Kind", resource.GetObjectKind())
+			logger.Info("Resource doesn't exist, there is nothing to remove", "GVK", resource.GetObjectKind().GroupVersionKind())
 			return false, nil
 		}
 		return false, err
@@ -213,11 +213,11 @@ func EnsureDeleted(ctx context.Context, c client.Client, obj client.Object, hcoN
 
 	if err != nil {
 		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-			logger.Info("Resource doesn't exist, there is nothing to remove", "Kind", obj.GetObjectKind())
+			logger.Info("Resource doesn't exist, there is nothing to remove", "GVK", obj.GetObjectKind().GroupVersionKind())
 			return false, nil
 		}
 
-		logger.Error(err, "failed to get object from kubernetes", "Kind", obj.GetObjectKind())
+		logger.Error(err, "failed to get object from kubernetes", "GVK", obj.GetObjectKind().GroupVersionKind())
 		return false, err
 	}
 


### PR DESCRIPTION
As for https://bugzilla.redhat.com/show_bug.cgi?id=2063991
we have also to remove CMs that are not correctly configured
with the right label and so are not matched by the client cache.
Let's correctly watch all the CMs in the namespace.
Improve the logging.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2063991

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

