### PR TITLE
graph: avoid looking for NMO objects

### DIFF
--- a/tools/k8s-label-visualizer/conf.json
+++ b/tools/k8s-label-visualizer/conf.json
@@ -78,11 +78,6 @@
       "kind": "cdiconfigs"
     },
     {
-      "group": "nodemaintenance.kubevirt.io",
-      "version": "v1beta1",
-      "kind": "nodemaintenances"
-    },
-    {
       "group": "networkaddonsoperator.network.kubevirt.io",
       "version": "v1alpha1",
       "kind": "networkaddonsconfigs"


### PR DESCRIPTION
Avoid looking for NMO objects during
component graph generation

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

