### PR TITLE
ConsolePlugin bugfix: Reconcile CR if labels were modified

### DIFF
--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -256,7 +256,8 @@ func (h consolePluginHooks) updateCr(req *common.HcoRequest, Client client.Clien
 		return false, false, errors.New("can't convert to ConsolePlugin")
 	}
 
-	if !reflect.DeepEqual(found.Spec, h.required.Spec) {
+	if !reflect.DeepEqual(found.Spec, h.required.Spec) ||
+		!reflect.DeepEqual(found.Labels, h.required.Labels) {
 		if req.HCOTriggered {
 			req.Logger.Info("Updating existing ConsolePlugin to new opinionated values", "name", h.required.Name)
 		} else {


### PR DESCRIPTION
Change in labels in the ConsolePlugin custom resource did not triggered a reconciliation.
This PR fix this and adds unit test for modification, addition and deletion of labels.
https://bugzilla.redhat.com/show_bug.cgi?id=2089078

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
reconcile console plugin on labels change as well.
```

