### PR TITLE
Fix hook receivers

### DIFF
--- a/controllers/operands/cdi.go
+++ b/controllers/operands/cdi.go
@@ -47,11 +47,11 @@ func (h *cdiHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, erro
 	}
 	return h.cache, nil
 }
-func (h cdiHooks) getEmptyCr() client.Object { return &cdiv1beta1.CDI{} }
-func (h cdiHooks) getConditions(cr runtime.Object) []metav1.Condition {
+func (*cdiHooks) getEmptyCr() client.Object { return &cdiv1beta1.CDI{} }
+func (*cdiHooks) getConditions(cr runtime.Object) []metav1.Condition {
 	return osConditionsToK8s(cr.(*cdiv1beta1.CDI).Status.Conditions)
 }
-func (h cdiHooks) checkComponentVersion(cr runtime.Object) bool {
+func (*cdiHooks) checkComponentVersion(cr runtime.Object) bool {
 	found := cr.(*cdiv1beta1.CDI)
 	return checkComponentVersion(hcoutil.CdiVersionEnvV, found.Status.ObservedVersion)
 }
@@ -59,7 +59,7 @@ func (h *cdiHooks) reset() {
 	h.cache = nil
 }
 
-func (h *cdiHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+func (*cdiHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	cdi, ok1 := required.(*cdiv1beta1.CDI)
 	found, ok2 := exists.(*cdiv1beta1.CDI)
 	if !ok1 || !ok2 {
@@ -86,7 +86,7 @@ func (h *cdiHooks) updateCr(req *common.HcoRequest, Client client.Client, exists
 	return false, false, nil
 }
 
-func (h cdiHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (*cdiHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func getDefaultFeatureGates() []string {
 	return []string{HonorWaitForFirstConsumerGate}

--- a/controllers/operands/cliDownload.go
+++ b/controllers/operands/cliDownload.go
@@ -41,15 +41,15 @@ func newCliDownloadHandler(Client client.Client, Scheme *runtime.Scheme) *cliDow
 
 type cliDownloadHooks struct{}
 
-func (h cliDownloadHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (*cliDownloadHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewConsoleCLIDownload(hc), nil
 }
 
-func (h cliDownloadHooks) getEmptyCr() client.Object {
+func (*cliDownloadHooks) getEmptyCr() client.Object {
 	return &consolev1.ConsoleCLIDownload{}
 }
 
-func (h *cliDownloadHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+func (*cliDownloadHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	ccd, ok1 := required.(*consolev1.ConsoleCLIDownload)
 	found, ok2 := exists.(*consolev1.ConsoleCLIDownload)
 	if !ok1 || !ok2 {
@@ -73,7 +73,7 @@ func (h *cliDownloadHooks) updateCr(req *common.HcoRequest, Client client.Client
 	return false, false, nil
 }
 
-func (h cliDownloadHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (*cliDownloadHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLIDownload {
 	baseUrl := "https://" + cliDownloadsServiceName + "-" + hc.Namespace + "." + hcoutil.GetClusterInfo().GetDomain()
@@ -147,15 +147,15 @@ func newCliDownloadsRouteHandler(Client client.Client, Scheme *runtime.Scheme) *
 
 type cliDownloadsRouteHooks struct{}
 
-func (h cliDownloadsRouteHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (cliDownloadsRouteHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewCliDownloadsRoute(hc), nil
 }
 
-func (h cliDownloadsRouteHooks) getEmptyCr() client.Object {
+func (cliDownloadsRouteHooks) getEmptyCr() client.Object {
 	return &routev1.Route{}
 }
 
-func (h *cliDownloadsRouteHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+func (*cliDownloadsRouteHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	route, ok1 := required.(*routev1.Route)
 	found, ok2 := exists.(*routev1.Route)
 	if !ok1 || !ok2 {
@@ -178,7 +178,7 @@ func (h *cliDownloadsRouteHooks) updateCr(req *common.HcoRequest, Client client.
 	return false, false, nil
 }
 
-func (h cliDownloadsRouteHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (cliDownloadsRouteHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func NewCliDownloadsRoute(hc *hcov1beta1.HyperConverged) *routev1.Route {
 	weight := int32(100)

--- a/controllers/operands/cmHandler.go
+++ b/controllers/operands/cmHandler.go
@@ -41,7 +41,7 @@ func (h cmHooks) getEmptyCr() client.Object {
 	}
 }
 
-func (h cmHooks) reset() { /* no implementation */ }
+func (cmHooks) reset() { /* no implementation */ }
 
 func (h cmHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
 	found, ok := exists.(*corev1.ConfigMap)
@@ -69,4 +69,4 @@ func (h cmHooks) updateCr(req *common.HcoRequest, Client client.Client, exists r
 	return false, false, nil
 }
 
-func (h cmHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (cmHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }

--- a/controllers/operands/cmHandler.go
+++ b/controllers/operands/cmHandler.go
@@ -41,8 +41,6 @@ func (h cmHooks) getEmptyCr() client.Object {
 	}
 }
 
-func (cmHooks) reset() { /* no implementation */ }
-
 func (h cmHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
 	found, ok := exists.(*corev1.ConfigMap)
 

--- a/controllers/operands/deploymentHandler.go
+++ b/controllers/operands/deploymentHandler.go
@@ -41,9 +41,9 @@ func (h deploymentHooks) getEmptyCr() client.Object {
 	}
 }
 
-func (h deploymentHooks) reset() { /* no implementation */ }
+func (deploymentHooks) reset() { /* no implementation */ }
 
-func (h deploymentHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (deploymentHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func (h deploymentHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
 	found, ok := exists.(*appsv1.Deployment)

--- a/controllers/operands/deploymentHandler.go
+++ b/controllers/operands/deploymentHandler.go
@@ -41,8 +41,6 @@ func (h deploymentHooks) getEmptyCr() client.Object {
 	}
 }
 
-func (deploymentHooks) reset() { /* no implementation */ }
-
 func (deploymentHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func (h deploymentHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {

--- a/controllers/operands/imageStream.go
+++ b/controllers/operands/imageStream.go
@@ -139,9 +139,9 @@ func (h isHooks) updateCr(req *common.HcoRequest, Client client.Client, exists r
 	return true, !req.HCOTriggered, nil
 }
 
-func (h isHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (isHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
-func (h *isHooks) compareAndUpgradeImageStream(found *imagev1.ImageStream) bool {
+func (h isHooks) compareAndUpgradeImageStream(found *imagev1.ImageStream) bool {
 	modified := false
 	if !reflect.DeepEqual(h.required.Labels, found.Labels) {
 		util.DeepCopyLabels(&h.required.ObjectMeta, &found.ObjectMeta)
@@ -157,7 +157,7 @@ func (h *isHooks) compareAndUpgradeImageStream(found *imagev1.ImageStream) bool 
 			continue
 		}
 
-		if h.compareOneTag(&foundTag, &reqTag) {
+		if compareOneTag(&foundTag, &reqTag) {
 			modified = true
 		}
 
@@ -174,7 +174,7 @@ func (h *isHooks) compareAndUpgradeImageStream(found *imagev1.ImageStream) bool 
 	return modified
 }
 
-func (h *isHooks) addMissingTags(found *imagev1.ImageStream, newTags []imagev1.TagReference, modified bool) ([]imagev1.TagReference, bool) {
+func (h isHooks) addMissingTags(found *imagev1.ImageStream, newTags []imagev1.TagReference, modified bool) ([]imagev1.TagReference, bool) {
 	for reqTagName, reqTag := range h.tags {
 		tagExist := false
 		for _, foundTag := range found.Spec.Tags {
@@ -230,7 +230,7 @@ func createImageStreamHandlersFromFiles(logger log.Logger, Client client.Client,
 	return handlers, err
 }
 
-func (h *isHooks) compareOneTag(foundTag, reqTag *imagev1.TagReference) bool {
+func compareOneTag(foundTag, reqTag *imagev1.TagReference) bool {
 	modified := false
 	if reqTag.From.Name != foundTag.From.Name || reqTag.From.Kind != foundTag.From.Kind {
 		foundTag.From = reqTag.From.DeepCopy()

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -194,11 +194,11 @@ func (h *kubevirtHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object,
 	return h.cache, nil
 }
 
-func (h kubevirtHooks) getEmptyCr() client.Object { return &kubevirtcorev1.KubeVirt{} }
-func (h kubevirtHooks) getConditions(cr runtime.Object) []metav1.Condition {
+func (*kubevirtHooks) getEmptyCr() client.Object { return &kubevirtcorev1.KubeVirt{} }
+func (*kubevirtHooks) getConditions(cr runtime.Object) []metav1.Condition {
 	return translateKubeVirtConds(cr.(*kubevirtcorev1.KubeVirt).Status.Conditions)
 }
-func (h kubevirtHooks) checkComponentVersion(cr runtime.Object) bool {
+func (*kubevirtHooks) checkComponentVersion(cr runtime.Object) bool {
 	found := cr.(*kubevirtcorev1.KubeVirt)
 	return checkComponentVersion(hcoutil.KubevirtVersionEnvV, found.Status.ObservedKubeVirtVersion)
 }
@@ -206,7 +206,7 @@ func (h *kubevirtHooks) reset() {
 	h.cache = nil
 }
 
-func (h *kubevirtHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+func (*kubevirtHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	virt, ok1 := required.(*kubevirtcorev1.KubeVirt)
 	found, ok2 := exists.(*kubevirtcorev1.KubeVirt)
 	if !ok1 || !ok2 {
@@ -230,7 +230,7 @@ func (h *kubevirtHooks) updateCr(req *common.HcoRequest, Client client.Client, e
 	return false, false, nil
 }
 
-func (h kubevirtHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (*kubevirtHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func NewKubeVirt(hc *hcov1beta1.HyperConverged, opts ...string) (*kubevirtcorev1.KubeVirt, error) {
 	config, err := getKVConfig(hc)
@@ -549,12 +549,12 @@ func newKvPriorityClassHandler(Client client.Client, Scheme *runtime.Scheme) *kv
 
 type kvPriorityClassHooks struct{}
 
-func (h kvPriorityClassHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (kvPriorityClassHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return NewKubeVirtPriorityClass(hc), nil
 }
-func (h kvPriorityClassHooks) getEmptyCr() client.Object { return &schedulingv1.PriorityClass{} }
+func (kvPriorityClassHooks) getEmptyCr() client.Object { return &schedulingv1.PriorityClass{} }
 
-func (h *kvPriorityClassHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+func (kvPriorityClassHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	pc, ok1 := required.(*schedulingv1.PriorityClass)
 	found, ok2 := exists.(*schedulingv1.PriorityClass)
 	if !ok1 || !ok2 {
@@ -590,7 +590,7 @@ func (h *kvPriorityClassHooks) updateCr(req *common.HcoRequest, Client client.Cl
 	return true, !req.HCOTriggered, nil
 }
 
-func (h kvPriorityClassHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (kvPriorityClassHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func NewKubeVirtPriorityClass(hc *hcov1beta1.HyperConverged) *schedulingv1.PriorityClass {
 	return &schedulingv1.PriorityClass{

--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -249,8 +249,6 @@ func (h consolePluginHooks) getEmptyCr() client.Object {
 	}
 }
 
-func (consolePluginHooks) reset() { /* no implementation */ }
-
 func (consolePluginHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func (h consolePluginHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {

--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -249,9 +249,9 @@ func (h consolePluginHooks) getEmptyCr() client.Object {
 	}
 }
 
-func (h consolePluginHooks) reset() { /* no implementation */ }
+func (consolePluginHooks) reset() { /* no implementation */ }
 
-func (h consolePluginHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (consolePluginHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func (h consolePluginHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
 	found, ok := exists.(*consolev1alpha1.ConsolePlugin)
@@ -321,7 +321,7 @@ func (h consoleHandler) ensure(req *common.HcoRequest) *EnsureResult {
 	}
 }
 
-func (h consoleHandler) reset() { /* no implementation */ }
+func (consoleHandler) reset() { /* no implementation */ }
 
 func newConsoleHandler(Client client.Client) Operand {
 	h := &consoleHandler{

--- a/controllers/operands/quickStart.go
+++ b/controllers/operands/quickStart.go
@@ -84,7 +84,7 @@ func (h qsHooks) updateCr(req *common.HcoRequest, Client client.Client, exists r
 	return false, false, nil
 }
 
-func (h qsHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (qsHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 // This function returns 3-state error:
 //   err := checkCrdExists(...)

--- a/controllers/operands/rbac.go
+++ b/controllers/operands/rbac.go
@@ -68,7 +68,7 @@ func (h *roleHooks) updateCr(req *common.HcoRequest, Client client.Client, exist
 	return false, false, nil
 }
 
-func (h roleHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (roleHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 // ********* Role Binding Handler *****************************
 
@@ -96,7 +96,7 @@ func (h roleBindingHooks) getEmptyCr() client.Object {
 		},
 	}
 }
-func (h *roleBindingHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
+func (h roleBindingHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, _ runtime.Object) (bool, bool, error) {
 	configReaderRoleBinding := h.required
 	found, ok := exists.(*rbacv1.RoleBinding)
 	if !ok {
@@ -123,4 +123,4 @@ func (h *roleBindingHooks) updateCr(req *common.HcoRequest, Client client.Client
 	return false, false, nil
 }
 
-func (h roleBindingHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (roleBindingHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }

--- a/controllers/operands/serviceHandler.go
+++ b/controllers/operands/serviceHandler.go
@@ -40,8 +40,6 @@ func (serviceHooks) getEmptyCr() client.Object {
 	return &corev1.Service{}
 }
 
-func (serviceHooks) reset() { /* no implementation */ }
-
 func (serviceHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func (serviceHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {

--- a/controllers/operands/serviceHandler.go
+++ b/controllers/operands/serviceHandler.go
@@ -32,19 +32,19 @@ type serviceHooks struct {
 	newCrFunc newSvcFunc
 }
 
-func (h *serviceHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h serviceHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
 	return h.newCrFunc(hc), nil
 }
 
-func (h serviceHooks) getEmptyCr() client.Object {
+func (serviceHooks) getEmptyCr() client.Object {
 	return &corev1.Service{}
 }
 
-func (h serviceHooks) reset() { /* no implementation */ }
+func (serviceHooks) reset() { /* no implementation */ }
 
-func (h serviceHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (serviceHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
-func (h serviceHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+func (serviceHooks) updateCr(req *common.HcoRequest, Client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	return updateService(req, Client, exists, required)
 }
 

--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -77,11 +77,11 @@ func (h *sspHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, erro
 	return h.cache, nil
 }
 
-func (h sspHooks) getEmptyCr() client.Object { return &sspv1beta1.SSP{} }
-func (h sspHooks) getConditions(cr runtime.Object) []metav1.Condition {
+func (*sspHooks) getEmptyCr() client.Object { return &sspv1beta1.SSP{} }
+func (*sspHooks) getConditions(cr runtime.Object) []metav1.Condition {
 	return osConditionsToK8s(cr.(*sspv1beta1.SSP).Status.Conditions)
 }
-func (h sspHooks) checkComponentVersion(cr runtime.Object) bool {
+func (*sspHooks) checkComponentVersion(cr runtime.Object) bool {
 	found := cr.(*sspv1beta1.SSP)
 	return checkComponentVersion(hcoutil.SspVersionEnvV, found.Status.ObservedVersion)
 }
@@ -90,7 +90,7 @@ func (h *sspHooks) reset() {
 	h.dictStatuses = nil
 }
 
-func (h *sspHooks) updateCr(req *common.HcoRequest, client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+func (*sspHooks) updateCr(req *common.HcoRequest, client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	ssp, ok1 := required.(*sspv1beta1.SSP)
 	found, ok2 := exists.(*sspv1beta1.SSP)
 	if !ok1 || !ok2 {
@@ -114,7 +114,7 @@ func (h *sspHooks) updateCr(req *common.HcoRequest, client client.Client, exists
 	return false, false, nil
 }
 
-func (h sspHooks) justBeforeComplete(req *common.HcoRequest) {
+func (h *sspHooks) justBeforeComplete(req *common.HcoRequest) {
 	if !reflect.DeepEqual(h.dictStatuses, req.Instance.Status.DataImportCronTemplates) {
 		req.Instance.Status.DataImportCronTemplates = h.dictStatuses
 		req.StatusDirty = true

--- a/controllers/operands/tto.go
+++ b/controllers/operands/tto.go
@@ -40,12 +40,12 @@ func (h *ttoHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, erro
 	return h.cache, nil
 }
 
-func (h ttoHooks) getEmptyCr() client.Object { return &ttov1alpha1.TektonTasks{} }
+func (*ttoHooks) getEmptyCr() client.Object { return &ttov1alpha1.TektonTasks{} }
 
-func (h ttoHooks) getConditions(cr runtime.Object) []metav1.Condition {
+func (*ttoHooks) getConditions(cr runtime.Object) []metav1.Condition {
 	return osConditionsToK8s(cr.(*ttov1alpha1.TektonTasks).Status.Conditions)
 }
-func (h ttoHooks) checkComponentVersion(cr runtime.Object) bool {
+func (*ttoHooks) checkComponentVersion(cr runtime.Object) bool {
 	found := cr.(*ttov1alpha1.TektonTasks)
 	return checkComponentVersion(hcoutil.TtoVersionEnvV, found.Status.ObservedVersion)
 }
@@ -53,9 +53,9 @@ func (h *ttoHooks) reset() {
 	h.cache = nil
 }
 
-func (h ttoHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (*ttoHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
-func (h *ttoHooks) updateCr(req *common.HcoRequest, client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+func (*ttoHooks) updateCr(req *common.HcoRequest, client client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
 	tto, ok1 := required.(*ttov1alpha1.TektonTasks)
 	found, ok2 := exists.(*ttov1alpha1.TektonTasks)
 	if !ok1 || !ok2 {


### PR DESCRIPTION
According to https://go.dev/doc/faq#methods_on_values_or_pointers, 
> "If some of the methods of the type must have pointer receivers, the rest should too, so the method set is consistent
regardless of how the type is used".

This PR make all the hook receivers to be the same within the same hook. If there is a method that changes the hook object fields, then **all** the method will be pointers, and vice versa.

Also, this PR remove the receiver names if it not used in the method.

In addition, the `reset()` method is not part of the hook interface, but it comes from
the `reseter` interface. Also, the `reset()` method is called only if the actual object implements the
`reseter` interface. So it is safe to remove these methods if there is no
implementation. This PR removes the not implemented `reset()` method.

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

```release-note
None
```

