### PR TITLE
[Clean code] Tiny JSON file reading improvement

### DIFF
--- a/controllers/hyperconverged/upgradePatches.go
+++ b/controllers/hyperconverged/upgradePatches.go
@@ -3,7 +3,6 @@ package hyperconverged
 import (
 	"encoding/json"
 	"errors"
-	"io"
 	"os"
 	"strings"
 
@@ -70,14 +69,12 @@ func readUpgradePatchesFromFile(req *common.HcoRequest) error {
 		return err
 	}
 
-	jsonBytes, err := io.ReadAll(file)
+	jDec := json.NewDecoder(file)
+	err = jDec.Decode(&hcoUpgradeChanges)
 	if err != nil {
 		return err
 	}
-	err = json.Unmarshal(jsonBytes, &hcoUpgradeChanges)
-	if err != nil {
-		return err
-	}
+
 	hcoUpgradeChangesRead = true
 	return nil
 }


### PR DESCRIPTION
Use the json.Decoder to read from a json file, instead of reading to a buffer and then unmarshal this buffer.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

/sig clean-code

```release-note
None
```

