### PR TITLE
kubevirt, Remove deprecated SR-IOV-Live Migration feature gate

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -49,7 +49,7 @@ type HyperConvergedSpec struct {
 
 	// featureGates is a map of feature gate flags. Setting a flag to `true` will enable
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
-	// +kubebuilder:default={"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true}
+	// +kubebuilder:default={"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true}
 	// +optional
 	FeatureGates HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
@@ -256,11 +256,6 @@ type HyperConvergedFeatureGates struct {
 	// +optional
 	// +kubebuilder:default=false
 	WithHostPassthroughCPU bool `json:"withHostPassthroughCPU"`
-
-	// Allow migrating a virtual machine with SRIOV interfaces.
-	// +optional
-	// +kubebuilder:default=true
-	SRIOVLiveMigration bool `json:"sriovLiveMigration"`
 
 	// Opt-in to automatic delivery/updates of the common data import cron templates.
 	// There are two sources for the data import cron templates: hard coded list of common templates, and custom
@@ -528,7 +523,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -199,14 +199,6 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 							Format:      "",
 						},
 					},
-					"sriovLiveMigration": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Allow migrating a virtual machine with SRIOV interfaces.",
-							Default:     false,
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"enableCommonBootImageImport": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.",

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -55,7 +55,6 @@ spec:
                 deployTektonTaskResources: false
                 enableCommonBootImageImport: true
                 nonRoot: true
-                sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
                 completionTimeoutPerGiB: 800
@@ -866,7 +865,6 @@ spec:
                   deployTektonTaskResources: false
                   enableCommonBootImageImport: true
                   nonRoot: true
-                  sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
@@ -890,10 +888,6 @@ spec:
                   nonRoot:
                     default: true
                     description: Enables rootless virt-launcher.
-                    type: boolean
-                  sriovLiveMigration:
-                    default: true
-                    description: Allow migrating a virtual machine with SRIOV interfaces.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1903,34 +1903,6 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(Not(BeNil()))
 					Expect(*foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(Equal(badBandwidthPerMigration))
 				})
