### PR TITLE
Prevent upgrade if one of the operand is not upgradeable

### DIFF
--- a/controllers/common/hcoConditions.go
+++ b/controllers/common/hcoConditions.go
@@ -54,3 +54,8 @@ func (hc HcoConditions) HasCondition(conditionType string) bool {
 
 	return exists
 }
+
+func (hc HcoConditions) GetCondition(conditionType string) (metav1.Condition, bool) {
+	cond, found := hc[conditionType]
+	return cond, found
+}

--- a/controllers/common/hcoRequest.go
+++ b/controllers/common/hcoRequest.go
@@ -21,6 +21,7 @@ type HcoRequest struct {
 	Dirty                      bool                       // is something was changed in the CR
 	StatusDirty                bool                       // is something was changed in the CR's Status
 	HCOTriggered               bool                       // if the request got triggered by a direct modification on HCO CR
+	Upgradeable                bool                       // if all the operands are upgradeable
 }
 
 func NewHcoRequest(ctx context.Context, request reconcile.Request, log logr.Logger, upgradeMode, hcoTriggered bool) *HcoRequest {
@@ -34,6 +35,7 @@ func NewHcoRequest(ctx context.Context, request reconcile.Request, log logr.Logg
 		Dirty:                      false,
 		StatusDirty:                false,
 		HCOTriggered:               hcoTriggered,
+		Upgradeable:                true,
 	}
 }
 

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -2427,7 +2427,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "CDI Test Error message",
 				})
 				cl := expected.initClient()
-				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
 
 				conditions := foundResource.Status.Conditions
 				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
@@ -2453,6 +2453,8 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cd.Reason).Should(Equal(commonDegradedReason))
 				Expect(cd.Message).Should(Equal("HCO is not Upgradeable due to degraded components"))
 
+				By("operator condition should be true even the upgradeable is false")
+				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 			})
 
 			It("should be degraded when a component is degraded + Progressing", func() {
@@ -2470,7 +2472,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "CDI Test Error message",
 				})
 				cl := expected.initClient()
-				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
 
 				conditions := foundResource.Status.Conditions
 				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
@@ -2493,6 +2495,9 @@ var _ = Describe("HyperconvergedController", func() {
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
 				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
 				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+
+				By("operator condition should be true even the upgradeable is false")
+				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 			})
 
 			It("should be degraded when a component is degraded + !Available", func() {
@@ -2510,7 +2515,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "CDI Test Error message",
 				})
 				cl := expected.initClient()
-				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
 
 				conditions := foundResource.Status.Conditions
 				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
@@ -2533,6 +2538,9 @@ var _ = Describe("HyperconvergedController", func() {
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
 				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
 				Expect(cd.Reason).Should(Equal(commonDegradedReason))
+
+				By("operator condition should be true even the upgradeable is false")
+				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 			})
 
 			It("should be Progressing when a component is Progressing", func() {
@@ -2544,7 +2552,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "CDI Test Error message",
 				})
 				cl := expected.initClient()
-				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
 
 				conditions := foundResource.Status.Conditions
 				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
@@ -2567,6 +2575,9 @@ var _ = Describe("HyperconvergedController", func() {
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
 				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
 				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+
+				By("operator condition should be true even the upgradeable is false")
+				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 			})
 
 			It("should be Progressing when a component is Progressing + !Available", func() {
@@ -2584,7 +2595,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "CDI Test Error message",
 				})
 				cl := expected.initClient()
-				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
 
 				conditions := foundResource.Status.Conditions
 				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
