### PR TITLE
Remove token auth from release-notes

### DIFF
--- a/tools/release-notes/git/git.go
+++ b/tools/release-notes/git/git.go
@@ -40,8 +40,7 @@ func InitProject(owner string, name string, short string, directory string, tag 
 	p.Name = name
 	p.Short = short
 	p.Directory = directory
-	p.Remote = fmt.Sprintf("https://%s@github.com/%s/%s.git", token, owner, name)
-
+	p.Remote = fmt.Sprintf("https://github.com/%s/%s.git", owner, name)
 	p.CurrentTag = tag
 
 	p.github = initGitHub(owner, name, token)


### PR DESCRIPTION
When this package was used with the GitHub Actions token, using the GitHub token in the remote URL caused a failure. Since the KubeVirt projects are open-source, using the token to checkout the upstream projects is not needed.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

