### PR TITLE
Clean old code

### DIFF
--- a/controllers/operands/cdi.go
+++ b/controllers/operands/cdi.go
@@ -27,11 +27,7 @@ func newCdiHandler(Client client.Client, Scheme *runtime.Scheme) *cdiHandler {
 		Client: Client,
 		Scheme: Scheme,
 		crType: "CDI",
-		// Previous versions used to have HCO-operator (scope namespace)
-		// as the owner of CDI (scope cluster).
-		// It's not legal, so remove that.
-		removeExistingOwner: true,
-		hooks:               &cdiHooks{Client: Client, Scheme: Scheme},
+		hooks:  &cdiHooks{Client: Client, Scheme: Scheme},
 	}
 }
 
@@ -58,9 +54,6 @@ func (h cdiHooks) getConditions(cr runtime.Object) []metav1.Condition {
 func (h cdiHooks) checkComponentVersion(cr runtime.Object) bool {
 	found := cr.(*cdiv1beta1.CDI)
 	return checkComponentVersion(hcoutil.CdiVersionEnvV, found.Status.ObservedVersion)
-}
-func (h cdiHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*cdiv1beta1.CDI).ObjectMeta
 }
 func (h *cdiHooks) reset() {
 	h.cache = nil

--- a/controllers/operands/cliDownload.go
+++ b/controllers/operands/cliDownload.go
@@ -34,7 +34,6 @@ func newCliDownloadHandler(Client client.Client, Scheme *runtime.Scheme) *cliDow
 		Client:                 Client,
 		Scheme:                 Scheme,
 		crType:                 "ConsoleCLIDownload",
-		removeExistingOwner:    false,
 		setControllerReference: false,
 		hooks:                  &cliDownloadHooks{},
 	}
@@ -48,10 +47,6 @@ func (h cliDownloadHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Objec
 
 func (h cliDownloadHooks) getEmptyCr() client.Object {
 	return &consolev1.ConsoleCLIDownload{}
-}
-
-func (h cliDownloadHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*consolev1.ConsoleCLIDownload).ObjectMeta
 }
 
 func (h *cliDownloadHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
@@ -145,7 +140,6 @@ func newCliDownloadsRouteHandler(Client client.Client, Scheme *runtime.Scheme) *
 		Client:                 Client,
 		Scheme:                 Scheme,
 		crType:                 "Route",
-		removeExistingOwner:    false,
 		setControllerReference: true,
 		hooks:                  &cliDownloadsRouteHooks{},
 	}
@@ -159,10 +153,6 @@ func (h cliDownloadsRouteHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client
 
 func (h cliDownloadsRouteHooks) getEmptyCr() client.Object {
 	return &routev1.Route{}
-}
-
-func (h cliDownloadsRouteHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*routev1.Route).ObjectMeta
 }
 
 func (h *cliDownloadsRouteHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {

--- a/controllers/operands/cmHandler.go
+++ b/controllers/operands/cmHandler.go
@@ -16,11 +16,10 @@ import (
 
 func newCmHandler(Client client.Client, Scheme *runtime.Scheme, required *corev1.ConfigMap) Operand {
 	h := &genericOperand{
-		Client:              Client,
-		Scheme:              Scheme,
-		crType:              "ConfigMap",
-		removeExistingOwner: false,
-		hooks:               &cmHooks{required: required},
+		Client: Client,
+		Scheme: Scheme,
+		crType: "ConfigMap",
+		hooks:  &cmHooks{required: required},
 	}
 
 	return h
@@ -40,10 +39,6 @@ func (h cmHooks) getEmptyCr() client.Object {
 			Name: h.required.Name,
 		},
 	}
-}
-
-func (h cmHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*corev1.ConfigMap).ObjectMeta
 }
 
 func (h cmHooks) reset() { /* no implementation */ }

--- a/controllers/operands/deploymentHandler.go
+++ b/controllers/operands/deploymentHandler.go
@@ -16,11 +16,10 @@ import (
 
 func newDeploymentHandler(Client client.Client, Scheme *runtime.Scheme, required *appsv1.Deployment) Operand {
 	h := &genericOperand{
-		Client:              Client,
-		Scheme:              Scheme,
-		crType:              "Deployment",
-		removeExistingOwner: false,
-		hooks:               &deploymentHooks{required: required},
+		Client: Client,
+		Scheme: Scheme,
+		crType: "Deployment",
+		hooks:  &deploymentHooks{required: required},
 	}
 
 	return h
@@ -40,10 +39,6 @@ func (h deploymentHooks) getEmptyCr() client.Object {
 			Name: h.required.Name,
 		},
 	}
-}
-
-func (h deploymentHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*appsv1.Deployment).ObjectMeta
 }
 
 func (h deploymentHooks) reset() { /* no implementation */ }

