### PR TITLE
[release-1.6] Prevent upgrade if one of the operand is not upgradeable

### DIFF
--- a/pkg/controller/common/hcoConditions.go
+++ b/pkg/controller/common/hcoConditions.go
@@ -54,3 +54,8 @@ func (hc HcoConditions) HasCondition(conditionType string) bool {
 
 	return exists
 }
+
+func (hc HcoConditions) GetCondition(conditionType string) (metav1.Condition, bool) {
+	cond, found := hc[conditionType]
+	return cond, found
+}

--- a/pkg/controller/common/hcoRequest.go
+++ b/pkg/controller/common/hcoRequest.go
@@ -21,6 +21,7 @@ type HcoRequest struct {
 	Dirty                      bool                       // is something was changed in the CR
 	StatusDirty                bool                       // is something was changed in the CR's Status
 	HCOTriggered               bool                       // if the request got triggered by a direct modification on HCO CR
+	Upgradeable                bool                       // if all the operands are upgradeable
 }
 
 func NewHcoRequest(ctx context.Context, request reconcile.Request, log logr.Logger, upgradeMode, hcoTriggered bool) *HcoRequest {
@@ -34,6 +35,7 @@ func NewHcoRequest(ctx context.Context, request reconcile.Request, log logr.Logg
 		Dirty:                      false,
 		StatusDirty:                false,
 		HCOTriggered:               hcoTriggered,
+		Upgradeable:                true,
 	}
 }
 

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -979,23 +979,33 @@ func (r *ReconcileHyperConverged) firstLoopInitialization(request *common.HcoReq
 func (r *ReconcileHyperConverged) setOperatorUpgradeableStatus(request *common.HcoRequest) error {
 	if hcoutil.GetClusterInfo().IsManagedByOLM() {
 
-		request.Logger.Info("setting the Upgradeable operator condition", requestedStatusKey, !r.upgradeMode)
+		upgradeable := !r.upgradeMode && request.Upgradeable
+
+		request.Logger.Info("setting the Upgradeable operator condition", requestedStatusKey, upgradeable)
 
 		msg := hcoutil.UpgradeableAllowMessage
 		status := metav1.ConditionTrue
 		reason := hcoutil.UpgradeableAllowReason
 
-		if r.upgradeMode {
-			msg = hcoutil.UpgradeableUpgradingMessage + r.ownVersion
+		if !upgradeable {
 			status = metav1.ConditionFalse
-			reason = hcoutil.UpgradeableUpgradingReason
+
+			if r.upgradeMode {
+				msg = hcoutil.UpgradeableUpgradingMessage + r.ownVersion
+				reason = hcoutil.UpgradeableUpgradingReason
+			} else {
+				condition, found := request.Conditions.GetCondition(hcov1beta1.ConditionUpgradeable)
+				if found && condition.Status == metav1.ConditionFalse {
+					reason = condition.Reason
+					msg = condition.Message
+				}
+			}
 		}
 
 		if err := r.upgradeableCondition.Set(request.Ctx, status, reason, msg); err != nil {
-			request.Logger.Error(err, "can't set the Upgradeable operator condition", requestedStatusKey, !r.upgradeMode)
+			request.Logger.Error(err, "can't set the Upgradeable operator condition", requestedStatusKey, upgradeable)
 			return err
 		}
-
 	}
 
 	return nil

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -2057,7 +2057,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "CDI Test Error message",
 				})
 				cl := expected.initClient()
-				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
 
 				conditions := foundResource.Status.Conditions
 				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
@@ -2083,6 +2083,8 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cd.Reason).Should(Equal(commonDegradedReason))
 				Expect(cd.Message).Should(Equal("HCO is not Upgradeable due to degraded components"))
 
+				By("operator condition should be true even the upgradeable is false")
+				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 			})
 
 			It("should be degraded when a component is degraded + Progressing", func() {
@@ -2100,7 +2102,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "CDI Test Error message",
 				})
 				cl := expected.initClient()
