### PR TITLE
Fix upgrade bug related to the console plugin rename

### DIFF
--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -111,6 +111,30 @@
         "name": "nodemaintenances.nodemaintenance.kubevirt.io",
         "namespace": ""
       }
+    },
+    {
+      "semverRange": "<1.9.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "apps/v1",
+        "kind": "Deployment"
+      },
+      "objectKey": {
+        "name": "kubevirt-plugin",
+        "namespace": "kubevirt-hyperconverged"
+      }
+    },
+    {
+      "semverRange": "<1.9.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "v1",
+        "kind": "Service"
+      },
+      "objectKey": {
+        "name": "kubevirt-plugin-service",
+        "namespace": "kubevirt-hyperconverged"
+      }
     }
   ]
 }

--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -26,11 +26,12 @@ import (
 )
 
 const (
-	kvUIPluginName     = "kubevirt-console-plugin"
-	kvUIPluginSvcName  = kvUIPluginName + "-service"
-	kvUIPluginNameEnv  = "UI_PLUGIN_NAME"
-	kvServingCertName  = "plugin-serving-cert"
-	nginxConfigMapName = "nginx-conf"
+	kvUIPluginName           = "kubevirt-plugin"
+	kvUIPluginDeploymentName = "kubevirt-console-plugin"
+	kvUIPluginSvcName        = kvUIPluginDeploymentName + "-service"
+	kvUIPluginNameEnv        = "UI_PLUGIN_NAME"
+	kvServingCertName        = "plugin-serving-cert"
+	nginxConfigMapName       = "nginx-conf"
 )
 
 // **** Kubevirt UI Plugin Deployment Handler ****
@@ -62,7 +63,7 @@ func NewKvUiPluginDeplymnt(hc *hcov1beta1.HyperConverged) (*appsv1.Deployment, e
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kvUIPluginName,
+			Name:      kvUIPluginDeploymentName,
 			Labels:    getLabels(hc, hcoutil.AppComponentDeployment),
 			Namespace: hc.Namespace,
 		},
@@ -70,7 +71,7 @@ func NewKvUiPluginDeplymnt(hc *hcov1beta1.HyperConverged) (*appsv1.Deployment, e
 			Replicas: pointer.Int32(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": kvUIPluginName,
+					"app": kvUIPluginDeploymentName,
 				},
 			},
 			Strategy: appsv1.DeploymentStrategy{
@@ -79,7 +80,7 @@ func NewKvUiPluginDeplymnt(hc *hcov1beta1.HyperConverged) (*appsv1.Deployment, e
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": kvUIPluginName,
+						"app": kvUIPluginDeploymentName,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -87,7 +88,7 @@ func NewKvUiPluginDeplymnt(hc *hcov1beta1.HyperConverged) (*appsv1.Deployment, e
 					SecurityContext:    components.GetStdPodSecurityContext(),
 					Containers: []corev1.Container{
 						{
-							Name:            kvUIPluginName,
+							Name:            kvUIPluginDeploymentName,
 							Image:           kvUiPluginImage,
 							ImagePullPolicy: corev1.PullAlways,
 							Resources: corev1.ResourceRequirements{
@@ -148,9 +149,9 @@ func NewKvUiPluginDeplymnt(hc *hcov1beta1.HyperConverged) (*appsv1.Deployment, e
 
 func NewKvUiPluginSvc(hc *hcov1beta1.HyperConverged) *corev1.Service {
 	servicePorts := []corev1.ServicePort{
-		{Port: hcoutil.UiPluginServerPort, Name: kvUIPluginName + "-port", Protocol: corev1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: hcoutil.UiPluginServerPort}},
+		{Port: hcoutil.UiPluginServerPort, Name: kvUIPluginDeploymentName + "-port", Protocol: corev1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: hcoutil.UiPluginServerPort}},
 	}
-	pluginName := kvUIPluginName
+	pluginName := kvUIPluginDeploymentName
 	val, ok := os.LookupEnv(kvUIPluginNameEnv)
 	if ok && val != "" {
 		pluginName = val

--- a/hack/check_upgrade_console_plugin.sh
+++ b/hack/check_upgrade_console_plugin.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+
+set -ex
+
+# Check the deployment name has been updated after upgrade
+NEW_DEPLOYMENT_NAME="kubevirt-console-plugin"
+OLD_DEPLOYMENT_NAME="kubevirt-plugin"
+[[ $(${KUBECTL_BINARY} get deployment ${NEW_DEPLOYMENT_NAME} -n ${INSTALLED_NAMESPACE}) ]]
+[[ ! $(${KUBECTL_BINARY} get deployment ${OLD_DEPLOYMENT_NAME} -n ${INSTALLED_NAMESPACE}) ]]
+
+# Check the service name has been updated after upgrade
+NEW_SERVICE_NAME="${NEW_DEPLOYMENT_NAME}-service"
+OLD_SERVICE_NAME="${OLD_DEPLOYMENT_NAME}-service"
+[[ $(${KUBECTL_BINARY} get svc ${NEW_SERVICE_NAME} -n ${INSTALLED_NAMESPACE}) ]]
+[[ ! $(${KUBECTL_BINARY} get svc ${OLD_SERVICE_NAME} -n ${INSTALLED_NAMESPACE}) ]]
+
+# Check the ConsolePlugin points to the new service name
+[[ $(${KUBECTL_BINARY} get consoleplugin ${OLD_DEPLOYMENT_NAME} -o jsonpath='{.spec.backend.service.name}') == "${NEW_SERVICE_NAME}" ]]
+

--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -293,6 +293,9 @@ Msg "Check that OVS is deployed or not deployed according to deployOVS annotatio
 ./hack/retry.sh 40 15 "CMD=${CMD} PREVIOUS_OVS_ANNOTATION=${PREVIOUS_OVS_ANNOTATION}\
  PREVIOUS_OVS_STATE=${PREVIOUS_OVS_STATE} ./hack/check_upgrade_ovs.sh"
 
+Msg "Ensure that console plugin deployment and service has been renamed successfully"
+KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} ./hack/check_upgrade_console_plugin.sh
+
 Msg "Check that managed objects has correct labels"
 ./hack/retry.sh 10 30 "KUBECTL_BINARY=${CMD} ./hack/check_labels.sh"
 

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -301,6 +301,9 @@ Msg "Check that OVS is deployed or not deployed according to deployOVS annotatio
 ./hack/retry.sh 40 15 "CMD=${CMD} PREVIOUS_OVS_ANNOTATION=${PREVIOUS_OVS_ANNOTATION}\
  PREVIOUS_OVS_STATE=${PREVIOUS_OVS_STATE} ./hack/check_upgrade_ovs.sh"
 
+Msg "Ensure that console plugin deployment and service has been renamed successfully"
+KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} ./hack/check_upgrade_console_plugin.sh
+
 Msg "Check that managed objects has correct labels"
 ./hack/retry.sh 10 30 "KUBECTL_BINARY=${CMD} ./hack/check_labels.sh"
 


### PR DESCRIPTION
in PR #2232, the ui plugin's deployment, service and consoleplugin have been renamed from `kubevirt-plugin` to `kubevirt-console-plugin`. However, on upgrade, the old resources are not removed, and instead new resources with the new name are getting created, resulting in old+new plugins running simultaneously. This PR only updates the deployment and the service, and removing the old ones after upgrade, using `upgradePatches.json`. The ConsolePlugin CR name remains `kubevirt-plugin` to avoid patching and deleting the `console.operator.openshift.io` singleton CR.

Signed-off-by: Oren Cohen <ocohen@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix console plugin rename bug on upgrade
```