--- a/controllers/operands/imageStream.go
+++ b/controllers/operands/imageStream.go
@@ -79,11 +79,7 @@ func newImageStreamHandler(Client client.Client, Scheme *runtime.Scheme, require
 			Client: Client,
 			Scheme: Scheme,
 			crType: "ImageStream",
-			// Previous versions used to have HCO-operator (scope namespace)
-			// as the owner of NetworkAddons (scope cluster).
-			// It's not legal, so remove that.
-			removeExistingOwner: false,
-			hooks:               newIsHook(required),
+			hooks:  newIsHook(required),
 		},
 	}
 }
@@ -112,10 +108,6 @@ func (h isHooks) getEmptyCr() client.Object {
 			Namespace: h.required.Namespace,
 		},
 	}
-}
-
-func (h isHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*imagev1.ImageStream).ObjectMeta
 }
 
 func (h isHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -172,7 +172,6 @@ func newKubevirtHandler(Client client.Client, Scheme *runtime.Scheme) *kubevirtH
 		Client:                 Client,
 		Scheme:                 Scheme,
 		crType:                 "KubeVirt",
-		removeExistingOwner:    false,
 		setControllerReference: true,
 		hooks:                  &kubevirtHooks{},
 	}
@@ -200,9 +199,6 @@ func (h kubevirtHooks) getConditions(cr runtime.Object) []metav1.Condition {
 func (h kubevirtHooks) checkComponentVersion(cr runtime.Object) bool {
 	found := cr.(*kubevirtcorev1.KubeVirt)
 	return checkComponentVersion(hcoutil.KubevirtVersionEnvV, found.Status.ObservedKubeVirtVersion)
-}
-func (h kubevirtHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*kubevirtcorev1.KubeVirt).ObjectMeta
 }
 func (h *kubevirtHooks) reset() {
 	h.cache = nil
@@ -544,7 +540,6 @@ func newKvPriorityClassHandler(Client client.Client, Scheme *runtime.Scheme) *kv
 		Client:                 Client,
 		Scheme:                 Scheme,
 		crType:                 "KubeVirtPriorityClass",
-		removeExistingOwner:    false,
 		setControllerReference: false,
 		hooks:                  &kvPriorityClassHooks{},
 	}
@@ -556,9 +551,6 @@ func (h kvPriorityClassHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.O
 	return NewKubeVirtPriorityClass(hc), nil
 }
 func (h kvPriorityClassHooks) getEmptyCr() client.Object { return &schedulingv1.PriorityClass{} }
