### PR TITLE
hack: add a workaround for OCPBUGS-2219

### DIFF
--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -60,5 +60,10 @@ sleep 10
 
 ./hack/check_update_priority_class.sh
 
+######
+# TODO: remove this, workaround for https://issues.redhat.com/browse/OCPBUGS-2219
+${KUBECTL_BINARY} patch ConsolePlugin kubevirt-plugin -o yaml --type=json -p '[{ "op": "replace", "path": "/spec/i18n/loadType", "value": "Preload" }]' || true
+######
+
 # Check the webhook, to see if it allow deleting of the HyperConverged CR
 ./hack/retry.sh 10 30 "${KUBECTL_BINARY} delete hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged"


### PR DESCRIPTION
See: https://issues.redhat.com/browse/OCPBUGS-2219 TODO: remove once properly fixed on the console

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

