### PR TITLE
Propagate TLSSecurityProfile to CDI

### DIFF
--- a/controllers/operands/cdi.go
+++ b/controllers/operands/cdi.go
@@ -101,7 +101,18 @@ func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, err
 	spec := cdiv1beta1.CDISpec{
 		UninstallStrategy: &uninstallStrategy,
 		Config: &cdiv1beta1.CDIConfigSpec{
-			FeatureGates: getDefaultFeatureGates(),
+			FeatureGates:       getDefaultFeatureGates(),
+			TLSSecurityProfile: hcoutil.GetClusterInfo().GetTLSSecurityProfile(hc.Spec.TLSSecurityProfile),
+		},
+		CertConfig: &cdiv1beta1.CDICertConfig{
+			CA: &cdiv1beta1.CertConfig{
+				Duration:    &hc.Spec.CertConfig.CA.Duration,
+				RenewBefore: &hc.Spec.CertConfig.CA.RenewBefore,
+			},
+			Server: &cdiv1beta1.CertConfig{
+				Duration:    &hc.Spec.CertConfig.Server.Duration,
+				RenewBefore: &hc.Spec.CertConfig.Server.RenewBefore,
+			},
 		},
 	}
 
@@ -130,20 +141,6 @@ func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, err
 
 	if hc.Spec.Workloads.NodePlacement != nil {
 		hc.Spec.Workloads.NodePlacement.DeepCopyInto(&spec.Workloads)
-	}
-
-	certConfig := hc.Spec.CertConfig
-
-	spec.CertConfig = &cdiv1beta1.CDICertConfig{}
-
-	spec.CertConfig.CA = &cdiv1beta1.CertConfig{
-		Duration:    certConfig.CA.Duration.DeepCopy(),
-		RenewBefore: certConfig.CA.RenewBefore.DeepCopy(),
-	}
-
-	spec.CertConfig.Server = &cdiv1beta1.CertConfig{
-		Duration:    certConfig.Server.Duration.DeepCopy(),
-		RenewBefore: certConfig.Server.RenewBefore.DeepCopy(),
 	}
 
 	cdi := NewCDIWithNameOnly(hc, opts...)


### PR DESCRIPTION
Propagate TLSSecurityProfile to CDI.
Add unit tests.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Propagate TLSSecurityProfile to CDI
```

