### PR TITLE
Fix bug where HCO does not reconcile PrometheusRule

### DIFF
--- a/controllers/alerts/alerts.go
+++ b/controllers/alerts/alerts.go
@@ -147,6 +147,11 @@ func (r AlertRuleReconciler) updateAlert(ctx context.Context, rule *monitoringv1
 		}
 	}
 
+	if !reflect.DeepEqual(r.theRule.Labels, rule.Labels) {
+		needUpdate = true
+		rule.SetLabels(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring))
+	}
+
 	if needUpdate {
 		logger.Info("updating the PrometheusRule")
 		err := r.client.Update(ctx, rule)


### PR DESCRIPTION
Fix BZ 2092158 (https://bugzilla.redhat.com/show_bug.cgi?id=2092158)

The bug is actually only about labels. This PR add label reconciliation
of the PrometheusRule.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix BZ 2092158
```

