### PR TITLE
[WIP] Fix alert bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,19 @@ DO=eval
 export JOB_TYPE=prow
 endif
 
-sanity: generate generate-doc validate-no-offensive-lang
+sanity: generate generate-doc validate-no-offensive-lang goimport
 	go version
 	go fmt ./...
-	go install golang.org/x/tools/cmd/goimports@latest
-	goimports -w -local="kubevirt.io,github.com/kubevirt,github.com/kubevirt/hyperconverged-cluster-operator"  $(shell find . -type f -name '*.go' ! -path "*/vendor/*" ! -path "./_kubevirtci/*" ! -path "*zz_generated*" )
 	go mod tidy -v
 	go mod vendor
 	./hack/build-manifests.sh
 	git add -N vendor
 	git difftool -y --trust-exit-code --extcmd=./hack/diff-csv.sh
+
+goimport:
+	go install golang.org/x/tools/cmd/goimports@latest
+	goimports -w -local="kubevirt.io,github.com/kubevirt,github.com/kubevirt/hyperconverged-cluster-operator"  $(shell find . -type f -name '*.go' ! -path "*/vendor/*" ! -path "./_kubevirtci/*" ! -path "*zz_generated*" )
+
 
 lint:
 	golangci-lint run
@@ -261,4 +264,6 @@ validate-no-offensive-lang:
 		build-docgen \
 		generate \
 		generate-doc \