-func (h kvPriorityClassHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*schedulingv1.PriorityClass).ObjectMeta
-}
 
 func (h *kvPriorityClassHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	pc, ok1 := required.(*schedulingv1.PriorityClass)

--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -221,11 +221,10 @@ func NewKvConsolePlugin(hc *hcov1beta1.HyperConverged) *consolev1alpha1.ConsoleP
 
 func newConsolePluginHandler(Client client.Client, Scheme *runtime.Scheme, required *consolev1alpha1.ConsolePlugin) Operand {
 	h := &genericOperand{
-		Client:              Client,
-		Scheme:              Scheme,
-		crType:              "ConsolePlugin",
-		removeExistingOwner: false,
-		hooks:               &consolePluginHooks{required: required},
+		Client: Client,
+		Scheme: Scheme,
+		crType: "ConsolePlugin",
+		hooks:  &consolePluginHooks{required: required},
 	}
 
 	return h
@@ -245,10 +244,6 @@ func (h consolePluginHooks) getEmptyCr() client.Object {
 			Name: h.required.Name,
 		},
 	}
-}
-
-func (h consolePluginHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*consolev1alpha1.ConsolePlugin).ObjectMeta
 }
 
 func (h consolePluginHooks) reset() { /* no implementation */ }

--- a/controllers/operands/networkAddons.go
+++ b/controllers/operands/networkAddons.go
@@ -27,11 +27,7 @@ func newCnaHandler(Client client.Client, Scheme *runtime.Scheme) *cnaHandler {
 		Client: Client,
 		Scheme: Scheme,
 		crType: "NetworkAddonsConfig",
-		// Previous versions used to have HCO-operator (scope namespace)
-		// as the owner of NetworkAddons (scope cluster).
-		// It's not legal, so remove that.
-		removeExistingOwner: true,
-		hooks:               &cnaHooks{},
+		hooks:  &cnaHooks{},
 	}
 }
 
@@ -57,9 +53,6 @@ func (h cnaHooks) getConditions(cr runtime.Object) []metav1.Condition {
 func (h cnaHooks) checkComponentVersion(cr runtime.Object) bool {
 	found := cr.(*networkaddonsv1.NetworkAddonsConfig)
 	return checkComponentVersion(hcoutil.CnaoVersionEnvV, found.Status.ObservedVersion)
-}
-func (h cnaHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*networkaddonsv1.NetworkAddonsConfig).ObjectMeta
 }
 func (h *cnaHooks) reset() {
 	h.cache = nil

--- a/controllers/operands/quickStart.go
+++ b/controllers/operands/quickStart.go
@@ -36,11 +36,7 @@ func newQuickStartHandler(Client client.Client, Scheme *runtime.Scheme, required
 		Client: Client,
 		Scheme: Scheme,
 		crType: "ConsoleQuickStart",
-		// Previous versions used to have HCO-operator (scope namespace)
-		// as the owner of NetworkAddons (scope cluster).
-		// It's not legal, so remove that.
-		removeExistingOwner: false,
-		hooks:               &qsHooks{required: required},
+		hooks:  &qsHooks{required: required},
 	}
 
 	return h
@@ -60,10 +56,6 @@ func (h qsHooks) getEmptyCr() client.Object {
 			Name: h.required.Name,
 		},
 	}
-}
-
-func (h qsHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*consolev1.ConsoleQuickStart).ObjectMeta
 }
 
 func (h qsHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {

--- a/controllers/operands/rbac.go
+++ b/controllers/operands/rbac.go
@@ -21,7 +21,6 @@ func newRoleHandler(Client client.Client, Scheme *runtime.Scheme, required *rbac
 		Client:                 Client,
 		Scheme:                 Scheme,
 		crType:                 "Role",
-		removeExistingOwner:    false,
 		setControllerReference: true,
 		hooks:                  &roleHooks{required: required},
 	}
@@ -40,9 +39,6 @@ func (h roleHooks) getEmptyCr() client.Object {
 			Name: h.required.Name,
 		},
 	}
-}
-func (h roleHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*rbacv1.Role).ObjectMeta
 }
 func (h *roleHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
 	role := h.required
@@ -81,7 +77,6 @@ func newRoleBindingHandler(Client client.Client, Scheme *runtime.Scheme, require
 		Client:                 Client,
 		Scheme:                 Scheme,
 		crType:                 "RoleBinding",
-		removeExistingOwner:    false,
 		setControllerReference: true,
 		hooks:                  &roleBindingHooks{required: required},
 	}
@@ -100,9 +95,6 @@ func (h roleBindingHooks) getEmptyCr() client.Object {
 			Name: h.required.Name,
 		},
 	}
