### PR TITLE
Comply with OCP 4.11 and 4.12 Pod Security Standards (#2036)

### DIFF
--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -21,6 +21,7 @@ import (
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/cmd/cmdcommon"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
@@ -83,6 +84,7 @@ func NewKvUiPluginDeplymnt(hc *hcov1beta1.HyperConverged) (*appsv1.Deployment, e
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "default",
+					SecurityContext:    components.GetStdPodSecurityContext(),
 					Containers: []corev1.Container{
 						{
 							Name:            kvUIPluginName,
@@ -98,6 +100,7 @@ func NewKvUiPluginDeplymnt(hc *hcov1beta1.HyperConverged) (*appsv1.Deployment, e
 								ContainerPort: hcoutil.UiPluginServerPort,
 								Protocol:      corev1.ProtocolTCP,
 							}},
+							SecurityContext:          components.GetStdContainerSecurityContext(),
 							TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 							VolumeMounts: []corev1.VolumeMount{

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.7.0/manifests/kubevirt-hyperconverged-operator.v1.7.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.7.0/manifests/kubevirt-hyperconverged-operator.v1.7.0.clusterserviceversion.yaml
@@ -2435,7 +2435,16 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 96Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               priorityClassName: system-cluster-critical
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: hyperconverged-cluster-operator
       - label:
           app.kubernetes.io/component: deployment
@@ -2502,7 +2511,16 @@ spec:
                   requests:
                     cpu: 5m
                     memory: 48Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               priorityClassName: system-node-critical
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: hyperconverged-cluster-operator
       - label:
           app.kubernetes.io/component: deployment
@@ -2538,7 +2556,16 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 96Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               priorityClassName: system-cluster-critical
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
       - label:
           app.kubernetes.io/component: network
           app.kubernetes.io/managed-by: olm

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.7.0/manifests/kubevirt-hyperconverged-operator.v1.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.7.0/manifests/kubevirt-hyperconverged-operator.v1.7.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.7.0-unstable
-    createdAt: "2022-06-28 05:24:34"
+    createdAt: "2022-07-26 15:18:39"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -2435,7 +2435,16 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 96Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               priorityClassName: system-cluster-critical
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: hyperconverged-cluster-operator
       - label:
           app.kubernetes.io/component: deployment
@@ -2502,7 +2511,16 @@ spec:
                   requests:
                     cpu: 5m
                     memory: 48Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               priorityClassName: system-node-critical
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: hyperconverged-cluster-operator
       - label:
           app.kubernetes.io/component: deployment
@@ -2538,7 +2556,16 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 96Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               priorityClassName: system-cluster-critical
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
       - label:
           app.kubernetes.io/component: network
           app.kubernetes.io/managed-by: olm

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -89,7 +89,16 @@ spec:
           requests:
             cpu: 10m
             memory: 96Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: hyperconverged-cluster-operator
 ---
 apiVersion: apps/v1
@@ -158,10 +167,19 @@ spec:
           requests:
             cpu: 5m
             memory: 48Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /apiserver.local.config/certificates
           name: apiservice-cert
       priorityClassName: system-node-critical
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: hyperconverged-cluster-operator
       volumes:
       - name: apiservice-cert
@@ -209,7 +227,16 @@ spec:
           requests:
             cpu: 10m
             memory: 96Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Set something like:
```
spec:
 securityContext:
   # Do not use SeccompProfile if your project must work on
   # old k8s versions < 1.19 and Openshift < 4.11
   seccompProfile:
      type: RuntimeDefault
   runAsNonRoot: true
 containers:
   - name: my-container
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
           - ALL
```
following OCP/OKD 4.12 best practices.

This is a manual cherry-pick of #2036

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Comply with OCP/OKD 4.11 and 4.12 Pod Security Standards
```

