### PR TITLE
dataImportCronTemplates: Add default instance type labels

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -1,5 +1,8 @@
 - metadata:
     name: centos-stream8-image-cron
+    labels:
+      instancetype.kubevirt.io/default-preference: centos.8.stream
+      instancetype.kubevirt.io/default-instancetype: server.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -15,6 +18,9 @@
     managedDataSource: centos-stream8
 - metadata:
     name: centos-stream9-image-cron
+    labels:
+      instancetype.kubevirt.io/default-preference: centos.9.stream
+      instancetype.kubevirt.io/default-instancetype: server.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -30,6 +36,9 @@
     managedDataSource: centos-stream9
 - metadata:
     name: fedora-image-cron
+    labels:
+      instancetype.kubevirt.io/default-preference: fedora
+      instancetype.kubevirt.io/default-instancetype: server.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -45,6 +54,9 @@
     managedDataSource: fedora
 - metadata:
     name: centos-7-image-cron
+    labels:
+      instancetype.kubevirt.io/default-preference: centos.7
+      instancetype.kubevirt.io/default-instancetype: server.medium
   spec:
     schedule: "0 */12 * * *"
     template:


### PR DESCRIPTION
Support has recently landed in KubeVirt [1][2] allowing default
instance types and preferences to be inferred from a given Volume
associated with a VirtualMachine.

Additional support has now also landed in CDI [3][4] allowing the
labels controlling this behaviour to be passed down from
DataImportCrons to DataVolumes, DataSources and PVCs created as part of
the import process.

This change adds these labels to the default
DataImportCronTemplates provided by HCO to the SSP operator that leads
to the creation of the initial DataImportCron resources. The above
changes then should result in these labels being passed down to the
created resources and thus being usable by KubeVirt end users.

[1] https://github.com/kubevirt/kubevirt/pull/8480
[2] https://github.com/kubevirt/kubevirt/pull/9040
[3] https://github.com/kubevirt/containerized-data-importer/pull/2490
[4] https://github.com/kubevirt/containerized-data-importer/pull/2534


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

