### PR TITLE
Limit the "Update Components Graph" github action

### DIFF
--- a/.github/workflows/graphs-updater.yml
+++ b/.github/workflows/graphs-updater.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build:
     name: Update Components Graph
+    if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository


### PR DESCRIPTION
the Update Components Graph github action works on any fork with a cron
expression. Then it fails every day and sends error email every day to
all the fork owners.

This PR limits the action to work only in the
kubevirt/hyperconverged-cluster-operator github repository.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

