### PR TITLE
Add Action URL for Rebase Bot Failures

### DIFF
--- a/.github/workflows/rebase-bot.yml
+++ b/.github/workflows/rebase-bot.yml
@@ -36,5 +36,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Rebase Bot action has failed.'
+              body: "Rebase Bot action has failed.\nAction URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             })


### PR DESCRIPTION
example run on my fork:
https://github.com/orenc1/hyperconverged-cluster-operator/pull/22


Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