-
-				It("should amend spec.featureGates.sriovLiveMigration upgrading from <= 1.5.0", func() {
-					UpdateVersion(&expected.hco.Status, hcoVersionName, "1.4.99")
-					expected.hco.Spec.FeatureGates.SRIOVLiveMigration = false
-
-					cl := expected.initClient()
-					_, reconciler, requeue := doReconcile(cl, expected.hco, nil)
-					Expect(requeue).To(BeTrue())
-					_, reconciler, requeue = doReconcile(cl, expected.hco, reconciler)
-					Expect(requeue).To(BeTrue())
-					foundResource, _, requeue := doReconcile(cl, expected.hco, reconciler)
-					Expect(requeue).To(BeFalse())
-
-					Expect(foundResource.Spec.FeatureGates.SRIOVLiveMigration).Should(BeTrue())
-				})
-
-				It("should not amend spec.featureGates.sriovLiveMigration upgrading from >= 1.5.1", func() {
-					UpdateVersion(&expected.hco.Status, hcoVersionName, "1.5.1")
-					expected.hco.Spec.FeatureGates.SRIOVLiveMigration = false
-
-					cl := expected.initClient()
-					foundResource, reconciler, requeue := doReconcile(cl, expected.hco, nil)
-					Expect(requeue).To(BeTrue())
-					foundResource, _, requeue = doReconcile(cl, foundResource, reconciler)
-					Expect(requeue).To(BeFalse())
-					Expect(foundResource.Spec.FeatureGates.SRIOVLiveMigration).Should(Not(BeTrue()))
-				})
-
 			})
 
 			Context("remove old quickstart guides", func() {

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -133,7 +133,6 @@ var (
 // KubeVirt feature gates that are exposed in HCO API
 const (
 	kvWithHostPassthroughCPU = "WithHostPassthroughCPU"
-	kvSRIOVLiveMigration     = "SRIOVLiveMigration"
 	kvNonRoot                = "NonRoot"
 )
 
@@ -522,10 +521,6 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) [
 
 	if featureGates.WithHostPassthroughCPU {
 		fgs = append(fgs, kvWithHostPassthroughCPU)
-	}
-
-	if featureGates.SRIOVLiveMigration {
-		fgs = append(fgs, kvSRIOVLiveMigration)
 	}
 
 	if featureGates.NonRoot {

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -1364,34 +1364,6 @@ Version: 1.2.3`)
 					})
 				})
 
-				It("should add the SRIOVLiveMigration feature gate if it's set in HyperConverged CR", func() {
-					// one enabled, one disabled and one missing
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						SRIOVLiveMigration: true,
-					}
-
-					existingResource, err := NewKubeVirt(hco)
-					Expect(err).ToNot(HaveOccurred())
-					By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
-						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
-						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvSRIOVLiveMigration))
-					})
-				})
-
-				It("should not add the SRIOVLiveMigration feature gate if it's disabled in HyperConverged CR", func() {
-					// one enabled, one disabled and one missing
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						SRIOVLiveMigration: false,
-					}
-
-					existingResource, err := NewKubeVirt(hco)
-					Expect(err).ToNot(HaveOccurred())
-					By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
-						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
-						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("SRIOVLiveMigration"))
-					})
-				})
-
 				It("should add the NonRoot feature gate if it's set in HyperConverged CR", func() {
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
 						NonRoot: true,
@@ -1415,42 +1387,6 @@ Version: 1.2.3`)
 					By("KV CR should contain the NonRoot feature gate", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("NonRoot"))
-					})
-				})
-
-				Context("should honor SRIOVLiveMigration on SNO ", func() {
-					BeforeEach(func() {
-						hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
-							return &commonTestUtils.ClusterInfoSNOMock{}
-						}
-					})
-
-					It("should add the SRIOVLiveMigration feature gate if it's set in HyperConverged on SNO", func() {
-						// one enabled, one disabled and one missing
-						hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-							SRIOVLiveMigration: true,
-						}
-
-						existingResource, err := NewKubeVirt(hco)
-						Expect(err).ToNot(HaveOccurred())
-						By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
-							Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
-							Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvSRIOVLiveMigration))
-						})
-					})
-
-					It("should not add the SRIOVLiveMigration feature gate if it's disabled in HyperConverged CR on SNO", func() {
-						// one enabled, one disabled and one missing
-						hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-							SRIOVLiveMigration: false,
-						}
-
-						existingResource, err := NewKubeVirt(hco)
-						Expect(err).ToNot(HaveOccurred())
-						By("KV CR should contain the SRIOVLiveMigration feature gate", func() {
-							Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
-							Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("SRIOVLiveMigration"))
-						})
 					})
 				})
 
@@ -1489,7 +1425,6 @@ Version: 1.2.3`)
 
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
 						WithHostPassthroughCPU: true,
-						SRIOVLiveMigration:     true,
 					}
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
@@ -1510,7 +1445,7 @@ Version: 1.2.3`)
 					By("KV CR should contain the HC enabled managed feature gates", func() {
 						Expect(foundResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
-							To(ContainElements(kvWithHostPassthroughCPU, kvSRIOVLiveMigration))
+							To(ContainElements(kvWithHostPassthroughCPU))
 					})
 				})
 
