### PR TITLE
Kubevirt: Add guest-to-request memory headroom to virt-launchers

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -536,6 +536,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - nodes

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
@@ -301,6 +301,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - ""
           resources:
           - nodes

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
@@ -301,6 +301,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - ""
           resources:
           - nodes

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -1124,7 +1124,23 @@ spec:
         memory: "1279755392"
 ```
 
-As can be seen, this `virt-launcher` has only CPU and memory requests - but not limits. This means that if this VMI is being created in a namespace that has a ResourceQuota defined in it - the virt-launcher Pod won't be able to start. This now can be solved using this feature.
+As can be seen, this `virt-launcher` has only CPU and memory requests - but not limits. This means that if this VMI is
+being created in a namespace that has a ResourceQuota defined in it - the virt-launcher Pod won't be able to start.
+This now can be solved using this feature.
+
+This feature supports either setting a ratio between request and limits or via setting a delta of additional resources.
+The two can be used, but not together. In other words, if a memory ratio is being set, setting a memory delta is not allowed and vice-versa.
+The same rules are applied to cpu.
+
+These two annotations control ratios:
+* `kubevirt.io/cpu-limit-to-request-ratio`
+* `kubevirt.io/memory-limit-to-request-ratio`
+
+And these two annotations control deltas:
+* `kubevirt.io/cpu-limit-to-request-delta`
+* `kubevirt.io/memory-limit-to-request-delta`
+
+The following examples uses ratios, but deltas could be used in a similar way.
 
 To enable this mechanism, first a ratio between memory/CPU limits to request needs to be defined as an annotation in HCO object:
 ```yaml

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -475,6 +475,11 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 			Verbs:     stringListToSlice("get", "list", "watch"),
 		},
 		{
+			APIGroups: stringListToSlice("kubevirt.io"),
+			Resources: stringListToSlice("virtualmachineinstances"),
+			Verbs:     stringListToSlice("get", "list", "watch"),
+		},
+		{
 			APIGroups: emptyAPIGroup,
 			Resources: stringListToSlice("nodes", "nodes/proxy"),
 			Verbs:     stringListToSlice("get", "list", "watch"),

--- a/pkg/webhooks/mutator/utils.go
+++ b/pkg/webhooks/mutator/utils.go
@@ -2,6 +2,9 @@ package mutator
 
 import (
 	"context"
+	"fmt"
+
+	v1 "kubevirt.io/api/core/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,4 +34,24 @@ func getHcoObject(ctx context.Context, cli client.Client, namespace string) (*v1
 	}
 
 	return hco, nil
+}
+
+func getVmi(ctx context.Context, cli client.Client, name, namespace string) (*v1.VirtualMachineInstance, error) {
+	vmi := &v1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	err := cli.Get(ctx, client.ObjectKeyFromObject(vmi), vmi)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("VMI %s/%s does not exist", namespace, name)
+		}
+
+		return nil, fmt.Errorf("failed getting VMI %s/%s: %v", namespace, name, err)
+	}
+
+	return vmi, nil
 }

