### PR TITLE
Revert "PSA: add a workaround for Kubevirt with PSA"

### DIFF
--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -121,14 +121,6 @@ KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} printOperatorConditio
 ### Create a VM ###
 Msg "Create a simple VM on the previous version cluster, before the upgrade"
 ${CMD} create namespace ${VMS_NAMESPACE}
-
-######
-# TODO remove this once https://bugzilla.redhat.com/show_bug.cgi?id=2128997 is properly fixed on Kubevirt side
-# excplitly label vm namespace as priviledged to let our VM start there
-# until Kubevirt can handle it
-${CMD} label namespace ${VMS_NAMESPACE} --overwrite pod-security.kubernetes.io/enforce=privileged security.openshift.io/scc.podSecurityLabelSync=false
-######
-
 ssh-keygen -f ./hack/test_ssh -q -N ""
 cat << END > ./hack/cloud-init.sh
 #!/bin/sh


### PR DESCRIPTION
This reverts commit 59575d7ec8d2a86312d94d806863095127881bb6.

Add a workaround to allow a VM to be started on
a user custom namespace while
https://bugzilla.redhat.com/show_bug.cgi?id=2128997 is properly fixed

Signed-off-by: Simone Tiraboschi [stirabos@redhat.com](mailto:stirabos@redhat.com)

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

