### PR TITLE
Fix ginkgo version in tests to v2.2.0

### DIFF
--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -8,7 +8,7 @@ JOB_TYPE="${JOB_TYPE:-}"
 if [ "${JOB_TYPE}" == "travis" ]; then
     go get -v -t ./...
     go install github.com/mattn/goveralls@latest
-    go install github.com/onsi/ginkgo/v2/ginkgo@latest
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.2.0
     go mod vendor
     PKG_PACKAGE_PATH="./pkg/"
     CONTROLLERS_PACKAGE_PATH="./controllers/"
@@ -18,7 +18,7 @@ if [ "${JOB_TYPE}" == "travis" ]; then
     ginkgo -cover -output-dir=./coverprofiles -coverprofile=cover.coverprofile -r ${PKG_PACKAGE_PATH} -r ${CONTROLLERS_PACKAGE_PATH}
 else
     test_path="tests/func-tests"
-    (cd $test_path; GOFLAGS='' go install github.com/onsi/ginkgo/v2/ginkgo@latest)
+    (cd $test_path; GOFLAGS='' go install github.com/onsi/ginkgo/v2/ginkgo@v2.2.0)
     (cd $test_path; go mod tidy; go mod vendor)
     test_out_path=${test_path}/_out
     mkdir -p ${test_out_path}

--- a/tests/build/Dockerfile
+++ b/tests/build/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     rm -rf go${GO_VERSION}.linux-amd64.tar.gz && \
     export PATH=${GOPATH}/bin:$PATH && \
     eval $(go env) && \
-    go install github.com/onsi/ginkgo/v2/ginkgo@latest && \
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.2.0 && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install golang.org/x/lint/golint@latest && \
     go install github.com/rmohr/go-swagger-utils/swagger-doc@latest && \


### PR DESCRIPTION
Yesterday, https://github.com/onsi/ginkgo released a new version, [v2.3.0](https://github.com/onsi/ginkgo/releases/tag/v2.3.0), which breaks our unit tests. See [jobs/5296270503](https://github.com/kubevirt/hyperconverged-cluster-operator/actions/runs/3233808924/jobs/5296270503) and [jobs/5296627422](https://github.com/kubevirt/hyperconverged-cluster-operator/actions/runs/3227541017/jobs/5296627422) which started failing after the update.

We are always using the latest version, I think it would be a better approach to fix a specific version and update it on a regular basis.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

