### PR TITLE
Remove label protection when removing old metrics objects

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -1304,7 +1304,7 @@ func (r ReconcileHyperConverged) removeOldMetricsObjs(req *common.HcoRequest) er
 	initOldMetricsObjects(req)
 
 	for name, object := range oldMetricsObjects {
-		removed, err := r.deleteObj(req, object, true)
+		removed, err := r.deleteObj(req, object, false)
 
 		if err != nil {
 			return err

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1956,18 +1956,12 @@ var _ = Describe("HyperconvergedController", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      operatorMetrics,
 								Namespace: namespace,
-								Labels: map[string]string{
-									hcoutil.AppLabel: expected.hco.Name,
-								},
 							},
 						},
 						&corev1.Service{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      webhookMetrics,
 								Namespace: namespace,
-								Labels: map[string]string{
-									hcoutil.AppLabel: expected.hco.Name,
-								},
 							},
 						},
 					}
@@ -2000,9 +1994,6 @@ var _ = Describe("HyperconvergedController", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      operatorMetrics,
 								Namespace: namespace,
-								Labels: map[string]string{
-									hcoutil.AppLabel: expected.hco.Name,
-								},
 							},
 						},
 					}


### PR DESCRIPTION
When upgrading, old "hyperconverged-cluster-operator-metrics" and "hyperconverged-cluster-webhook-metrics" services and endpoints were not being removed because these objects were not previously updated to contain the "app" label indicating they are managed by HCO and therefore they were being protected from deletion.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Force delete old HCO metrics objects
```