@@ -2607,6 +2618,9 @@ var _ = Describe("HyperconvergedController", func() {
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
 				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
 				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+
+				By("operator condition should be true even the upgradeable is false")
+				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 			})
 
 			It("should be not Available when a component is not Available", func() {
@@ -2710,6 +2724,146 @@ var _ = Describe("HyperconvergedController", func() {
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
 				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
 				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+			})
+
+			It("should not be upgradeable when a component is not upgradeable", func() {
+				expected := getBasicDeployment()
+				conditionsv1.SetStatusCondition(&expected.cdi.Status.Conditions, conditionsv1.Condition{
+					Type:    conditionsv1.ConditionUpgradeable,
+					Status:  corev1.ConditionFalse,
+					Reason:  errorReason,
+					Message: "CDI Test Error message",
+				})
+				cl := expected.initClient()
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
+
+				conditions := foundResource.Status.Conditions
+				GinkgoWriter.Println("\nActual Conditions:")
+				wr := json.NewEncoder(GinkgoWriter)
+				wr.SetIndent("", "  ")
+				_ = wr.Encode(conditions)
+
+				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal("CDINotUpgradeable"))
+				Expect(cd.Message).Should(Equal("CDI is not upgradeable: CDI Test Error message"))
+
+				By("operator condition should be false")
+				validateOperatorCondition(r, metav1.ConditionFalse, "CDINotUpgradeable", "is not upgradeable:")
+			})
+
+			It("should not be with its own reason and message if a component is not upgradeable, even if there are it also progressing", func() {
+				expected := getBasicDeployment()
+				conditionsv1.SetStatusCondition(&expected.cdi.Status.Conditions, conditionsv1.Condition{
+					Type:    conditionsv1.ConditionUpgradeable,
+					Status:  corev1.ConditionFalse,
+					Reason:  errorReason,
+					Message: "CDI Upgrade Error message",
+				})
+				conditionsv1.SetStatusCondition(&expected.cdi.Status.Conditions, conditionsv1.Condition{
+					Type:    conditionsv1.ConditionProgressing,
+					Status:  corev1.ConditionTrue,
+					Reason:  errorReason,
+					Message: "CDI Test Error message",
+				})
+
+				cl := expected.initClient()
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
+
+				conditions := foundResource.Status.Conditions
+				GinkgoWriter.Println("\nActual Conditions:")
+				wr := json.NewEncoder(GinkgoWriter)
+				wr.SetIndent("", "  ")
+				_ = wr.Encode(conditions)
+
+				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal("CDINotUpgradeable"))
+				Expect(cd.Message).Should(Equal("CDI is not upgradeable: CDI Upgrade Error message"))
+
+				By("operator condition should be false")
+				validateOperatorCondition(r, metav1.ConditionFalse, "CDINotUpgradeable", "is not upgradeable:")
+			})
+
+			It("should not be with its own reason and message if a component is not upgradeable, even if there are it also degraded", func() {
+				expected := getBasicDeployment()
+				conditionsv1.SetStatusCondition(&expected.cdi.Status.Conditions, conditionsv1.Condition{
+					Type:    conditionsv1.ConditionUpgradeable,
+					Status:  corev1.ConditionFalse,
+					Reason:  errorReason,
+					Message: "CDI Upgrade Error message",
+				})
+				conditionsv1.SetStatusCondition(&expected.cdi.Status.Conditions, conditionsv1.Condition{
+					Type:    conditionsv1.ConditionDegraded,
+					Status:  corev1.ConditionTrue,
+					Reason:  errorReason,
+					Message: "CDI Test Error message",
+				})
+
+				cl := expected.initClient()
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
+
+				conditions := foundResource.Status.Conditions
+				GinkgoWriter.Println("\nActual Conditions:")
+				wr := json.NewEncoder(GinkgoWriter)
+				wr.SetIndent("", "  ")
+				_ = wr.Encode(conditions)
+
+				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal(commonDegradedReason))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal("CDIDegraded"))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal("CDINotUpgradeable"))
+				Expect(cd.Message).Should(Equal("CDI is not upgradeable: CDI Upgrade Error message"))
+
+				By("operator condition should be false")
+				validateOperatorCondition(r, metav1.ConditionFalse, "CDINotUpgradeable", "is not upgradeable:")
 			})
 		})
 


### PR DESCRIPTION
If an operand upgradeable condition is false, HCO will set the operator
condition's Upgradeable condition to false.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent upgrade if one of the operand is not upgradeable

If an operand upgradeable condition is false, HCO will set the operator
condition's Upgradeable condition to false.
```

