### PR TITLE
Explicitly creating a token for prometheus-k8s SA

### DIFF
--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -39,6 +39,9 @@ trap "cleanup" INT TERM EXIT
 # the test image can be overwritten by the caller
 FUNC_TEST_IMAGE=${FUNC_TEST_IMAGE:-${computed_test_image}}
 
+echo "Ensuring we have a token for prometheus-k8s SA"
+$KUBECTL_BINARY create token -n openshift-monitoring prometheus-k8s || true
+
 echo "Running tests with $FUNC_TEST_IMAGE"
 
 $KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" create serviceaccount functest \


### PR DESCRIPTION
Since k8s 1.24 (and so OCP 4.11 after the rebase),
tokens are not automatically created for SA.
Let's explicitly create it if needed to
unlock functest on CI.

See:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#no-really-you-must-read-this-before-you-upgrade

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

