### PR TITLE
Fix the unit test in Makefile

### DIFF
--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -8,14 +8,12 @@ JOB_TYPE="${JOB_TYPE:-}"
 if [ "${JOB_TYPE}" == "travis" ]; then
     go get -v -t ./...
     go install github.com/mattn/goveralls@latest
-    go install github.com/onsi/ginkgo/v2/ginkgo@latest
-    go get -v github.com/onsi/gomega
-    go get -u github.com/evanphx/json-patch
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.3
     go mod vendor
     PKG_PACKAGE_PATH="pkg/"
     CONTROLLERS_PACKAGE_PATH="controllers/"
     mkdir -p coverprofiles
-    ginkgo -r -cover -output-dir=./coverprofiles -coverprofile=cover.coverprofile ${PKG_PACKAGE_PATH} ${CONTROLLERS_PACKAGE_PATH}
+    ginkgo -cover -output-dir=./coverprofiles -coverprofile=cover.coverprofile -r ${PKG_PACKAGE_PATH} -r ${CONTROLLERS_PACKAGE_PATH}
 else
     test_path="tests/func-tests"
     (cd $test_path; go install github.com/onsi/ginkgo/v2/ginkgo@latest)


### PR DESCRIPTION
For some reason, testing pkg and the controllers, fails in ginkgo v2
from time to time; e.g. `ginkgo -r pkg/ controllers/`

Switching them solved the issue: `ginkgo -r controllers/ pkg/`

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

