### PR TITLE
Make caches for TlsSecurityProfile on HCO and APIServer independent

### DIFF
--- a/cmd/hyperconverged-cluster-webhook/main.go
+++ b/cmd/hyperconverged-cluster-webhook/main.go
@@ -142,7 +142,7 @@ func main() {
 	err = webhookscontrollers.RegisterReconciler(mgr, ci)
 	cmdHelper.ExitOnError(err, "Cannot register APIServer reconciler")
 
-	if err = webhooks.SetupWebhookWithManager(ctx, mgr, ci.IsOpenshift(), ci.GetTLSSecurityProfile(hcoTLSSecurityProfile)); err != nil {
+	if err = webhooks.SetupWebhookWithManager(ctx, mgr, ci.IsOpenshift(), hcoTLSSecurityProfile); err != nil {
 		logger.Error(err, "unable to create webhook", "webhook", "HyperConverged")
 		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to create webhook")
 		os.Exit(1)

--- a/pkg/webhooks/setup.go
+++ b/pkg/webhooks/setup.go
@@ -38,14 +38,14 @@ func GetWebhookCertDir() string {
 	return hcoutil.DefaultWebhookCertDir
 }
 
-func SetupWebhookWithManager(ctx context.Context, mgr ctrl.Manager, isOpenshift bool, tlsSecurityProfile *openshiftconfigv1.TLSSecurityProfile) error {
+func SetupWebhookWithManager(ctx context.Context, mgr ctrl.Manager, isOpenshift bool, hcoTlsSecurityProfile *openshiftconfigv1.TLSSecurityProfile) error {
 	operatorNsEnv, nserr := hcoutil.GetOperatorNamespaceFromEnv()
 	if nserr != nil {
 		logger.Error(nserr, "failed to get operator namespace from the environment")
 		return nserr
 	}
 
-	whHandler := validator.NewWebhookHandler(logger, mgr.GetClient(), operatorNsEnv, isOpenshift, tlsSecurityProfile)
+	whHandler := validator.NewWebhookHandler(logger, mgr.GetClient(), operatorNsEnv, isOpenshift, hcoTlsSecurityProfile)
 
 	nsMutator := mutator.NewNsMutator(mgr.GetClient(), operatorNsEnv)
 


### PR DESCRIPTION
For performance reasons, the webhook is caching in memory TlsSecurityProfile on HCO CR and also on the APIServer one.
But the cluster admin can freely alter both of them at any time, so the two caches should be fully independent.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2137896

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make caches for TlsSecurityProfile on HCO and APIServer independent
```

