### PR TITLE
Introduce a new jsonpatch annotation for SSP

### DIFF
--- a/controllers/common/consts.go
+++ b/controllers/common/consts.go
@@ -8,6 +8,7 @@ const (
 	JSONPatchKVAnnotationName   = "kubevirt.kubevirt.io/jsonpatch"
 	JSONPatchCDIAnnotationName  = "containerizeddataimporter.kubevirt.io/jsonpatch"
 	JSONPatchCNAOAnnotationName = "networkaddonsconfigs.kubevirt.io/jsonpatch"
+	JSONPatchSSPAnnotationName  = "ssp.kubevirt.io/jsonpatch"
 	// Tuning Policy annotation name
 	TuningPolicyAnnotationName = "hco.kubevirt.io/tuningPolicy"
 )

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -96,6 +96,7 @@ var JSONPatchAnnotationNames = []string{
 	common.JSONPatchKVAnnotationName,
 	common.JSONPatchCDIAnnotationName,
 	common.JSONPatchCNAOAnnotationName,
+	common.JSONPatchSSPAnnotationName,
 }
 
 // RegisterReconciler creates a new HyperConverged Reconciler and registers it into manager.

--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -167,6 +167,10 @@ func NewSSP(hc *hcov1beta1.HyperConverged, _ ...string) (*sspv1beta1.SSP, []hcov
 	ssp := NewSSPWithNameOnly(hc)
 	ssp.Spec = spec
 
+	if err := applyPatchToSpec(hc, common.JSONPatchSSPAnnotationName, ssp); err != nil {
+		return nil, nil, err
+	}
+
 	return ssp, dataImportCronStatuses, nil
 }
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -846,6 +846,7 @@ The following annotations are supported in the HyperConverged CR:
 * `kubevirt.kubevirt.io/jsonpatch` - for [KubeVirt configurations](https://github.com/kubevirt/api)
 * `containerizeddataimporter.kubevirt.io/jsonpatch` - for [CDI configurations](https://github.com/kubevirt/containerized-data-importer-api)
 * `networkaddonsconfigs.kubevirt.io/jsonpatch` - for [CNAO](https://github.com/kubevirt/cluster-network-addons-operator) configurations
+* `ssp.kubevirt.io/jsonpatch` - for [SSP](https://github.com/kubevirt/ssp-operator) configurations
 
 The content of the annotation will be a json array of patch objects, as defined in [RFC6902](https://tools.ietf.org/html/rfc6902).
 
@@ -1034,6 +1035,7 @@ FIELDS:
 * To explore kubevirt configuration options, use `kubectl explain kv.spec`
 * To explore CDI configuration options, use `kubectl explain cdi.spec`
 * To explore CNAO configuration options, use `kubectl explain networkaddonsconfig.spec`
+* To explore SSP configuration options, use `kubectl explain ssp.spec`
 
 ### WARNING
 Using the jsonpatch annotation feature incorrectly might lead to unexpected results and could potentially render the Kubevirt-Hyperconverged system unstable.  

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -115,6 +115,9 @@ tests:
   - series: 'kubevirt_hco_unsafe_modification_count{annotation_name="networkaddonsconfigs.kubevirt.io/jsonpatch"}'
     # time:      0     1 2 3 4 5 6 7 8     9    10 11
     values: "stale stale 5 1 1 1 0 0 3 stale stale  1"
+  - series: 'kubevirt_hco_unsafe_modification_count{annotation_name="ssp.kubevirt.io/jsonpatch"}'
+    # time:      0     1 2 3 4 5 6 7 8     9    10 11
+    values: "stale stale 5 4 3 2 0 0 3 stale stale  1"
 
   alert_rule_test:
   # No metric, no alert
@@ -156,6 +159,16 @@ tests:
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+    - exp_annotations:
+        description: "unsafe modification for the ssp.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+        runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
+        summary: "5 unsafe modifications were detected in the HyperConverged resource."
+      exp_labels:
+        severity: "info"
+        operator_health_impact: "warning"
+        kubernetes_operator_part_of: "kubevirt"
+        kubernetes_operator_component: "hyperconverged-cluster-operator"
+        annotation_name: "ssp.kubevirt.io/jsonpatch"
 
   # New increases must be detected
   - eval_time: 4m
@@ -192,6 +205,16 @@ tests:
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+    - exp_annotations:
+        description: "unsafe modification for the ssp.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+        summary: "3 unsafe modifications were detected in the HyperConverged resource."
+        runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
+      exp_labels:
+        severity: "info"
+        operator_health_impact: "warning"
+        kubernetes_operator_part_of: "kubevirt"
+        kubernetes_operator_component: "hyperconverged-cluster-operator"
+        annotation_name: "ssp.kubevirt.io/jsonpatch"
 
   # counter can be reduced
   - eval_time: 5m
@@ -228,6 +251,16 @@ tests:
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+    - exp_annotations:
+        description: "unsafe modification for the ssp.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+        summary: "2 unsafe modifications were detected in the HyperConverged resource."
+        runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
+      exp_labels:
+        severity: "info"
+        operator_health_impact: "warning"
+        kubernetes_operator_part_of: "kubevirt"
+        kubernetes_operator_component: "hyperconverged-cluster-operator"
+        annotation_name: "ssp.kubevirt.io/jsonpatch"
 
   # no alert if the value is 0
   - eval_time: 6m
@@ -294,6 +327,16 @@ tests:
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+    - exp_annotations:
+        description: "unsafe modification for the ssp.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+        summary: "3 unsafe modifications were detected in the HyperConverged resource."
+        runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
+      exp_labels:
+        severity: "info"
+        operator_health_impact: "warning"
+        kubernetes_operator_part_of: "kubevirt"
+        kubernetes_operator_component: "hyperconverged-cluster-operator"
+        annotation_name: "ssp.kubevirt.io/jsonpatch"
 
   # no data
   - eval_time: 9m
@@ -335,6 +378,16 @@ tests:
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+    - exp_annotations:
+        description: "unsafe modification for the ssp.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+        summary: "1 unsafe modifications were detected in the HyperConverged resource."
+        runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
+      exp_labels:
+        severity: "info"
+        operator_health_impact: "warning"
+        kubernetes_operator_part_of: "kubevirt"
+        kubernetes_operator_component: "hyperconverged-cluster-operator"
+        annotation_name: "ssp.kubevirt.io/jsonpatch"
 
 # Test hyperconverged exists counter
 - interval: 1m

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -152,6 +152,10 @@ func (wh *WebhookHandler) ValidateCreate(ctx context.Context, dryrun bool, hc *v
 		return err
 	}
 
+	if _, _, err := operands.NewSSP(hc); err != nil {
+		return err
+	}
+
 	if !dryrun {
 		hcoTlsConfigCache = hc.Spec.TLSSecurityProfile
 	}

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -95,9 +95,17 @@ const (
 						"value": "Always"
 					}
 			]`
+	validSspAnnotation = `[
+					{
+						"op": "replace",
+						"path": "/spec/templateValidator/replicas",
+						"value": 5
+					}
+			]`
 	invalidKvAnnotation  = `[{"op": "wrongOp", "path": "/spec/configuration/cpuRequest", "value": "12m"}]`
 	invalidCdiAnnotation = `[{"op": "wrongOp", "path": "/spec/config/featureGates/-", "value": "fg1"}]`
 	invalidCnaAnnotation = `[{"op": "wrongOp", "path": "/spec/kubeMacPool", "value": {"rangeStart": "1.1.1.1.1.1", "rangeEnd": "5.5.5.5.5.5" }}]`
+	invalidSspAnnotation = `[{"op": "wrongOp", "path": "/spec/templateValidator/replicas", "value": 5}]`
 )
 
 var _ = Describe("webhooks validator", func() {
@@ -214,6 +222,14 @@ var _ = Describe("webhooks validator", func() {
 			),
 			Entry("should reject creation of a resource with an invalid cna annotation",
 				map[string]string{common.JSONPatchCNAOAnnotationName: invalidCnaAnnotation},
+				Not(Succeed()),
+			),
+			Entry("should accept creation of a resource with a valid ssp annotation",
+				map[string]string{common.JSONPatchSSPAnnotationName: validSspAnnotation},
+				Succeed(),
+			),
+			Entry("should reject creation of a resource with an invalid ssp annotation",
+				map[string]string{common.JSONPatchSSPAnnotationName: invalidSspAnnotation},
 				Not(Succeed()),
 			),
 		)
@@ -1243,6 +1259,7 @@ var _ = Describe("webhooks validator", func() {
 			Entry("should accept if kv annotation is valid", common.JSONPatchKVAnnotationName, validKvAnnotation),
 			Entry("should accept if cdi annotation is valid", common.JSONPatchCDIAnnotationName, validCdiAnnotation),
 			Entry("should accept if cna annotation is valid", common.JSONPatchCNAOAnnotationName, validCnaAnnotation),
+			Entry("should accept if ssp annotation is valid", common.JSONPatchSSPAnnotationName, validSspAnnotation),
 		)
 
 		DescribeTable("should reject if annotation is invalid",
@@ -1268,6 +1285,7 @@ var _ = Describe("webhooks validator", func() {
 			Entry("should reject if kv annotation is invalid", common.JSONPatchKVAnnotationName, invalidKvAnnotation),
 			Entry("should reject if cdi annotation is invalid", common.JSONPatchCDIAnnotationName, invalidCdiAnnotation),
 			Entry("should reject if cna annotation is invalid", common.JSONPatchCNAOAnnotationName, invalidCnaAnnotation),
+			Entry("should accept if ssp annotation is invalid", common.JSONPatchSSPAnnotationName, invalidSspAnnotation),
 		)
 	})
 


### PR DESCRIPTION
Introduce an additional jsonpatch annotation
to let the cluster admin override also SSP
configuration for test/dev purposes.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2166923 JIRA-ticket: https://issues.redhat.com/browse/CNV-25035

Signed-off-by: stirabos <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce a new jsonpatch annotation for SSP
```

