### PR TITLE
Add ConsolePlugin CR to HCO controller watch list

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -236,6 +236,9 @@ func getNewManagerCache(operatorNamespace string) cache.NewCacheFunc {
 				&consolev1.ConsoleQuickStart{}: {
 					Label: labelSelector,
 				},
+				&consolev1.ConsolePlugin{}: {
+					Label: labelSelector,
+				},
 				&appsv1.Deployment{}: {
 					Label: labelSelector,
 					Field: namespaceSelector,

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -192,6 +192,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo) er
 			&routev1.Route{},
 			&consolev1.ConsoleCLIDownload{},
 			&consolev1.ConsoleQuickStart{},
+			&consolev1.ConsolePlugin{},
 			&imagev1.ImageStream{},
 			&corev1.Namespace{},
 			&appsv1.Deployment{},


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2161340

By adding `&consolev1.ConsolePlugin{}` to the resources that are being watched in hyperconverged controller, any change at the `kubevirt-plugin` ConsolePlugin CR will trigger a reconciliation and rollback.

Signed-off-by: Oren Cohen <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ConsolePlugin to HCO watch list
```

