### PR TITLE
ksd: Support passing BaseDomain on Openshift

### DIFF
--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2022 Red Hat, Inc.
+ * Copyright 2023 Red Hat, Inc.
  *
  */
 

--- a/api/v1beta1/zz_generated.defaults.go
+++ b/api/v1beta1/zz_generated.defaults.go
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2022 Red Hat, Inc.
+ * Copyright 2023 Red Hat, Inc.
  *
  */
 

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2022 Red Hat, Inc.
+ * Copyright 2023 Red Hat, Inc.
  *
  */
 

--- a/controllers/commonTestUtils/testUtils.go
+++ b/controllers/commonTestUtils/testUtils.go
@@ -211,8 +211,9 @@ func (matcher *RepresentConditionMatcher) NegatedFailureMessage(actual interface
 }
 
 const (
-	RSName  = "hco-operator"
-	podName = RSName + "-12345"
+	RSName     = "hco-operator"
+	podName    = RSName + "-12345"
+	BaseDomain = "basedomain"
 )
 
 var ( // own resources
@@ -291,6 +292,9 @@ func (ClusterInfoMock) IsInfrastructureHighlyAvailable() bool {
 func (ClusterInfoMock) GetDomain() string {
 	return "domain"
 }
+func (ClusterInfoMock) GetBaseDomain() string {
+	return BaseDomain
+}
 func (c ClusterInfoMock) IsConsolePluginImageProvided() bool {
 	return true
 }
@@ -338,6 +342,9 @@ func (ClusterInfoSNOMock) IsInfrastructureHighlyAvailable() bool {
 }
 func (ClusterInfoSNOMock) GetDomain() string {
 	return "domain"
+}
+func (ClusterInfoSNOMock) GetBaseDomain() string {
+	return BaseDomain
 }
 func (c ClusterInfoSNOMock) GetPod() *corev1.Pod {
 	return pod
@@ -398,6 +405,9 @@ func (ClusterInfoSRCPHAIMock) GetCSV() *csvv1alpha1.ClusterServiceVersion {
 }
 func (ClusterInfoSRCPHAIMock) GetDomain() string {
 	return "domain"
+}
+func (ClusterInfoSRCPHAIMock) GetBaseDomain() string {
+	return BaseDomain
 }
 func (ClusterInfoSRCPHAIMock) IsConsolePluginImageProvided() bool {
 	return true

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1087,11 +1087,20 @@ var _ = Describe("HyperconvergedController", func() {
 					},
 				}
 
+				dns := &openshiftconfigv1.DNS{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: openshiftconfigv1.DNSSpec{
+						BaseDomain: commonTestUtils.BaseDomain,
+					},
+				}
+
 				expected := getBasicDeployment()
 				Expect(expected.hco.Spec.TLSSecurityProfile).To(BeNil())
 
 				resources := expected.toArray()
-				resources = append(resources, clusterVersion, infrastructure, ingress, apiServer)
+				resources = append(resources, clusterVersion, infrastructure, ingress, apiServer, dns)
 				cl := commonTestUtils.InitClient(resources)
 
 				logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("hyperconverged_controller_test")

--- a/controllers/operands/networkAddons.go
+++ b/controllers/operands/networkAddons.go
@@ -145,6 +145,10 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged, opts ...string) (*networkad
 
 	if hc.Spec.FeatureGates.DeployKubeSecondaryDNS != nil && *hc.Spec.FeatureGates.DeployKubeSecondaryDNS {
 		cnaoSpec.KubeSecondaryDNS = &networkaddonsshared.KubeSecondaryDNS{}
+		baseDomain := hcoutil.GetClusterInfo().GetBaseDomain()
+		if baseDomain != "" {
+			cnaoSpec.KubeSecondaryDNS.Domain = baseDomain
+		}
 	}
 
 	cnaoSpec.Ovs = hcoAnnotation2CnaoSpec(hc.ObjectMeta.Annotations)

--- a/controllers/webhooks/controller_test.go
+++ b/controllers/webhooks/controller_test.go
@@ -128,7 +128,16 @@ var _ = Describe("HyperconvergedController", func() {
 					},
 				}
 
-				resources := []runtime.Object{clusterVersion, infrastructure, ingress, apiServer}
+				dns := &openshiftconfigv1.DNS{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: openshiftconfigv1.DNSSpec{
+						BaseDomain: commonTestUtils.BaseDomain,
+					},
+				}
+
+				resources := []runtime.Object{clusterVersion, infrastructure, ingress, apiServer, dns}
 				cl := commonTestUtils.InitClient(resources)
 
 				err := hcoutil.GetClusterInfo().Init(context.TODO(), cl, logger)

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -663,6 +663,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - dnses
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
@@ -437,6 +437,12 @@ spec:
           - list
           - watch
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - dnses
+          verbs:
+          - get
+        - apiGroups:
           - coordination.k8s.io
           resources:
           - leases

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.9.0-unstable
-    createdAt: "2023-01-04 05:14:06"
+    createdAt: "2023-01-04 15:04:11"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -436,6 +436,12 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - dnses
+          verbs:
+          - get
         - apiGroups:
           - coordination.k8s.io
           resources:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -446,7 +446,7 @@ var (
 )
 
 func GetClusterPermissions() []rbacv1.PolicyRule {
-
+	const configOpenshiftIO = "config.openshift.io"
 	return []rbacv1.PolicyRule{
 		{
 			APIGroups: stringListToSlice(util.APIVersionGroup),
@@ -524,14 +524,19 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		},
 		roleWithAllPermissions("console.openshift.io", stringListToSlice("consoleclidownloads", "consolequickstarts")),
 		{
-			APIGroups: stringListToSlice("config.openshift.io"),
+			APIGroups: stringListToSlice(configOpenshiftIO),
 			Resources: stringListToSlice("clusterversions", "infrastructures", "ingresses"),
 			Verbs:     stringListToSlice("get", "list"),
 		},
 		{
-			APIGroups: stringListToSlice("config.openshift.io"),
+			APIGroups: stringListToSlice(configOpenshiftIO),
 			Resources: stringListToSlice("apiservers"),
 			Verbs:     stringListToSlice("get", "list", "watch"),
+		},
+		{
+			APIGroups: stringListToSlice(configOpenshiftIO),
+			Resources: stringListToSlice("dnses"),
+			Verbs:     stringListToSlice("get"),
 		},
 		roleWithAllPermissions("coordination.k8s.io", stringListToSlice("leases")),
 		roleWithAllPermissions("route.openshift.io", stringListToSlice("routes")),

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -1496,8 +1496,16 @@ var _ = Describe("webhooks validator", func() {
 						Name: namespace,
 					},
 				}
+				dns := &openshiftconfigv1.DNS{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: openshiftconfigv1.DNSSpec{
+						BaseDomain: commonTestUtils.BaseDomain,
+					},
+				}
 
-				resources := []runtime.Object{clusterVersion, infrastructure, ingress, apiServer, namespace}
+				resources := []runtime.Object{clusterVersion, infrastructure, ingress, apiServer, namespace, dns}
 				cl = commonTestUtils.InitClient(resources)
 			})
 


### PR DESCRIPTION
When running OpenShift the cluster name is available via cluster DNS config resource.
Fetch it and pass it to KSD if it is deployed.
KSD will use it in order to build the FQDN.
This way different clusters will have different FQDN suffix.

Tested on CRC with HCO that the DOMAIN env var of KSD is updated according:
`oc get dnses.config.openshift.io cluster -o json | jq .spec.baseDomain`

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

