### PR TITLE
[release-1.6] reconcile ConsoleCLIDownload and ConsoleQuickStart (#1944)

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -225,6 +225,12 @@ func getNewManagerCache(operatorNamespace string) cache.NewCacheFunc {
 				&corev1.Namespace{}: {
 					Label: labelSelectorForNamespace,
 				},
+				&consolev1.ConsoleCLIDownload{}: {
+					Label: labelSelector,
+				},
+				&consolev1.ConsoleQuickStart{}: {
+					Label: labelSelector,
+				},
 			},
 		},
 	)

--- a/pkg/controller/hyperconverged/hyperconverged_controller.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller.go
@@ -179,6 +179,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo) er
 			&monitoringv1.PrometheusRule{},
 			&routev1.Route{},
 			&consolev1.ConsoleCLIDownload{},
+			&consolev1.ConsoleQuickStart{},
 			&imagev1.ImageStream{},
 			&corev1.Namespace{},
 		}...)


### PR DESCRIPTION
correctly add consolev1.ConsoleCLIDownload and
consolev1.ConsoleQuickStart to the client cache
and the reconciliation loop.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2086114

This is a manual cherry-pick of #1944

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
reconcile ConsoleCLIDownload and ConsoleQuickStart
```

