### PR TITLE
[Release-1.7] Fix BZ 2097465 - PrometheusRule modifications are not count

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -274,7 +274,7 @@ func (r *ReconcileHyperConverged) Reconcile(ctx context.Context, request reconci
 	}
 	hcoRequest := common.NewHcoRequest(ctx, resolvedRequest, log, r.upgradeMode, hcoTriggered)
 
-	err = r.alertReconciler.Reconcile(ctx, hcoRequest.Logger)
+	err = r.alertReconciler.Reconcile(hcoRequest)
 	if err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
The reconcileiation of the PrometheusRule moved to different mechanism, and
the update of the `kubevirt_hco_out_of_band_modifications_count` metric
is not implemented in this case.

This PR add the missing implementation.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix BZ 2097465
```

