### PR TITLE
ksd: Support NameServerIP

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -165,6 +165,10 @@ type HyperConvergedSpec struct {
 	// be deployed.
 	// +optional
 	TektonPipelinesNamespace *string `json:"tektonPipelinesNamespace,omitempty"`
+
+	// KubeSecondaryDNSNameServerIP defines name server IP used by KubeSecondaryDNS
+	// +optional
+	KubeSecondaryDNSNameServerIP *string `json:"kubeSecondaryDNSNameServerIP,omitempty"`
 }
 
 // CertRotateConfigCA contains the tunables for TLS certificates.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -383,6 +383,11 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.KubeSecondaryDNSNameServerIP != nil {
+		in, out := &in.KubeSecondaryDNSNameServerIP, &out.KubeSecondaryDNSNameServerIP
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -454,6 +454,13 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 							Format:      "",
 						},
 					},
+					"kubeSecondaryDNSNameServerIP": {
+						SchemaProps: spec.SchemaProps{
+							Description: "KubeSecondaryDNSNameServerIP defines name server IP used by KubeSecondaryDNS",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -1899,6 +1899,10 @@ spec:
                         type: array
                     type: object
                 type: object
+              kubeSecondaryDNSNameServerIP:
+                description: KubeSecondaryDNSNameServerIP defines name server IP used
+                  by KubeSecondaryDNS
+                type: string
               liveMigrationConfig:
                 default:
                   allowAutoConverge: false

--- a/controllers/operands/networkAddons_test.go
+++ b/controllers/operands/networkAddons_test.go
@@ -540,9 +540,11 @@ var _ = Describe("CNA Operand", func() {
 				existingCNAO.Spec.KubeSecondaryDNS = &networkaddonsshared.KubeSecondaryDNS{}
 			}
 
+			kubeSecondaryDNSNameServerIP := "127.0.0.1"
 			if o.setFeatureGate {
 				deployKubeSecondaryDNS := o.featureGateValue
 				hco.Spec.FeatureGates.DeployKubeSecondaryDNS = &deployKubeSecondaryDNS
+				hco.Spec.KubeSecondaryDNSNameServerIP = &kubeSecondaryDNSNameServerIP
 			}
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, existingCNAO})
@@ -562,6 +564,8 @@ var _ = Describe("CNA Operand", func() {
 				Expect(foundCNAO.Spec.KubeSecondaryDNS).ToNot(BeNil(), "KSD spec should be added")
 				Expect(foundCNAO.Spec.KubeSecondaryDNS.Domain).To(Equal(o.expectedBaseDomain),
 					"Expected domain should be set on KSD spec")
+				Expect(foundCNAO.Spec.KubeSecondaryDNS.NameServerIP).To(Equal(kubeSecondaryDNSNameServerIP),
+					"Expected NameServerIP should be set on KSD spec")
 			} else {
 				Expect(foundCNAO.Spec.KubeSecondaryDNS).To(BeNil(), "KSD spec should not be added")
 			}

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1899,6 +1899,10 @@ spec:
                         type: array
                     type: object
                 type: object
+              kubeSecondaryDNSNameServerIP:
+                description: KubeSecondaryDNSNameServerIP defines name server IP used
+                  by KubeSecondaryDNS
+                type: string
               liveMigrationConfig:
                 default:
                   allowAutoConverge: false

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
@@ -1899,6 +1899,10 @@ spec:
                         type: array
                     type: object
                 type: object
+              kubeSecondaryDNSNameServerIP:
+                description: KubeSecondaryDNSNameServerIP defines name server IP used
+                  by KubeSecondaryDNS
+                type: string
               liveMigrationConfig:
                 default:
                   allowAutoConverge: false

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
@@ -1899,6 +1899,10 @@ spec:
                         type: array
                     type: object
                 type: object
+              kubeSecondaryDNSNameServerIP:
+                description: KubeSecondaryDNSNameServerIP defines name server IP used
+                  by KubeSecondaryDNS
+                type: string
               liveMigrationConfig:
                 default:
                   allowAutoConverge: false

--- a/docs/api.md
+++ b/docs/api.md
@@ -185,6 +185,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | logVerbosityConfig | LogVerbosityConfig configures the verbosity level of Kubevirt's different components. The higher the value - the higher the log verbosity. | *[LogVerbosityConfiguration](#logverbosityconfiguration) |  | false |
 | tlsSecurityProfile | TLSSecurityProfile specifies the settings for TLS connections to be propagated to all kubevirt-hyperconverged components. If unset, the hyperconverged cluster operator will consume the value set on the APIServer CR on OCP/OKD or Intermediate if on vanilla k8s. Note that only Old, Intermediate and Custom profiles are currently supported, and the maximum available MinTLSVersions is VersionTLS12. | *openshiftconfigv1.TLSSecurityProfile |  | false |
 | tektonPipelinesNamespace | TektonPipelinesNamespace defines namespace in which example pipelines will be deployed. | *string |  | false |
+| kubeSecondaryDNSNameServerIP | KubeSecondaryDNSNameServerIP defines name server IP used by KubeSecondaryDNS | *string |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -636,6 +636,22 @@ spec:
       - "private-registry-example-2:5000"
       ...
 ```
+
+## KubeSecondaryDNS Name Server IP
+In order to set KSD's NameServerIP, set it on HyperConverged CR under spec.kubeSecondaryDNSNameServerIP field.
+Default: empty string. Value is a string representation of IPv4 (i.e "127.0.0.1").
+For more info see [deployKubeSecondaryDNS Feature Gate](#deploykubesecondarydns-feature-gate).
+
+### KubeSecondaryDNS Name Server IP example
+```yaml
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  kubeSecondaryDNSNameServerIP: "127.0.0.1"
+```
+
 ## Modify common golden images
 Golden images are root disk images for commonly used operating systems. HCO provides several common images, but it is possible to modify them, if needed.
 


### PR DESCRIPTION
Add support of NameServerIP field to HCO CR spec (`kubeSecondaryDNSNameServerIP`).
In case the value is set, and KSD is deployed
it will be populated to CNAO CR and from there to KSD deployment.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

