### PR TITLE
Add an infra label to each of HCO alerts

### DIFF
--- a/controllers/alerts/alerts.go
+++ b/controllers/alerts/alerts.go
@@ -35,6 +35,7 @@ const (
 	partOfAlertLabelValue         = "kubevirt"
 	componentAlertLabelKey        = "kubernetes_operator_component"
 	componentAlertLabelValue      = "hyperconverged-cluster-operator"
+	infraAlertLabelKey            = "infra_alert"
 	ruleName                      = hcoutil.HyperConvergedName + "-prometheus-rule"
 )
 
@@ -219,6 +220,7 @@ func createOutOfBandUpdateAlertRule() monitoringv1.Rule {
 			severityAlertLabelKey:  "warning",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
+			infraAlertLabelKey:     "true",
 		},
 	}
 }
@@ -236,6 +238,7 @@ func createUnsafeModificationAlertRule() monitoringv1.Rule {
 			severityAlertLabelKey:  "info",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
+			infraAlertLabelKey:     "true",
 		},
 	}
 }
@@ -254,6 +257,7 @@ func createInstallationNotCompletedAlertRule() monitoringv1.Rule {
 			severityAlertLabelKey:  "info",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
+			infraAlertLabelKey:     "true",
 		},
 	}
 }

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -31,6 +31,7 @@ tests:
         severity: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
   # New increases must be detected
@@ -45,6 +46,7 @@ tests:
         severity: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
   # Old increases must be ignored.
@@ -59,6 +61,7 @@ tests:
         severity: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
   # Should resolve after 10 minutes if there is no new change
@@ -83,6 +86,7 @@ tests:
         severity: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
   # After restart, new increases must be detected
@@ -97,6 +101,7 @@ tests:
         severity: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 # Test unsafe modification counter
 - interval: 1m
@@ -129,6 +134,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -138,6 +144,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -147,6 +154,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
 
   # New increases must be detected
@@ -161,6 +169,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -170,6 +179,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
     # still using the 10 minutes max
     - exp_annotations:
@@ -180,6 +190,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
 
   # counter can be reduced
@@ -194,6 +205,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     # Reduced
     - exp_annotations:
@@ -204,6 +216,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -213,6 +226,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
 
   # no alert if the value is 0
@@ -227,6 +241,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -236,6 +251,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
 
   # no alert if the value is 0 for all of the annotations
@@ -255,6 +271,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     # Reduced
     - exp_annotations:
@@ -265,6 +282,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -274,6 +292,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
 
   # no data
@@ -293,6 +312,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     # Reduced
     - exp_annotations:
@@ -303,6 +323,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -312,6 +333,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
 
 # Test hyperconverged exists counter
@@ -363,6 +385,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
 
   # counter is 0 for more than an hour
   - eval_time: 63m
@@ -376,6 +399,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
 
   # counter is 0 for more than an hour
   - eval_time: 67m
@@ -389,6 +413,7 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
+        infra_alert: "true"
 
   - eval_time: 68m
     alertname: KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert


### PR DESCRIPTION
This PR adds a boolean label to each of HCO alerts, so that we can differentiate between alerts that are related to infrastructure, and alerts that are related to vmi. 
For more info, please see [#7796](https://github.com/kubevirt/kubevirt/pull/7796).

Signed-off-by: assafad [aadmi@redhat.com](mailto:aadmi@redhat.com)

```release-note
None
```