-}
-func (h roleBindingHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*rbacv1.RoleBinding).ObjectMeta
 }
 func (h *roleBindingHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
 	configReaderRoleBinding := h.required

--- a/controllers/operands/serviceHandler.go
+++ b/controllers/operands/serviceHandler.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -18,11 +17,10 @@ type genericServiceHandler genericOperand
 
 func newServiceHandler(Client client.Client, Scheme *runtime.Scheme, newCrFunc newSvcFunc) *genericServiceHandler {
 	h := &genericServiceHandler{
-		Client:              Client,
-		Scheme:              Scheme,
-		crType:              "Service",
-		removeExistingOwner: false,
-		hooks:               &serviceHooks{newCrFunc: newCrFunc},
+		Client: Client,
+		Scheme: Scheme,
+		crType: "Service",
+		hooks:  &serviceHooks{newCrFunc: newCrFunc},
 	}
 
 	return h
@@ -40,10 +38,6 @@ func (h *serviceHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, 
 
 func (h serviceHooks) getEmptyCr() client.Object {
 	return &corev1.Service{}
-}
-
-func (h serviceHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*corev1.Service).ObjectMeta
 }
 
 func (h serviceHooks) reset() { /* no implementation */ }

--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -58,7 +58,6 @@ func newSspHandler(Client client.Client, Scheme *runtime.Scheme) *sspHandler {
 			Client:                 Client,
 			Scheme:                 Scheme,
 			crType:                 "SSP",
-			removeExistingOwner:    false,
 			setControllerReference: false,
 			hooks:                  &sspHooks{},
 		},
@@ -89,9 +88,6 @@ func (h sspHooks) getConditions(cr runtime.Object) []metav1.Condition {
 func (h sspHooks) checkComponentVersion(cr runtime.Object) bool {
 	found := cr.(*sspv1beta1.SSP)
 	return checkComponentVersion(hcoutil.SspVersionEnvV, found.Status.ObservedVersion)
-}
-func (h sspHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*sspv1beta1.SSP).ObjectMeta
 }
 func (h *sspHooks) reset() {
 	h.cache = nil

--- a/controllers/operands/tto.go
+++ b/controllers/operands/tto.go
@@ -23,7 +23,6 @@ func newTtoHandler(Client client.Client, Scheme *runtime.Scheme) *ttoHandler {
 		Client:                 Client,
 		Scheme:                 Scheme,
 		crType:                 "TektonTasks",
-		removeExistingOwner:    false,
 		setControllerReference: true,
 		hooks:                  &ttoHooks{},
 	}
@@ -49,9 +48,6 @@ func (h ttoHooks) getConditions(cr runtime.Object) []metav1.Condition {
 func (h ttoHooks) checkComponentVersion(cr runtime.Object) bool {
 	found := cr.(*ttov1alpha1.TektonTasks)
 	return checkComponentVersion(hcoutil.TtoVersionEnvV, found.Status.ObservedVersion)
-}
-func (h ttoHooks) getObjectMeta(cr runtime.Object) *metav1.ObjectMeta {
-	return &cr.(*ttov1alpha1.TektonTasks).ObjectMeta
 }
 func (h *ttoHooks) reset() {
 	h.cache = nil


### PR DESCRIPTION
HCO keeps check for wrong owner references in the underline operands.
This was done to handle a bug in old release of HCO, and we can assume
that it's no longer relevant.

This PR remove the `doRemoveExistingOwners` method and the `removeExistingOwner`
field from the generic operand, and the `getObjectMeta` function from the
`hcoResourceHooks` interface.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

