### PR TITLE
cluster-up: Fix tag updating

### DIFF
--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -15,8 +15,24 @@
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.23'}
 export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
+KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
+
+function cluster::_get_repo() {
+    git --git-dir ${KUBEVIRTCI_PATH}/.git remote get-url origin
+}
+
+function cluster::_get_tag() {
+    git -C ${KUBEVIRTCI_PATH} describe --tags
+}
 
 function kubevirtci::install() {
+    # Remove cloned kubevirtci repository if it does not match the requested one
+    if [ -d ${KUBEVIRTCI_PATH} ]; then
+        if [ $(cluster::_get_repo) != ${KUBEVIRTCI_REPO} ] || [ $(cluster::_get_tag) != ${KUBEVIRTCI_TAG} ]; then
+            rm -rf ${KUBEVIRTCI_PATH}
+        fi
+    fi
+
     if [ ! -d ${KUBEVIRTCI_PATH} ]; then
         git clone https://github.com/kubevirt/kubevirtci.git ${KUBEVIRTCI_PATH}
         (


### PR DESCRIPTION
In case the _kubevirtci folder exists,
changing the tag won't reclone the folder.
The cluster-up folder won't be updated and it can lead to bugs in case the folder is changed.

Fix it by deleting the folder in case of tag mismatch.
It will enforce a reclone.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

