### PR TITLE
[test] Consume fresh prometheus image

### DIFF
--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-readonly PROM_IMAGE="docker.io/prom/prometheus:v2.15.2"
+readonly PROM_IMAGE="quay.io/prometheus/prometheus:v2.42.0"
 
 function cleanup() {
     local cleanup_files=("${@:?}")
@@ -12,7 +12,7 @@ function cleanup() {
 function lint() {
     local target_file="${1:?}"
     podman run --rm --entrypoint=/bin/promtool \
-        -v "$target_file":/tmp/rules.verify:ro "$PROM_IMAGE" \
+        -v "$target_file":/tmp/rules.verify:ro,Z "$PROM_IMAGE" \
         check rules /tmp/rules.verify
 }
 
@@ -20,8 +20,8 @@ function unit_test() {
     local target_file="${1:?}"
     local tests_file="${2:?}"
     podman run --rm --entrypoint=/bin/promtool \
-        -v "$tests_file":/tmp/rules.test:ro \
-        -v "$target_file":/tmp/rules.verify:ro \
+        -v "$tests_file":/tmp/rules.test:ro,Z \
+        -v "$target_file":/tmp/rules.verify:ro,Z \
         "$PROM_IMAGE" \
         test rules /tmp/rules.test
 }


### PR DESCRIPTION
Consume fresh prometheus image from quay.io
in alerts unit tests.
Label the temporary artifacts as "private unshared" with SELinux.

Signed-off-by: stirabos <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

