### PR TITLE
Don't increase the overwrittenModifications metric during upgrade

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -1147,7 +1147,7 @@ func (r *ReconcileHyperConverged) migrateBeforeUpgrade(req *common.HcoRequest) (
 	return upgradePatched, nil
 }
 
-func (r ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (bool, error) {
+func (r *ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (bool, error) {
 	modified := false
 
 	knownHcoVersion, _ := GetVersion(&req.Instance.Status, hcoVersionName)
@@ -1194,7 +1194,7 @@ func (r ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (bo
 	return modified, nil
 }
 
-func (r ReconcileHyperConverged) applyUpgradePatch(req *common.HcoRequest, hcoJson []byte, knownHcoSV semver.Version, p hcoCRPatch) ([]byte, error) {
+func (r *ReconcileHyperConverged) applyUpgradePatch(req *common.HcoRequest, hcoJson []byte, knownHcoSV semver.Version, p hcoCRPatch) ([]byte, error) {
 	affectedRange, err := semver.ParseRange(p.SemverRange)
 	if err != nil {
 		return hcoJson, err
@@ -1214,7 +1214,7 @@ func (r ReconcileHyperConverged) applyUpgradePatch(req *common.HcoRequest, hcoJs
 	return hcoJson, nil
 }
 
-func (r ReconcileHyperConverged) removeLeftover(req *common.HcoRequest, knownHcoSV semver.Version, p objectToBeRemoved) (bool, error) {
+func (r *ReconcileHyperConverged) removeLeftover(req *common.HcoRequest, knownHcoSV semver.Version, p objectToBeRemoved) (bool, error) {
 
 	affectedRange, err := semver.ParseRange(p.SemverRange)
 	if err != nil {
@@ -1271,7 +1271,7 @@ func initOldMetricsObjects(req *common.HcoRequest) {
 	}
 }
 
-func (r ReconcileHyperConverged) removeOldMetricsObjs(req *common.HcoRequest) error {
+func (r *ReconcileHyperConverged) removeOldMetricsObjs(req *common.HcoRequest) error {
 	initOldMetricsObjects(req)
 
 	for name, object := range oldMetricsObjects {

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -240,6 +240,7 @@ func getBasicDeployment() *BasicExpected {
 	expectedCDI, err := operands.NewCDI(hco)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	expectedCDI.Status.Conditions = getGenericCompletedConditions()
+	expectedCDI.Kind = cdiv1beta1.CDIGroupVersionKind.Kind
 	res.cdi = expectedCDI
 
 	expectedCNA, err := operands.NewNetworkAddons(hco)

--- a/controllers/operands/operandHandler.go
+++ b/controllers/operands/operandHandler.go
@@ -74,6 +74,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 	}
 }
 
+// FirstUseInitiation is a lazy init function
 // The k8s client is not available when calling to NewOperandHandler.
 // Initial operations that need to read/write from the cluster can only be done when the client is already working.
 func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.ClusterInfo, hc *hcov1beta1.HyperConverged) {
@@ -130,7 +131,7 @@ func (h *OperandHandler) addOperands(scheme *runtime.Scheme, hc *hcov1beta1.Hype
 	}
 }
 
-func (h OperandHandler) Ensure(req *common.HcoRequest) error {
+func (h *OperandHandler) Ensure(req *common.HcoRequest) error {
 	for _, handler := range h.operands {
 		res := handler.ensure(req)
 		if res.Err != nil {
@@ -161,7 +162,7 @@ func (h OperandHandler) Ensure(req *common.HcoRequest) error {
 
 }
 
-func (h OperandHandler) handleUpdatedOperand(req *common.HcoRequest, res *EnsureResult) {
+func (h *OperandHandler) handleUpdatedOperand(req *common.HcoRequest, res *EnsureResult) {
 	if !res.Overwritten {
 		h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Updated", fmt.Sprintf("Updated %s %s", res.Type, res.Name))
 	} else {
@@ -175,7 +176,7 @@ func (h OperandHandler) handleUpdatedOperand(req *common.HcoRequest, res *Ensure
 	}
 }
 
-func (h OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
+func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 
 	tCtx, cancel := context.WithTimeout(req.Ctx, deleteTimeOut)
 	defer cancel()

--- a/controllers/operands/operandHandler.go
+++ b/controllers/operands/operandHandler.go
@@ -166,9 +166,11 @@ func (h OperandHandler) handleUpdatedOperand(req *common.HcoRequest, res *Ensure
 		h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Updated", fmt.Sprintf("Updated %s %s", res.Type, res.Name))
 	} else {
 		h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, "Overwritten", fmt.Sprintf("Overwritten %s %s", res.Type, res.Name))
-		err := metrics.HcoMetrics.IncOverwrittenModifications(res.Type, res.Name)
-		if err != nil {
-			req.Logger.Error(err, "couldn't update 'OverwrittenModifications' metric")
+		if !req.UpgradeMode {
+			err := metrics.HcoMetrics.IncOverwrittenModifications(res.Type, res.Name)
+			if err != nil {
+				req.Logger.Error(err, "couldn't update 'OverwrittenModifications' metric")
+			}
 		}
 	}
 }

--- a/controllers/operands/operand_test.go
+++ b/controllers/operands/operand_test.go
@@ -179,11 +179,11 @@ var _ = Describe("Test operator.go", func() {
 			operand := genericOperand{Scheme: scheme.Scheme, Client: cl}
 			outRes := operand.createNewCr(req, expectedResource, res)
 			Expect(outRes.Err).ToNot(HaveOccurred())
-			Expect(outRes.Created).To(Equal(true))
-			Expect(outRes.Deleted).To(Equal(false))
-			Expect(outRes.Updated).To(Equal(false))
-			Expect(outRes.Overwritten).To(Equal(false))
-			Expect(outRes.UpgradeDone).To(Equal(false))
+			Expect(outRes.Created).To(BeTrue())
+			Expect(outRes.Deleted).To(BeFalse())
+			Expect(outRes.Updated).To(BeFalse())
+			Expect(outRes.Overwritten).To(BeFalse())
+			Expect(outRes.UpgradeDone).To(BeFalse())
 
 			foundResource := &cdiv1beta1.CDI{}
 			Expect(
@@ -208,11 +208,11 @@ var _ = Describe("Test operator.go", func() {
 			operand := genericOperand{Scheme: scheme.Scheme, Client: cl}
 			outRes := operand.createNewCr(req, expectedResource, res)
 			Expect(outRes.Err).ToNot(HaveOccurred())
-			Expect(outRes.Created).To(Equal(true))
-			Expect(outRes.Deleted).To(Equal(false))
-			Expect(outRes.Updated).To(Equal(false))
-			Expect(outRes.Overwritten).To(Equal(false))
-			Expect(outRes.UpgradeDone).To(Equal(false))
+			Expect(outRes.Created).To(BeTrue())
+			Expect(outRes.Deleted).To(BeFalse())
+			Expect(outRes.Updated).To(BeFalse())
+			Expect(outRes.Overwritten).To(BeFalse())
+			Expect(outRes.UpgradeDone).To(BeFalse())
 
 			foundResource := &cdiv1beta1.CDI{}
 			Expect(
@@ -236,12 +236,12 @@ var _ = Describe("Test operator.go", func() {
 			operand := genericOperand{Scheme: scheme.Scheme, Client: cl}
 			outRes := operand.createNewCr(req, expectedResource, res)
 			Expect(outRes.Err).To(HaveOccurred())
-			Expect(apierrors.IsAlreadyExists(outRes.Err)).To(Equal(true))
-			Expect(outRes.Created).To(Equal(false))
-			Expect(outRes.Deleted).To(Equal(false))
-			Expect(outRes.Updated).To(Equal(false))
-			Expect(outRes.Overwritten).To(Equal(false))
-			Expect(outRes.UpgradeDone).To(Equal(false))
+			Expect(apierrors.IsAlreadyExists(outRes.Err)).To(BeTrue())
+			Expect(outRes.Created).To(BeFalse())
+			Expect(outRes.Deleted).To(BeFalse())
+			Expect(outRes.Updated).To(BeFalse())
+			Expect(outRes.Overwritten).To(BeFalse())
+			Expect(outRes.UpgradeDone).To(BeFalse())
 
 		})
 


### PR DESCRIPTION
Some of the underline custom resources are getting changed as part of the upgrade process.
This causes HCO to increase the `overwrittenModifications` metric, while this is not a user
action.

This PR changes this behaviour to not increase the metric during upgrade, and so changes made
during upgrade are not count.

Also, added some clean code in separate commits.

```release-note
None
```

