### PR TITLE
[release-1.6] Enable PSA FG on Kubevirt

### DIFF
--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -8,8 +8,8 @@ JOB_TYPE="${JOB_TYPE:-}"
 if [ "${JOB_TYPE}" == "travis" ]; then
     go get -v -t ./...
     go install github.com/mattn/goveralls@latest
-    go install github.com/onsi/ginkgo/ginkgo@latest
-    go get -v github.com/onsi/gomega
+    go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+    go get -v github.com/onsi/gomega@v1.18.1
     go get -u github.com/evanphx/json-patch
     go mod vendor
     PACKAGE_PATH="pkg/"
@@ -17,8 +17,8 @@ if [ "${JOB_TYPE}" == "travis" ]; then
     KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1 ginkgo -r -covermode atomic -outputdir=./coverprofiles -coverprofile=cover.coverprofile ${PACKAGE_PATH}
 else
     test_path="tests/func-tests"
-    (cd $test_path; go install github.com/onsi/ginkgo/ginkgo@latest)
-    (cd $test_path; GOFLAGS= go get github.com/onsi/gomega)
+    (cd $test_path; go install github.com/onsi/ginkgo/ginkgo@v1.16.5)
+    (cd $test_path; GOFLAGS= go get github.com/onsi/gomega@v1.18.1)
     (cd $test_path; go mod  tidy; go mod vendor)
     test_out_path=${test_path}/_out
     mkdir -p ${test_out_path}

--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -204,7 +204,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(kvList.Items).Should(HaveLen(1))
 				kv := kvList.Items[0]
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(15))
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(16))
 
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(
 					"DataVolumes",
@@ -221,6 +221,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"DownwardMetrics",
 					"ExpandDisks",
 					"NUMA",
+					"PSA",
 				),
 				)
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement("WithHostPassthroughCPU"))

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -91,6 +91,9 @@ const (
 
 	// Allow automatic numa mapping on VMs with dedicated CPUs, if requested
 	kvNUMA = "NUMA"
+
+	// enable Pod Security Admission handling
+	kvPSA = "PSA"
 )
 
 var (
@@ -107,6 +110,7 @@ var (
 		kvDownwardMetricsGate,
 		kvNUMA,
 		kvLiveMigrationGate,
+		kvPSA,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of


### PR DESCRIPTION
Enable PSA FG on Kubevirt to be compatible with
k8s >= 1.24 and derivates with PSA in enforcing mode.

Once available also in older versions of Kubevirt, we will have also to backport it to release-1.6
and release-1.7.

This is a manual cherry-pick of #2093

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable PSA FG on Kubevirt
```