-		validate-no-offensive-lang
+		validate-no-offensive-lang \
+		sanity \
+		goimport

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.1 AS builder
+FROM docker.io/golang:1.18.2 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -1,4 +1,4 @@
-FROM golang:1.18.1 AS builder
+FROM docker.io/golang:1.18.2 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM golang:1.18.1 AS builder
+FROM docker.io/golang:1.18.2 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -127,7 +127,7 @@ func main() {
 	cmdHelper.ExitOnError(err, "Cannot detect cluster type")
 
 	eventEmitter := hcoutil.GetEventEmitter()
-	eventEmitter.Init(ctx, apiClient, mgr.GetEventRecorderFor(hcoutil.HyperConvergedName), logger)
+	eventEmitter.Init(ci.GetPod(), ci.GetCSV(), mgr.GetEventRecorderFor(hcoutil.HyperConvergedName))
 
 	err = mgr.AddHealthzCheck("ping", healthz.Ping)
 	cmdHelper.ExitOnError(err, "unable to add health check")

--- a/cmd/hyperconverged-cluster-webhook/main.go
+++ b/cmd/hyperconverged-cluster-webhook/main.go
@@ -94,7 +94,7 @@ func main() {
 	cmdHelper.ExitOnError(err, "Cannot detect cluster type")
 
 	eventEmitter := hcoutil.GetEventEmitter()
-	eventEmitter.Init(ctx, apiClient, mgr.GetEventRecorderFor(hcoutil.HyperConvergedName), logger)
+	eventEmitter.Init(ci.GetPod(), ci.GetCSV(), mgr.GetEventRecorderFor(hcoutil.HyperConvergedName))
 
 	err = mgr.AddHealthzCheck("ping", healthz.Ping)
 	cmdHelper.ExitOnError(err, "unable to add health check")

--- a/controllers/commonTestUtils/eventEmitterMock.go
+++ b/controllers/commonTestUtils/eventEmitterMock.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"sync"
 
+	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -35,7 +38,7 @@ func (eem *EventEmitterMock) Reset() {
 	eem.storedEvents = make([]MockEvent, 0)
 }
 
-func (EventEmitterMock) Init(_ context.Context, _ client.Client, _ record.EventRecorder, _ logr.Logger) {
+func (EventEmitterMock) Init(_ *corev1.Pod, _ *csvv1alpha1.ClusterServiceVersion, _ record.EventRecorder) {
 	/* not implemented; mock only */
 }
 

--- a/controllers/commonTestUtils/testUtils.go
+++ b/controllers/commonTestUtils/testUtils.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 
 	"github.com/go-logr/logr"
@@ -242,6 +245,17 @@ func (ClusterInfoMock) GetDomain() string {
 func (c ClusterInfoMock) IsConsolePluginImageProvided() bool {
 	return true
 }
+func (c ClusterInfoMock) GetPod() *corev1.Pod {
+	return nil
+}
+
+func (c ClusterInfoMock) GetDeployment() *appsv1.Deployment {
+	return nil
+}
+
+func (c ClusterInfoMock) GetCSV() *csvv1alpha1.ClusterServiceVersion {
+	return nil
+}
 func (ClusterInfoMock) GetTLSSecurityProfile(_ *openshiftconfigv1.TLSSecurityProfile) *openshiftconfigv1.TLSSecurityProfile {
 	return &openshiftconfigv1.TLSSecurityProfile{
 		Type:         openshiftconfigv1.TLSProfileIntermediateType,
@@ -275,6 +289,17 @@ func (ClusterInfoSNOMock) IsInfrastructureHighlyAvailable() bool {
 }
 func (ClusterInfoSNOMock) GetDomain() string {
 	return "domain"
+}
+func (c ClusterInfoSNOMock) GetPod() *corev1.Pod {
+	return nil
+}
+
+func (c ClusterInfoSNOMock) GetDeployment() *appsv1.Deployment {
+	return nil
+}
+
+func (c ClusterInfoSNOMock) GetCSV() *csvv1alpha1.ClusterServiceVersion {
+	return nil
 }
 func (ClusterInfoSNOMock) GetTLSSecurityProfile(_ *openshiftconfigv1.TLSSecurityProfile) *openshiftconfigv1.TLSSecurityProfile {
 	return &openshiftconfigv1.TLSSecurityProfile{
@@ -310,6 +335,17 @@ func (ClusterInfoSRCPHAIMock) IsControlPlaneHighlyAvailable() bool {
 }
 func (ClusterInfoSRCPHAIMock) IsInfrastructureHighlyAvailable() bool {
 	return true
+}
+func (ClusterInfoSRCPHAIMock) GetPod() *corev1.Pod {
+	return nil
+}
+
+func (ClusterInfoSRCPHAIMock) GetDeployment() *appsv1.Deployment {
+	return nil
+}
+
+func (ClusterInfoSRCPHAIMock) GetCSV() *csvv1alpha1.ClusterServiceVersion {
+	return nil
 }
 func (ClusterInfoSRCPHAIMock) GetDomain() string {
 	return "domain"

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -186,7 +186,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo) er
 		secondaryResources = append(secondaryResources, []client.Object{
 			&corev1.Service{},
 			&monitoringv1.ServiceMonitor{},
-			&monitoringv1.PrometheusRule{},
 			&routev1.Route{},
 			&consolev1.ConsoleCLIDownload{},
 			&imagev1.ImageStream{},

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -718,7 +718,7 @@ var _ = Describe("HyperconvergedController", func() {
 				).To(BeNil())
 
 				Expect(foundResource.Status.RelatedObjects).ToNot(BeNil())
-				Expect(len(foundResource.Status.RelatedObjects)).Should(Equal(18))
+				Expect(len(foundResource.Status.RelatedObjects)).Should(Equal(17))
 				Expect(foundResource.ObjectMeta.Finalizers).Should(Equal([]string{FinalizerName}))
 
 				// Now, delete HCO

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -119,7 +119,6 @@ type BasicExpected struct {
 	tto                  *ttov1alpha1.TektonTasks
 	mService             *corev1.Service
 	serviceMonitor       *monitoringv1.ServiceMonitor
-	promRule             *monitoringv1.PrometheusRule
 	cliDownload          *consolev1.ConsoleCLIDownload
 	cliDownloadsRoute    *routev1.Route
 	cliDownloadsService  *corev1.Service
@@ -145,7 +144,6 @@ func (be BasicExpected) toArray() []runtime.Object {
 		be.tto,
 		be.mService,
 		be.serviceMonitor,
-		be.promRule,
 		be.cliDownload,
 		be.cliDownloadsRoute,
 		be.cliDownloadsService,
@@ -208,7 +206,6 @@ func getBasicDeployment() *BasicExpected {
 	res.pc = operands.NewKubeVirtPriorityClass(hco)
 	res.mService = operands.NewMetricsService(hco)
 	res.serviceMonitor = operands.NewServiceMonitor(hco, namespace)
-	res.promRule = operands.NewPrometheusRule(hco, namespace)
 
 	expectedKV, err := operands.NewKubeVirt(hco, namespace)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())

--- a/controllers/monitoring/monitoring_controller.go
+++ b/controllers/monitoring/monitoring_controller.go
@@ -1,0 +1,226 @@
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	operatorhandler "github.com/operator-framework/operator-lib/handler"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	alertRuleGroup                = "kubevirt.hyperconverged.rules"
+	outOfBandUpdateAlert          = "KubevirtHyperconvergedClusterOperatorCRModification"
+	unsafeModificationAlert       = "KubevirtHyperconvergedClusterOperatorUSModification"
+	installationNotCompletedAlert = "KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert"
+	severityAlertLabelKey         = "severity"
+	partOfAlertLabelKey           = "kubernetes_operator_part_of"
+	partOfAlertLabelValue         = "kubevirt"
+	componentAlertLabelKey        = "kubernetes_operator_component"
+	componentAlertLabelValue      = "hyperconverged-cluster-operator"
+	ruleName                      = hcoutil.HyperConvergedName + "-prometheus-rule"
+)
+
+var (
+	log = logf.Log.WithName(ruleName)
+
+	runbookUrlTemplate = "https://kubevirt.io/monitoring/runbooks/%s"
+
+	outOfBandUpdateRunbookUrl          = fmt.Sprintf(runbookUrlTemplate, outOfBandUpdateAlert)
+	unsafeModificationRunbookUrl       = fmt.Sprintf(runbookUrlTemplate, unsafeModificationAlert)
+	installationNotCompletedRunbookUrl = fmt.Sprintf(runbookUrlTemplate, installationNotCompletedAlert)
+)
+
+type AlertRuleReconciler struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client     client.Client
+	scheme     *runtime.Scheme
+	namespace  string
+	deployment *appsv1.Deployment
+	theRule    *monitoringv1.PrometheusRule
+}
+
+func newAlertRuleReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo, namespace string) *AlertRuleReconciler {
+
+	r := &AlertRuleReconciler{
+		client:     mgr.GetClient(),
+		scheme:     mgr.GetScheme(),
+		namespace:  namespace,
+		deployment: ci.GetDeployment(),
+	}
+
+	r.theRule = r.newPrometheusRule()
+
+	return r
+}
+
+func RegisterReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo) error {
+	namespace, err := hcoutil.GetOperatorNamespaceFromEnv()
+	if err != nil {
+		return err
+	}
+
+	return add(mgr, newAlertRuleReconciler(mgr, ci, namespace))
+}
+
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("alert-rule-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	err = c.Watch(
+		&source.Kind{Type: &monitoringv1.PrometheusRule{}},
+		&operatorhandler.InstrumentedEnqueueRequestForObject{},
+		predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}),
+	)
+
+	return err
+}
+
+var _ reconcile.Reconciler = &AlertRuleReconciler{}
+
+func (r *AlertRuleReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+
+	logger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	logger.Info("Reconciling the PrometheusRule", "namespacedName.Name", request.NamespacedName.Name, "namespacedName.Namespace", request.NamespacedName.Namespace)
+
+	rule := &monitoringv1.PrometheusRule{}
+	logger.Info("Reading the ")
+	err := r.client.Get(ctx, request.NamespacedName, rule)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("Can't find the Prometheus rule; creating a new one")
+			err := r.client.Create(ctx, r.theRule.DeepCopy())
+			if err != nil {
+				logger.Error(err, "failed to create PrometheusRule")
+				return reconcile.Result{}, err
+			}
+			logger.Info("successfully created the PrometheusRule")
+			return reconcile.Result{}, nil
+		}
+
+		logger.Error(err, "unexpected error while reading the PrometheusRule")
+		return reconcile.Result{}, err
+	}
+
+	if !reflect.DeepEqual(r.theRule.Spec, rule.Spec) {
+		logger.Info("updating the PrometheusRule")
+		err = r.client.Update(ctx, rule)
+		if err != nil {
+			logger.Error(err, "failed to update the PrometheusRule")
+			return reconcile.Result{}, err
+		}
+	}
+
+	logger.V(5).Info("nothing to do")
+	return reconcile.Result{}, nil
+}
+
+func (r AlertRuleReconciler) newPrometheusRule() *monitoringv1.PrometheusRule {
+	return &monitoringv1.PrometheusRule{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: monitoringv1.SchemeGroupVersion.String(),
+			Kind:       "PrometheusRule",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ruleName,
+			Labels:    map[string]string{hcoutil.AppLabel: hcoutil.HyperConvergedName},
+			Namespace: r.namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				getDeploymentReference(r.deployment),
+			},
+		},
+		Spec: *NewPrometheusRuleSpec(),
+	}
+}
+
+// NewPrometheusRuleSpec creates PrometheusRuleSpec for alert rules
+func NewPrometheusRuleSpec() *monitoringv1.PrometheusRuleSpec {
+	return &monitoringv1.PrometheusRuleSpec{
+		Groups: []monitoringv1.RuleGroup{{
+			Name: alertRuleGroup,
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: outOfBandUpdateAlert,
+					Expr:  intstr.FromString("sum by(component_name) ((round(increase(kubevirt_hco_out_of_band_modifications_count[10m]))>0 and kubevirt_hco_out_of_band_modifications_count offset 10m) or (kubevirt_hco_out_of_band_modifications_count != 0 unless kubevirt_hco_out_of_band_modifications_count offset 10m))"),
+					Annotations: map[string]string{
+						"description": "Out-of-band modification for {{ $labels.component_name }}.",
+						"summary":     "{{ $value }} out-of-band CR modifications were detected in the last 10 minutes.",
+						"runbook_url": outOfBandUpdateRunbookUrl,
+					},
+					Labels: map[string]string{
+						severityAlertLabelKey:  "warning",
+						partOfAlertLabelKey:    partOfAlertLabelValue,
+						componentAlertLabelKey: componentAlertLabelValue,
+					},
+				},
+				{
+					Alert: unsafeModificationAlert,
+					Expr:  intstr.FromString("sum by(annotation_name) ((kubevirt_hco_unsafe_modification_count)>0)"),
+					Annotations: map[string]string{
+						"description": "unsafe modification for the {{ $labels.annotation_name }} annotation in the HyperConverged resource.",
+						"summary":     "{{ $value }} unsafe modifications were detected in the HyperConverged resource.",
+						"runbook_url": unsafeModificationRunbookUrl,
+					},
+					Labels: map[string]string{
+						severityAlertLabelKey:  "info",
+						partOfAlertLabelKey:    partOfAlertLabelValue,
+						componentAlertLabelKey: componentAlertLabelValue,
+					},
+				},
+				{
+					Alert: installationNotCompletedAlert,
+					Expr:  intstr.FromString("kubevirt_hco_hyperconverged_cr_exists == 0"),
+					Annotations: map[string]string{
+						"description": "the installation was not completed; the HyperConverged custom resource is missing. In order to complete the installation of the Hyperconverged Cluster Operator you should create the HyperConverged custom resource.",
+						"summary":     "the installation was not completed; to complete the installation, create a HyperConverged custom resource.",
+						"runbook_url": installationNotCompletedRunbookUrl,
+					},
+					For: "1h",
+					Labels: map[string]string{
+						severityAlertLabelKey:  "info",
+						partOfAlertLabelKey:    partOfAlertLabelValue,
+						componentAlertLabelKey: componentAlertLabelValue,
+					},
+				},
+				// Recording rules for openshift/cluster-monitoring-operator
+				{
+					Record: "cluster:vmi_request_cpu_cores:sum",
+					Expr:   intstr.FromString(`sum(kube_pod_container_resource_requests{resource="cpu"} and on (pod) kube_pod_status_phase{phase="Running"} * on (pod) group_left kube_pod_labels{ label_kubevirt_io="virt-launcher"} > 0)`),
+				},
+			},
+		}},
+	}
+}
+
+func getDeploymentReference(deployment *appsv1.Deployment) metav1.OwnerReference {
+	gvk := deployment.GroupVersionKind()
+	return metav1.OwnerReference{
+		APIVersion:         gvk.GroupVersion().String(),
+		Kind:               gvk.Kind,
+		Name:               deployment.GetName(),
+		UID:                deployment.GetUID(),
+		BlockOwnerDeletion: pointer.BoolPtr(false),
+		Controller:         pointer.BoolPtr(false),
+	}
+}

