### PR TITLE
[release-1.8] Avoid omitempty on WorkloadUpdateMethods (#2180)

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -389,8 +389,7 @@ type HyperConvergedWorkloadUpdateStrategy struct {
 	//
 	// +listType=atomic
 	// +kubebuilder:default={"LiveMigrate"}
-	// +optional
-	WorkloadUpdateMethods []string `json:"workloadUpdateMethods,omitempty"`
+	WorkloadUpdateMethods []string `json:"workloadUpdateMethods"`
 
 	// BatchEvictionSize Represents the number of VMIs that can be forced updated per
 	// the BatchShutdownInterval interval

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -584,6 +584,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedW
 						},
 					},
 				},
+				Required: []string{"workloadUpdateMethods"},
 			},
 		},
 		Dependencies: []string{

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2290,6 +2290,8 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
+                required:
+                - workloadUpdateMethods
                 type: object
               workloads:
                 description: workloads HyperConvergedConfig influences the pod configuration

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2290,6 +2290,8 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
+                required:
+                - workloadUpdateMethods
                 type: object
               workloads:
                 description: workloads HyperConvergedConfig influences the pod configuration

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
@@ -2290,6 +2290,8 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
+                required:
+                - workloadUpdateMethods
                 type: object
               workloads:
                 description: workloads HyperConvergedConfig influences the pod configuration

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
@@ -2290,6 +2290,8 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
+                required:
+                - workloadUpdateMethods
                 type: object
               workloads:
                 description: workloads HyperConvergedConfig influences the pod configuration

--- a/docs/api.md
+++ b/docs/api.md
@@ -207,7 +207,7 @@ HyperConvergedWorkloadUpdateStrategy defines options related to updating a KubeV
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| workloadUpdateMethods | WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Evict methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. | []string | {"LiveMigrate"} | false |
+| workloadUpdateMethods | WorkloadUpdateMethods defines the methods that can be used to disrupt workloads during automated workload updates. When multiple methods are present, the least disruptive method takes precedence over more disruptive methods. For example if both LiveMigrate and Evict methods are listed, only VMs which are not live migratable will be restarted/shutdown. An empty list defaults to no automated workload updating. | []string | {"LiveMigrate"} | true |
 | batchEvictionSize | BatchEvictionSize Represents the number of VMIs that can be forced updated per the BatchShutdownInterval interval | *int | 10 | false |
 | batchEvictionInterval | BatchEvictionInterval Represents the interval to wait before issuing the next batch of shutdowns | *metav1.Duration | "1m0s" | false |
 


### PR DESCRIPTION
In our API for WorkloadUpdateMethods we read:
...
An empty list defaults to no automated workload updating.

and a default of: ["LiveMigrate"]

but in the past the json representation of
WorkloadUpdateMethods was defined with omitempty
but, as for:
https://go.dev/src/encoding/json/encode.go
// The "omitempty" option specifies that the field should be omitted // from the encoding if the field has an empty value, defined as // false, 0, a nil pointer, a nil interface value, and any empty array, // slice, map, or string.

the golang json encoder is omitting also empty array and slice and so an empty list on WorkloadUpdateMethods gets omitted at json level and so the APIServer will then replace it with the default value (["LiveMigrate"]).

Avoid declaring omitempty on WorkloadUpdateMethods to make an empty list an acceptable value.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2151693

This is a manual cherry-pick of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2180

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid omitempty on WorkloadUpdateMethods
```

