### PR TITLE
Fix panic: "nil pointer dereference"

### DIFF
--- a/controllers/alerts/reconciler.go
+++ b/controllers/alerts/reconciler.go
@@ -120,7 +120,7 @@ func (r *MonitoringReconciler) ReconcileOneResource(req *common.HcoRequest, reco
 		if req.HCOTriggered {
 			r.eventEmitter.EmitEvent(nil, corev1.EventTypeNormal, "Updated", fmt.Sprintf("Updated %s %s", reconciler.Kind(), reconciler.ResourceName()))
 		} else {
-			r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, "Overwritten", fmt.Sprintf("Overwritten %s %s", reconciler.Kind(), reconciler.ResourceName()))
+			r.eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "Overwritten", fmt.Sprintf("Overwritten %s %s", reconciler.Kind(), reconciler.ResourceName()))
 			err := metrics.HcoMetrics.IncOverwrittenModifications(reconciler.Kind(), reconciler.ResourceName())
 			if err != nil {
 				req.Logger.Error(err, "couldn't update 'OverwrittenModifications' metric")

--- a/pkg/util/event_emmiter.go
+++ b/pkg/util/event_emmiter.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"reflect"
+
 	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,7 +39,9 @@ func (ee eventEmitter) EmitEvent(object runtime.Object, eventType, reason, msg s
 		ee.recorder.Event(ee.pod, eventType, reason, msg)
 	}
 
-	if object != nil {
+	// checking object != nil does not work because object is an interface, and nil interface instance is not nil.
+	// We need to check that it's actually nil, using reflection.
+	if t := reflect.ValueOf(object); t.Kind() != reflect.Pointer || !t.IsNil() {
 		ee.recorder.Event(object, eventType, reason, msg)
 	}
 


### PR DESCRIPTION
The software craches when updating a metric resource, because then we're
trying to send a nil HyperConverged pointer to a function as an interface.
The function does check for nil, but this is not working, because
`interface(nil) != nil`.

This PR fixes the bug by not sending the nil interface but an actual
nil, and also changes the check to use reflection in order to make sure
that the function parameter is nil.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix sw crash 
```

