### PR TITLE
Fix StorageClass name for HPP backend in Azure SNO

### DIFF
--- a/hack/hpp/configure_hpp_pool.sh
+++ b/hack/hpp/configure_hpp_pool.sh
@@ -21,7 +21,7 @@ CLUSTER_PLATFORM=$(
 
 case "${CLUSTER_PLATFORM}" in
   Azure)
-    HPP_BACKEND_STORAGE_CLASS=managed-premium
+    HPP_BACKEND_STORAGE_CLASS=managed-csi
     HPP_VOLUME_SIZE=128Gi
     ;;
   AWS)


### PR DESCRIPTION
`managed-premium` StorageClass on Azure is no longer exists. It should be changed to `managed-csi`.

See a failure example in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/kubevirt_hyperconverged-cluster-operator/1972/pull-ci-kubevirt-hyperconverged-cluster-operator-main-hco-e2e-image-index-sno-azure/1533781013849706496#1:build-log.txt%3A162
Which is caused by pending PVC due to unrecognized storage class name.

```
        {
            "apiVersion": "v1",
            "count": 43,
            "eventTime": null,
            "firstTimestamp": "2022-06-06T13:15:21Z",
            "involvedObject": {
                "apiVersion": "v1",
                "kind": "PersistentVolumeClaim",
                "name": "hpp-pool-local-ci-op-7kc7z82c-e677a-28btc-master-0",
                "namespace": "kubevirt-hyperconverged",
                "resourceVersion": "31785",
                "uid": "0a1fec6c-7693-4c1d-a70f-540e9264b1a5"
            },
            "kind": "Event",
            "lastTimestamp": "2022-06-06T13:25:33Z",
            "message": "storageclass.storage.k8s.io \"managed-premium\" not found",
            "metadata": {
                "creationTimestamp": "2022-06-06T13:15:22Z",
                "name": "hpp-pool-local-ci-op-7kc7z82c-e677a-28btc-master-0.16f60a605619e8a8",
                "namespace": "kubevirt-hyperconverged",
                "resourceVersion": "60771",
                "uid": "138e8d33-640b-4b7f-919d-96e59a244a88"
            },
            "reason": "ProvisioningFailed",
            "reportingComponent": "",
            "reportingInstance": "",
            "source": {
                "component": "persistentvolume-controller"
            },
            "type": "Warning"
        },
```

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

