### PR TITLE
Fix BZ-2080547: mis-read the priority class after update

### DIFF
--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -591,11 +590,7 @@ func (h *kvPriorityClassHooks) updateCr(req *common.HcoRequest, Client client.Cl
 		return false, false, err
 	}
 
-	// update found object for object references
-	err = Client.Get(req.Ctx, types.NamespacedName{Name: found.Name, Namespace: found.Namespace}, found)
-	if err != nil {
-		return true, !req.HCOTriggered, err
-	}
+	pc.DeepCopyInto(found)
 
 	return true, !req.HCOTriggered, nil
 }

--- a/hack/check_update_priority_class.sh
+++ b/hack/check_update_priority_class.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -ex
+
+# edit priority class labels, causing HCO to recreate it, making sure that the relatedObjects list contains the new priorityClass
+
+# check that the new priority class was created and that it does not include the new label
+function check_priority_class() {
+  set -ex
+  OLD_PC_UID=$1
+
+  # make sure the object was actually changed
+  NEW_PC_UID=$(${KUBECTL_BINARY} get priorityclass -n ${INSTALLED_NAMESPACE} kubevirt-cluster-critical -o jsonpath='{.metadata.uid}')
+  [[ "${OLD_PC_UID}" != "${NEW_PC_UID}" ]]
+
+  # read the UID from the HyperConverged relatedObject list
+  NEW_PC_REF_UID=$(${KUBECTL_BINARY} get hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged -o json | jq -r '.status.relatedObjects[] | select(.kind == "PriorityClass" and .name == "kubevirt-cluster-critical") | .uid')
+
+  [[ "${NEW_PC_UID}" == "${NEW_PC_REF_UID}" ]]
+
+  # make sure the new label was removed:
+  TEST_LABEL=$(${KUBECTL_BINARY} get priorityclass -n ${INSTALLED_NAMESPACE} kubevirt-cluster-critical -o jsonpath='{.metadata.labels.test}')
+  [[ -z "${TEST_LABEL}" ]]
+}
+
+export -f check_priority_class
+
+OLD_PC_REF_UID=$(${KUBECTL_BINARY} get hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged -o json | jq -r '.status.relatedObjects[] | select(.kind == "PriorityClass" and .name == "kubevirt-cluster-critical") | .uid')
+OLD_PC_UID=$(${KUBECTL_BINARY} get priorityclass -n ${INSTALLED_NAMESPACE} kubevirt-cluster-critical -o jsonpath='{.metadata.uid}')
+[[ "${OLD_PC_REF_UID}" == "${OLD_PC_UID}" ]]
+
+${KUBECTL_BINARY} patch priorityclass kubevirt-cluster-critical -n ${INSTALLED_NAMESPACE} --type=json -p='[{"op": "add", "path": "/metadata/labels/test", "value": "test"}]'
+./hack/retry.sh 3 10 "check_priority_class ${OLD_PC_UID}"

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE:-"kubevirt-hyperconverged"}
+export INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE:-"kubevirt-hyperconverged"}
 
 source hack/common.sh
 source cluster/kubevirtci.sh

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -55,5 +55,7 @@ ${KUBECTL_BINARY} label priorityclass kubevirt-cluster-critical app-
 sleep 10
 [[ $(${KUBECTL_BINARY} get priorityclass kubevirt-cluster-critical -o=jsonpath='{.metadata.labels.app}') == 'kubevirt-hyperconverged' ]]
 
+./hack/check_update_priority_class.sh
+
 # Check the webhook, to see if it allow deleteing of the HyperConverged CR
 ./hack/retry.sh 10 30 "${KUBECTL_BINARY} delete hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged"


### PR DESCRIPTION
Since most of the priority class fiels are emutable, when updating it,
HCO remove and re-create it. Then HCO reads the new created priority
class in order to set its refertence in the HyperConverged
relatedObjects list.

The re-reading often fails with "no found" just because some timing and
cache issues.

This PR is fixing the issue by droping the re-read.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix BZ-2080547
```