@@ -1520,7 +1455,6 @@ Version: 1.2.3`)
 
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
 						WithHostPassthroughCPU: false,
-						SRIOVLiveMigration:     false,
 					}
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
@@ -1581,20 +1515,19 @@ Version: 1.2.3`)
 
 				It("should keep FG if already exist", func() {
 					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(true)
-					fgs := append(hardCodeKvFgs, kvWithHostPassthroughCPU, kvSRIOVLiveMigration)
+					fgs := append(hardCodeKvFgs, kvWithHostPassthroughCPU)
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 					existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates = fgs
 
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
 						WithHostPassthroughCPU: true,
-						SRIOVLiveMigration:     true,
 					}
 
 					By("Make sure the existing KV is with the the expected FGs", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
-							To(ContainElements(kvWithHostPassthroughCPU, kvSRIOVLiveMigration))
+							To(ContainElements(kvWithHostPassthroughCPU))
 					})
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
@@ -1614,7 +1547,7 @@ Version: 1.2.3`)
 
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
-						To(ContainElements(kvWithHostPassthroughCPU, kvSRIOVLiveMigration))
+						To(ContainElements(kvWithHostPassthroughCPU))
 
 				})
 
@@ -1623,18 +1556,17 @@ Version: 1.2.3`)
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 					existingResource.Spec.Configuration.DeveloperConfiguration = &kubevirtcorev1.DeveloperConfiguration{
-						FeatureGates: []string{kvWithHostPassthroughCPU, kvSRIOVLiveMigration},
+						FeatureGates: []string{kvWithHostPassthroughCPU},
 					}
 
 					By("Make sure the existing KV is with the the expected FGs", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
-							To(ContainElements(kvWithHostPassthroughCPU, kvSRIOVLiveMigration))
+							To(ContainElements(kvWithHostPassthroughCPU))
 					})
 
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
 						WithHostPassthroughCPU: false,
-						SRIOVLiveMigration:     false,
 					}
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
@@ -1663,13 +1595,13 @@ Version: 1.2.3`)
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 					existingResource.Spec.Configuration.DeveloperConfiguration = &kubevirtcorev1.DeveloperConfiguration{
-						FeatureGates: []string{kvWithHostPassthroughCPU, kvSRIOVLiveMigration},
+						FeatureGates: []string{kvWithHostPassthroughCPU},
 					}
 
 					By("Make sure the existing KV is with the the expected FGs", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
-							To(ContainElements(kvWithHostPassthroughCPU, kvSRIOVLiveMigration))
+							To(ContainElements(kvWithHostPassthroughCPU))
 					})
 
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{}
@@ -1700,13 +1632,13 @@ Version: 1.2.3`)
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 					existingResource.Spec.Configuration.DeveloperConfiguration = &kubevirtcorev1.DeveloperConfiguration{
-						FeatureGates: []string{kvWithHostPassthroughCPU, kvSRIOVLiveMigration},
+						FeatureGates: []string{kvWithHostPassthroughCPU},
 					}
 
 					By("Make sure the existing KV is with the the expected FGs", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
-							To(ContainElements(kvWithHostPassthroughCPU, kvSRIOVLiveMigration))
+							To(ContainElements(kvWithHostPassthroughCPU))
 					})
 
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{}
@@ -1769,26 +1701,26 @@ Version: 1.2.3`)
 					),
 					Entry("When not using kvm-emulation and all FGs are disabled",
 						false,
-						&hcov1beta1.HyperConvergedFeatureGates{SRIOVLiveMigration: false, WithHostPassthroughCPU: false},
+						&hcov1beta1.HyperConvergedFeatureGates{WithHostPassthroughCPU: false},
 						basicNumFgOnOpenshift,
 						[][]string{hardCodeKvFgs, sspConditionKvFgs},
 					),
 					Entry("When using kvm-emulation all FGs are disabled",
 						true,
-						&hcov1beta1.HyperConvergedFeatureGates{SRIOVLiveMigration: false, WithHostPassthroughCPU: false},
+						&hcov1beta1.HyperConvergedFeatureGates{WithHostPassthroughCPU: false},
 						len(hardCodeKvFgs),
 						[][]string{hardCodeKvFgs},
 					),
 					Entry("When not using kvm-emulation and all FGs are enabled",
 						false,
-						&hcov1beta1.HyperConvergedFeatureGates{SRIOVLiveMigration: true, WithHostPassthroughCPU: true},
-						basicNumFgOnOpenshift+2,
+						&hcov1beta1.HyperConvergedFeatureGates{WithHostPassthroughCPU: true},
+						basicNumFgOnOpenshift+1,
 						[][]string{hardCodeKvFgs, sspConditionKvFgs, {kvWithHostPassthroughCPU}},
 					),
 					Entry("When using kvm-emulation all FGs are enabled",
 						true,
-						&hcov1beta1.HyperConvergedFeatureGates{SRIOVLiveMigration: true, WithHostPassthroughCPU: true},
-						len(hardCodeKvFgs)+2,
+						&hcov1beta1.HyperConvergedFeatureGates{WithHostPassthroughCPU: true},
+						len(hardCodeKvFgs)+1,
 						[][]string{hardCodeKvFgs, {kvWithHostPassthroughCPU}},
 					))
 			})
@@ -2804,7 +2736,7 @@ Version: 1.2.3`)
 				).ToNot(HaveOccurred())
 
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(mandatoryKvFeatureGates) + 2))
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(mandatoryKvFeatureGates) + 1))
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(hardCodeKvFgs))
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvSRIOVGate))
 				Expect(kv.Spec.Configuration.CPURequest).To(BeNil())

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -55,7 +55,6 @@ spec:
                 deployTektonTaskResources: false
                 enableCommonBootImageImport: true
                 nonRoot: true
