### PR TITLE
KubeVirt: enable the seccomp feature gate and custom profile

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -214,6 +214,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"WithHostPassthroughCPU",
 					"VMExport",
 					"DisableCustomSELinuxPolicy",
+					"KubevirtSeccompProfile",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}
@@ -223,6 +224,13 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(expectedFeatureGates)))
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(expectedFeatureGates))
+
+				// Ensure the KubeVirt seccomp profile is set
+				Expect(kv.Spec.Configuration.SeccompConfiguration).ToNot(BeNil())
+				Expect(kv.Spec.Configuration.SeccompConfiguration.VirtualMachineInstanceProfile).ToNot(BeNil())
+				Expect(kv.Spec.Configuration.SeccompConfiguration.VirtualMachineInstanceProfile.CustomProfile).ToNot(BeNil())
+				Expect(kv.Spec.Configuration.SeccompConfiguration.VirtualMachineInstanceProfile.CustomProfile.RuntimeDefaultProfile).To(BeFalse())
+				Expect(*kv.Spec.Configuration.SeccompConfiguration.VirtualMachineInstanceProfile.CustomProfile.LocalhostProfile).To(Equal("kubevirt/kubevirt.json"))
 
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -95,6 +95,9 @@ const (
 
 	// Disable the installation and usage of the custom SELinux policy
 	kvDisableCustomSELinuxPolicyGate = "DisableCustomSELinuxPolicy"
+
+	// Enable the installation of the KubeVirt seccomp profile
+	kvKubevirtSeccompProfile = "KubevirtSeccompProfile"
 )
 
 var (
@@ -112,6 +115,7 @@ var (
 		kvNUMA,
 		kvVMExportGate,
 		kvDisableCustomSELinuxPolicyGate,
+		kvKubevirtSeccompProfile,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of
@@ -353,6 +357,8 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		return nil, err
 	}
 
+	seccompConfig := getKVSeccompConfig()
+
 	config := &kubevirtcorev1.KubeVirtConfiguration{
 		DeveloperConfiguration: devConfig,
 		NetworkConfiguration: &kubevirtcorev1.NetworkConfiguration{
@@ -368,6 +374,7 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		WebhookConfiguration:         rateLimiter,
 		ControllerConfiguration:      rateLimiter,
 		HandlerConfiguration:         rateLimiter,
+		SeccompConfiguration:         seccompConfig,
 	}
 
 	if smbiosConfig, ok := os.LookupEnv(smbiosEnvName); ok {
@@ -566,6 +573,18 @@ func getKVDevConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.DeveloperCon
 	}
 
 	return devConf, nil
+}
+
+// Static for now, could be configured in the HCO CR in the future
+func getKVSeccompConfig() *kubevirtcorev1.SeccompConfiguration {
+	kubevirtProfile := "kubevirt/kubevirt.json"
+	return &kubevirtcorev1.SeccompConfiguration{
+		VirtualMachineInstanceProfile: &kubevirtcorev1.VirtualMachineInstanceProfile{
+			CustomProfile: &kubevirtcorev1.CustomProfile{
+				LocalhostProfile: &kubevirtProfile,
+			},
+		},
+	}
 }
 
 func NewKubeVirtWithNameOnly(hc *hcov1beta1.HyperConverged, opts ...string) *kubevirtcorev1.KubeVirt {


### PR DESCRIPTION
**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt is now configured to always install and use its custom seccomp policy
```

