### PR TITLE
[bump-bot] Add module paths for kubevirt in `go.mod` to be updated

### DIFF
--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -99,7 +99,7 @@ function get_updated_versions {
   )
 
   IMPORT_REPOS=(
-    ["KUBEVIRT"]="kubevirt.io/api"
+    ["KUBEVIRT"]="kubevirt.io/api,kubevirt.io/client-go,kubevirt.io/kubevirt"
     ["CDI"]="kubevirt.io/containerized-data-importer-api"
     ["NETWORK_ADDONS"]="kubevirt/cluster-network-addons-operator"
     ["SSP"]="kubevirt.io/ssp-operator/api"
@@ -240,9 +240,12 @@ function update_go_mod() {
   UPDATED_VERSION=$(cat updated_version.txt)
 
   if [[ -v IMPORT_REPOS[$UPDATED_COMPONENT] ]]; then
-    MODULE_PATH=${IMPORT_REPOS[$UPDATED_COMPONENT]}
-    sed -E -i "s|(${MODULE_PATH}.*)v.+|\1${UPDATED_VERSION}|" go.mod
-    sed -E -i "s|(${MODULE_PATH}.*)v.+|\1${UPDATED_VERSION}|" tests/go.mod
+    MODULE_PATH_LIST=${IMPORT_REPOS[$UPDATED_COMPONENT]}
+    for MODULE_PATH in $(echo "${MODULE_PATH_LIST}" | tr "," "\n")
+    do
+      sed -E -i "s|(${MODULE_PATH}.*)v.+|\1${UPDATED_VERSION}|" go.mod
+      sed -E -i "s|(${MODULE_PATH}.*)v.+|\1${UPDATED_VERSION}|" tests/go.mod
+    done
   else
     echo "No need to update go.mod for ${UPDATED_COMPONENT}"
   fi


### PR DESCRIPTION
in `tests/go.mod` we have additional module paths for kubevirt:
- `kubevirt.io/client-go`
- `kubevirt.io/kubevirt`

That need to be updated as well when a KubeVirt version is being bumped.
This PR updates these module paths to the updated version.

Signed-off-by: Oren Cohen <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

