### PR TITLE
Remove live migration feature gate since it's deprecated

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -196,7 +196,6 @@ var _ = Describe("HyperconvergedController", func() {
 				expectedFeatureGates := []string{
 					"DataVolumes",
 					"SRIOV",
-					"LiveMigration",
 					"CPUManager",
 					"CPUNodeDiscovery",
 					"Snapshot",

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -61,9 +61,6 @@ const (
 	// Enable Single-root input/output virtualization
 	kvSRIOVGate = "SRIOV"
 
-	// Enables VMIs to be live migrated. Without this, migrations are not possible and will be blocked
-	kvLiveMigrationGate = "LiveMigration"
-
 	// Enables the CPUManager feature gate to label the nodes which have the Kubernetes CPUManager running. VMIs that
 	// require dedicated CPU resources will automatically be scheduled on the labeled nodes
 	kvCPUManagerGate = "CPUManager"
@@ -106,7 +103,6 @@ var (
 		kvHostDevicesGate,
 		kvDownwardMetricsGate,
 		kvNUMA,
-		kvLiveMigrationGate,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -1594,7 +1594,7 @@ Version: 1.2.3`)
 					By("Make sure the existing KV is with the the expected FGs", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
-							To(ContainElements(kvLiveMigrationGate, kvWithHostPassthroughCPU, kvSRIOVLiveMigration))
+							To(ContainElements(kvWithHostPassthroughCPU, kvSRIOVLiveMigration))
 					})
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
@@ -1791,26 +1791,6 @@ Version: 1.2.3`)
 						len(hardCodeKvFgs)+2,
 						[][]string{hardCodeKvFgs, {kvWithHostPassthroughCPU}},
 					))
-
-				It("Should include LiveMigration if running in openshift with HighlyAvailable infrastructure", func() {
-					hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
-						return &commonTestUtils.ClusterInfoMock{}
-					}
-					hco_fg := hcov1beta1.HyperConvergedFeatureGates{}
-					fgs := getKvFeatureGateList(&hco_fg)
-					Expect(fgs).To(HaveLen(len(hardCodeKvFgs)))
-					Expect(fgs).To(ContainElement(kvLiveMigrationGate))
-				})
-
-				It("Should include LiveMigration if running in openshift with SingleReplica infrastructure", func() {
-					hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
-						return &commonTestUtils.ClusterInfoSNOMock{}
-					}
-					hco_fg := hcov1beta1.HyperConvergedFeatureGates{}
-					fgs := getKvFeatureGateList(&hco_fg)
-					Expect(fgs).To(HaveLen(len(hardCodeKvFgs)))
-					Expect(fgs).To(ContainElement(kvLiveMigrationGate))
-				})
 			})
 
 			Context("Test getMandatoryKvFeatureGates", func() {


### PR DESCRIPTION
Removing live migration feature gate as it's deprecated in this PR: https://github.com/kubevirt/kubevirt/pull/8047

Fixes #2039

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove deprecated live migration feature gate
```

