### PR TITLE
Add Watch for HCO-controlled Deployments

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -237,6 +237,10 @@ func getNewManagerCache(operatorNamespace string) cache.NewCacheFunc {
 				&consolev1.ConsoleQuickStart{}: {
 					Label: labelSelector,
 				},
+				&appsv1.Deployment{}: {
+					Label: labelSelector,
+					Field: namespaceSelector,
+				},
 			},
 		},
 	)

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -18,6 +18,7 @@ import (
 	operatorhandler "github.com/operator-framework/operator-lib/handler"
 	"github.com/pkg/errors"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -193,6 +194,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo) er
 			&consolev1.ConsoleQuickStart{},
 			&imagev1.ImageStream{},
 			&corev1.Namespace{},
+			&appsv1.Deployment{},
 		}...)
 	}
 


### PR DESCRIPTION
By adding a watch for Deployments with HCO's label selector, change in a deployment that is managed by HCO will trigger a reconciliation loop.
https://bugzilla.redhat.com/show_bug.cgi?id=2100415

Signed-off-by: orenc1 <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

