### PR TITLE
fix go mod for nigtly builds

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -18,6 +18,7 @@ latest_kubevirt_commit=$(curl -sL "https://storage.googleapis.com/kubevirt-prow/
 
 # Update HCO dependencies
 go mod edit -require "kubevirt.io/kubevirt@${latest_kubevirt_commit}"
+go mod tidy
 go mod vendor
 rm -rf kubevirt
 
@@ -27,6 +28,7 @@ git clone https://github.com/kubevirt/kubevirt.git
 go mod edit -replace kubevirt.io/client-go=./kubevirt/staging/src/kubevirt.io/client-go
 go mod edit -replace kubevirt.io/api=./kubevirt/staging/src/kubevirt.io/api
 go mod edit -replace kubevirt.io/containerized-data-importer-api=$(grep "kubevirt.io/containerized-data-importer-api v" go.mod | xargs | sed "s/ /@/g")
+go mod tidy
 go mod vendor
 
 # set envs

--- a/hack/kubevirt-nightly-build-images.sh
+++ b/hack/kubevirt-nightly-build-images.sh
@@ -25,6 +25,7 @@ LATEST_KUBEVIRT=$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/nig
 LATEST_KUBEVIRT_IMAGE=$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST_KUBEVIRT}/kubevirt-operator.yaml | grep 'OPERATOR_IMAGE' -A1 | tail -n 1 | sed 's/.*value: //g')
 LATEST_KUBEVIRT_COMMIT=$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST_KUBEVIRT}/commit)
 go mod edit -require kubevirt.io/kubevirt@${LATEST_KUBEVIRT_COMMIT}
+go mod tidy
 go mod vendor
 KUBEVIRT_IMAGE=${LATEST_KUBEVIRT_IMAGE} hack/build-manifests.sh
 


### PR DESCRIPTION
Nightly builds with nightly kubevirt
are failing with:

go: updates to go.mod needed; to update it:
	go mod tidy

let's automate it

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