--- a/pkg/webhooks/mutator/virt-launcher-mutator.go
+++ b/pkg/webhooks/mutator/virt-launcher-mutator.go
@@ -34,6 +34,8 @@ const (
 	customMemoryHeadroomAnnotation = kubevirtIoAnnotationPrefix + "custom-guest-to-request-memory-headroom"
 
 	launcherMutatorStr = "virtLauncherMutator"
+
+	virtLauncherVmiNameLabel = "vm.kubevirt.io/name"
 )
 
 type VirtLauncherMutator struct {
@@ -159,13 +161,13 @@ func (m *VirtLauncherMutator) handleVirtLauncherMemoryHeadroom(ctx context.Conte
 
 	// fetch VMI
 	var vmi *v1.VirtualMachineInstance
-	if vmiName, exists := launcherPod.Labels["vm.kubevirt.io/name"]; exists {
+	if vmiName, exists := launcherPod.Labels[virtLauncherVmiNameLabel]; exists {
 		vmi, err = getVmi(ctx, m.cli, vmiName, launcherPod.Namespace)
 		if err != nil {
 			return err
 		}
 	} else {
-		return fmt.Errorf("warning: cannot find label key %s in virt launcher pod %s/%s", "vm.kubevirt.io/name", launcherPod.Namespace, launcherPod.Name)
+		return fmt.Errorf("warning: cannot find label key %s in virt launcher pod %s/%s", virtLauncherVmiNameLabel, launcherPod.Namespace, launcherPod.Name)
 	}
 
 	if _, memoryLimitExists := vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceMemory]; memoryLimitExists {

--- a/pkg/webhooks/mutator/virt-launcher-mutator_test.go
+++ b/pkg/webhooks/mutator/virt-launcher-mutator_test.go
@@ -70,7 +70,7 @@ var _ = Describe("virt-launcher webhook mutator", func() {
 			enforceMemoryLimits: true,
 			memRatioStr:         memRatio,
 		}
-		Expect(mutator.handleVirtLauncherCreation(launcherPod, hco, creationConfig)).To(Succeed())
+		Expect(mutator.handleVirtLauncherCreation(context.Background(), launcherPod, creationConfig)).To(Succeed())
 
 		resources := launcherPod.Spec.Containers[0].Resources
 		Expect(resources.Limits[k8sv1.ResourceCPU].Equal(expectedResources.Limits[k8sv1.ResourceCPU])).To(BeTrue())

--- a/pkg/webhooks/mutator/virt-launcher-mutator_test.go
+++ b/pkg/webhooks/mutator/virt-launcher-mutator_test.go
@@ -75,10 +75,10 @@ var _ = Describe("virt-launcher webhook mutator", func() {
 
 			launcherPod.Spec.Containers[0].Resources = podResources
 			creationConfig := virtLauncherCreationConfig{
-				enforceCpuLimits:    true,
-				cpuRatioStr:         cpuRatio,
-				enforceMemoryLimits: true,
-				memRatioStr:         memRatio,
+				enforceCpuLimitsRatio:    true,
+				cpuRatioStr:              cpuRatio,
+				enforceMemoryLimitsRatio: true,
+				memRatioStr:              memRatio,
 			}
 			err := mutator.handleVirtLauncherCreation(context.Background(), launcherPod, creationConfig)
 			Expect(err).ToNot(HaveOccurred())
@@ -143,9 +143,9 @@ var _ = Describe("virt-launcher webhook mutator", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				if resourceName == k8sv1.ResourceCPU {
-					Expect(creationConfig.enforceCpuLimits).To(Equal(shouldEnforce))
+					Expect(creationConfig.enforceCpuLimitsRatio).To(Equal(shouldEnforce))
 				} else {
-					Expect(creationConfig.enforceMemoryLimits).To(Equal(shouldEnforce))
+					Expect(creationConfig.enforceMemoryLimitsRatio).To(Equal(shouldEnforce))
 				}
 			},
 				Entry("memory: setRatio, setLimit - shouldEnforce", k8sv1.ResourceMemory, setRatio, setLimit, shouldEnforce),

--- a/tests/func-tests/utils.go
+++ b/tests/func-tests/utils.go
@@ -3,12 +3,10 @@ package tests
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"sync"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -48,7 +46,7 @@ func SkipIfNotOpenShift(cli kubecli.KubevirtClient, testName string) {
 	kvtutil.PanicOnError(err)
 
 	if !isOpenShift {
-		ginkgo.Skip(fmt.Sprintf("Skipping %s tests when the cluster is not OpenShift", testName))
+		//ginkgo.Skip(fmt.Sprintf("Skipping %s tests when the cluster is not OpenShift", testName))
 	}
 }
 

--- a/tests/func-tests/virt-launcher-mutating-webhook.go
+++ b/tests/func-tests/virt-launcher-mutating-webhook.go
@@ -1,0 +1,163 @@
+package tests
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	kubevirtcorev1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	kvtests "kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/flags"
+	kvtutil "kubevirt.io/kubevirt/tests/util"
+
+	g "github.com/onsi/ginkgo/v2"
+)
+
+var _ = g.Describe("virt-launcher mutating webhook", func() {
+	flag.Parse()
+
+	var hcoOriginalAnnotations map[string]string
+
+	g.BeforeEach(func() {
+		BeforeEach()
+
+		hco := getHco()
+		hcoOriginalAnnotations = hco.Annotations
+	})
+
+	g.AfterEach(func() {
+		hco := getHco()
+		hco.Annotations = hcoOriginalAnnotations
+		hcoOriginalAnnotations = map[string]string{}
+
+		setHco(hco)
+	})
+
+	g.Context("guest-to-request memory headroom", func() {
+
+		enableWebhook := func(customHeadroom *string) {
+			hco := getHco()
+			if hco.Annotations == nil {
+				hco.Annotations = map[string]string{}
+			}
+
+			hco.Annotations["kubevirt.io/enable-guest-to-request-memory-headroom"] = "true"
+			if customHeadroom != nil {
+				hco.Annotations["kubevirt.io/custom-guest-to-request-memory-headroom"] = *customHeadroom
+			}
+
+			setHco(hco)
+		}
+
+		g.It("with default headroom", func() {
+			enableWebhook(nil)
+
+			vmi := kvtests.NewRandomVMI()
+			vmi = kvtests.RunVMIAndExpectLaunch(vmi, 60)
+			launcherPod := kvtests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+
+			vmiMemRequest := vmi.Spec.Domain.Resources.Requests[v1.ResourceMemory]
+
+			expectedPodRequest := vmiMemRequest.DeepCopy()
+			expectedPodRequest.Add(resource.MustParse("2G"))
+
+			actualPodRequest := getComputeContainer(launcherPod).Resources.Requests[v1.ResourceMemory]
+
+			Expect(actualPodRequest.Cmp(expectedPodRequest)).To(BeTrue(), fmt.Sprintf("expecting pod requests (%v) to equal %v", actualPodRequest, expectedPodRequest))
+		})
+
+	})
+
+})
+
+func getHco() *hcov1beta1.HyperConverged {
+	virtCli, err := kubecli.GetKubevirtClient()
+	Expect(err).ToNot(HaveOccurred())
+
+	SkipIfNotOpenShift(virtCli, "DataImportCronTemplate")
+
+	cli, err := kubecli.GetKubevirtClientFromRESTConfig(virtCli.Config())
+	Expect(err).ToNot(HaveOccurred())
+
+	hc := &hcov1beta1.HyperConverged{}
+	Expect(cli.RestClient().
+		Get().
+		Resource("hyperconvergeds").
+		Name("kubevirt-hyperconverged").
+		Namespace(flags.KubeVirtInstallNamespace).
+		AbsPath("/apis", hcov1beta1.SchemeGroupVersion.Group, hcov1beta1.SchemeGroupVersion.Version).
+		Timeout(10 * time.Second).
+		Do(context.TODO()).
+		Into(hc),
+	).To(Succeed())
+
+	return hc
+}
+
+func setHco(hc *hcov1beta1.HyperConverged) *hcov1beta1.HyperConverged {
+	virtCli, err := kubecli.GetKubevirtClient()
+	Expect(err).ToNot(HaveOccurred())
+
+	SkipIfNotOpenShift(virtCli, "DataImportCronTemplate")
+
+	cli, err := kubecli.GetKubevirtClientFromRESTConfig(virtCli.Config())
+	Expect(err).ToNot(HaveOccurred())
+
+	res := cli.RestClient().Put().
+		Resource("hyperconvergeds").
+		Name(hcov1beta1.HyperConvergedName).
+		Namespace(flags.KubeVirtInstallNamespace).
+		AbsPath("/apis", hcov1beta1.SchemeGroupVersion.Group, hcov1beta1.SchemeGroupVersion.Version).
+		Timeout(10 * time.Second).
+		Body(hc).Do(context.TODO())
+
+	Expect(res.Error()).ToNot(HaveOccurred())
+	newHC := &hcov1beta1.HyperConverged{}
+	err = res.Into(newHC)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return newHC
+}
+
+func createAndRunVmi() *kubevirtcorev1.VirtualMachineInstance {
+	virtCli, err := kubecli.GetKubevirtClient()
+	Expect(err).ToNot(HaveOccurred())
+
+	vmi := kvtests.NewRandomVMI()
+	g.By(fmt.Sprintf("Creating VMI %s", vmi.Name))
+	EventuallyWithOffset(1, func() error {
+		var err error
+		vmi, err = virtCli.VirtualMachineInstance(kvtutil.NamespaceTestDefault).Create(context.Background(), vmi)
+		return err
+	}, 60*time.Second, 2*time.Second).Should(Succeed(), "failed to create a vmi")
+
+	g.By("Verifying VMI is running")
+	EventuallyWithOffset(1, func(g Gomega) kubevirtcorev1.VirtualMachineInstancePhase {
+		var err error
+		vmi, err = virtCli.VirtualMachineInstance(kvtutil.NamespaceTestDefault).Get(context.Background(), vmi.Name, &k8smetav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		return vmi.Status.Phase
+	}, 60*time.Second, 2*time.Second).Should(Equal(kubevirtcorev1.Running), "failed to get the vmi Running")
+
+	return vmi
+}
+
+func getComputeContainer(launcherPod *v1.Pod) v1.Container {
+	for _, container := range launcherPod.Spec.Containers {
+		if container.Name == "compute" {
+			return container
+		}
+	}
+
+	Expect(true).To(BeFalse(), "could not find compute container")
+	return v1.Container{}
+}


### PR DESCRIPTION
**Overview**
This PR introduces a mechanism to add guest-to-request memory headroom (a.k.a. "wiggle-room") to virt-launcher pods.

Please note that the additional memory is being added solely to the virt-launcher pod while the the VMI object remains untouched. This means that the guest memory will remain the same as defined at the VMI level (either explicitly through `vmi.spec.domain.memory.guest` or implicitly by `vmi.spec.domain.resources.requests[memory]`). If the VMI sets limits, the mechanism would skip adding memory headroom.

**Motivation**
Currently, Kubevirt's [overhead calculation](https://github.com/kubevirt/kubevirt/blob/v0.59.0-rc.1/pkg/virt-controller/services/renderresources.go#L272) [1] is not accurate. Therefore, during memory bursts that cause a high memory pressure, VMIs are being OOM killed.

This mechanism ensures that less VMIs are being scheduled to a node, therefore would have a lot of free space on the node that could be used by VMIs during bursts. We know from empiric testings that this dramatically reduces the probability of workloads being killed.

In the future, we plan to improve the memory overhead calculation in Kubevirt. Once the memory overhead calculation is accurate enough and we'd get to a more stable situation, this mechanism will be deleted.

[1] https://github.com/kubevirt/kubevirt/blob/v0.59.0-rc.1/pkg/virt-controller/services/renderresources.go#L272

**How to use this mechanism**
The following two HCO annotations would control the mechanism:
* `kubevirt.io/enable-guest-to-request-memory-headroom: "true"` needs to be used in order to enable this mechanism.
* `kubevirt.io/custom-guest-to-request-memory-headroom: <quantity>` overrides the default memory headroom amount, which is `2GB`.

As an example, let's add the enablement annotation to the HCO object:
```yaml
apiVersion: hco.kubevirt.io/v1beta1
kind: HyperConverged
metadata:
  annotations:
    kubevirt.io/enable-guest-to-request-memory-headroom: "true"
```

Then, we can create vmi-fedora (this is not the full manifest):
```yaml
apiVersion: kubevirt.io/v1
kind: VirtualMachineInstance
metadata:
  name: vmi-fedora
spec:
  domain:
    resources:
      requests:
        memory: 1024M
```

The virt-launcher pod then will be created as the following (this is, again, not the full manifest):
```yaml
apiVersion: v1
kind: Pod
spec:
  containers:
-   name: compute
    resources:
      limits:
        devices.kubevirt.io/kvm: "1"
        devices.kubevirt.io/tun: "1"
        devices.kubevirt.io/vhost-net: "1"
      requests:
        cpu: 100m
        devices.kubevirt.io/kvm: "1"
        devices.kubevirt.io/tun: "1"
        devices.kubevirt.io/vhost-net: "1"
        ephemeral-storage: 50M
        memory: "3279755392"  # <-- 1024M + 2GB
```

Then, if we check how the memory size from the guest's perspective:
```bash
$> virtctl console vmi-fedora
[fedora@vmi-fedora ~]$ free -h

               total        used        free      shared  buff/cache   available
Mem:           912Mi       154Mi       601Mi       0.0Ki       156Mi       622Mi
Swap:          911Mi          0B       911Mi
```

**Enforce limits & requests by delta**
As a follow-up to this PR: https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2206, I add two more knobs to allow configuring a memory/cpu delta, not only ratios. The tests and documentation is also updated.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [X] PR Message
- [X] Commit Messages
- [X] How to test
- [X] Unit Tests
- [ ] Functional Tests
- [X] User Documentation
- [X] Developer Documentation
- [X] Upgrade Scenario
- [X] Uninstallation Scenario
- [X] Backward Compatibility
- [X] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kubevirt: Add guest-to-request memory headroom to virt-launchers
```