### PR TITLE
[release-1.6] Bump fedora image (#2233)

### DIFF
--- a/deploy/Dockerfile.registry.upgrade
+++ b/deploy/Dockerfile.registry.upgrade
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:33-x86_64 AS builder
+FROM quay.io/fedora/fedora:37-x86_64 AS builder
 ARG UPGRADE_VERSION=100.0.0
 
 ENV GOPATH=/go

--- a/deploy/Dockerfile.registry.upgrade-prev
+++ b/deploy/Dockerfile.registry.upgrade-prev
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:33-x86_64 AS builder
+FROM quay.io/fedora/fedora:37-x86_64 AS builder
 ARG UPGRADE_VERSION=100.0.0
 
 ENV GOPATH=/go

--- a/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:33-x86_64 AS builder
+FROM quay.io/fedora/fedora:37-x86_64 AS builder
 ARG INITIAL_VERSION=1.6.0
 ARG INITIAL_VERSION_SED="1\.6\.0"
 ARG TARGET_VERSION=100.0.0

--- a/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:33-x86_64 AS builder
+FROM quay.io/fedora/fedora:37-x86_64 AS builder
 ARG INITIAL_VERSION=1.6.0
 ARG INITIAL_VERSION_SED="1\.6\.0"
 ARG TARGET_VERSION=100.0.0

--- a/tests/build/Dockerfile
+++ b/tests/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:37
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
@@ -22,7 +22,7 @@ RUN \
     export PATH=${GOPATH}/bin:$PATH && \
     eval $(go env) && \
     go install github.com/onsi/ginkgo/ginkgo@latest && \
-    go get github.com/onsi/gomega && \
+    go get github.com/onsi/gomega@v1.22.1 && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go get -u -d golang.org/x/lint/golint && \
     go install github.com/rmohr/go-swagger-utils/swagger-doc@latest && \

--- a/tools/operator-sdk-validate/Dockerfile
+++ b/tools/operator-sdk-validate/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:33-x86_64
+FROM quay.io/fedora/fedora:37-x86_64
 
 COPY deploy/olm-catalog/community-kubevirt-hyperconverged /manifests
 COPY tools/operator-sdk-validate/validate-bundles.sh .


### PR DESCRIPTION
Bump fedora image used for various internal
images to fedora:37

This is a manual cherry-pick of #2233

Pin to an older version of onsi/gomega
since recent ones are not compatible
with golang 1.17 used here.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

