### PR TITLE
Correcty set links in release notes

### DIFF
--- a/tools/release-notes/git/github.go
+++ b/tools/release-notes/git/github.go
@@ -41,9 +41,9 @@ func initClient(token string) *github.Client {
 	return github.NewClient(tc)
 }
 
-func (g *gh) getReleaseNote(number int) (string, error) {
-	log.Printf("Searching for `%s` release note for PR #%d", g.name, number)
-	pr, _, err := g.githubClient.PullRequests.Get(context.Background(), "kubevirt", g.name, number)
+func (g *gh) getReleaseNote(prNumber int) (string, error) {
+	log.Printf("Searching for `%s` release note for PR #%d", g.name, prNumber)
+	pr, _, err := g.githubClient.PullRequests.Get(context.Background(), "kubevirt", g.name, prNumber)
 	if err != nil {
 		return "", err
 	}
@@ -63,7 +63,7 @@ func (g *gh) getReleaseNote(number int) (string, error) {
 	for i, line := range body {
 		note, err := parseReleaseNote(i, line, body)
 		if err == nil {
-			note = fmt.Sprintf("[PR #%d][%s] %s", number, *pr.User.Login, note)
+			note = fmt.Sprintf("[PR [#%d](https://github.com/%s/%s/pull/%d)][[%s](https://github.com/%s)] %s", prNumber, g.owner, g.name, prNumber, *pr.User.Login, *pr.User.Login, note)
 			return note, nil
 		}
 	}


### PR DESCRIPTION
See:
https://github.com/kubevirt/hyperconverged-cluster-operator/releases/tag/v1.8.0 for an example

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

