### PR TITLE
Improve test readability

### DIFF
--- a/controllers/operands/cdi_test.go
+++ b/controllers/operands/cdi_test.go
@@ -51,7 +51,7 @@ var _ = Describe("CDI Operand", func() {
 				cl.Get(context.TODO(),
 					types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
 					foundResource),
-			).ToNot(HaveOccurred())
+			).To(Succeed())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
 			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commonTestUtils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))

--- a/controllers/operands/dashboard_test.go
+++ b/controllers/operands/dashboard_test.go
@@ -42,8 +42,7 @@ var _ = Describe("Dashboard tests", func() {
 				Expect(handlers).To(BeEmpty())
 			})
 
-			err := os.Mkdir(dir, 0744)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(os.Mkdir(dir, 0744)).To(Succeed())
 			defer os.RemoveAll(dir)
 
 			By("folder is empty", func() {
@@ -70,8 +69,9 @@ var _ = Describe("Dashboard tests", func() {
 				Expect(handlers).To(BeEmpty())
 			})
 
-			err = commonTestUtils.CopyFile(path.Join(dir, "dashboard.yaml"), path.Join(testFilesLocation, "kubevirt-top-consumers.yaml"))
-			Expect(err).ToNot(HaveOccurred())
+			Expect(
+				commonTestUtils.CopyFile(path.Join(dir, "dashboard.yaml"), path.Join(testFilesLocation, "kubevirt-top-consumers.yaml")),
+			).To(Succeed())
 
 			By("yaml file exists", func() {
 				cli := commonTestUtils.InitClient([]runtime.Object{})
@@ -157,8 +157,7 @@ var _ = Describe("Dashboard tests", func() {
 				Expect(res.Updated).To(BeTrue())
 
 				cmList := &corev1.ConfigMapList{}
-				err := cli.List(context.TODO(), cmList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), cmList)).To(Succeed())
 				Expect(cmList.Items).To(HaveLen(1))
 				Expect(cmList.Items[0].Name).Should(Equal("grafana-dashboard-kubevirt-top-consumers"))
 

--- a/controllers/operands/operandHandler_test.go
+++ b/controllers/operands/operandHandler_test.go
@@ -48,8 +48,7 @@ var _ = Describe("Test operandHandler", func() {
 
 			req := commonTestUtils.NewReq(hco)
 
-			err := handler.Ensure(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.Ensure(req)).To(Succeed())
 			expectedEvents := []commonTestUtils.MockEvent{
 				{
 					EventType: corev1.EventTypeNormal,
@@ -97,8 +96,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("make sure the KV object created", func() {
 				// Read back KV
 				kvList := kubevirtcorev1.KubeVirtList{}
-				err := cli.List(req.Ctx, &kvList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &kvList)).To(Succeed())
 				Expect(kvList).ToNot(BeNil())
 				Expect(kvList.Items).To(HaveLen(1))
 				Expect(kvList.Items[0].Name).Should(Equal("kubevirt-kubevirt-hyperconverged"))
@@ -107,8 +105,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("make sure the CNA object created", func() {
 				// Read back CNA
 				cnaList := networkaddonsv1.NetworkAddonsConfigList{}
-				err := cli.List(req.Ctx, &cnaList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &cnaList)).To(Succeed())
 				Expect(cnaList).ToNot(BeNil())
 				Expect(cnaList.Items).To(HaveLen(1))
 				Expect(cnaList.Items[0].Name).Should(Equal("cluster"))
@@ -117,8 +114,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("make sure the CDI object created", func() {
 				// Read back CDI
 				cdiList := cdiv1beta1.CDIList{}
-				err := cli.List(req.Ctx, &cdiList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &cdiList)).To(Succeed())
 				Expect(cdiList).ToNot(BeNil())
 				Expect(cdiList.Items).To(HaveLen(1))
 				Expect(cdiList.Items[0].Name).Should(Equal("cdi-kubevirt-hyperconverged"))
@@ -127,8 +123,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("make sure the ConsoleQuickStart object created", func() {
 				// Read back the ConsoleQuickStart
 				qsList := consolev1.ConsoleQuickStartList{}
-				err := cli.List(req.Ctx, &qsList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &qsList)).To(Succeed())
 				Expect(qsList).ToNot(BeNil())
 				Expect(qsList.Items).To(HaveLen(1))
 				Expect(qsList.Items[0].Name).Should(Equal("test-quick-start"))
@@ -136,8 +131,7 @@ var _ = Describe("Test operandHandler", func() {
 
 			By("make sure the Dashboard confimap created", func() {
 				cmList := corev1.ConfigMapList{}
-				err := cli.List(req.Ctx, &cmList, &client.ListOptions{Namespace: "openshift-config-managed"})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &cmList, &client.ListOptions{Namespace: "openshift-config-managed"})).To(Succeed())
 				Expect(cmList).ToNot(BeNil())
 				Expect(cmList.Items).To(HaveLen(1))
 				Expect(cmList.Items[0].Name).Should(Equal("grafana-dashboard-kubevirt-top-consumers"))
@@ -180,8 +174,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("make sure the CDI object not created", func() {
 				// Read back CDI
 				cdiList := cdiv1beta1.CDIList{}
-				err := cli.List(req.Ctx, &cdiList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &cdiList)).To(Succeed())
 				Expect(cdiList).ToNot(BeNil())
 				Expect(cdiList.Items).To(BeEmpty())
 			})
@@ -198,12 +191,10 @@ var _ = Describe("Test operandHandler", func() {
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), ci, hco)
 
 			req := commonTestUtils.NewReq(hco)
-			err := handler.Ensure(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.Ensure(req)).To(Succeed())
 
 			eventEmitter.Reset()
-			err = handler.EnsureDeleted(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.EnsureDeleted(req)).To(Succeed())
 
 			expectedEvents := []commonTestUtils.MockEvent{
 				{
@@ -252,8 +243,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("check that KV is deleted", func() {
 				// Read back KV
 				kvList := kubevirtcorev1.KubeVirtList{}
-				err = cli.List(req.Ctx, &kvList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &kvList)).To(Succeed())
 				Expect(kvList).ToNot(BeNil())
 				Expect(kvList.Items).To(BeEmpty())
 			})
@@ -261,8 +251,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("make sure the CNA object deleted", func() {
 				// Read back CNA
 				cnaList := networkaddonsv1.NetworkAddonsConfigList{}
-				err := cli.List(req.Ctx, &cnaList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &cnaList)).To(Succeed())
 				Expect(cnaList).ToNot(BeNil())
 				Expect(cnaList.Items).To(BeEmpty())
 			})
@@ -270,8 +259,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("make sure the CDI object deleted", func() {
 				// Read back CDI
 				cdiList := cdiv1beta1.CDIList{}
-				err := cli.List(req.Ctx, &cdiList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &cdiList)).To(Succeed())
 				Expect(cdiList).ToNot(BeNil())
 				Expect(cdiList.Items).To(BeEmpty())
 			})
@@ -279,8 +267,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("check that ConsoleQuickStart is deleted", func() {
 				// Read back the ConsoleQuickStart
 				qsList := consolev1.ConsoleQuickStartList{}
-				err = cli.List(req.Ctx, &qsList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &qsList)).To(Succeed())
 				Expect(qsList).ToNot(BeNil())
 				Expect(qsList.Items).To(BeEmpty())
 			})
@@ -297,8 +284,7 @@ var _ = Describe("Test operandHandler", func() {
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), ci, hco)
 
 			req := commonTestUtils.NewReq(hco)
-			err := handler.Ensure(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.Ensure(req)).To(Succeed())
 
 			fakeError := fmt.Errorf("fake KV deletion error")
 			cli.InitiateDeleteErrors(func(obj client.Object) error {
@@ -319,7 +305,7 @@ var _ = Describe("Test operandHandler", func() {
 				},
 			}
 			eventEmitter.Reset()
-			err = handler.EnsureDeleted(req)
+			err := handler.EnsureDeleted(req)
 			Expect(err).Should(Equal(fakeError))
 
 			By("Check that event was emitted", func() {
@@ -329,8 +315,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("check that KV still exists", func() {
 				// Read back KV
 				kvList := kubevirtcorev1.KubeVirtList{}
-				err := cli.List(req.Ctx, &kvList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &kvList)).To(Succeed())
 				Expect(kvList).ToNot(BeNil())
 				Expect(kvList.Items).To(HaveLen(1))
 				Expect(kvList.Items[0].Name).Should(Equal("kubevirt-kubevirt-hyperconverged"))
@@ -348,8 +333,7 @@ var _ = Describe("Test operandHandler", func() {
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), ci, hco)
 
 			req := commonTestUtils.NewReq(hco)
-			err := handler.Ensure(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.Ensure(req)).To(Succeed())
 
 			fakeError := fmt.Errorf("fake CDI deletion error")
 			cli.InitiateDeleteErrors(func(obj client.Object) error {
@@ -371,7 +355,7 @@ var _ = Describe("Test operandHandler", func() {
 			}
 
 			eventEmitter.Reset()
-			err = handler.EnsureDeleted(req)
+			err := handler.EnsureDeleted(req)
 			Expect(err).Should(Equal(fakeError))
 
 			By("Check that event was emitted", func() {
@@ -381,8 +365,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("make sure the CDI object still exists", func() {
 				// Read back KV
 				cdiList := cdiv1beta1.CDIList{}
-				err := cli.List(req.Ctx, &cdiList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &cdiList)).To(Succeed())
 				Expect(cdiList).ToNot(BeNil())
 				Expect(cdiList.Items).To(HaveLen(1))
 				Expect(cdiList.Items[0].Name).Should(Equal("cdi-kubevirt-hyperconverged"))
@@ -401,8 +384,7 @@ var _ = Describe("Test operandHandler", func() {
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), ci, hco)
 
 			req := commonTestUtils.NewReq(hco)
-			err := handler.Ensure(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.Ensure(req)).To(Succeed())
 
 			cli.InitiateDeleteErrors(func(obj client.Object) error {
 				if unstructed, ok := obj.(runtime.Unstructured); ok {
@@ -423,7 +405,7 @@ var _ = Describe("Test operandHandler", func() {
 			}
 
 			eventEmitter.Reset()
-			err = handler.EnsureDeleted(req)
+			err := handler.EnsureDeleted(req)
 			Expect(err).Should(Equal(fakeError))
 
 			By("Check that event was emitted", func() {
@@ -433,8 +415,7 @@ var _ = Describe("Test operandHandler", func() {
 			By("make sure the CNA object still exists", func() {
 				// Read back CNA
 				cnaList := networkaddonsv1.NetworkAddonsConfigList{}
-				err := cli.List(req.Ctx, &cnaList)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(req.Ctx, &cnaList)).To(Succeed())
 				Expect(cnaList).ToNot(BeNil())
 				Expect(cnaList.Items).To(HaveLen(1))
 				Expect(cnaList.Items[0].Name).Should(Equal("cluster"))
@@ -452,8 +433,7 @@ var _ = Describe("Test operandHandler", func() {
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), ci, hco)
 
 			req := commonTestUtils.NewReq(hco)
-			err := handler.Ensure(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.Ensure(req)).To(Succeed())
 
 			cli.InitiateDeleteErrors(func(obj client.Object) error {
 				if unstructed, ok := obj.(runtime.Unstructured); ok {
@@ -469,7 +449,7 @@ var _ = Describe("Test operandHandler", func() {
 			ctx, cancelFunc := context.WithTimeout(req.Ctx, time.Millisecond*300)
 			defer cancelFunc()
 			req.Ctx = ctx
-			err = handler.EnsureDeleted(req)
+			err := handler.EnsureDeleted(req)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(Equal("context deadline exceeded"))
 

--- a/pkg/util/cluster_test.go
+++ b/pkg/util/cluster_test.go
@@ -73,7 +73,7 @@ var _ = Describe("test clusterInfo", func() {
 	)
 
 	testScheme := scheme.Scheme
-	Expect(openshiftconfigv1.Install(testScheme)).ToNot(HaveOccurred())
+	Expect(openshiftconfigv1.Install(testScheme)).To(Succeed())
 
 	logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("clusterInfo_test")
 
@@ -82,8 +82,7 @@ var _ = Describe("test clusterInfo", func() {
 		cl := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			Build()
-		err := GetClusterInfo().Init(context.TODO(), cl, logger)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
 
 		Expect(GetClusterInfo().IsOpenshift()).To(BeFalse(), "should return false for IsOpenshift()")
 		Expect(GetClusterInfo().IsManagedByOLM()).To(BeFalse(), "should return false for IsManagedByOLM()")
@@ -94,8 +93,7 @@ var _ = Describe("test clusterInfo", func() {
 		cl := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			Build()
-		err := GetClusterInfo().Init(context.TODO(), cl, logger)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
 
 		Expect(GetClusterInfo().IsOpenshift()).To(BeFalse(), "should return false for IsOpenshift()")
 		Expect(GetClusterInfo().IsManagedByOLM()).To(BeTrue(), "should return true for IsManagedByOLM()")
@@ -107,8 +105,7 @@ var _ = Describe("test clusterInfo", func() {
 			WithScheme(testScheme).
 			WithRuntimeObjects(clusterVersion, infrastructure, ingress, apiServer, dns).
 			Build()
-		err := GetClusterInfo().Init(context.TODO(), cl, logger)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
 
 		Expect(GetClusterInfo().IsOpenshift()).To(BeTrue(), "should return true for IsOpenshift()")
 		Expect(GetClusterInfo().IsManagedByOLM()).To(BeTrue(), "should return true for IsManagedByOLM()")
@@ -125,8 +122,7 @@ var _ = Describe("test clusterInfo", func() {
 			WithScheme(testScheme).
 			WithRuntimeObjects(clusterVersion, infrastructure, ingress, apiServer, dns).
 			Build()
-		err := GetClusterInfo().Init(context.TODO(), cl, logger)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
 
 		Expect(GetClusterInfo().IsOpenshift()).To(BeTrue(), "should return true for IsOpenshift()")
 		Expect(GetClusterInfo().IsManagedByOLM()).To(BeFalse(), "should return false for IsManagedByOLM()")
@@ -154,8 +150,7 @@ var _ = Describe("test clusterInfo", func() {
 				WithScheme(testScheme).
 				WithRuntimeObjects(clusterVersion, testInfrastructure, ingress, apiServer, dns).
 				Build()
-			err := GetClusterInfo().Init(context.TODO(), cl, logger)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
 
 			Expect(GetClusterInfo().IsOpenshift()).To(BeTrue(), "should return true for IsOpenshift()")
 			Expect(GetClusterInfo().IsManagedByOLM()).To(BeTrue(), "should return true for IsManagedByOLM()")
@@ -225,8 +220,7 @@ var _ = Describe("test clusterInfo", func() {
 				WithRuntimeObjects(nodesArray...).
 				Build()
 
-			err := GetClusterInfo().Init(context.TODO(), cl, logger)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
 
 			Expect(GetClusterInfo().IsOpenshift()).To(BeFalse(), "should return false for IsOpenshift()")
 			Expect(GetClusterInfo().IsManagedByOLM()).To(BeFalse(), "should return false for IsManagedByOLM()")
@@ -289,8 +283,7 @@ var _ = Describe("test clusterInfo", func() {
 						WithRuntimeObjects(clusterVersion, infrastructure, ingress, testApiServer, dns).
 						Build()
 				}
-				err := GetClusterInfo().Init(context.TODO(), cl, logger)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
 
 				Expect(GetClusterInfo().IsOpenshift()).To(Equal(isOnOpenshift), "should return true for IsOpenshift()")
 				Expect(GetClusterInfo().GetTLSSecurityProfile(hcoTLSSecurityProfile)).To(Equal(expectedTLSSecurityProfile), "should return the expected TLSSecurityProfile")
@@ -460,8 +453,7 @@ var _ = Describe("test clusterInfo", func() {
 				WithScheme(testScheme).
 				WithRuntimeObjects(clusterVersion, infrastructure, ingress, testApiServer, dns).
 				Build()
-			err := GetClusterInfo().Init(context.TODO(), cl, logger)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
 
 			Expect(GetClusterInfo().IsOpenshift()).To(BeTrue(), "should return true for IsOpenshift()")
 			Expect(GetClusterInfo().IsManagedByOLM()).To(BeTrue(), "should return true for IsManagedByOLM()")
@@ -469,12 +461,10 @@ var _ = Describe("test clusterInfo", func() {
 			Expect(GetClusterInfo().GetTLSSecurityProfile(nil)).To(Equal(initialTLSSecurityProfile), "should return the initial value")
 
 			testApiServer.Spec.TLSSecurityProfile = updatedTLSSecurityProfile
-			err = cl.Update(context.TODO(), testApiServer)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(cl.Update(context.TODO(), testApiServer)).To(Succeed())
 			Expect(GetClusterInfo().GetTLSSecurityProfile(nil)).To(Equal(initialTLSSecurityProfile), "should still return the cached value (initial value)")
 
-			err = GetClusterInfo().RefreshAPIServerCR(context.TODO(), cl)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(GetClusterInfo().RefreshAPIServerCR(context.TODO(), cl)).To(Succeed())
 
 			Expect(GetClusterInfo().GetTLSSecurityProfile(nil)).To(Equal(updatedTLSSecurityProfile), "should return the updated value")
 

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -32,8 +32,7 @@ fieldObj:
             `
 			reader := strings.NewReader(input)
 			var obj testType
-			err := UnmarshalYamlFileToObject(reader, &obj)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(UnmarshalYamlFileToObject(reader, &obj)).To(Succeed())
 
 			Expect(obj).Should(Equal(testType{FieldStr: "abcd", FieldInt: 123, FieldObj: &nestedObj{NestedStr: "nested", NestedInt: 456}}))
 		})
@@ -48,15 +47,13 @@ fieldObj:
             `
 			reader := strings.NewReader(input)
 			var obj testType
-			err := UnmarshalYamlFileToObject(reader, &obj)
-			Expect(err).To(HaveOccurred())
+			Expect(UnmarshalYamlFileToObject(reader, &obj)).ToNot(Succeed())
 		})
 
 		It("should return error if failed to read", func() {
 			reader := badReader{}
 			var obj testType
-			err := UnmarshalYamlFileToObject(reader, &obj)
-			Expect(err).To(HaveOccurred())
+			Expect(UnmarshalYamlFileToObject(reader, &obj)).ToNot(Succeed())
 		})
 	})
 
@@ -93,8 +90,7 @@ fieldObj:
 				_ = os.RemoveAll(tempDir)
 			}()
 
-			err = ValidateManifestDir(tempDir)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(ValidateManifestDir(tempDir)).To(Succeed())
 		})
 	})
 

--- a/pkg/util/hcoping_test.go
+++ b/pkg/util/hcoping_test.go
@@ -8,7 +8,7 @@ import (
 var _ = Describe("test hco ping", func() {
 	Context("test hcoChecker", func() {
 		It("should return no error", func() {
-			Expect(GetHcoPing()(nil)).ToNot(HaveOccurred())
+			Expect(GetHcoPing()(nil)).To(Succeed())
 		})
 	})
 })

--- a/pkg/util/operatorcondition_test.go
+++ b/pkg/util/operatorcondition_test.go
@@ -24,8 +24,7 @@ var _ = Describe("OperatorCondition", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		ctx := context.Background()
-		err = oc.Set(ctx, metav1.ConditionTrue, "Reason", "message")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(oc.Set(ctx, metav1.ConditionTrue, "Reason", "message")).To(Succeed())
 	},
 		Entry("should no-op when not managed by OLM", &ClusterInfoImp{
 			managedByOLM:   false,
@@ -43,8 +42,7 @@ var _ = Describe("OperatorCondition", func() {
 
 	It("valid condition", func() {
 		testScheme := scheme.Scheme
-		err := operatorsapiv2.AddToScheme(testScheme)
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(operatorsapiv2.AddToScheme(testScheme)).Should(Succeed())
 
 		cl := fake.NewClientBuilder().
 			WithScheme(testScheme).
@@ -70,8 +68,9 @@ var _ = Describe("OperatorCondition", func() {
 
 		Expect(cond.Type).Should(Equal("testCondition"))
 
-		err = oc.Set(context.TODO(), metav1.ConditionTrue, "myReason", "my message")
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(
+			oc.Set(context.TODO(), metav1.ConditionTrue, "myReason", "my message"),
+		).Should(Succeed())
 
 		cond, err = oc.cond.Get(context.TODO())
 		Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Test general utilities", func() {
 		}
 
 		testScheme := scheme.Scheme
-		Expect(openshiftconfigv1.Install(testScheme)).ToNot(HaveOccurred())
+		Expect(openshiftconfigv1.Install(testScheme)).To(Succeed())
 
 		ctx := context.Background()
 
@@ -107,8 +107,7 @@ var _ = Describe("Test general utilities", func() {
 			Expect(deleted).To(BeTrue())
 
 			podToSearch := &corev1.Pod{}
-			err = cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)
-			Expect(err).Should(HaveOccurred())
+			Expect(cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)).ShouldNot(Succeed())
 		})
 
 		It("should not return error if the resource does not exist", func() {
@@ -121,8 +120,7 @@ var _ = Describe("Test general utilities", func() {
 			Expect(deleted).To(BeFalse())
 
 			podToSearch := &corev1.Pod{}
-			err = cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)
-			Expect(err).Should(HaveOccurred())
+			Expect(cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)).ShouldNot(Succeed())
 		})
 	})
 

--- a/pkg/webhooks/mutator/mutator_test.go
+++ b/pkg/webhooks/mutator/mutator_test.go
@@ -156,8 +156,7 @@ func initMutator(s *runtime.Scheme, testClient client.Client) *NsMutator {
 	decoder, err := admission.NewDecoder(s)
 	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
 
-	err = nsMutator.InjectDecoder(decoder)
-	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+	ExpectWithOffset(1, nsMutator.InjectDecoder(decoder)).Should(Succeed())
 
 	return nsMutator
 }

--- a/pkg/webhooks/setup_test.go
+++ b/pkg/webhooks/setup_test.go
@@ -69,8 +69,7 @@ var _ = Describe("Hyperconverged API: Webhook", func() {
 			mgr, err := commonTestUtils.NewManagerMock(&rest.Config{}, manager.Options{WebhookServer: ws}, cl, logger)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = SetupWebhookWithManager(context.TODO(), mgr, true, nil)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(SetupWebhookWithManager(context.TODO(), mgr, true, nil)).To(Succeed())
 		})
 
 		It("should fail setting up the webhooks with the manager when certificates are not accessible", func() {

--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -56,14 +56,13 @@ func checkConsoleCliDownloadSpec(client kubecli.KubevirtClient) {
 	s.AddKnownTypes(consolev1.GroupVersion)
 
 	var ccd consolev1.ConsoleCLIDownload
-	err := client.RestClient().Get().
+	ExpectWithOffset(1, client.RestClient().Get().
 		Resource("consoleclidownloads").
 		Name("virtctl-clidownloads-kubevirt-hyperconverged").
 		AbsPath("/apis", consolev1.GroupVersion.Group, consolev1.GroupVersion.Version).
-		Timeout(10 * time.Second).
-		Do(context.TODO()).Into(&ccd)
+		Timeout(10*time.Second).
+		Do(context.TODO()).Into(&ccd)).To(Succeed())
 
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, ccd.Spec.Links).Should(HaveLen(3))
 
 	for _, link := range ccd.Spec.Links {

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -124,15 +124,16 @@ func getHCO(client kubecli.KubevirtClient) v1beta1.HyperConverged {
 	s.AddKnownTypes(v1beta1.SchemeGroupVersion)
 
 	var hco v1beta1.HyperConverged
-	err := client.RestClient().Get().
-		Resource("hyperconvergeds").
-		Name("kubevirt-hyperconverged").
-		Namespace(flags.KubeVirtInstallNamespace).
-		AbsPath("/apis", v1beta1.SchemeGroupVersion.Group, v1beta1.SchemeGroupVersion.Version).
-		Timeout(10 * time.Second).
-		Do(context.TODO()).Into(&hco)
-
-	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+	ExpectWithOffset(
+		1,
+		client.RestClient().Get().
+			Resource("hyperconvergeds").
+			Name("kubevirt-hyperconverged").
+			Namespace(flags.KubeVirtInstallNamespace).
+			AbsPath("/apis", v1beta1.SchemeGroupVersion.Group, v1beta1.SchemeGroupVersion.Version).
+			Timeout(10*time.Second).
+			Do(context.TODO()).Into(&hco),
+	).To(Succeed())
 
 	return hco
 }
@@ -141,16 +142,14 @@ func updateHCO(client kubecli.KubevirtClient, hco v1beta1.HyperConverged) v1beta
 	hco.Kind = "HyperConverged"
 	hco.APIVersion = v1beta1.SchemeGroupVersion.String()
 
-	err := client.RestClient().Put().
+	ExpectWithOffset(1, client.RestClient().Put().
 		Resource("hyperconvergeds").
 		Name("kubevirt-hyperconverged").
 		Namespace(flags.KubeVirtInstallNamespace).
 		AbsPath("/apis", v1beta1.SchemeGroupVersion.Group, v1beta1.SchemeGroupVersion.Version).
 		Body(&hco).
-		Timeout(10 * time.Second).
-		Do(context.TODO()).Into(&hco)
-
-	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+		Timeout(10*time.Second).
+		Do(context.TODO()).Into(&hco)).Should(Succeed())
 
 	return hco
 }
@@ -171,14 +170,13 @@ func getPrometheusRule(client kubecli.KubevirtClient) monitoringv1.PrometheusRul
 
 	var prometheusRule monitoringv1.PrometheusRule
 
-	err := client.RestClient().Get().
+	ExpectWithOffset(1, client.RestClient().Get().
 		Resource("prometheusrules").
 		Name("kubevirt-hyperconverged-prometheus-rule").
 		Namespace(flags.KubeVirtInstallNamespace).
 		AbsPath("/apis", monitoringv1.SchemeGroupVersion.Group, monitoringv1.SchemeGroupVersion.Version).
-		Timeout(10 * time.Second).
-		Do(context.TODO()).Into(&prometheusRule)
-	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+		Timeout(10*time.Second).
+		Do(context.TODO()).Into(&prometheusRule)).Should(Succeed())
 	return prometheusRule
 }
 

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -166,14 +166,12 @@ func getNetworkAddonsConfigs(client kubecli.KubevirtClient) *networkaddonsv1.Net
 	_ = networkaddonsv1.AddToScheme(s)
 	s.AddKnownTypes(networkaddonsv1.GroupVersion)
 
-	err := client.RestClient().Get().
+	ExpectWithOffset(1, client.RestClient().Get().
 		Resource("networkaddonsconfigs").
 		Name("cluster").
 		AbsPath("/apis", networkaddonsv1.GroupVersion.Group, networkaddonsv1.GroupVersion.Version).
-		Timeout(10 * time.Second).
-		Do(context.TODO()).Into(&cnaoCR)
-
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		Timeout(10*time.Second).
+		Do(context.TODO()).Into(&cnaoCR)).To(Succeed())
 
 	return &cnaoCR
 }

--- a/tests/func-tests/quickstart_test.go
+++ b/tests/func-tests/quickstart_test.go
@@ -62,14 +62,13 @@ func checkExpectedQuickStarts(client kubecli.KubevirtClient) {
 	for _, qs := range items {
 		// use a fresh object for each loop. get requests only override non-empty fields
 		var cqs consolev1.ConsoleQuickStart
-		err := client.RestClient().Get().
+		ExpectWithOffset(1, client.RestClient().Get().
 			Resource("consolequickstarts").
 			Name(qs.Name).
 			AbsPath("/apis", consolev1.GroupVersion.Group, consolev1.GroupVersion.Version).
-			Timeout(10 * time.Second).
-			Do(context.TODO()).Into(&cqs)
+			Timeout(10*time.Second).
+			Do(context.TODO()).Into(&cqs)).To(Succeed())
 
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		ExpectWithOffset(1, cqs.Spec.DisplayName).Should(Equal(qs.DisplayName))
 	}
 


### PR DESCRIPTION
When validating error returned from function `Expect(f()).To(Succeed())` is more readable than
```golang
Expect(f()).ToNot(HaveOccurred())
```
Or
```golang
err := f()
Expect(err).ToNot(HaveOccurred())
```

This PR changes the assertions for function that returns (only) errors. It doesn't change the current assertion, if the error is later used for additional assertions.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

