### PR TITLE
Enable PSA FG on Kubevirt

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -209,6 +209,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"NUMA",
 					"WithHostPassthroughCPU",
 					"VMExport",
+					"PSA",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -91,6 +91,9 @@ const (
 
 	// Export VMs to outside of the cluster
 	kvVMExportGate = "VMExport"
+
+	// enable Pod Security Admission handling
+	kvPSA = "PSA"
 )
 
 var (
@@ -107,6 +110,7 @@ var (
 		kvDownwardMetricsGate,
 		kvNUMA,
 		kvVMExportGate,
+		kvPSA,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of


### PR DESCRIPTION
Enable PSA FG on Kubevirt to be compatible with
k8s >= 1.24 and derivates with PSA in enforcing mode.

Once available also in older versions of Kubevirt, we will have also to backport it to release-1.6
and release-1.7.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable PSA FG on Kubevirt
```

