### PR TITLE
Revert "[release-1.6] Enable PSA FG on Kubevirt (#2105)"

### DIFF
--- a/pkg/controller/hyperconverged/hyperconverged_controller_test.go
+++ b/pkg/controller/hyperconverged/hyperconverged_controller_test.go
@@ -204,7 +204,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(kvList.Items).Should(HaveLen(1))
 				kv := kvList.Items[0]
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(16))
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(15))
 
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(
 					"DataVolumes",
@@ -221,7 +221,6 @@ var _ = Describe("HyperconvergedController", func() {
 					"DownwardMetrics",
 					"ExpandDisks",
 					"NUMA",
-					"PSA",
 				),
 				)
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement("WithHostPassthroughCPU"))

--- a/pkg/controller/operands/kubevirt.go
+++ b/pkg/controller/operands/kubevirt.go
@@ -91,9 +91,6 @@ const (
 
 	// Allow automatic numa mapping on VMs with dedicated CPUs, if requested
 	kvNUMA = "NUMA"
-
-	// enable Pod Security Admission handling
-	kvPSA = "PSA"
 )
 
 var (
@@ -110,7 +107,6 @@ var (
 		kvDownwardMetricsGate,
 		kvNUMA,
 		kvLiveMigrationGate,
-		kvPSA,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of


### PR DESCRIPTION
This reverts commit ca5b4713c3ca905f5edbd717cb0787c6bc609d7a.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Revert PSA FG on Kubevirt
```

