### PR TITLE
[release-1.7] Fix panic: "nil pointer dereference"

### DIFF
--- a/controllers/alerts/alerts.go
+++ b/controllers/alerts/alerts.go
@@ -160,9 +160,9 @@ func (r AlertRuleReconciler) updateAlert(req *common.HcoRequest, rule *monitorin
 		}
 		req.Logger.Info("successfully updated the PrometheusRule")
 		if req.HCOTriggered {
-			r.eventEmitter.EmitEvent(rule, corev1.EventTypeNormal, "Updated", fmt.Sprintf("Updated %s %s", monitoringv1.PrometheusRuleKind, ruleName))
+			r.eventEmitter.EmitEvent(nil, corev1.EventTypeNormal, "Updated", fmt.Sprintf("Updated %s %s", monitoringv1.PrometheusRuleKind, ruleName))
 		} else {
-			r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, "Overwritten", fmt.Sprintf("Overwritten %s %s", monitoringv1.PrometheusRuleKind, ruleName))
+			r.eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "Overwritten", fmt.Sprintf("Overwritten %s %s", monitoringv1.PrometheusRuleKind, ruleName))
 			err := metrics.HcoMetrics.IncOverwrittenModifications(monitoringv1.PrometheusRuleKind, ruleName)
 			if err != nil {
 				req.Logger.Error(err, "couldn't update 'OverwrittenModifications' metric")

--- a/pkg/util/event_emmiter.go
+++ b/pkg/util/event_emmiter.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"reflect"
+
 	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,7 +39,9 @@ func (ee eventEmitter) EmitEvent(object runtime.Object, eventType, reason, msg s
 		ee.recorder.Event(ee.pod, eventType, reason, msg)
 	}
 
-	if object != nil {
+	// checking object != nil does not work because object is an interface, and nil interface instance is not nil.
+	// We need to check that it's actually nil, using reflection.
+	if t := reflect.ValueOf(object); t.Kind() != reflect.Ptr || !t.IsNil() {
 		ee.recorder.Event(object, eventType, reason, msg)
 	}
 


### PR DESCRIPTION
The software craches when updating the prometheusRule, because then we're
trying to send a nil HyperConverged pointer to a function as an interface.
The function does check for nil, but this is not working, because
`interface(nil) != nil`.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x146c420]

goroutine 1176 [running]:
github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.(*HyperConverged).GetObjectKind(0x1867900?)
	<autogenerated>:1
k8s.io/client-go/tools/reference.GetReference(0x18cdf45?, {0x1b25fb8, 0x0})
	/remote-source/app/vendor/k8s.io/client-go/tools/reference/ref.go:59 +0x137
k8s.io/client-go/tools/record.(*recorderImpl).generateEvent(0xc000a5d8c0, {0x1b25fb8?, 0x0}, 0x1b464c8?, {0x18a076f, 0x7}, {0x18a460c, 0xb}, {0xc00333a7d0, 0x42})
	/remote-source/app/vendor/k8s.io/client-go/tools/record/event.go:330 +0x76
k8s.io/client-go/tools/record.(*recorderImpl).Event(0x73?, {0x1b25fb8?, 0x0?}, {0x18a076f?, 0x27?}, {0x18a460c?, 0x0?}, {0xc00333a7d0?, 0x1?})
	/remote-source/app/vendor/k8s.io/client-go/tools/record/event.go:355 +0x4f
sigs.k8s.io/controller-runtime/pkg/internal/recorder.(*lazyRecorder).Event(0xc000799300, {0x1b25fb8, 0x0}, {0x18a076f, 0x7}, {0x18a460c, 0xb}, {0xc00333a7d0, 0x42})
	/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/recorder/recorder.go:155 +0xcb
github.com/kubevirt/hyperconverged-cluster-operator/pkg/util.eventEmitter.EmitEvent({{0x1b38740?, 0xc000799300?}, 0xc000144000?, 0xc000839680?}, {0x1b25fb8?, 0x0?}, {0x18a076f, 0x7}, {0x18a460c, 0xb}, ...)
	/remote-source/app/pkg/util/event_emmiter.go:41 +0x114
github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts.AlertRuleReconciler.updateAlert({{0x1b3e5d0, 0xc0001aee10}, {0xc000a083e0, 0xd}, 0xc0000be500, 0xc0030f7680, {0x1b260d0, 0x277d0c0}, 0xc0001403f0}, 0xc002def7a0, ...)
	/remote-source/app/controllers/alerts/alerts.go:165 +0x564
github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts.(*AlertRuleReconciler).Reconcile(0xc000116410, 0xc002def7a0)
	/remote-source/app/controllers/alerts/alerts.go:109 +0x1e5
github.com/kubevirt/hyperconverged-cluster-operator/controllers/hyperconverged.(*ReconcileHyperConverged).Reconcile(0xc0000b21c0, {0x1b393f0, 0xc003303d40}, {{{0xc000054013?, 0x17c4ee0?}, {0xc000afc240?, 0x30?}}})
	/remote-source/app/controllers/hyperconverged/hyperconverged_controller.go:277 +0x279
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc00023cf20, {0x1b393f0, 0xc003303c80}, {{{0xc000054013?, 0x17c4ee0?}, {0xc000afc240?, 0x409514?}}})
	/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114 +0x27e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00023cf20, {0x1b39348, 0xc000996d00}, {0x16f41e0?, 0xc00193a520?})
	/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311 +0x349
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00023cf20, {0x1b39348, 0xc000996d00})
	/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:223 +0x31c
```

This PR fixes the bug by not sending the nil interface but an actual
nil, and also changes the check to use reflection in order to make sure
that the function parameter is nil.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix sw crash 
```

