### PR TITLE
Fix 'ocp4-moderate-routes-protected-by-tls' Compliance failure

### DIFF
--- a/controllers/operands/cliDownload.go
+++ b/controllers/operands/cliDownload.go
@@ -193,7 +193,8 @@ func NewCliDownloadsRoute(hc *hcov1beta1.HyperConverged) *routev1.Route {
 				TargetPort: intstr.IntOrString{IntVal: util.CliDownloadsServerPort},
 			},
 			TLS: &routev1.TLSConfig{
-				Termination: routev1.TLSTerminationEdge,
+				Termination:                   routev1.TLSTerminationEdge,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 			},
 			To: routev1.RouteTargetReference{
 				Kind:   "Service",


### PR DESCRIPTION
According to:
https://github.com/ComplianceAsCode/content/blob/master/applications/openshift/networking/routes_protected_by_tls/rule.yml
The ocp4-moderate profile of the compliance operator expects that all Routes on the cluster should have either `None` or `Redirect` setting under their `.spec.tls.insecureEdgeTerminationPolicy`
We chose `Redirect`, to be aligned with all other default routes on an OCP cluster, and not to fail HTTP requests but redirect them to HTTPS requests.

https://bugzilla.redhat.com/show_bug.cgi?id=2110562
Signed-off-by: Oren Cohen <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix ocp4-moderate-routes-protected-by-tls compliance check fail.
```