--- a/controllers/operands/monitoring_test.go
+++ b/controllers/operands/monitoring_test.go
@@ -191,90 +191,90 @@ var _ = Describe("Monitoring Operand", func() {
 
 	})
 
-	Context("Prometheus rule", func() {
-
-		var hco *hcov1beta1.HyperConverged
-		var req *common.HcoRequest
-
-		BeforeEach(func() {
-			hco = commonTestUtils.NewHco()
-			req = commonTestUtils.NewReq(hco)
-		})
-
-		It("should create if not present", func() {
-			expectedResource := NewPrometheusRule(hco, commonTestUtils.Namespace)
-			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := (*genericOperand)(newMonitoringPrometheusRuleHandler(cl, commonTestUtils.GetScheme()))
-			res := handler.ensure(req)
-			Expect(res.Created).To(BeTrue())
-			Expect(res.Updated).To(BeFalse())
-			Expect(res.Overwritten).To(BeFalse())
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Err).ToNot(HaveOccurred())
-
-			foundResource := &monitoringv1.PrometheusRule{}
-			Expect(
-				cl.Get(context.TODO(),
-					types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
-					foundResource),
-			).ToNot(HaveOccurred())
-			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commonTestUtils.Name))
-			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
-		})
-
-		It("should find if present", func() {
-			expectedResource := NewPrometheusRule(hco, commonTestUtils.Namespace)
-			cl := commonTestUtils.InitClient([]runtime.Object{expectedResource})
-			handler := (*genericOperand)(newMonitoringPrometheusRuleHandler(cl, commonTestUtils.GetScheme()))
-			res := handler.ensure(req)
-			Expect(res.Created).To(BeFalse())
-			Expect(res.Updated).To(BeFalse())
-			Expect(res.Overwritten).To(BeFalse())
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Err).ToNot(HaveOccurred())
-
-			objectRef, err := reference.GetReference(handler.Scheme, expectedResource)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRef))
-		})
-
-		It("should reconcile to default", func() {
-			existingResource := NewPrometheusRule(hco, commonTestUtils.Namespace)
-			existingResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", existingResource.Namespace, existingResource.Name)
-
-			existingResource.Spec.Groups[0].Name = "Non default value"
-			existingResource.Spec.Groups[0].Rules[0].Alert = "Non default value"
-			req.HCOTriggered = false
-
-			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-			handler := (*genericOperand)(newMonitoringPrometheusRuleHandler(cl, commonTestUtils.GetScheme()))
-			res := handler.ensure(req)
-			Expect(res.Created).To(BeFalse())
-			Expect(res.Updated).To(BeTrue())
-			Expect(res.Overwritten).To(BeTrue())
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Err).ToNot(HaveOccurred())
-
-			foundResource := &monitoringv1.PrometheusRule{}
-			Expect(
-				cl.Get(context.TODO(),
-					types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
-					foundResource),
-			).ToNot(HaveOccurred())
-			Expect(foundResource.Spec.Groups[0].Name).To(BeIdenticalTo(alertRuleGroup))
-			Expect(foundResource.Spec.Groups[0].Rules[0].Alert).To(BeIdenticalTo(outOfBandUpdateAlert))
-
-			// ObjectReference should have been updated
-			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
-			objectRefOutdated, err := reference.GetReference(handler.Scheme, existingResource)
-			Expect(err).ToNot(HaveOccurred())
-			objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
-			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
-		})
-
-	})
+	//Context("Prometheus rule", func() {
+	//
+	//	var hco *hcov1beta1.HyperConverged
+	//	var req *common.HcoRequest
+	//
+	//	BeforeEach(func() {
+	//		hco = commonTestUtils.NewHco()
+	//		req = commonTestUtils.NewReq(hco)
+	//	})
+	//
+	//	It("should create if not present", func() {
+	//		expectedResource := NewPrometheusRule(hco, commonTestUtils.Namespace)
+	//		cl := commonTestUtils.InitClient([]runtime.Object{})
+	//		handler := (*genericOperand)(newMonitoringPrometheusRuleHandler(cl, commonTestUtils.GetScheme()))
+	//		res := handler.ensure(req)
+	//		Expect(res.Created).To(BeTrue())
+	//		Expect(res.Updated).To(BeFalse())
+	//		Expect(res.Overwritten).To(BeFalse())
+	//		Expect(res.UpgradeDone).To(BeFalse())
+	//		Expect(res.Err).ToNot(HaveOccurred())
+	//
+	//		foundResource := &monitoringv1.PrometheusRule{}
+	//		Expect(
+	//			cl.Get(context.TODO(),
+	//				types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
+	//				foundResource),
+	//		).ToNot(HaveOccurred())
+	//		Expect(foundResource.Name).To(Equal(expectedResource.Name))
+	//		Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commonTestUtils.Name))
+	//		Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
+	//	})
+	//
+	//	It("should find if present", func() {
+	//		expectedResource := NewPrometheusRule(hco, commonTestUtils.Namespace)
+	//		cl := commonTestUtils.InitClient([]runtime.Object{expectedResource})
+	//		handler := (*genericOperand)(newMonitoringPrometheusRuleHandler(cl, commonTestUtils.GetScheme()))
+	//		res := handler.ensure(req)
+	//		Expect(res.Created).To(BeFalse())
+	//		Expect(res.Updated).To(BeFalse())
+	//		Expect(res.Overwritten).To(BeFalse())
+	//		Expect(res.UpgradeDone).To(BeFalse())
+	//		Expect(res.Err).ToNot(HaveOccurred())
+	//
+	//		objectRef, err := reference.GetReference(handler.Scheme, expectedResource)
+	//		Expect(err).ToNot(HaveOccurred())
+	//		Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRef))
+	//	})
+	//
+	//	It("should reconcile to default", func() {
+	//		existingResource := NewPrometheusRule(hco, commonTestUtils.Namespace)
+	//		existingResource.ObjectMeta.SelfLink = fmt.Sprintf("/apis/v1/namespaces/%s/dummies/%s", existingResource.Namespace, existingResource.Name)
+	//
+	//		existingResource.Spec.Groups[0].Name = "Non default value"
+	//		existingResource.Spec.Groups[0].Rules[0].Alert = "Non default value"
+	//		req.HCOTriggered = false
+	//
+	//		cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+	//		handler := (*genericOperand)(newMonitoringPrometheusRuleHandler(cl, commonTestUtils.GetScheme()))
+	//		res := handler.ensure(req)
+	//		Expect(res.Created).To(BeFalse())
+	//		Expect(res.Updated).To(BeTrue())
+	//		Expect(res.Overwritten).To(BeTrue())
+	//		Expect(res.UpgradeDone).To(BeFalse())
+	//		Expect(res.Err).ToNot(HaveOccurred())
+	//
+	//		foundResource := &monitoringv1.PrometheusRule{}
+	//		Expect(
+	//			cl.Get(context.TODO(),
+	//				types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+	//				foundResource),
+	//		).ToNot(HaveOccurred())
+	//		Expect(foundResource.Spec.Groups[0].Name).To(BeIdenticalTo(alertRuleGroup))
+	//		Expect(foundResource.Spec.Groups[0].Rules[0].Alert).To(BeIdenticalTo(outOfBandUpdateAlert))
+	//
+	//		// ObjectReference should have been updated
+	//		Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
+	//		objectRefOutdated, err := reference.GetReference(handler.Scheme, existingResource)
+	//		Expect(err).ToNot(HaveOccurred())
+	//		objectRefFound, err := reference.GetReference(handler.Scheme, foundResource)
+	//		Expect(err).ToNot(HaveOccurred())
+	//		Expect(hco.Status.RelatedObjects).To(Not(ContainElement(*objectRefOutdated)))
+	//		Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
+	//	})
+	//
+	//})
 
 })

