### PR TITLE
Add HCO API to set CDIConfig DataVolumeTTLSeconds

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -379,6 +379,9 @@ type StorageImportConfig struct {
 	// +listType=set
 	// +optional
 	InsecureRegistries []string `json:"insecureRegistries,omitempty"`
+	// DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected.
+	// +optional
+	DataVolumeTTLSeconds *int32 `json:"dataVolumeTTLSeconds,omitempty"`
 }
 
 //

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2140,6 +2140,11 @@ spec:
                 description: StorageImport contains configuration for importing containerized
                   data
                 properties:
+                  dataVolumeTTLSeconds:
+                    description: DataVolumeTTLSeconds is the time in seconds after
+                      DataVolume completion it can be garbage collected.
+                    format: int32
+                    type: integer
                   insecureRegistries:
                     description: InsecureRegistries is a list of image registries
                       URLs that are not secured. Setting an insecure registry URL

--- a/controllers/operands/cdi.go
+++ b/controllers/operands/cdi.go
@@ -122,6 +122,7 @@ func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, err
 			spec.Config.InsecureRegistries = make([]string, length)
 			copy(spec.Config.InsecureRegistries, hc.Spec.StorageImport.InsecureRegistries)
 		}
+		spec.Config.DataVolumeTTLSeconds = hc.Spec.StorageImport.DataVolumeTTLSeconds
 	}
 
 	if hc.Spec.Infra.NodePlacement != nil {

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2140,6 +2140,11 @@ spec:
                 description: StorageImport contains configuration for importing containerized
                   data
                 properties:
+                  dataVolumeTTLSeconds:
+                    description: DataVolumeTTLSeconds is the time in seconds after
+                      DataVolume completion it can be garbage collected.
+                    format: int32
+                    type: integer
                   insecureRegistries:
                     description: InsecureRegistries is a list of image registries
                       URLs that are not secured. Setting an insecure registry URL

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
@@ -2140,6 +2140,11 @@ spec:
                 description: StorageImport contains configuration for importing containerized
                   data
                 properties:
+                  dataVolumeTTLSeconds:
+                    description: DataVolumeTTLSeconds is the time in seconds after
+                      DataVolume completion it can be garbage collected.
+                    format: int32
+                    type: integer
                   insecureRegistries:
                     description: InsecureRegistries is a list of image registries
                       URLs that are not secured. Setting an insecure registry URL

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
@@ -2140,6 +2140,11 @@ spec:
                 description: StorageImport contains configuration for importing containerized
                   data
                 properties:
+                  dataVolumeTTLSeconds:
+                    description: DataVolumeTTLSeconds is the time in seconds after
+                      DataVolume completion it can be garbage collected.
+                    format: int32
+                    type: integer
                   insecureRegistries:
                     description: InsecureRegistries is a list of image registries
                       URLs that are not secured. Setting an insecure registry URL

--- a/docs/api.md
+++ b/docs/api.md
@@ -315,6 +315,7 @@ StorageImportConfig contains configuration for importing containerized data
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | insecureRegistries | InsecureRegistries is a list of image registries URLs that are not secured. Setting an insecure registry URL in this list allows pulling images from this registry. | []string |  | false |
+| dataVolumeTTLSeconds | DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. | *int32 |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -606,8 +606,8 @@ spec:
     batchEvictionInterval: "1m"
 ```
 
-## Insecure Registries for Imported Data containerized Images
-If there is a need to import data images from an insecure registry, these registries should be added to the
+## Import from Insecure Registry
+If there is a need to import data images from an insecure registry, it should be added to the
 `insecureRegistries` field under the `storageImport` in the `HyperConverged`'s `spec` field.
 
 ### Insecure Registry Example
@@ -621,6 +621,19 @@ spec:
     insecureRegistries:
       - "private-registry-example-1:5000"
       - "private-registry-example-2:5000"
+      ...
+```
+## Garbage Collection of successfully completed DataVolumes
+Once the `PVC` population process is completed, its corresponding `DV` has no use, so it is better garbage collected. Garbage collection can be configured in the `dataVolumeTTLSeconds` field under the `storageImport` in the `HyperConverged`'s `spec` field. It defines the time in seconds after `DataVolume` completion it can be garbage collected.
+### Garbage Collection Example
+```yaml
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  storageImport:
+    dataVolumeTTLSeconds: 0
       ...
 ```
 ## Modify common golden images


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```release-note
Add HCO API to set CDIConfig DataVolumeTTLSeconds
```

