### PR TITLE
Fix CSV retrieval command in upgrade test to get only HCO CSV

### DIFF
--- a/build/Dockerfile.functest.ci
+++ b/build/Dockerfile.functest.ci
@@ -18,7 +18,7 @@ RUN curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-r
     chmod a+x /usr/local/bin/kubectl && \
     curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod a+x /usr/local/bin/jq && \
-    microdnf install tar python3 graphviz
+    microdnf install tar
 
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/_out/func-tests.test  ${TEST_OUT_PATH}/
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/hack  ${TEST_OUT_PATH}/hack

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -2039,7 +2039,13 @@ var _ = Describe("HyperconvergedController", func() {
 							Reason:   "fake reason",
 						},
 					}
-					resources := []runtime.Object{nmoCrBefore}
+					nmoOldCrd := &apiextensionsv1.CustomResourceDefinition{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      oldNmoCrdName,
+							Namespace: "",
+						},
+					}
+					resources := []runtime.Object{nmoCrBefore, nmoOldCrd}
 					cl := commonTestUtils.InitClient(resources)
 					r := initReconciler(cl, nil)
 					req := commonTestUtils.NewReq(expected.hco)


### PR DESCRIPTION
Now we have 2 CSVs in `kubevirt-hyperconverged` namespace (NMO was added), and we need to extract only the kubevirt-hyperconverged one.

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

