### PR TITLE
Don't publish to community operators for unstable tags

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -6,7 +6,7 @@ on:
       - v1.*
 jobs:
   publish_hco:
-    if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')
+    if: (github.repository == 'kubevirt/hyperconverged-cluster-operator' && !contains(github.ref, 'unstable'))
     name: Publish HCO tagged version to community-operators
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
When tagging unstable tags (e.g. `1.8.0-unstable`), we don't want the publish job to community operators and operatorhub.io to be triggered.
Adding a condition to the workflow to prevent execution in case `unstable` is in the tag name.

Signed-off-by: Oren Cohen <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

