### PR TITLE
Revert infra_label for HCO alerts

### DIFF
--- a/controllers/alerts/alerts.go
+++ b/controllers/alerts/alerts.go
@@ -29,7 +29,6 @@ const (
 	partOfAlertLabelValue         = "kubevirt"
 	componentAlertLabelKey        = "kubernetes_operator_component"
 	componentAlertLabelValue      = "hyperconverged-cluster-operator"
-	infraAlertLabelKey            = "infra_alert"
 	ruleName                      = hcoutil.HyperConvergedName + "-prometheus-rule"
 )
 
@@ -135,7 +134,6 @@ func createOutOfBandUpdateAlertRule() monitoringv1.Rule {
 			severityAlertLabelKey:  "warning",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
-			infraAlertLabelKey:     "true",
 		},
 	}
 }
@@ -153,7 +151,6 @@ func createUnsafeModificationAlertRule() monitoringv1.Rule {
 			severityAlertLabelKey:  "info",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
-			infraAlertLabelKey:     "true",
 		},
 	}
 }
@@ -172,7 +169,6 @@ func createInstallationNotCompletedAlertRule() monitoringv1.Rule {
 			severityAlertLabelKey:  "info",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
-			infraAlertLabelKey:     "true",
 		},
 	}
 }

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -31,7 +31,6 @@ tests:
         severity: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
   # New increases must be detected
@@ -46,7 +45,6 @@ tests:
         severity: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
   # Old increases must be ignored.
@@ -61,7 +59,6 @@ tests:
         severity: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
   # Should resolve after 10 minutes if there is no new change
@@ -86,7 +83,6 @@ tests:
         severity: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 
   # After restart, new increases must be detected
@@ -101,7 +97,6 @@ tests:
         severity: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
 # Test unsafe modification counter
 - interval: 1m
@@ -134,7 +129,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -144,7 +138,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -154,7 +147,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
 
   # New increases must be detected
@@ -169,7 +161,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -179,7 +170,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
     # still using the 10 minutes max
     - exp_annotations:
@@ -190,7 +180,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
 
   # counter can be reduced
@@ -205,7 +194,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     # Reduced
     - exp_annotations:
@@ -216,7 +204,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -226,7 +213,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
 
   # no alert if the value is 0
@@ -241,7 +227,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the containerizeddataimporter.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -251,7 +236,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
 
   # no alert if the value is 0 for all of the annotations
@@ -271,7 +255,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     # Reduced
     - exp_annotations:
@@ -282,7 +265,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -292,7 +274,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
 
   # no data
@@ -312,7 +293,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
     # Reduced
     - exp_annotations:
@@ -323,7 +303,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
     - exp_annotations:
         description: "unsafe modification for the networkaddonsconfigs.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
@@ -333,7 +312,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
 
 # Test hyperconverged exists counter
@@ -385,7 +363,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
 
   # counter is 0 for more than an hour
   - eval_time: 63m
@@ -399,7 +376,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
 
   # counter is 0 for more than an hour
   - eval_time: 67m
@@ -413,7 +389,6 @@ tests:
         severity: "info"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
-        infra_alert: "true"
 
   - eval_time: 68m
     alertname: KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert


### PR DESCRIPTION
Reverts [#1988](https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1988). The design is not yet agreed as a standard for all operators alerts, so this label won't be used for now.

Signed-off-by: assafad <aadmi@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

