### PR TITLE
WIP: avoid creating and watching kubevirt priorityclass

### DIFF
--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -4179,3 +4179,11 @@ spec:
     storage: true
     subresources:
       status: {}
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class should be used for KubeVirt core components only.
+kind: PriorityClass
+metadata:
+  name: kubevirt-cluster-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -21,7 +21,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimetav1 "k8s.io/apimachinery/pkg/api/meta"
@@ -176,7 +175,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo) er
 		&kubevirtcorev1.KubeVirt{},
 		&cdiv1beta1.CDI{},
 		&networkaddonsv1.NetworkAddonsConfig{},
-		&schedulingv1.PriorityClass{},
 		&corev1.ConfigMap{},
 		&corev1.Service{},
 		&rbacv1.Role{},

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -234,7 +234,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 				// Check conditions
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(21))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(20))
 				expectedRef := corev1.ObjectReference{
 					Kind:            "PrometheusRule",
 					Namespace:       namespace,
@@ -317,7 +317,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "TektonTasks resource has no conditions",
 				})))
 
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(20))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(19))
 				expectedRef := corev1.ObjectReference{
 					Kind:            "PrometheusRule",
 					Namespace:       namespace,
@@ -786,7 +786,7 @@ var _ = Describe("HyperconvergedController", func() {
 				).To(Succeed())
 
 				Expect(foundResource.Status.RelatedObjects).ToNot(BeNil())
-				Expect(foundResource.Status.RelatedObjects).Should(HaveLen(20))
+				Expect(foundResource.Status.RelatedObjects).Should(HaveLen(19))
 				Expect(foundResource.ObjectMeta.Finalizers).Should(Equal([]string{FinalizerName}))
 
 				// Now, delete HCO

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -17,7 +17,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -113,7 +112,6 @@ func validateOperatorCondition(r *ReconcileHyperConverged, status metav1.Conditi
 type BasicExpected struct {
 	namespace            *corev1.Namespace
 	hco                  *hcov1beta1.HyperConverged
-	pc                   *schedulingv1.PriorityClass
 	kv                   *kubevirtcorev1.KubeVirt
 	cdi                  *cdiv1beta1.CDI
 	cna                  *networkaddonsv1.NetworkAddonsConfig
@@ -138,7 +136,6 @@ func (be BasicExpected) toArray() []runtime.Object {
 	return []runtime.Object{
 		be.namespace,
 		be.hco,
-		be.pc,
 		be.kv,
 		be.cdi,
 		be.cna,
@@ -204,8 +201,6 @@ func getBasicDeployment() *BasicExpected {
 			},
 		},
 	}
-
-	res.pc = operands.NewKubeVirtPriorityClass(hco)
 
 	deploymentRef := metav1.OwnerReference{
 		APIVersion:         appsv1.SchemeGroupVersion.String(),

--- a/controllers/operands/operandHandler.go
+++ b/controllers/operands/operandHandler.go
@@ -46,7 +46,6 @@ type OperandHandler struct {
 
 func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.ClusterInfo, eventEmitter hcoutil.EventEmitter) *OperandHandler {
 	operands := []Operand{
-		(*genericOperand)(newKvPriorityClassHandler(client, scheme)),
 		(*genericOperand)(newKubevirtHandler(client, scheme)),
 		(*genericOperand)(newCdiHandler(client, scheme)),
 		(*genericOperand)(newCnaHandler(client, scheme)),

--- a/controllers/operands/operandHandler_test.go
+++ b/controllers/operands/operandHandler_test.go
@@ -54,11 +54,6 @@ var _ = Describe("Test operandHandler", func() {
 				{
 					EventType: corev1.EventTypeNormal,
 					Reason:    "Created",
-					Msg:       "Created PriorityClass kubevirt-cluster-critical",
-				},
-				{
-					EventType: corev1.EventTypeNormal,
-					Reason:    "Created",
 					Msg:       "Created KubeVirt kubevirt-kubevirt-hyperconverged",
 				},
 				{

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -615,16 +615,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - scheduling.k8s.io
-  resources:
-  - priorityclasses
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations

--- a/deploy/crds/hco01.crd.yaml
+++ b/deploy/crds/hco01.crd.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class should be used for KubeVirt core components only.
+kind: PriorityClass
+metadata:
+  name: kubevirt-cluster-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/hco01.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/hco01.crd.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class should be used for KubeVirt core components only.
+kind: PriorityClass
+metadata:
+  name: kubevirt-cluster-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/kubevirt-hyperconverged-operator.v1.8.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/kubevirt-hyperconverged-operator.v1.8.0.clusterserviceversion.yaml
@@ -389,16 +389,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - scheduling.k8s.io
-          resources:
-          - priorityclasses
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - delete
-        - apiGroups:
           - admissionregistration.k8s.io
           resources:
           - validatingwebhookconfigurations

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/hco01.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/hco01.crd.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class should be used for KubeVirt core components only.
+kind: PriorityClass
+metadata:
+  name: kubevirt-cluster-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/kubevirt-hyperconverged-operator.v1.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/kubevirt-hyperconverged-operator.v1.8.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.8.0-unstable
-    createdAt: "2022-10-03 19:15:37"
+    createdAt: "2022-10-05 15:24:31"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -388,16 +388,6 @@ spec:
           - get
           - list
           - watch
-        - apiGroups:
-          - scheduling.k8s.io
-          resources:
-          - priorityclasses
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - delete
         - apiGroups:
           - admissionregistration.k8s.io
           resources:

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -132,6 +132,15 @@ func genHcoCrds() error {
 		return err
 	}
 
+	// TODO: temporary handling additional objects in bundles as fake CRDs
+	// see: https://github.com/operator-framework/operator-lifecycle-manager/pull/1564
+	additionalObjects := components.GetAdditionalObjectsForBundle()
+	for _, obj := range additionalObjects {
+		if err := util.MarshallObject(obj, os.Stdout); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Starting with v0.16.0, OLM is able to directly manage priority classes shipped in the bundle image.
See: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/adding-priority-classes.md

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

