### PR TITLE
Use oc binary in functest container if on Openshift

### DIFF
--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -12,11 +12,12 @@ ENV USER_UID=1001 \
 WORKDIR ${TEST_OUT_PATH}
 ENTRYPOINT ["./hack/run-tests.sh"]
 
-RUN curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+RUN microdnf install tar gzip && \
+    curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
     chmod a+x /usr/local/bin/kubectl && \
+    curl -Lsv --fail https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar xvzf - -C /usr/local/bin/ oc && \
     curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    chmod a+x /usr/local/bin/jq && \
-    microdnf install tar
+    chmod a+x /usr/local/bin/jq
 
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/_out/func-tests.test  ${TEST_OUT_PATH}/
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/hack  ${TEST_OUT_PATH}/hack

--- a/build/Dockerfile.functest.ci
+++ b/build/Dockerfile.functest.ci
@@ -13,11 +13,12 @@ ENV USER_UID=1001 \
 WORKDIR ${TEST_OUT_PATH}
 ENTRYPOINT ["./hack/run-tests.sh"]
 
-RUN curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+RUN microdnf install tar gzip && \
+    curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
     chmod a+x /usr/local/bin/kubectl && \
+    curl -Lsv --fail https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar xvzf - -C /usr/local/bin/ oc && \
     curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    chmod a+x /usr/local/bin/jq && \
-    microdnf install tar
+    chmod a+x /usr/local/bin/jq
 
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/_out/func-tests.test  ${TEST_OUT_PATH}/
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/hack  ${TEST_OUT_PATH}/hack

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -15,7 +15,7 @@ if [ "${JOB_TYPE}" == "stdci" ]; then
     KUBECTL_BINARY="cluster/kubectl.sh"
 fi
 
-if [[ ${JOB_TYPE} = "prow" ]]; then
+if [ -n "${OPENSHIFT_BUILD_NAMESPACE:-}" ]; then
     KUBECTL_BINARY="oc"
 fi
 


### PR DESCRIPTION
Currently we are always using kubectl binary in
the functest images.
Let's download and extract
https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
at iamge build time.
and use it if running on Openshift.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

