### PR TITLE
Reset operands cache on APIServer updates

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1035,6 +1035,39 @@ var _ = Describe("HyperconvergedController", func() {
 				checkAvailability(foundResource, metav1.ConditionTrue)
 				Expect(foundResource.Spec.TLSSecurityProfile).To(BeNil(), "TLSSecurityProfile on HCO CR should still be nil")
 
+				// TODO: check also Kubevirt once managed
+				By("Verify that CDI was properly configured with initialTLSSecurityProfile", func() {
+					cdi := operands.NewCDIWithNameOnly(foundResource)
+					Expect(
+						cl.Get(context.TODO(),
+							types.NamespacedName{Name: cdi.Name, Namespace: cdi.Namespace},
+							cdi),
+					).To(Succeed())
+
+					Expect(cdi.Spec.Config.TLSSecurityProfile).To(Equal(initialTLSSecurityProfile))
+
+				})
+				By("Verify that CNA was properly configured with initialTLSSecurityProfile", func() {
+					cna := operands.NewNetworkAddonsWithNameOnly(foundResource)
+					Expect(
+						cl.Get(context.TODO(),
+							types.NamespacedName{Name: cna.Name, Namespace: cna.Namespace},
+							cna),
+					).To(Succeed())
+
+					Expect(cna.Spec.TLSSecurityProfile).To(Equal(initialTLSSecurityProfile))
+				})
+				By("Verify that SSP was properly configured with initialTLSSecurityProfile", func() {
+					ssp := operands.NewSSPWithNameOnly(foundResource)
+					Expect(
+						cl.Get(context.TODO(),
+							types.NamespacedName{Name: ssp.Name, Namespace: ssp.Namespace},
+							ssp),
+					).To(Succeed())
+
+					Expect(ssp.Spec.TLSSecurityProfile).To(Equal(initialTLSSecurityProfile))
+				})
+
 				// Update ApiServer CR
 				apiServer.Spec.TLSSecurityProfile = customTLSSecurityProfile
 				err = cl.Update(context.TODO(), apiServer)
@@ -1062,6 +1095,39 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.Spec.TLSSecurityProfile).To(BeNil(), "TLSSecurityProfile on HCO CR should still be nil")
 
 				Expect(hcoutil.GetClusterInfo().GetTLSSecurityProfile(expected.hco.Spec.TLSSecurityProfile)).To(Equal(customTLSSecurityProfile), "should return the up-to-date value")
+
+				// TODO: check also Kubevirt once managed
+				By("Verify that CDI was properly updated with customTLSSecurityProfile", func() {
+					cdi := operands.NewCDIWithNameOnly(foundResource)
+					Expect(
+						cl.Get(context.TODO(),
+							types.NamespacedName{Name: cdi.Name, Namespace: cdi.Namespace},
+							cdi),
+					).To(Succeed())
+
+					Expect(cdi.Spec.Config.TLSSecurityProfile).To(Equal(customTLSSecurityProfile))
+
+				})
+				By("Verify that CNA was properly updated with customTLSSecurityProfile", func() {
+					cna := operands.NewNetworkAddonsWithNameOnly(foundResource)
+					Expect(
+						cl.Get(context.TODO(),
+							types.NamespacedName{Name: cna.Name, Namespace: cna.Namespace},
+							cna),
+					).To(Succeed())
+
+					Expect(cna.Spec.TLSSecurityProfile).To(Equal(customTLSSecurityProfile))
+				})
+				By("Verify that SSP was properly updated with customTLSSecurityProfile", func() {
+					ssp := operands.NewSSPWithNameOnly(foundResource)
+					Expect(
+						cl.Get(context.TODO(),
+							types.NamespacedName{Name: ssp.Name, Namespace: ssp.Namespace},
+							ssp),
+					).To(Succeed())
+
+					Expect(ssp.Spec.TLSSecurityProfile).To(Equal(customTLSSecurityProfile))
+				})
 
 			})
 


### PR DESCRIPTION
TLSSecurityProfile value on operands can
also change due to changes at cluster scope
level on the APIServer CR.
Invalidate in-memory cache of operands
configuration also when we detect
changes on the APIServer CR to correctly
propagate them.
Add unit test for this specific case.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2127947

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

