### PR TITLE
Fix error reporting of the rebase bot

### DIFF
--- a/.github/workflows/rebase-bot.yml
+++ b/.github/workflows/rebase-bot.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Rebase and rebuild manifests
         id: rebase_rebuild
+        continue-on-error: true
         run: ./automation/rebase-bot/rebase-bot.sh
         env:
           GITHUB_TOKEN: ${{ secrets.HCO_BOT_TOKEN }}


### PR DESCRIPTION
Currently, when the rebase bot script is failing, it fails the entire job, and the next step of commenting the error is not being executed.
By adding 'continue-on-error: true', the next step will be executed on error.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error

current situation:
![image](https://user-images.githubusercontent.com/45337834/169228396-9c4d78eb-7fc1-4426-9e89-a295e090d7ad.png)


Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