--- a/controllers/operands/operandHandler.go
+++ b/controllers/operands/operandHandler.go
@@ -58,7 +58,6 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 			newSspHandler(client, scheme),
 			(*genericOperand)(newServiceHandler(client, scheme, NewMetricsService)),
 			(*genericOperand)(newMetricsServiceMonitorHandler(client, scheme)),
-			(*genericOperand)(newMonitoringPrometheusRuleHandler(client, scheme)),
 			(*genericOperand)(newCliDownloadHandler(client, scheme)),
 			(*genericOperand)(newCliDownloadsRouteHandler(client, scheme)),
 			(*genericOperand)(newServiceHandler(client, scheme, NewCliDownloadsService)),

--- a/controllers/operands/operandHandler_test.go
+++ b/controllers/operands/operandHandler_test.go
@@ -94,11 +94,6 @@ var _ = Describe("Test operandHandler", func() {
 				{
 					EventType: corev1.EventTypeNormal,
 					Reason:    "Created",
-					Msg:       "Created PrometheusRule kubevirt-hyperconverged-prometheus-rule",
-				},
-				{
-					EventType: corev1.EventTypeNormal,
-					Reason:    "Created",
 					Msg:       "Created ConsoleQuickStart test-quick-start",
 				},
 				{

--- a/hack/prom-rule-ci/rule-spec-dumper.go
+++ b/hack/prom-rule-ci/rule-spec-dumper.go
@@ -3,11 +3,11 @@ package main
 import (
 	"encoding/json"
 
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/monitoring"
+
 	"fmt"
 	"io/ioutil"
 	"os"
-
-	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 )
 
 func verifyArgs(args []string) error {
@@ -26,7 +26,7 @@ func main() {
 
 	targetFile := os.Args[1]
 
-	promRuleSpec := operands.NewPrometheusRuleSpec()
+	promRuleSpec := monitoring.NewPrometheusRuleSpec()
 	b, err := json.Marshal(promRuleSpec)
 	if err != nil {
 		panic(err)

--- a/pkg/util/own_resources.go
+++ b/pkg/util/own_resources.go
@@ -1,0 +1,185 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// OwnResources holds the running POd, Deployment and CSV, if exist
+type OwnResources struct {
+	pod        *corev1.Pod
+	deployment *appsv1.Deployment
+	csv        *csvv1alpha1.ClusterServiceVersion
+}
+
+// GetPod returns the running pod, or nil if not exists
+func (or *OwnResources) GetPod() *corev1.Pod {
+	if or == nil {
+		return nil
+	}
+	return or.pod
+}
+
+// GetDeployment returns the deployment that controls the running pod, or nil if not exists
+func (or *OwnResources) GetDeployment() *appsv1.Deployment {
+	if or == nil {
+		return nil
+	}
+	return or.deployment
+}
+
+// GetCSV returns the CSV that defines the application, or nil if not exists
+func (or *OwnResources) GetCSV() *csvv1alpha1.ClusterServiceVersion {
+	if or == nil {
+		return nil
+	}
+	return or.csv
+}
+
+func findOwnResources(ctx context.Context, cl client.Reader, logger logr.Logger) (or *OwnResources) {
+	or = &OwnResources{}
+
+	if !GetClusterInfo().IsRunningLocally() {
+		var err error
+
+		or.pod, err = getPod(ctx, cl, logger)
+		if err != nil {
+			or.pod = nil
+			logger.Error(err, "Can't get self pod")
+		}
+	}
+
+	operatorNs, err := GetOperatorNamespace(logger)
+	if err != nil {
+		logger.Error(err, "Can't get operator namespace")
+		return
+	}
+
+	or.deployment, err = getDeploymentFromPod(or.pod, cl, operatorNs, logger)
+	if err != nil {
+		logger.Error(err, "Can't the deployment")
+		return
+	}
+	if GetClusterInfo().IsOpenshift() {
+		var err error
+		or.csv, err = getCSVFromDeployment(or.deployment, cl, operatorNs, logger)
+		if err != nil {
+			logger.Error(err, "Can't get CSV")
+			or.csv = nil
+		}
+	}
+	return
+}
+
+func getPod(ctx context.Context, c client.Reader, logger logr.Logger) (*corev1.Pod, error) {
+	ci := GetClusterInfo()
+	operatorNs, err := GetOperatorNamespace(logger)
+	if err != nil {
+		logger.Error(err, "Failed to get HCO namespace")
+		return nil, err
+	}
+
+	// This is taken from k8sutil.getPod. This method only receives client. But the client is not always ready. We'll
+	// use --- instead
+	if ci.IsRunningLocally() {
+		return nil, nil
+	}
+	podName := os.Getenv(PodNameEnvVar)
+	if podName == "" {
+		return nil, fmt.Errorf("required env %s not set, please configure downward API", PodNameEnvVar)
+	}
+
+	pod := &corev1.Pod{}
+	key := client.ObjectKey{Namespace: operatorNs, Name: podName}
+	err = c.Get(ctx, key, pod)
+	if err != nil {
+		logger.Error(err, "Failed to get Pod", "Pod.Namespace", operatorNs, "Pod.Name", podName)
+		return nil, err
+	}
+
+	// .Get() clears the APIVersion and Kind,
+	// so we need to set them before returning the object.
+	pod.TypeMeta.APIVersion = "v1"
+	pod.TypeMeta.Kind = "Pod"
+
+	logger.Info("Found Pod", "Pod.Namespace", operatorNs, "Pod.Name", pod.Name)
+
+	return pod, nil
+}
+
+func getDeploymentFromPod(pod *corev1.Pod, c client.Reader, operatorNs string, logger logr.Logger) (*appsv1.Deployment, error) {
+	if pod == nil {
+		return nil, nil
+	}
+	//operatorNs, err := GetOperatorNamespace(logger)
+	//if err != nil {
+	//	return nil, err
+	//}
+	rsReference := metav1.GetControllerOf(pod)
+	if rsReference == nil || rsReference.Kind != "ReplicaSet" {
+		err := errors.New("failed getting HCO replicaSet reference")
+		logger.Error(err, "Failed getting HCO replicaSet reference")
+		return nil, err
+	}
+	rs := &appsv1.ReplicaSet{}
+	err := c.Get(context.TODO(), client.ObjectKey{
+		Namespace: operatorNs,
+		Name:      rsReference.Name,
+	}, rs)
+	if err != nil {
+		logger.Error(err, "Failed to get HCO ReplicaSet")
+		return nil, err
+	}
+
+	dReference := metav1.GetControllerOf(rs)
+	if dReference == nil || dReference.Kind != "Deployment" {
+		err = errors.New("failed getting HCO deployment reference")
+		logger.Error(err, "Failed getting HCO deployment reference")
+		return nil, err
+	}
+	deployment := &appsv1.Deployment{}
+	err = c.Get(context.TODO(), client.ObjectKey{
+		Namespace: operatorNs,
+		Name:      dReference.Name,
+	}, deployment)
+	if err != nil {
+		logger.Error(err, "Failed to get HCO Deployment")
+		return nil, err
+	}
+
+	return deployment, nil
+}
+
+func getCSVFromDeployment(d *appsv1.Deployment, c client.Reader, operatorNs string, logger logr.Logger) (*csvv1alpha1.ClusterServiceVersion, error) {
+	var csvReference *metav1.OwnerReference
+	for _, owner := range d.GetOwnerReferences() {
+		if owner.Kind == "ClusterServiceVersion" {
+			csvReference = &owner
+		}
+	}
+	if csvReference == nil {
+		err := errors.New("failed getting HCO CSV reference")
+		logger.Error(err, "Failed getting HCO CSV reference")
+		return nil, err
+	}
+	csv := &csvv1alpha1.ClusterServiceVersion{}
+	err := c.Get(context.TODO(), client.ObjectKey{
+		Namespace: operatorNs,
+		Name:      csvReference.Name,
+	}, csv)
+	if err != nil {
+		logger.Error(err, "Failed to get HCO CSV")
+		return nil, err
+	}
+
+	return csv, nil
+}

--- a/pkg/util/own_resources_test.go
+++ b/pkg/util/own_resources_test.go
@@ -1,0 +1,137 @@
+package util
+
+import (
+	"context"
+	"os"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Test OwnResources", func() {
+	const (
+		rsName    = "hco-operator"
+		podName   = rsName + "-12345"
+		namespace = "kubevirt-hyperconverged"
+	)
+
+	var (
+		origGetOperatorNamespace = GetOperatorNamespace
+		origPodName              = os.Getenv(PodNameEnvVar)
+		origGetClusterInfo       = GetClusterInfo
+	)
+
+	BeforeEach(func() {
+		GetOperatorNamespace = func(_ logr.Logger) (string, error) {
+			return namespace, nil
+		}
+
+		os.Setenv(PodNameEnvVar, podName)
+
+		GetClusterInfo = func() ClusterInfo {
+			return &ClusterInfoImp{
+				runningInOpenshift: true,
+				managedByOLM:       true,
+				runningLocally:     false,
+			}
+		}
+	})
+
+	AfterEach(func() {
+		GetOperatorNamespace = origGetOperatorNamespace
+		os.Setenv(PodNameEnvVar, origPodName)
+		GetClusterInfo = origGetClusterInfo
+	})
+
+	testScheme := scheme.Scheme
+	_ = csvv1alpha1.AddToScheme(testScheme)
+
+	It("should update pod and csv if they are found", func() {
+		csv := &csvv1alpha1.ClusterServiceVersion{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ClusterServiceVersion",
+				APIVersion: "operators.coreos.com/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rsName,
+				Namespace: namespace,
+			},
+		}
+
+		dep := &appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rsName,
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "operators.coreos.com/v1alpha1",
+						Kind:       csvv1alpha1.ClusterServiceVersionKind,
+						Name:       rsName,
+						Controller: pointer.BoolPtr(true),
+					},
+				},
+			},
+		}
+
+		rs := &appsv1.ReplicaSet{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ReplicaSet",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rsName,
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       rsName,
+						Controller: pointer.BoolPtr(true),
+					},
+				},
+			},
+		}
+
+		pod := &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "apps/v1",
+						Kind:       "ReplicaSet",
+						Name:       rsName,
+						Controller: pointer.BoolPtr(true),
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithRuntimeObjects(csv, dep, rs, pod).
+			Build()
+
+		or := findOwnResources(context.Background(), cl, logger)
+		Expect(*or.GetPod()).Should(Equal(*pod))
+		Expect(*or.GetDeployment()).Should(Equal(*dep))
+		Expect(*or.GetCSV()).Should(Equal(*csv))
+	})
+
+})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,9 +10,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,106 +82,6 @@ func GetWatchNamespace() (string, error) {
 		return "", fmt.Errorf("%s must be set", WatchNamespaceEnvVar)
 	}
 	return ns, nil