-                sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
                 completionTimeoutPerGiB: 800
@@ -866,7 +865,6 @@ spec:
                   deployTektonTaskResources: false
                   enableCommonBootImageImport: true
                   nonRoot: true
-                  sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
@@ -890,10 +888,6 @@ spec:
                   nonRoot:
                     default: true
                     description: Enables rootless virt-launcher.
-                    type: boolean
-                  sriovLiveMigration:
-                    default: true
-                    description: Allow migrating a virtual machine with SRIOV interfaces.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -15,7 +15,6 @@ spec:
     deployTektonTaskResources: false
     enableCommonBootImageImport: false
     nonRoot: true
-    sriovLiveMigration: true
     withHostPassthroughCPU: false
   infra: {}
   liveMigrationConfig:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
@@ -55,7 +55,6 @@ spec:
                 deployTektonTaskResources: false
                 enableCommonBootImageImport: true
                 nonRoot: true
-                sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
                 completionTimeoutPerGiB: 800
@@ -866,7 +865,6 @@ spec:
                   deployTektonTaskResources: false
                   enableCommonBootImageImport: true
                   nonRoot: true
-                  sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
@@ -890,10 +888,6 @@ spec:
                   nonRoot:
                     default: true
                     description: Enables rootless virt-launcher.
-                    type: boolean
-                  sriovLiveMigration:
-                    default: true
-                    description: Allow migrating a virtual machine with SRIOV interfaces.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
@@ -55,7 +55,6 @@ spec:
                 deployTektonTaskResources: false
                 enableCommonBootImageImport: true
                 nonRoot: true
-                sriovLiveMigration: true
                 withHostPassthroughCPU: false
               liveMigrationConfig:
                 completionTimeoutPerGiB: 800
@@ -866,7 +865,6 @@ spec:
                   deployTektonTaskResources: false
                   enableCommonBootImageImport: true
                   nonRoot: true
-                  sriovLiveMigration: true
                   withHostPassthroughCPU: false
                 description: featureGates is a map of feature gate flags. Setting
                   a flag to `true` will enable the feature. Setting `false` or removing
@@ -890,10 +888,6 @@ spec:
                   nonRoot:
                     default: true
                     description: Enables rootless virt-launcher.
