### PR TITLE
Require OKD/OCP console to enable cluster-monitoring on namespace

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/kubevirt-hyperconverged-operator.v1.8.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/kubevirt-hyperconverged-operator.v1.8.0.clusterserviceversion.yaml
@@ -12,6 +12,7 @@ metadata:
     createdAt: "2020-10-23 08:58:25"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
+    operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
     operatorframework.io/suggested-namespace: kubevirt-hyperconverged
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/kubevirt-hyperconverged-operator.v1.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/kubevirt-hyperconverged-operator.v1.8.0.clusterserviceversion.yaml
@@ -9,9 +9,10 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.8.0-unstable
-    createdAt: "2022-06-04 05:13:53"
+    createdAt: "2022-06-07 17:15:51"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
+    operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
     operatorframework.io/suggested-namespace: kubevirt-hyperconverged
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -834,6 +834,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 				"operatorframework.io/suggested-namespace":       params.Namespace,
 				"operators.openshift.io/infrastructure-features": `["disconnected","proxy-aware"]`,
 				"operatorframework.io/initialization-resource":   string(almExamples),
+				"operatorframework.io/cluster-monitoring":        "true",
 			},
 		},
 		Spec: csvv1alpha1.ClusterServiceVersionSpec{


### PR DESCRIPTION
Set operatorframework.io/cluster-monitoring=true annotation
on the CSV to require the console
to set label openshift.io/cluster-monitoring=true
on the install namespace at creation time.
This will ensure that cluster-monitoring can
scrape the metrics on the namespace even before the cluster
admin creates the CR for HCO.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Require OKD/OCP console to enable cluster-monitoring on namespace
```