-}
-
-func GetPod(ctx context.Context, c client.Reader, logger logr.Logger) (*corev1.Pod, error) {
-	ci := GetClusterInfo()
-	operatorNs, err := GetOperatorNamespace(logger)
-	if err != nil {
-		logger.Error(err, "Failed to get HCO namespace")
-		return nil, err
-	}
-
-	// This is taken from k8sutil.GetPod. This method only receives client. But the client is not always ready. We'll
-	// use --- instead
-	if ci.IsRunningLocally() {
-		return nil, nil
-	}
-	podName := os.Getenv(PodNameEnvVar)
-	if podName == "" {
-		return nil, fmt.Errorf("required env %s not set, please configure downward API", PodNameEnvVar)
-	}
-
-	pod := &corev1.Pod{}
-	key := client.ObjectKey{Namespace: operatorNs, Name: podName}
-	err = c.Get(ctx, key, pod)
-	if err != nil {
-		logger.Error(err, "Failed to get Pod", "Pod.Namespace", operatorNs, "Pod.Name", podName)
-		return nil, err
-	}
-
-	// .Get() clears the APIVersion and Kind,
-	// so we need to set them before returning the object.
-	pod.TypeMeta.APIVersion = "v1"
-	pod.TypeMeta.Kind = "Pod"
-
-	logger.Info("Found Pod", "Pod.Namespace", operatorNs, "Pod.Name", pod.Name)
-
-	return pod, nil
-}
-
-func GetCSVfromPod(pod *corev1.Pod, c client.Reader, logger logr.Logger) (*csvv1alpha1.ClusterServiceVersion, error) {
-	if pod == nil {
-		return nil, nil
-	}
-	operatorNs, err := GetOperatorNamespace(logger)
-	if err != nil {
-		return nil, err
-	}
-	rsReference := metav1.GetControllerOf(pod)
-	if rsReference == nil || rsReference.Kind != "ReplicaSet" {
-		err = errors.New("failed getting HCO replicaSet reference")
-		logger.Error(err, "Failed getting HCO replicaSet reference")
-		return nil, err
-	}
-	rs := &appsv1.ReplicaSet{}
-	err = c.Get(context.TODO(), client.ObjectKey{
-		Namespace: operatorNs,
-		Name:      rsReference.Name,
-	}, rs)
-	if err != nil {
-		logger.Error(err, "Failed to get HCO ReplicaSet")
-		return nil, err
-	}
-
-	dReference := metav1.GetControllerOf(rs)
-	if dReference == nil || dReference.Kind != "Deployment" {
-		err = errors.New("failed getting HCO deployment reference")
-		logger.Error(err, "Failed getting HCO deployment reference")
-		return nil, err
-	}
-	d := &appsv1.Deployment{}
-	err = c.Get(context.TODO(), client.ObjectKey{
-		Namespace: operatorNs,
-		Name:      dReference.Name,
-	}, d)
-	if err != nil {
-		logger.Error(err, "Failed to get HCO Deployment")
-		return nil, err
-	}
-
-	var csvReference *metav1.OwnerReference
-	for _, owner := range d.GetOwnerReferences() {
-		if owner.Kind == "ClusterServiceVersion" {
-			csvReference = &owner
-		}
-	}
-	if csvReference == nil {
-		err = errors.New("failed getting HCO CSV reference")
-		logger.Error(err, "Failed getting HCO CSV reference")
-		return nil, err
-	}
-	csv := &csvv1alpha1.ClusterServiceVersion{}
-	err = c.Get(context.TODO(), client.ObjectKey{
-		Namespace: operatorNs,
-		Name:      csvReference.Name,
-	}, csv)
-	if err != nil {
-		logger.Error(err, "Failed to get HCO CSV")
-		return nil, err
-	}
-
-	return csv, nil
 }
 
 // ToUnstructured converts an arbitrary object (which MUST obey the


### PR DESCRIPTION
Fix Prometheus alert bug, where the KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert alert is not working when the HyperConverged CR is not present, by moving the reconciling of the Prometheuse Rule to a new AlertRule controller.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Prometheus alert bug, where the KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert alert is not working when the HyperConverged CR is not present.
```