-				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
 
 				conditions := foundResource.Status.Conditions
 				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
@@ -2123,6 +2125,9 @@ var _ = Describe("HyperconvergedController", func() {
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
 				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
 				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+
+				By("operator condition should be true even the upgradeable is false")
+				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 			})
 
 			It("should be degraded when a component is degraded + !Available", func() {
@@ -2140,7 +2145,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "CDI Test Error message",
 				})
 				cl := expected.initClient()
-				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
 
 				conditions := foundResource.Status.Conditions
 				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
@@ -2163,6 +2168,9 @@ var _ = Describe("HyperconvergedController", func() {
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
 				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
 				Expect(cd.Reason).Should(Equal(commonDegradedReason))
+
+				By("operator condition should be true even the upgradeable is false")
+				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 			})
 
 			It("should be Progressing when a component is Progressing", func() {
@@ -2174,7 +2182,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "CDI Test Error message",
 				})
 				cl := expected.initClient()
-				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
 
 				conditions := foundResource.Status.Conditions
 				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
@@ -2197,6 +2205,9 @@ var _ = Describe("HyperconvergedController", func() {
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
 				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
 				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+
+				By("operator condition should be true even the upgradeable is false")
+				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 			})
 
 			It("should be Progressing when a component is Progressing + !Available", func() {
@@ -2214,7 +2225,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "CDI Test Error message",
 				})
 				cl := expected.initClient()
-				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
 
 				conditions := foundResource.Status.Conditions
 				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
@@ -2237,6 +2248,9 @@ var _ = Describe("HyperconvergedController", func() {
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
 				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
 				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+
+				By("operator condition should be true even the upgradeable is false")
+				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 			})
 
 			It("should be not Available when a component is not Available", func() {
@@ -2340,6 +2354,146 @@ var _ = Describe("HyperconvergedController", func() {
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
 				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
 				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+			})
+
+			It("should not be upgradeable when a component is not upgradeable", func() {
+				expected := getBasicDeployment()
+				conditionsv1.SetStatusCondition(&expected.cdi.Status.Conditions, conditionsv1.Condition{
+					Type:    conditionsv1.ConditionUpgradeable,
+					Status:  corev1.ConditionFalse,
+					Reason:  errorReason,
+					Message: "CDI Test Error message",
+				})
+				cl := expected.initClient()
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
+
+				conditions := foundResource.Status.Conditions
+				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
+				wr := json.NewEncoder(GinkgoWriter)
+				wr.SetIndent("", "  ")
+				_ = wr.Encode(conditions)
+
+				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal("CDINotUpgradeable"))
+				Expect(cd.Message).Should(Equal("CDI is not upgradeable: CDI Test Error message"))
+
+				By("operator condition should be false")
+				validateOperatorCondition(r, metav1.ConditionFalse, "CDINotUpgradeable", "is not upgradeable:")
+			})
+
+			It("should not be with its own reason and message if a component is not upgradeable, even if there are it also progressing", func() {
+				expected := getBasicDeployment()
+				conditionsv1.SetStatusCondition(&expected.cdi.Status.Conditions, conditionsv1.Condition{
+					Type:    conditionsv1.ConditionUpgradeable,
+					Status:  corev1.ConditionFalse,
+					Reason:  errorReason,
+					Message: "CDI Upgrade Error message",
+				})
+				conditionsv1.SetStatusCondition(&expected.cdi.Status.Conditions, conditionsv1.Condition{
+					Type:    conditionsv1.ConditionProgressing,
+					Status:  corev1.ConditionTrue,
+					Reason:  errorReason,
+					Message: "CDI Test Error message",
+				})
+
+				cl := expected.initClient()
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
+
+				conditions := foundResource.Status.Conditions
+				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
+				wr := json.NewEncoder(GinkgoWriter)
+				wr.SetIndent("", "  ")
+				_ = wr.Encode(conditions)
+
+				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal("CDINotUpgradeable"))
+				Expect(cd.Message).Should(Equal("CDI is not upgradeable: CDI Upgrade Error message"))
+
+				By("operator condition should be false")
+				validateOperatorCondition(r, metav1.ConditionFalse, "CDINotUpgradeable", "is not upgradeable:")
+			})
+
+			It("should not be with its own reason and message if a component is not upgradeable, even if there are it also degraded", func() {
+				expected := getBasicDeployment()
+				conditionsv1.SetStatusCondition(&expected.cdi.Status.Conditions, conditionsv1.Condition{
+					Type:    conditionsv1.ConditionUpgradeable,
+					Status:  corev1.ConditionFalse,
+					Reason:  errorReason,
+					Message: "CDI Upgrade Error message",
+				})
+				conditionsv1.SetStatusCondition(&expected.cdi.Status.Conditions, conditionsv1.Condition{
+					Type:    conditionsv1.ConditionDegraded,
+					Status:  corev1.ConditionTrue,
+					Reason:  errorReason,
+					Message: "CDI Test Error message",
+				})
+
+				cl := expected.initClient()
+				foundResource, r, _ := doReconcile(cl, expected.hco, nil)
+
+				conditions := foundResource.Status.Conditions
+				_, _ = fmt.Fprintln(GinkgoWriter, "\nActual Conditions:")
+				wr := json.NewEncoder(GinkgoWriter)
+				wr.SetIndent("", "  ")
+				_ = wr.Encode(conditions)
+
+				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal(commonDegradedReason))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).Should(Equal("CDIDegraded"))
+
+				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
+				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).Should(Equal("CDINotUpgradeable"))
+				Expect(cd.Message).Should(Equal("CDI is not upgradeable: CDI Upgrade Error message"))
+
+				By("operator condition should be false")
+				validateOperatorCondition(r, metav1.ConditionFalse, "CDINotUpgradeable", "is not upgradeable:")
 			})
 		})
 

