### PR TITLE
[release-1.8] Introduce a new jsonpatch annotation for SSP (#2229)

### DIFF
--- a/controllers/common/consts.go
+++ b/controllers/common/consts.go
@@ -8,4 +8,5 @@ const (
 	JSONPatchKVAnnotationName   = "kubevirt.kubevirt.io/jsonpatch"
 	JSONPatchCDIAnnotationName  = "containerizeddataimporter.kubevirt.io/jsonpatch"
 	JSONPatchCNAOAnnotationName = "networkaddonsconfigs.kubevirt.io/jsonpatch"
+	JSONPatchSSPAnnotationName  = "ssp.kubevirt.io/jsonpatch"
 )

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -94,6 +94,7 @@ var JSONPatchAnnotationNames = []string{
 	common.JSONPatchKVAnnotationName,
 	common.JSONPatchCDIAnnotationName,
 	common.JSONPatchCNAOAnnotationName,
+	common.JSONPatchSSPAnnotationName,
 }
 
 // RegisterReconciler creates a new HyperConverged Reconciler and registers it into manager.

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -3557,6 +3557,141 @@ var _ = Describe("HyperconvergedController", func() {
 				})
 			})
 
+			Context("Detection of a tainted configuration for SSP", func() {
+
+				It("Raises a TaintedConfiguration condition upon detection of such configuration", func() {
+					hco.ObjectMeta.Annotations = map[string]string{
+						common.JSONPatchSSPAnnotationName: `[
+							{
+								"op": "replace",
+								"path": "/spec/templateValidator/replicas",
+								"value": 5
+							}
+						]`,
+					}
+
+					err := metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchSSPAnnotationName)
+					Expect(err).ToNot(HaveOccurred())
+
+					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
+					r := initReconciler(cl, nil)
+
+					By("Reconcile", func() {
+						res, err := r.Reconcile(context.TODO(), request)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+					})
+
+					foundResource := &hcov1beta1.HyperConverged{}
+					Expect(
+						cl.Get(context.TODO(),
+							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
+							foundResource),
+					).To(Succeed())
+
+					By("Verify HC conditions", func() {
+						Expect(foundResource.Status.Conditions).To(ContainElement(commonTestUtils.RepresentCondition(metav1.Condition{
+							Type:    hcov1beta1.ConditionTaintedConfiguration,
+							Status:  metav1.ConditionTrue,
+							Reason:  taintedConfigurationReason,
+							Message: taintedConfigurationMessage,
+						})))
+					})
+
+					By("verify that the metrics match to the annotation", func() {
+						verifyUnsafeMetrics(1, common.JSONPatchSSPAnnotationName)
+					})
+
+					By("Verify that SSP was modified by the annotation", func() {
+						ssp := operands.NewSSPWithNameOnly(hco)
+						Expect(
+							cl.Get(context.TODO(),
+								types.NamespacedName{Name: ssp.Name, Namespace: ssp.Namespace},
+								ssp),
+						).To(Succeed())
+
+						Expect(ssp.Spec.TemplateValidator.Replicas).Should(Not(BeNil()))
+						Expect(*ssp.Spec.TemplateValidator.Replicas).Should(Equal(int32(5)))
+					})
+				})
+
+				It("Removes the TaintedConfiguration condition upon removal of such configuration", func() {
+					hco.Status.Conditions = append(hco.Status.Conditions, metav1.Condition{
+						Type:    hcov1beta1.ConditionTaintedConfiguration,
+						Status:  metav1.ConditionTrue,
+						Reason:  taintedConfigurationReason,
+						Message: taintedConfigurationMessage,
+					})
+					err := metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchSSPAnnotationName)
+					Expect(err).ToNot(HaveOccurred())
+
+					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
+					r := initReconciler(cl, nil)
+
+					// Do the reconcile
+					res, err := r.Reconcile(context.TODO(), request)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Expecting "Requeue: false" since the conditions aren't empty
+					Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+
+					// Get the HCO
+					foundResource := &hcov1beta1.HyperConverged{}
+					Expect(
+						cl.Get(context.TODO(),
+							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
+							foundResource),
+					).To(Succeed())
+
+					// Check conditions
+					Expect(foundResource.Status.Conditions).To(Not(ContainElement(commonTestUtils.RepresentCondition(metav1.Condition{
+						Type:    hcov1beta1.ConditionTaintedConfiguration,
+						Status:  metav1.ConditionTrue,
+						Reason:  taintedConfigurationReason,
+						Message: taintedConfigurationMessage,
+					}))))
+					By("verify that the metrics match to the annotation", func() {
+						verifyUnsafeMetrics(0, common.JSONPatchSSPAnnotationName)
+					})
+				})
+
+				It("Removes the TaintedConfiguration condition if the annotation is wrong", func() {
+					hco.ObjectMeta.Annotations = map[string]string{
+						// Set bad json
+						common.JSONPatchSSPAnnotationName: `[{`,
+					}
+					err := metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchSSPAnnotationName)
+					Expect(err).ToNot(HaveOccurred())
+
+					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
+					r := initReconciler(cl, nil)
+
+					By("Reconcile", func() {
+						res, err := r.Reconcile(context.TODO(), request)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+					})
+
+					foundResource := &hcov1beta1.HyperConverged{}
+					Expect(
+						cl.Get(context.TODO(),
+							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
+							foundResource),
+					).To(Succeed())
+
+					// Check conditions
+					Expect(foundResource.Status.Conditions).To(Not(ContainElement(commonTestUtils.RepresentCondition(metav1.Condition{
+						Type:    hcov1beta1.ConditionTaintedConfiguration,
+						Status:  metav1.ConditionTrue,
+						Reason:  taintedConfigurationReason,
+						Message: taintedConfigurationMessage,
+					}))))
+					By("verify that the metrics match to the annotation", func() {
+						verifyUnsafeMetrics(0, common.JSONPatchSSPAnnotationName)
+					})
+				})
+			})
+
 			Context("Detection of a tainted configuration for all the annotations", func() {
 				It("Raises a TaintedConfiguration condition upon detection of such configuration", func() {
 					hco.ObjectMeta.Annotations = map[string]string{
@@ -3592,12 +3727,21 @@ var _ = Describe("HyperconvergedController", func() {
 								"value": "Always"
 							}
 						]`,
+						common.JSONPatchSSPAnnotationName: `[
+							{
+								"op": "replace",
+								"path": "/spec/templateValidator/replicas",
+								"value": 5
+							}
+						]`,
 					}
 					err := metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchKVAnnotationName)
 					Expect(err).ToNot(HaveOccurred())
 					err = metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchCDIAnnotationName)
 					Expect(err).ToNot(HaveOccurred())
 					err = metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchCNAOAnnotationName)
+					Expect(err).ToNot(HaveOccurred())
+					err = metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchSSPAnnotationName)
 					Expect(err).ToNot(HaveOccurred())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
@@ -3629,6 +3773,7 @@ var _ = Describe("HyperconvergedController", func() {
 						verifyUnsafeMetrics(1, common.JSONPatchKVAnnotationName)
 						verifyUnsafeMetrics(2, common.JSONPatchCDIAnnotationName)
 						verifyUnsafeMetrics(2, common.JSONPatchCNAOAnnotationName)
+						verifyUnsafeMetrics(1, common.JSONPatchSSPAnnotationName)
 					})
 
 					By("Verify that KV was modified by the annotation", func() {
@@ -3671,6 +3816,17 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(cna.Spec.KubeMacPool.RangeStart).Should(Equal("1.1.1.1.1.1"))
 						Expect(cna.Spec.KubeMacPool.RangeEnd).Should(Equal("5.5.5.5.5.5"))
 						Expect(cna.Spec.ImagePullPolicy).Should(BeEquivalentTo("Always"))
+					})
+					By("Verify that SSP was modified by the annotation", func() {
+						ssp := operands.NewSSPWithNameOnly(hco)
+						Expect(
+							cl.Get(context.TODO(),
+								types.NamespacedName{Name: ssp.Name, Namespace: ssp.Namespace},
+								ssp),
+						).To(Succeed())
+
+						Expect(ssp.Spec.TemplateValidator.Replicas).Should(Not(BeNil()))
+						Expect(*ssp.Spec.TemplateValidator.Replicas).Should(Equal(int32(5)))
 					})
 				})
 			})

--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -167,6 +167,10 @@ func NewSSP(hc *hcov1beta1.HyperConverged, _ ...string) (*sspv1beta1.SSP, []hcov
 	ssp := NewSSPWithNameOnly(hc)
 	ssp.Spec = spec
 
+	if err := applyPatchToSpec(hc, common.JSONPatchSSPAnnotationName, ssp); err != nil {
+		return nil, nil, err
+	}
+
 	return ssp, dataImportCronStatuses, nil
 }
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -807,6 +807,7 @@ The following annotations are supported in the HyperConverged CR:
 * `kubevirt.kubevirt.io/jsonpatch` - for [KubeVirt configurations](https://github.com/kubevirt/api)
 * `containerizeddataimporter.kubevirt.io/jsonpatch` - for [CDI configurations](https://github.com/kubevirt/containerized-data-importer-api)
 * `networkaddonsconfigs.kubevirt.io/jsonpatch` - for [CNAO](https://github.com/kubevirt/cluster-network-addons-operator) configurations
+* `ssp.kubevirt.io/jsonpatch` - for [SSP](https://github.com/kubevirt/ssp-operator) configurations
 
 The content of the annotation will be a json array of patch objects, as defined in [RFC6902](https://tools.ietf.org/html/rfc6902).
 
@@ -964,6 +965,7 @@ FIELDS:
 * To explore kubevirt configuration options, use `kubectl explain kv.spec`
 * To explore CDI configuration options, use `kubectl explain cdi.spec`
 * To explore CNAO configuration options, use `kubectl explain networkaddonsconfig.spec`
+* To explore SSP configuration options, use `kubectl explain ssp.spec`
 
 ### WARNING
 Using the jsonpatch annotation feature incorrectly might lead to unexpected results and could potentially render the Kubevirt-Hyperconverged system unstable.  

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -110,6 +110,9 @@ tests:
   - series: 'kubevirt_hco_unsafe_modification_count{annotation_name="networkaddonsconfigs.kubevirt.io/jsonpatch"}'
     # time:      0     1 2 3 4 5 6 7 8     9    10 11
     values: "stale stale 5 1 1 1 0 0 3 stale stale  1"
+  - series: 'kubevirt_hco_unsafe_modification_count{annotation_name="ssp.kubevirt.io/jsonpatch"}'
+    # time:      0     1 2 3 4 5 6 7 8     9    10 11
+    values: "stale stale 5 4 3 2 0 0 3 stale stale  1"
 
   alert_rule_test:
   # No metric, no alert
@@ -148,6 +151,15 @@ tests:
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+    - exp_annotations:
+        description: "unsafe modification for the ssp.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+        runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
+        summary: "5 unsafe modifications were detected in the HyperConverged resource."
+      exp_labels:
+        severity: "info"
+        kubernetes_operator_part_of: "kubevirt"
+        kubernetes_operator_component: "hyperconverged-cluster-operator"
+        annotation_name: "ssp.kubevirt.io/jsonpatch"
 
   # New increases must be detected
   - eval_time: 4m
@@ -181,6 +193,15 @@ tests:
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+    - exp_annotations:
+        description: "unsafe modification for the ssp.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+        summary: "3 unsafe modifications were detected in the HyperConverged resource."
+        runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
+      exp_labels:
+        severity: "info"
+        kubernetes_operator_part_of: "kubevirt"
+        kubernetes_operator_component: "hyperconverged-cluster-operator"
+        annotation_name: "ssp.kubevirt.io/jsonpatch"
 
   # counter can be reduced
   - eval_time: 5m
@@ -214,6 +235,15 @@ tests:
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+    - exp_annotations:
+        description: "unsafe modification for the ssp.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+        summary: "2 unsafe modifications were detected in the HyperConverged resource."
+        runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
+      exp_labels:
+        severity: "info"
+        kubernetes_operator_part_of: "kubevirt"
+        kubernetes_operator_component: "hyperconverged-cluster-operator"
+        annotation_name: "ssp.kubevirt.io/jsonpatch"
 
   # no alert if the value is 0
   - eval_time: 6m
@@ -275,6 +305,15 @@ tests:
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+    - exp_annotations:
+        description: "unsafe modification for the ssp.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+        summary: "3 unsafe modifications were detected in the HyperConverged resource."
+        runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
+      exp_labels:
+        severity: "info"
+        kubernetes_operator_part_of: "kubevirt"
+        kubernetes_operator_component: "hyperconverged-cluster-operator"
+        annotation_name: "ssp.kubevirt.io/jsonpatch"
 
   # no data
   - eval_time: 9m
@@ -313,6 +352,15 @@ tests:
         kubernetes_operator_part_of: "kubevirt"
         kubernetes_operator_component: "hyperconverged-cluster-operator"
         annotation_name: "networkaddonsconfigs.kubevirt.io/jsonpatch"
+    - exp_annotations:
+        description: "unsafe modification for the ssp.kubevirt.io/jsonpatch annotation in the HyperConverged resource."
+        summary: "1 unsafe modifications were detected in the HyperConverged resource."
+        runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtHyperconvergedClusterOperatorUSModification"
+      exp_labels:
+        severity: "info"
+        kubernetes_operator_part_of: "kubevirt"
+        kubernetes_operator_component: "hyperconverged-cluster-operator"
+        annotation_name: "ssp.kubevirt.io/jsonpatch"
 
 # Test hyperconverged exists counter
 - interval: 1m

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -152,6 +152,10 @@ func (wh *WebhookHandler) ValidateCreate(ctx context.Context, dryrun bool, hc *v
 		return err
 	}
 
+	if _, _, err := operands.NewSSP(hc); err != nil {
+		return err
+	}
+
 	if !dryrun {
 		hcoTlsConfigCache = hc.Spec.TLSSecurityProfile
 	}


### PR DESCRIPTION
Introduce an additional jsonpatch annotation
to let the cluster admin override also SSP
configuration for test/dev purposes.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2166923 JIRA-ticket: https://issues.redhat.com/browse/CNV-25035

This is a manual cherry-pick of #2229

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce a new jsonpatch annotation for SSP
```

