### PR TITLE
Allow modifiying runbook URL on build time

### DIFF
--- a/controllers/operands/monitoring.go
+++ b/controllers/operands/monitoring.go
@@ -28,7 +28,6 @@ const (
 	alertRuleGroup           = "kubevirt.hyperconverged.rules"
 	outOfBandUpdateAlert     = "KubevirtHyperconvergedClusterOperatorCRModification"
 	unsafeModificationAlert  = "KubevirtHyperconvergedClusterOperatorUSModification"
-	runbookUrlTemplate       = "https://kubevirt.io/monitoring/runbooks/%s"
 	severityAlertLabelKey    = "severity"
 	partOfAlertLabelKey      = "kubernetes_operator_part_of"
 	partOfAlertLabelValue    = "kubevirt"
@@ -37,6 +36,8 @@ const (
 )
 
 var (
+	runbookUrlTemplate = "https://kubevirt.io/monitoring/runbooks/%s"
+
 	outOfBandUpdateRunbookUrl    = fmt.Sprintf(runbookUrlTemplate, outOfBandUpdateAlert)
 	unsafeModificationRunbookUrl = fmt.Sprintf(runbookUrlTemplate, unsafeModificationAlert)
 )


### PR DESCRIPTION
Change the runbookUrlTemplate constant to be a variable.

It's now possible to override its value on build time; e.g.

```
go build -ldflags "-X github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands.runbookUrlTemplate=http://something-else/%s/suffix"
```

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