--- a/pkg/controller/operands/networkAddons_test.go
+++ b/pkg/controller/operands/networkAddons_test.go
@@ -572,6 +572,89 @@ var _ = Describe("CNA Operand", func() {
 			}))
 		})
 
+		It("should handle upgrade condition", func() {
+			expectedResource, err := NewNetworkAddons(hco)
+			Expect(err).ToNot(HaveOccurred())
+			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
+			expectedResource.Status.Conditions = []conditionsv1.Condition{
+				{
+					Type:   conditionsv1.ConditionAvailable,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:    conditionsv1.ConditionUpgradeable,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Foo",
+					Message: "Bar",
+				},
+			}
+			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
+			handler := (*genericOperand)(newCnaHandler(cl, commonTestUtils.GetScheme()))
+			res := handler.ensure(req)
+			Expect(res.UpgradeDone).To(BeFalse())
+			Expect(res.Err).ToNot(HaveOccurred())
+
+			// Check HCO's status
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRef, err := reference.GetReference(handler.Scheme, expectedResource)
+			Expect(err).ToNot(HaveOccurred())
+			// ObjectReference should have been added
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRef))
+			// Check conditions
+			Expect(req.Conditions).To(HaveLen(1))
+			Expect(req.Conditions[hcov1beta1.ConditionUpgradeable]).To(commonTestUtils.RepresentCondition(metav1.Condition{
+				Type:    hcov1beta1.ConditionUpgradeable,
+				Status:  metav1.ConditionFalse,
+				Reason:  "NetworkAddonsConfigNotUpgradeable",
+				Message: "NetworkAddonsConfig is not upgradeable: Bar",
+			}))
+		})
+
+		It("should override ann existing upgrade condition, if the operand one is false", func() {
+			expectedResource, err := NewNetworkAddons(hco)
+			req.Conditions.SetStatusCondition(metav1.Condition{
+				Type:    hcov1beta1.ConditionUpgradeable,
+				Status:  metav1.ConditionFalse,
+				Reason:  "another reason",
+				Message: "another message",
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			expectedResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", expectedResource.Namespace, expectedResource.Name)
+			expectedResource.Status.Conditions = []conditionsv1.Condition{
+				{
+					Type:   conditionsv1.ConditionAvailable,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:    conditionsv1.ConditionUpgradeable,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Foo",
+					Message: "Bar",
+				},
+			}
+			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
+			handler := (*genericOperand)(newCnaHandler(cl, commonTestUtils.GetScheme()))
+			res := handler.ensure(req)
+			Expect(res.UpgradeDone).To(BeFalse())
+			Expect(res.Err).ToNot(HaveOccurred())
+
+			// Check HCO's status
+			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+			objectRef, err := reference.GetReference(handler.Scheme, expectedResource)
+			Expect(err).ToNot(HaveOccurred())
+			// ObjectReference should have been added
+			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRef))
+			// Check conditions
+			Expect(req.Conditions).To(HaveLen(1))
+			Expect(req.Conditions[hcov1beta1.ConditionUpgradeable]).To(commonTestUtils.RepresentCondition(metav1.Condition{
+				Type:    hcov1beta1.ConditionUpgradeable,
+				Status:  metav1.ConditionFalse,
+				Reason:  "NetworkAddonsConfigNotUpgradeable",
+				Message: "NetworkAddonsConfig is not upgradeable: Bar",
+			}))
+		})
+
 		Context("jsonpath Annotation", func() {
 			It("Should create CNA object with changes from the annotation", func() {
 				hco.Annotations = map[string]string{common.JSONPatchCNAOAnnotationName: `[

--- a/pkg/controller/operands/operand.go
+++ b/pkg/controller/operands/operand.go
@@ -289,6 +289,9 @@ func setConditionsByOperandConditions(req *common.HcoRequest, component string, 
 		case hcov1beta1.ConditionDegraded:
 			foundDegradedCond = true
 			isReady = handleOperandDegradedCond(req, component, condition) && isReady
+
+		case hcov1beta1.ConditionUpgradeable:
+			handleOperandUpgradeableCond(req, component, condition)
 		}
 	}
 
@@ -325,7 +328,7 @@ func handleOperandProgressingCond(req *common.HcoRequest, component string, cond
 			Message:            fmt.Sprintf("%s is progressing: %v", component, condition.Message),
 			ObservedGeneration: req.Instance.Generation,
 		})
-		req.Conditions.SetStatusCondition(metav1.Condition{
+		req.Conditions.SetStatusConditionIfUnset(metav1.Condition{
 			Type:               hcov1beta1.ConditionUpgradeable,
 			Status:             metav1.ConditionFalse,
 			Reason:             fmt.Sprintf("%sProgressing", component),
@@ -336,6 +339,20 @@ func handleOperandProgressingCond(req *common.HcoRequest, component string, cond
 		return false
 	}
 	return true
+}
+
+func handleOperandUpgradeableCond(req *common.HcoRequest, component string, condition metav1.Condition) {
+	if condition.Status == metav1.ConditionFalse {
+		req.Upgradeable = false
+		req.Logger.Info(fmt.Sprintf("%s is 'Progressing'", component))
+		req.Conditions.SetStatusCondition(metav1.Condition{
+			Type:               hcov1beta1.ConditionUpgradeable,
+			Status:             metav1.ConditionFalse,
+			Reason:             fmt.Sprintf("%sNotUpgradeable", component),
+			Message:            fmt.Sprintf("%s is not upgradeable: %v", component, condition.Message),
+			ObservedGeneration: req.Instance.Generation,
+		})
+	}
 }
 
 func handleOperandAvailableCond(req *common.HcoRequest, component string, condition metav1.Condition) bool {


### PR DESCRIPTION
Manual cherry-pick of #1920

If an operand upgradeable condition is false, HCO will set the operator
condition's Upgradeable condition to false

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent upgrade if one of the operand is not upgradeable

If an operand upgradeable condition is false, HCO will set the operator
condition's Upgradeable condition to false
```

