### PR TITLE
Migrate index generation process to File-Based Catalog

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -19,7 +19,7 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       REGISTRY_NAMESPACE: kubevirt
-      OPM_VERSION: v1.23.0
+      OPM_VERSION: v1.24.0
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v2


### PR DESCRIPTION
SQLite-Based catlog format, which we were using so far, is being deprecated in favour of the new format of file-based catalog.
With this change, the 'opm index add --bundles' command no longer works, and we need to change the workflow to work with json files inside the catalog image.
References:
- https://olm.operatorframework.io/docs/reference/file-based-catalogs/
- https://github.com/k8s-operatorhub/community-operators/discussions/505

Signed-off-by: Oren Cohen <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
migrate to FBC in index image workflows.
```

