### PR TITLE
Fix bug in metric reconciling

### DIFF
--- a/controllers/alerts/reconciler.go
+++ b/controllers/alerts/reconciler.go
@@ -134,7 +134,7 @@ func (r *MonitoringReconciler) ReconcileOneResource(ctx context.Context, reconci
 			required := reconciler.GetFullResource()
 			err := r.client.Create(ctx, required)
 			if err != nil {
-				logger.Error(err, "failed to create PrometheusRule")
+				logger.Error(err, fmt.Sprintf("failed to create %s", reconciler.Kind()))
 				r.eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "UnexpectedError", fmt.Sprintf("failed to create the %s %s", reconciler.ResourceName(), reconciler.Kind()))
 				return nil, err
 			}

--- a/controllers/alerts/service.go
+++ b/controllers/alerts/service.go
@@ -39,7 +39,7 @@ func (r metricServiceReconciler) ResourceName() string {
 }
 
 func (r metricServiceReconciler) GetFullResource() client.Object {
-	return r.theService
+	return r.theService.DeepCopy()
 }
 
 func (r metricServiceReconciler) EmptyObject() client.Object {

--- a/controllers/alerts/serviceMonitor.go
+++ b/controllers/alerts/serviceMonitor.go
@@ -29,7 +29,7 @@ func (r serviceMonitorReconciler) ResourceName() string {
 }
 
 func (r serviceMonitorReconciler) GetFullResource() client.Object {
-	return r.theServiceMonitor
+	return r.theServiceMonitor.DeepCopy()
 }
 
 func (r serviceMonitorReconciler) EmptyObject() client.Object {


### PR DESCRIPTION
The metrics Service and ServiceMonitor can't be recreated if deleted.

This PR fixes this issue by creating with a new clone of the resource,
instead of directly from the stored object.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