-                    type: boolean
-                  sriovLiveMigration:
-                    default: true
-                    description: Allow migrating a virtual machine with SRIOV interfaces.
                     type: boolean
                   withHostPassthroughCPU:
                     default: false

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,7 +94,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -127,7 +127,6 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here | bool | false | true |
-| sriovLiveMigration | Allow migrating a virtual machine with SRIOV interfaces. | bool | true | true |
 | enableCommonBootImageImport | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | bool | true | true |
 | deployTektonTaskResources | deploy resources (kubevirt tekton tasks and example pipelines) in Tekton tasks operator | bool | false | true |
 | nonRoot | Enables rootless virt-launcher. | bool | true | true |
@@ -165,7 +164,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | localStorageClassName | Deprecated: LocalStorageClassName the name of the local storage class. | string |  | false |
 | infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarily directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
 | workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
-| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "sriovLiveMigration": true, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true} | false |
+| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true} | false |
 | liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150} | false |
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
 | mediatedDevicesConfiguration | MediatedDevicesConfiguration holds information about MDEV types to be defined on nodes, if available | *[MediatedDevicesConfiguration](#mediateddevicesconfiguration) |  | false |

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -139,14 +139,6 @@ CPU HW perspective.
 
 Additional information: [LibvirtXMLCPUModel](https://wiki.openstack.org/wiki/LibvirtXMLCPUModel)
 
-### sriovLiveMigration Feature Gate
-
-Set the `sriovLiveMigration` feature gate in order to allow migrating a virtual machine with SRIOV interfaces. When
-enabled virt-launcher pods of virtual machines with SRIOV interfaces run with CAP_SYS_RESOURCE capability. This may
-degrade virt-launcher security.
-
-**Default**: `true`
-
 ### enableCommonBootImageImport Feature Gate
 
 Set the `enableCommonBootImageImport` feature gate to `false` in order to disable the common golden images in the cluster 
@@ -190,7 +182,6 @@ spec:
   workloads: {}
   featureGates:
     withHostPassthroughCPU: true
-    sriovLiveMigration: true
     enableCommonBootImageImport: true
     deployTektonTaskResources: true
 ```

--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euxo pipefail
 
 export PATH=$PATH:$HOME/gopath/bin
 JOB_TYPE="${JOB_TYPE:-}"

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -22,7 +22,7 @@ echo "Read the CR's spec before starting the test"
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o json | jq '.spec'
 
 CERTCONFIGDEFAULTS='{"ca":{"duration":"48h0m0s","renewBefore":"24h0m0s"},"server":{"duration":"24h0m0s","renewBefore":"12h0m0s"}}'
-FGDEFAULTS='{"deployTektonTaskResources":false,"enableCommonBootImageImport":true,"nonRoot":true,"sriovLiveMigration":true,"withHostPassthroughCPU":false}'
+FGDEFAULTS='{"deployTektonTaskResources":false,"enableCommonBootImageImport":true,"nonRoot":true,"withHostPassthroughCPU":false}'
 LMDEFAULTS='{"completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'
@@ -43,7 +43,6 @@ CERTCONFIGPATHS=(
 FGPATHS=(
     "/spec/featureGates/enableCommonBootImageImport"
     "/spec/featureGates/withHostPassthroughCPU"
-    "/spec/featureGates/sriovLiveMigration"
     "/spec/featureGates"
     "/spec"
 )

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -693,7 +693,6 @@ func GetOperatorCR() *hcov1beta1.HyperConverged {
 			},
 			FeatureGates: hcov1beta1.HyperConvergedFeatureGates{
 				WithHostPassthroughCPU: false,
-				SRIOVLiveMigration:     true,
 				NonRoot:                true,
 			},
 			LiveMigrationConfig: hcov1beta1.LiveMigrationConfigurations{


### PR DESCRIPTION
Following kubevirt/kubevirt#7990, this PR remove SR-IOV live migration feature gate since it's deprecated.

Signed-off-by: Or Mergi <ormergi@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove deprecated SR-IOV live migration feature gate
```

