### PR TITLE
Fix new bug found by the go linter

### DIFF
--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -69,11 +69,14 @@ fieldObj:
 		})
 
 		It("should return real error if trying to get the file stat (instead of a dir)", func() {
-			tempDir := os.TempDir()
-			defer os.RemoveAll(tempDir)
+			tempDir, err := os.MkdirTemp("", "")
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				_ = os.RemoveAll(tempDir)
+			}()
 
 			fileName := tempDir + "/testFile.txt"
-			_, err := os.Create(fileName)
+			_, err = os.Create(fileName)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = ValidateManifestDir(fileName)
@@ -84,10 +87,13 @@ fieldObj:
 		})
 
 		It("should return no error for a valid dir name", func() {
-			tempDir := os.TempDir()
-			defer os.RemoveAll(tempDir)
+			tempDir, err := os.MkdirTemp("", "")
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				_ = os.RemoveAll(tempDir)
+			}()
 
-			err := ValidateManifestDir(tempDir)
+			err = ValidateManifestDir(tempDir)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
The new version of the golangci-lint (v1.46.0) found a new bug in
pkg/util/file_test.go where the test get the temp directory (e.g. /tmp)
and then trying to remove it in the defer:

```golang
tempDit := os.TempDir() // returns /tmp
defer os.RemoveAll(tempDir)
```

This PR fixes the issue by using the right os function - `MkdirTemp`

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

