### PR TITLE
Keep using SQLite-based catalog for unstable tags

### DIFF
--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -42,8 +42,16 @@ function create_index_image() {
   # unalignment between cached index image and fetched bundle image.
   BUNDLE_IMAGE_NAME=$("${PROJECT_ROOT}/tools/digester/digester" --image "${BUNDLE_IMAGE_NAME}")
 
-  mkdir -p "${OUT_DIR}"
-  (cd "${OUT_DIR}" && create_file_based_catalog)
+  if [[ "${UNSTABLE}" == "UNSTABLE" ]]; then
+    # Currently, ci-operator does not support index images with file-based catalogs.
+    # To maintain CI functionality, we'll keep using SQLite-based catalogs for the unstable tags
+    # until FBC handling will be implemented in openshift ci-operator.
+    # shellcheck disable=SC2086
+    ${OPM} index add --bundles "${BUNDLE_IMAGE_NAME}" ${INDEX_IMAGE_PARAM} --tag "${INDEX_IMAGE_NAME}" -u podman --mode semver
+  else
+    mkdir -p "${OUT_DIR}"
+    (cd "${OUT_DIR}" && create_file_based_catalog)
+  fi
 
   podman push "${INDEX_IMAGE_NAME}"
 }


### PR DESCRIPTION
Currently, ci-operator does not support index images with file-based catalogs.
To maintain CI functionality, we'll keep using SQLite-based catalogs for the unstable tags
until FBC handling will be implemented in openshift ci-operator.

Signed-off-by: Oren Cohen <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

