### PR TITLE
[FBC] add missing _out dir

### DIFF
--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -42,6 +42,7 @@ function create_index_image() {
   # unalignment between cached index image and fetched bundle image.
   BUNDLE_IMAGE_NAME=$("${PROJECT_ROOT}/tools/digester/digester" --image "${BUNDLE_IMAGE_NAME}")
 
+  mkdir -p "${OUT_DIR}"
   (cd "${OUT_DIR}" && create_file_based_catalog)
 
   podman push "${INDEX_IMAGE_NAME}"


### PR DESCRIPTION
Signed-off-by: Oren Cohen <ocohen@redhat.com>

```
./hack/build-index-image.sh: line 45: cd: /home/runner/work/hyperconverged-cluster-operator/hyperconverged-cluster-operator/_out: No such file or directory
```

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

