### PR TITLE
full base image name in Dockerfiles

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.1 AS builder
+FROM docker.io/golang:1.18.2 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -1,4 +1,4 @@
-FROM golang:1.18.1 AS builder
+FROM docker.io/golang:1.18.2 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM golang:1.18.1 AS builder
+FROM docker.io/golang:1.18.2 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .


### PR DESCRIPTION
Fix the kubevirtci lane. This lane is failing because podman now
requires full names, and return error when trying to get the golang:1.18 image:

`Error: error creating build container: short-name resolution enforced but cannot prompt without a TTY`

Change this image to docker.io/golang:1.18.2

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

