### PR TITLE
Fix the smoke test

### DIFF
--- a/hack/kv-smoke-tests.sh
+++ b/hack/kv-smoke-tests.sh
@@ -224,10 +224,10 @@ ${TESTS_BINARY} \
     -junit-output="${OUTPUT_DIR}/junit_kv_smoke_tests.xml" \
     -kubeconfig="$KUBECONFIG" \
     -ginkgo.focus='(rfe_id:1177)|(rfe_id:273)|(rfe_id:151)' \
-    -ginkgo.noColor \
+    -ginkgo.no-color \
     -ginkgo.seed=0 \
     -ginkgo.skip='(Slirp Networking)|(with CPU spec)|(with TX offload disabled)|(with cni flannel and ptp plugin interface)|(with ovs-cni plugin)|(test_id:1752)|(SRIOV)|(with EFI)|(Operator)|(GPU)|(DataVolume Integration)|(when virt-handler is not responsive)|(with default cpu model)|(should set the default MachineType when created without explicit value)|(should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself)|(test_id:3468)|(test_id:3466)|(test_id:1015)|(rfe_id:393)|(test_id:4646)|(test_id:4647)|(test_id:4648)|(test_id:4649)|(test_id:4650)|(test_id:4651)|(test_id:4652)|(test_id:4654)|(test_id:4655)|(test_id:4656)|(test_id:4657)|(test_id:4658)|(test_id:4659)|(should obey the disk verification limits in the KubeVirt CR)' \
-    -ginkgo.slowSpecThreshold=60 \
+    -ginkgo.slow-spec-threshold=60s \
     -ginkgo.succinct \
     -ginkgo.flake-attempts=3 \
     -oc-path="$(which oc)" \


### PR DESCRIPTION
Replace some ginkgo deprecated flags:
* `ginkgo.noColor` ===> `ginkgo.no-color`
* `ginkgo.slowSpecThreshold` ===> `slow-spec-threshold`

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
None
```

