### PR TITLE
Remove another workaround for PSA on OCP/OKD 4.12

### DIFF
--- a/hack/kv-smoke-tests.sh
+++ b/hack/kv-smoke-tests.sh
@@ -13,13 +13,7 @@ BIN_DIR="$(pwd)/_out" && mkdir -p "${BIN_DIR}"
 export BIN_DIR
 
 TESTS_BINARY="$BIN_DIR/kv_smoke_tests.test"
-######
-# workaround for PSA on OCP 4.12:
-# TODO: remove this once https://github.com/kubevirt/kubevirt/pull/8748 will land in
-# Kubevirt v0.59.0
-#curl -Lo "$TESTS_BINARY" "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/tests.test"
-curl -Lo "$TESTS_BINARY" "https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/20221115/testing/tests.test"
-######
+curl -Lo "$TESTS_BINARY" "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/tests.test"
 chmod +x "$TESTS_BINARY"
 
 # TODO: brutal workaround to bypass SCC -> PSA on OCP >= 4.12, remove ASAP!!!


### PR DESCRIPTION
Merge once kubevirt/kubevirt#8748
lands in Kubevirt v0.59.0

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

