### PR TITLE
Fix an issue in DataImportCron templates

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -1,4 +1,6 @@
 - metadata:
+    annotations:
+      cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: centos-stream8-image-cron
   spec:
     schedule: "0 */12 * * *"
@@ -14,6 +16,8 @@
     garbageCollect: Outdated
     managedDataSource: centos-stream8
 - metadata:
+    annotations:
+      cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: centos-stream9-image-cron
   spec:
     schedule: "0 */12 * * *"
@@ -29,6 +33,8 @@
     garbageCollect: Outdated
     managedDataSource: centos-stream9
 - metadata:
+    annotations:
+      cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: fedora-image-cron
   spec:
     schedule: "0 */12 * * *"
@@ -44,6 +50,8 @@
     garbageCollect: Outdated
     managedDataSource: fedora
 - metadata:
+    annotations:
+      cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: centos-7-image-cron
   spec:
     schedule: "0 */12 * * *"


### PR DESCRIPTION
The templates are not annotated with `cdi.kubevirt.io/storage.bind.immediate.requested` so in some cases they are never become ready.

This PR adds the missing annotation.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix problem with DataImportCron that are never become ready
```

