### PR TITLE
Add `operator_health_impact` label to HCO alerts

### DIFF
--- a/controllers/alerts/alerts.go
+++ b/controllers/alerts/alerts.go
@@ -25,6 +25,7 @@ const (
 	unsafeModificationAlert       = "KubevirtHyperconvergedClusterOperatorUSModification"
 	installationNotCompletedAlert = "KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert"
 	severityAlertLabelKey         = "severity"
+	healthImpactAlertLabelKey     = "operator_health_impact"
 	partOfAlertLabelKey           = "kubernetes_operator_part_of"
 	partOfAlertLabelValue         = "kubevirt"
 	componentAlertLabelKey        = "kubernetes_operator_component"
@@ -131,9 +132,10 @@ func createOutOfBandUpdateAlertRule() monitoringv1.Rule {
 			"runbook_url": outOfBandUpdateRunbookUrl,
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:  "warning",
-			partOfAlertLabelKey:    partOfAlertLabelValue,
-			componentAlertLabelKey: componentAlertLabelValue,
+			severityAlertLabelKey:     "warning",
+			healthImpactAlertLabelKey: "warning",
+			partOfAlertLabelKey:       partOfAlertLabelValue,
+			componentAlertLabelKey:    componentAlertLabelValue,
 		},
 	}
 }
@@ -148,9 +150,10 @@ func createUnsafeModificationAlertRule() monitoringv1.Rule {
 			"runbook_url": unsafeModificationRunbookUrl,
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:  "info",
-			partOfAlertLabelKey:    partOfAlertLabelValue,
-			componentAlertLabelKey: componentAlertLabelValue,
+			severityAlertLabelKey:     "info",
+			healthImpactAlertLabelKey: "warning",
+			partOfAlertLabelKey:       partOfAlertLabelValue,
+			componentAlertLabelKey:    componentAlertLabelValue,
 		},
 	}
 }
@@ -166,9 +169,10 @@ func createInstallationNotCompletedAlertRule() monitoringv1.Rule {
 		},
 		For: "1h",
 		Labels: map[string]string{
-			severityAlertLabelKey:  "info",
-			partOfAlertLabelKey:    partOfAlertLabelValue,
-			componentAlertLabelKey: componentAlertLabelValue,
+			severityAlertLabelKey:     "info",
+			healthImpactAlertLabelKey: "critical",
+			partOfAlertLabelKey:       partOfAlertLabelValue,
+			componentAlertLabelKey:    componentAlertLabelValue,
 		},
 	}
 }

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -29,6 +29,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorCRModification"
       exp_labels:
         severity: "warning"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -43,6 +44,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorCRModification"
       exp_labels:
         severity: "warning"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -57,6 +59,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorCRModification"
       exp_labels:
         severity: "warning"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -81,6 +84,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorCRModification"
       exp_labels:
         severity: "warning"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -95,6 +99,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorCRModification"
       exp_labels:
         severity: "warning"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         component_name: "kubevirt/kubevirt-kubevirt-hyperconverged"
@@ -127,6 +132,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -136,6 +142,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
@@ -145,6 +152,7 @@ tests:
         summary: "5 unsafe modifications were detected in the HyperConverged resource."
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -159,6 +167,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -168,6 +177,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
@@ -178,6 +188,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -192,6 +203,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -202,6 +214,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
@@ -211,6 +224,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -225,6 +239,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -234,6 +249,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
@@ -253,6 +269,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -263,6 +280,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
@@ -272,6 +290,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -291,6 +310,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "kubevirt.kubevirt.io/jsonpatch"
@@ -301,6 +321,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "containerizeddataimporter.kubevirt.io/jsonpatch"
@@ -310,6 +331,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
       exp_labels:
         severity: "info"
+        operator_health_impact: "warning"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
@@ -361,6 +383,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert"
       exp_labels:
         severity: "info"
+        operator_health_impact: "critical"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
 
@@ -374,6 +397,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert"
       exp_labels:
         severity: "info"
+        operator_health_impact: "critical"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
 
@@ -387,6 +411,7 @@ tests:
         runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert"
       exp_labels:
         severity: "info"
+        operator_health_impact: "critical"
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
 

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -74,6 +74,8 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 						fmt.Sprintf("%s kubernetes_operator_part_of label is missing or not valid", rule.Alert))
 					Expect(rule.Labels).To(HaveKeyWithValue("kubernetes_operator_component", "hyperconverged-cluster-operator"),
 						fmt.Sprintf("%s kubernetes_operator_component label is missing or not valid", rule.Alert))
+					Expect(rule.Labels).To(HaveKeyWithValue("operator_health_impact", BeElementOf("none", "warning", "critical")),
+						fmt.Sprintf("%s operator_health_impact label is missing or not valid", rule.Alert))
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds to each of HCO alerts a label named `operator_health_impact`, which indicates how the alerts impact the operator health. This will enable us filtering alerts based on their impact on the operator health, and to later have an operator health metric, which will tell the user what is the aggregated operator health.

This label gets one of the following values:
- `critical` indicates that the alert fires due to an issue that impacts the operator's functionality badly, and an action must be taken immediately in order to solve it.
-  `warning` indicates that the alert fires due to an issue that soon might impact the operator's functionality badly, and the user should be warned in order to solve the issue.
- `none` indicates that the alert fires due to an issue that doesn't affect the operator health, and in most cases is related to the workload rather than the operator itself.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/CNV-18923

Signed-off-by: assafad <aadmi@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

