### PR TITLE
artifacts-server: fix single stack compatibility

### DIFF
--- a/build/Dockerfile.artifacts
+++ b/build/Dockerfile.artifacts
@@ -5,7 +5,9 @@ WORKDIR /opt/app-root/src
 COPY hack/config /tmp/config
 
 USER 0
-RUN dnf -y install zip
+RUN dnf -y install zip && \
+    sed '/^\s*listen\s*\[::\]:8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv4 && \
+    sed '/^\s*listen\s*8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv6
 USER 1001
 
 ARG download_url=https://github.com/kubevirt/kubevirt/releases/download
@@ -26,4 +28,16 @@ ARG git_sha=NONE
 LABEL multi.GIT_URL=${git_url} \
       multi.GIT_SHA=${git_sha}
 
-CMD nginx -g "daemon off;"
+CMD if [[ -d "/proc/sys/net/ipv4" && -d "/proc/sys/net/ipv6" ]]; \
+    then \
+      nginx -g "daemon off;"; \
+    elif [[ -d "/proc/sys/net/ipv4" ]]; \
+    then \
+      nginx -c /etc/nginx/nginx.conf.ipv4 -g "daemon off;"; \
+    elif [[ -d "/proc/sys/net/ipv6" ]]; \
+    then \
+      nginx -c /etc/nginx/nginx.conf.ipv6 -g "daemon off;"; \
+    else \
+      echo "unable to identify IP configuration"; \
+      exit -1; \
+    fi


### PR DESCRIPTION
artifacts-server pod is based on nginx
which is expected to fail on a single
stack enviroment if configured to listen
on IPv4 and IPv6.

Safely handle it choosing dual-stack,
IPv4 only or IPv6 only configuration
at runtime according to
/proc/sys/net/ipv* existence.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2140405

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
artifacts-server: fix single stack compatibility
```

