### PR TITLE
[release-1.7] Cosmetic: match main code

### DIFF
--- a/pkg/util/event_emmiter.go
+++ b/pkg/util/event_emmiter.go
@@ -41,7 +41,7 @@ func (ee eventEmitter) EmitEvent(object runtime.Object, eventType, reason, msg s
 
 	// checking object != nil does not work because object is an interface, and nil interface instance is not nil.
 	// We need to check that it's actually nil, using reflection.
-	if t := reflect.ValueOf(object); t.Kind() != reflect.Ptr || !t.IsNil() {
+	if t := reflect.ValueOf(object); t.Kind() != reflect.Pointer || !t.IsNil() {
 		ee.recorder.Event(object, eventType, reason, msg)
 	}
 


### PR DESCRIPTION
`reflect.Pointer` that is used in the main branch, is not supported by go1.17, so we had to use `reflect.Ptr` instead.
 
Now, that this branch also built with go1.18, we can fix the code to match the main brance.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

