### PR TITLE
CNAO, KubeSecondaryDNS: Support KSD by a feature gate

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -49,7 +49,7 @@ type HyperConvergedSpec struct {
 
 	// featureGates is a map of feature gate flags. Setting a flag to `true` will enable
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
-	// +kubebuilder:default={"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true}
+	// +kubebuilder:default={"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false, "nonRoot": true}
 	// +optional
 	FeatureGates HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
@@ -280,6 +280,12 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=false
 	// +default=false
 	DeployTektonTaskResources *bool `json:"deployTektonTaskResources,omitempty"`
+
+	// Deploy KubeSecondaryDNS by CNAO
+	// +optional
+	// +kubebuilder:default=false
+	// +default=false
+	DeployKubeSecondaryDNS *bool `json:"deployKubeSecondaryDNS,omitempty"`
 
 	// Enables rootless virt-launcher.
 	// +optional
@@ -536,7 +542,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -225,6 +225,11 @@ func (in *HyperConvergedFeatureGates) DeepCopyInto(out *HyperConvergedFeatureGat
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DeployKubeSecondaryDNS != nil {
+		in, out := &in.DeployKubeSecondaryDNS, &out.DeployKubeSecondaryDNS
+		*out = new(bool)
+		**out = **in
+	}
 	if in.NonRoot != nil {
 		in, out := &in.NonRoot, &out.NonRoot
 		*out = new(bool)

--- a/api/v1beta1/zz_generated.defaults.go
+++ b/api/v1beta1/zz_generated.defaults.go
@@ -52,6 +52,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.FeatureGates.DeployTektonTaskResources = &ptrVar1
 	}
+	if in.Spec.FeatureGates.DeployKubeSecondaryDNS == nil {
+		var ptrVar1 bool = false
+		in.Spec.FeatureGates.DeployKubeSecondaryDNS = &ptrVar1
+	}
 	if in.Spec.FeatureGates.NonRoot == nil {
 		var ptrVar1 bool = true
 		in.Spec.FeatureGates.NonRoot = &ptrVar1

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -219,6 +219,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 							Format:      "",
 						},
 					},
+					"deployKubeSecondaryDNS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Deploy KubeSecondaryDNS by CNAO",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"nonRoot": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Enables rootless virt-launcher.",

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -52,6 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
+                deployKubeSecondaryDNS: false
                 deployTektonTaskResources: false
                 enableCommonBootImageImport: true
                 nonRoot: true
@@ -862,6 +863,7 @@ spec:
                 type: string
               featureGates:
                 default:
+                  deployKubeSecondaryDNS: false
                   deployTektonTaskResources: false
                   enableCommonBootImageImport: true
                   nonRoot: true
@@ -870,6 +872,10 @@ spec:
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
+                  deployKubeSecondaryDNS:
+                    default: false
+                    description: Deploy KubeSecondaryDNS by CNAO
+                    type: boolean
                   deployTektonTaskResources:
                     default: false
                     description: deploy resources (kubevirt tekton tasks and example

--- a/controllers/operands/networkAddons.go
+++ b/controllers/operands/networkAddons.go
@@ -143,6 +143,10 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged, opts ...string) (*networkad
 		KubeMacPool: &networkaddonsshared.KubeMacPool{},
 	}
 
+	if hc.Spec.FeatureGates.DeployKubeSecondaryDNS != nil && *hc.Spec.FeatureGates.DeployKubeSecondaryDNS {
+		cnaoSpec.KubeSecondaryDNS = &networkaddonsshared.KubeSecondaryDNS{}
+	}
+
 	cnaoSpec.Ovs = hcoAnnotation2CnaoSpec(hc.ObjectMeta.Annotations)
 	cnaoInfra := hcoConfig2CnaoPlacement(hc.Spec.Infra.NodePlacement)
 	cnaoWorkloads := hcoConfig2CnaoPlacement(hc.Spec.Workloads.NodePlacement)

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
+                deployKubeSecondaryDNS: false
                 deployTektonTaskResources: false
                 enableCommonBootImageImport: true
                 nonRoot: true
@@ -862,6 +863,7 @@ spec:
                 type: string
               featureGates:
                 default:
+                  deployKubeSecondaryDNS: false
                   deployTektonTaskResources: false
                   enableCommonBootImageImport: true
                   nonRoot: true
@@ -870,6 +872,10 @@ spec:
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
+                  deployKubeSecondaryDNS:
+                    default: false
+                    description: Deploy KubeSecondaryDNS by CNAO
+                    type: boolean
                   deployTektonTaskResources:
                     default: false
                     description: deploy resources (kubevirt tekton tasks and example

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -12,6 +12,7 @@ spec:
       duration: 24h0m0s
       renewBefore: 12h0m0s
   featureGates:
+    deployKubeSecondaryDNS: false
     deployTektonTaskResources: false
     enableCommonBootImageImport: true
     nonRoot: true

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
+                deployKubeSecondaryDNS: false
                 deployTektonTaskResources: false
                 enableCommonBootImageImport: true
                 nonRoot: true
@@ -862,6 +863,7 @@ spec:
                 type: string
               featureGates:
                 default:
+                  deployKubeSecondaryDNS: false
                   deployTektonTaskResources: false
                   enableCommonBootImageImport: true
                   nonRoot: true
@@ -870,6 +872,10 @@ spec:
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
+                  deployKubeSecondaryDNS:
+                    default: false
+                    description: Deploy KubeSecondaryDNS by CNAO
+                    type: boolean
                   deployTektonTaskResources:
                     default: false
                     description: deploy resources (kubevirt tekton tasks and example

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
               featureGates:
+                deployKubeSecondaryDNS: false
                 deployTektonTaskResources: false
                 enableCommonBootImageImport: true
                 nonRoot: true
@@ -862,6 +863,7 @@ spec:
                 type: string
               featureGates:
                 default:
+                  deployKubeSecondaryDNS: false
                   deployTektonTaskResources: false
                   enableCommonBootImageImport: true
                   nonRoot: true
@@ -870,6 +872,10 @@ spec:
                   a flag to `true` will enable the feature. Setting `false` or removing
                   the feature gate, disables the feature.
                 properties:
+                  deployKubeSecondaryDNS:
+                    default: false
+                    description: Deploy KubeSecondaryDNS by CNAO
+                    type: boolean
                   deployTektonTaskResources:
                     default: false
                     description: deploy resources (kubevirt tekton tasks and example

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,7 +94,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -129,6 +129,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here | *bool | false | false |
 | enableCommonBootImageImport | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | *bool | true | false |
 | deployTektonTaskResources | deploy resources (kubevirt tekton tasks and example pipelines) in Tekton tasks operator | *bool | false | false |
+| deployKubeSecondaryDNS | Deploy KubeSecondaryDNS by CNAO | *bool | false | false |
 | nonRoot | Enables rootless virt-launcher. | *bool | true | false |
 
 [Back to TOC](#table-of-contents)
@@ -164,7 +165,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | localStorageClassName | Deprecated: LocalStorageClassName the name of the local storage class. | string |  | false |
 | infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarily directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
 | workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
-| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "nonRoot": true} | false |
+| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false, "nonRoot": true} | false |
 | liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150} | false |
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
 | mediatedDevicesConfiguration | MediatedDevicesConfiguration holds information about MDEV types to be defined on nodes, if available | *[MediatedDevicesConfiguration](#mediateddevicesconfiguration) |  | false |

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -160,6 +160,11 @@ reverted back to false.
 
 **Default**: `false`
 
+### deployKubeSecondaryDNS Feature Gate
+Set the `deployKubeSecondaryDNS` feature gate to true to allow deploying KubeSecondaryDNS by CNAO.
+For additional information, see here: [KubeSecondaryDNS](https://github.com/kubevirt/kubesecondarydns)
+
+**Default**: `false`
 
 ### nonRoot Feature Gate
 Set the `nonRoot` feature gate to false in order to not run your virtual machines in rootless virt-launcher.
@@ -184,6 +189,7 @@ spec:
     withHostPassthroughCPU: true
     enableCommonBootImageImport: true
     deployTektonTaskResources: true
+    deployKubeSecondaryDNS: true
 ```
 
 ## Live Migration Configurations

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -22,7 +22,7 @@ echo "Read the CR's spec before starting the test"
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o json | jq '.spec'
 
 CERTCONFIGDEFAULTS='{"ca":{"duration":"48h0m0s","renewBefore":"24h0m0s"},"server":{"duration":"24h0m0s","renewBefore":"12h0m0s"}}'
-FGDEFAULTS='{"deployTektonTaskResources":false,"enableCommonBootImageImport":true,"nonRoot":true,"withHostPassthroughCPU":false}'
+FGDEFAULTS='{"deployKubeSecondaryDNS":false,"deployTektonTaskResources":false,"enableCommonBootImageImport":true,"nonRoot":true,"withHostPassthroughCPU":false}'
 LMDEFAULTS='{"completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -63,12 +63,16 @@ var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 				//"kube-multus":     false,
 				"ovs-cni-marker": false,
 				"virt-handler":   false,
+				"secondary-dns":  false,
 			}
 
 			By("Getting Network Addons Configs")
 			cnaoCR := getNetworkAddonsConfigs(client)
 			if cnaoCR.Spec.Ovs == nil {
 				delete(expectedWorkloadsPods, "ovs-cni-marker")
+			}
+			if cnaoCR.Spec.KubeSecondaryDNS == nil {
+				delete(expectedWorkloadsPods, "secondary-dns")
 			}
 
 			By("Listing pods in infra node")


### PR DESCRIPTION
Add a feature gate to HCO CR, DeployKubeSecondaryDNS. 
This will toggle deploying of KSD by CNAO.
Default value is false.

Signed-off-by: Or Shoval <oshoval@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

