### PR TITLE
Update DataImportCron of Fedora to latest tag

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -36,7 +36,7 @@
       spec:
         source:
           registry:
-            url: docker://quay.io/containerdisks/fedora:35
+            url: docker://quay.io/containerdisks/fedora:latest
         storage:
           resources:
             requests:


### PR DESCRIPTION
A latest tag for the Fedora containerdisk was added in [1]. Use that
instead of explicitly specifying a version tag to be always up to date.

[1] https://github.com/kubevirt/containerdisks/commit/db30dfc6f9cf190cda17ef5488be965433ab1e42

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

