### PR TITLE
Replace `HaveLen(0)` with `BeEmpty()`

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1119,8 +1119,7 @@ var _ = Describe("HyperconvergedController", func() {
 				cl := commonTestUtils.InitClient(resources)
 
 				logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("hyperconverged_controller_test")
-				err := hcoutil.GetClusterInfo().Init(context.TODO(), cl, logger)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(hcoutil.GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
 
 				Expect(initialTLSSecurityProfile).ToNot(Equal(customTLSSecurityProfile), "customTLSSecurityProfile should be a different value")
 
@@ -1193,8 +1192,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 				// Update ApiServer CR
 				apiServer.Spec.TLSSecurityProfile = customTLSSecurityProfile
-				err = cl.Update(context.TODO(), apiServer)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cl.Update(context.TODO(), apiServer)).To(Succeed())
 				Expect(hcoutil.GetClusterInfo().GetTLSSecurityProfile(expected.hco.Spec.TLSSecurityProfile)).To(Equal(initialTLSSecurityProfile), "should still return the cached value (initial value)")
 
 				// mock a reconciliation triggered by a change in the APIServer CR
@@ -2394,11 +2392,8 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved1), foundCM)
-					Expect(err).ToNot(HaveOccurred())
-
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved2), foundCM)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved1), foundCM)).To(Succeed())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved2), foundCM)).To(Succeed())
 
 					for _, objRef := range toBeRemovedRelatedObjects {
 						Expect(foundResource.Status.RelatedObjects).ToNot(ContainElement(objRef))
@@ -2459,18 +2454,10 @@ var _ = Describe("HyperconvergedController", func() {
 					checkAvailability(foundResource, metav1.ConditionTrue)
 
 					foundCM := &corev1.ConfigMap{}
-					err := cl.Get(context.TODO(), client.ObjectKeyFromObject(cmToBeRemoved1), foundCM)
-					Expect(err).ToNot(HaveOccurred())
-
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(cmToBeRemoved2), foundCM)
-					Expect(err).ToNot(HaveOccurred())
-
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved1), foundCM)
-					Expect(err).ToNot(HaveOccurred())
-
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved2), foundCM)
-					Expect(err).ToNot(HaveOccurred())
-
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmToBeRemoved1), foundCM)).To(Succeed())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmToBeRemoved2), foundCM)).To(Succeed())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved1), foundCM)).To(Succeed())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved2), foundCM)).To(Succeed())
 				})
 
 				It("should remove ConfigMap kubevirt-storage-class-defaults upgrading from < 1.7.0", func() {
@@ -2598,11 +2585,8 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved1), foundCM)
-					Expect(err).ToNot(HaveOccurred())
-
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved2), foundCM)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved1), foundCM)).To(Succeed())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved2), foundCM)).To(Succeed())
 
 					for _, objRef := range toBeRemovedRelatedObjects {
 						Expect(foundResource.Status.RelatedObjects).ToNot(ContainElement(objRef))
@@ -2677,20 +2661,12 @@ var _ = Describe("HyperconvergedController", func() {
 					foundCM := &corev1.ConfigMap{}
 					foundRole := &rbacv1.Role{}
 					foundRoleBinding := &rbacv1.RoleBinding{}
-					err := cl.Get(context.TODO(), client.ObjectKeyFromObject(cmToBeRemoved1), foundCM)
-					Expect(err).ToNot(HaveOccurred())
 
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(roleToBeRemoved), foundRole)
-					Expect(err).ToNot(HaveOccurred())
-
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(roleBindingToBeRemoved), foundRoleBinding)
-					Expect(err).ToNot(HaveOccurred())
-
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved1), foundCM)
-					Expect(err).ToNot(HaveOccurred())
-
-					err = cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved2), foundCM)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmToBeRemoved1), foundCM)).To(Succeed())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(roleToBeRemoved), foundRole)).To(Succeed())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(roleBindingToBeRemoved), foundRoleBinding)).To(Succeed())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved1), foundCM)).To(Succeed())
+					Expect(cl.Get(context.TODO(), client.ObjectKeyFromObject(cmNotToBeRemoved2), foundCM)).To(Succeed())
 				})
 
 			})
@@ -3221,8 +3197,7 @@ var _ = Describe("HyperconvergedController", func() {
 							}
 						]`,
 					}
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchKVAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchKVAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)
@@ -3275,8 +3250,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Message: taintedConfigurationMessage,
 					})
 
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchKVAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchKVAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)
@@ -3297,7 +3271,6 @@ var _ = Describe("HyperconvergedController", func() {
 					).To(Succeed())
 
 					// Check conditions
-					// Check conditions
 					Expect(foundResource.Status.Conditions).To(Not(ContainElement(commonTestUtils.RepresentCondition(metav1.Condition{
 						Type:    hcov1beta1.ConditionTaintedConfiguration,
 						Status:  metav1.ConditionTrue,
@@ -3317,8 +3290,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Message: taintedConfigurationMessage,
 					})
 
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchKVAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchKVAnnotationName)).To(Succeed())
 
 					hco.ObjectMeta.Annotations = map[string]string{
 						// Set bad json format (missing comma)
@@ -3348,7 +3320,6 @@ var _ = Describe("HyperconvergedController", func() {
 							foundResource),
 					).To(Succeed())
 
-					// Check conditions
 					// Check conditions
 					Expect(foundResource.Status.Conditions).To(Not(ContainElement(commonTestUtils.RepresentCondition(metav1.Condition{
 						Type:    hcov1beta1.ConditionTaintedConfiguration,
@@ -3381,8 +3352,7 @@ var _ = Describe("HyperconvergedController", func() {
 				]`,
 					}
 
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchCDIAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchCDIAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)
@@ -3439,8 +3409,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Message: taintedConfigurationMessage,
 					})
 
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchCDIAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchCDIAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)
@@ -3461,7 +3430,6 @@ var _ = Describe("HyperconvergedController", func() {
 					).To(Succeed())
 
 					// Check conditions
-					// Check conditions
 					Expect(foundResource.Status.Conditions).To(Not(ContainElement(commonTestUtils.RepresentCondition(metav1.Condition{
 						Type:    hcov1beta1.ConditionTaintedConfiguration,
 						Status:  metav1.ConditionTrue,
@@ -3481,8 +3449,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Message: taintedConfigurationMessage,
 					})
 
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchCDIAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchCDIAnnotationName)).To(Succeed())
 
 					hco.ObjectMeta.Annotations = map[string]string{
 						// Set bad json format (missing comma)
@@ -3505,7 +3472,6 @@ var _ = Describe("HyperconvergedController", func() {
 							foundResource),
 					).To(Succeed())
 
-					// Check conditions
 					// Check conditions
 					Expect(foundResource.Status.Conditions).To(Not(ContainElement(commonTestUtils.RepresentCondition(metav1.Condition{
 						Type:    hcov1beta1.ConditionTaintedConfiguration,
@@ -3537,8 +3503,7 @@ var _ = Describe("HyperconvergedController", func() {
 						]`,
 					}
 
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchCNAOAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchCNAOAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)
@@ -3591,8 +3556,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Reason:  taintedConfigurationReason,
 						Message: taintedConfigurationMessage,
 					})
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchCNAOAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchCNAOAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)
@@ -3613,7 +3577,6 @@ var _ = Describe("HyperconvergedController", func() {
 					).To(Succeed())
 
 					// Check conditions
-					// Check conditions
 					Expect(foundResource.Status.Conditions).To(Not(ContainElement(commonTestUtils.RepresentCondition(metav1.Condition{
 						Type:    hcov1beta1.ConditionTaintedConfiguration,
 						Status:  metav1.ConditionTrue,
@@ -3630,8 +3593,7 @@ var _ = Describe("HyperconvergedController", func() {
 						// Set bad json
 						common.JSONPatchKVAnnotationName: `[{`,
 					}
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchCNAOAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchCNAOAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)
@@ -3649,7 +3611,6 @@ var _ = Describe("HyperconvergedController", func() {
 							foundResource),
 					).To(Succeed())
 
-					// Check conditions
 					// Check conditions
 					Expect(foundResource.Status.Conditions).To(Not(ContainElement(commonTestUtils.RepresentCondition(metav1.Condition{
 						Type:    hcov1beta1.ConditionTaintedConfiguration,
@@ -3676,8 +3637,7 @@ var _ = Describe("HyperconvergedController", func() {
 						]`,
 					}
 
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchSSPAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchSSPAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)
@@ -3728,8 +3688,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Reason:  taintedConfigurationReason,
 						Message: taintedConfigurationMessage,
 					})
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchSSPAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchSSPAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)
@@ -3766,8 +3725,7 @@ var _ = Describe("HyperconvergedController", func() {
 						// Set bad json
 						common.JSONPatchSSPAnnotationName: `[{`,
 					}
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchSSPAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(5, common.JSONPatchSSPAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)
@@ -3841,14 +3799,10 @@ var _ = Describe("HyperconvergedController", func() {
 							}
 						]`,
 					}
-					err := metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchKVAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
-					err = metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchCDIAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
-					err = metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchCNAOAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
-					err = metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchSSPAnnotationName)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchKVAnnotationName)).To(Succeed())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchCDIAnnotationName)).To(Succeed())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchCNAOAnnotationName)).To(Succeed())
+					Expect(metrics.HcoMetrics.SetUnsafeModificationCount(0, common.JSONPatchSSPAnnotationName)).To(Succeed())
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hcoNamespace, hco})
 					r := initReconciler(cl, nil)

--- a/controllers/hyperconverged/hyperconverged_suite_test.go
+++ b/controllers/hyperconverged/hyperconverged_suite_test.go
@@ -35,15 +35,12 @@ func TestHyperconverged(t *testing.T) {
 
 		wd, _ := os.Getwd()
 		destFile = path.Join(wd, "upgradePatches.json")
-		err := commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "upgradePatches.json"))
-		Expect(err).ToNot(HaveOccurred())
-
+		Expect(commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "upgradePatches.json"))).To(Succeed())
 	})
 
 	AfterSuite(func() {
 		hcoutil.GetClusterInfo = getClusterInfo
-		err := os.Remove(destFile)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(os.Remove(destFile)).To(Succeed())
 	})
 
 	RunSpecs(t, "Hyperconverged Suite")

--- a/controllers/hyperconverged/upgradePatches_test.go
+++ b/controllers/hyperconverged/upgradePatches_test.go
@@ -19,14 +19,12 @@ var _ = Describe("upgradePatches", func() {
 	BeforeEach(func() {
 		wd, _ := os.Getwd()
 		origFile = path.Join(wd, "upgradePatches.json")
-		err := commonTestUtils.CopyFile(origFile+".orig", origFile)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(commonTestUtils.CopyFile(origFile+".orig", origFile)).To(Succeed())
 		hcoUpgradeChangesRead = false
 	})
 
 	AfterEach(func() {
-		err := os.Remove(origFile + ".orig")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(os.Remove(origFile + ".orig")).To(Succeed())
 		hcoUpgradeChangesRead = false
 	})
 
@@ -41,28 +39,22 @@ var _ = Describe("upgradePatches", func() {
 		})
 
 		AfterEach(func() {
-			err := commonTestUtils.CopyFile(origFile, origFile+".orig")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(commonTestUtils.CopyFile(origFile, origFile+".orig")).To(Succeed())
 		})
 
 		It("should correctly parse and validate actual upgradePatches.json", func() {
-			err := validateUpgradePatches(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(validateUpgradePatches(req)).To(Succeed())
 		})
 
 		It("should correctly parse and validate empty upgradePatches", func() {
-			err := copyTestFile("empty.json")
-			Expect(err).ToNot(HaveOccurred())
-
-			err = validateUpgradePatches(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(copyTestFile("empty.json")).To(Succeed())
+			Expect(validateUpgradePatches(req)).To(Succeed())
 		})
 
 		It("should fail parsing upgradePatches with bad json", func() {
-			err := copyTestFile("badJson.json")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(copyTestFile("badJson.json")).To(Succeed())
 
-			err = validateUpgradePatches(req)
+			err := validateUpgradePatches(req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(HavePrefix("invalid character"))
 		})
@@ -70,10 +62,9 @@ var _ = Describe("upgradePatches", func() {
 		Context("hcoCRPatchList", func() {
 
 			It("should fail validating upgradePatches with bad semver ranges", func() {
-				err := copyTestFile("badSemverRange.json")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(copyTestFile("badSemverRange.json")).To(Succeed())
 
-				err = validateUpgradePatches(req)
+				err := validateUpgradePatches(req)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(HavePrefix("Could not get version from string:"))
 			})
@@ -81,10 +72,9 @@ var _ = Describe("upgradePatches", func() {
 			DescribeTable(
 				"should fail validating upgradePatches with bad patches",
 				func(filename, message string) {
-					err := copyTestFile(filename)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(copyTestFile(filename)).To(Succeed())
 
-					err = validateUpgradePatches(req)
+					err := validateUpgradePatches(req)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).Should(HavePrefix(message))
 				},
@@ -110,10 +100,9 @@ var _ = Describe("upgradePatches", func() {
 		Context("objectsToBeRemoved", func() {
 
 			It("should fail validating upgradePatches with bad semver ranges", func() {
-				err := copyTestFile("badSemverRangeOR.json")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(copyTestFile("badSemverRangeOR.json")).To(Succeed())
 
-				err = validateUpgradePatches(req)
+				err := validateUpgradePatches(req)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(HavePrefix("Could not get version from string:"))
 			})
@@ -121,10 +110,9 @@ var _ = Describe("upgradePatches", func() {
 			DescribeTable(
 				"should fail validating upgradePatches with bad patches",
 				func(filename, message string) {
-					err := copyTestFile(filename)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(copyTestFile(filename)).To(Succeed())
 
-					err = validateUpgradePatches(req)
+					err := validateUpgradePatches(req)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).Should(HavePrefix(message))
 				},
@@ -168,6 +156,5 @@ var _ = Describe("upgradePatches", func() {
 
 func copyTestFile(filename string) error {
 	testFilesLocation := getTestFilesLocation() + "/upgradePatches"
-	err := commonTestUtils.CopyFile(origFile, path.Join(testFilesLocation, filename))
-	return err
+	return commonTestUtils.CopyFile(origFile, path.Join(testFilesLocation, filename))
 }

--- a/controllers/operands/dashboard_test.go
+++ b/controllers/operands/dashboard_test.go
@@ -130,8 +130,7 @@ var _ = Describe("Dashboard tests", func() {
 				Expect(res.Created).To(BeTrue())
 
 				cms := &corev1.ConfigMapList{}
-				err := cli.List(context.TODO(), cms)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), cms)).To(Succeed())
 				Expect(cms.Items).To(HaveLen(1))
 				Expect(cms.Items[0].Name).Should(Equal("grafana-dashboard-kubevirt-top-consumers"))
 			})

--- a/controllers/operands/imageStream_test.go
+++ b/controllers/operands/imageStream_test.go
@@ -65,8 +65,7 @@ var _ = Describe("imageStream tests", func() {
 			Expect(res.Created).To(BeFalse())
 
 			imageStreamObjects := &imagev1.ImageStreamList{}
-			err = cli.List(context.TODO(), imageStreamObjects)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(cli.List(context.TODO(), imageStreamObjects)).To(Succeed())
 			Expect(imageStreamObjects.Items).To(BeEmpty())
 		})
 
@@ -115,8 +114,7 @@ var _ = Describe("imageStream tests", func() {
 			Expect(res.Created).To(BeFalse())
 
 			imageStreamObjects := &imagev1.ImageStreamList{}
-			err = cli.List(context.TODO(), imageStreamObjects)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(cli.List(context.TODO(), imageStreamObjects)).To(Succeed())
 			Expect(imageStreamObjects.Items).To(BeEmpty())
 		})
 
@@ -139,12 +137,10 @@ var _ = Describe("imageStream tests", func() {
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), ci, hco)
 
 			req := commonTestUtils.NewReq(hco)
-			err := handler.Ensure(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.Ensure(req)).To(Succeed())
 
 			ImageStreamObjects := &imagev1.ImageStreamList{}
-			err = cli.List(context.TODO(), ImageStreamObjects)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 			Expect(ImageStreamObjects.Items).To(HaveLen(1))
 			Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
 
@@ -161,13 +157,11 @@ var _ = Describe("imageStream tests", func() {
 			eventEmitter.Reset()
 			hco.Spec.FeatureGates.EnableCommonBootImageImport = pointer.Bool(false)
 			req = commonTestUtils.NewReq(hco)
-			err = handler.Ensure(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.Ensure(req)).To(Succeed())
 
 			By("check that the image stream was removed")
 			ImageStreamObjects = &imagev1.ImageStreamList{}
-			err = cli.List(context.TODO(), ImageStreamObjects)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 			Expect(ImageStreamObjects.Items).To(BeEmpty())
 
 			By("check that the delete event was emitted")
@@ -205,8 +199,7 @@ var _ = Describe("imageStream tests", func() {
 			handler.FirstUseInitiation(commonTestUtils.GetScheme(), ci, hco)
 
 			req := commonTestUtils.NewReq(hco)
-			err := handler.Ensure(req)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.Ensure(req)).To(Succeed())
 
 			expectedEvents := []commonTestUtils.MockEvent{
 				{
@@ -242,8 +235,7 @@ var _ = Describe("imageStream tests", func() {
 			Expect(res.Created).To(BeTrue())
 
 			ImageStreamObjects := &imagev1.ImageStreamList{}
-			err = cli.List(context.TODO(), ImageStreamObjects)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 			Expect(ImageStreamObjects.Items).To(HaveLen(1))
 			Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
 
@@ -291,8 +283,7 @@ var _ = Describe("imageStream tests", func() {
 				Expect(res.Updated).To(BeTrue())
 
 				imageStreamObjects := &imagev1.ImageStreamList{}
-				err := cli.List(context.TODO(), imageStreamObjects)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), imageStreamObjects)).To(Succeed())
 				Expect(imageStreamObjects.Items).To(HaveLen(1))
 
 				is := imageStreamObjects.Items[0]
@@ -357,8 +348,7 @@ var _ = Describe("imageStream tests", func() {
 				Expect(res.Updated).To(BeTrue())
 
 				imageStreamObjects := &imagev1.ImageStreamList{}
-				err := cli.List(context.TODO(), imageStreamObjects)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), imageStreamObjects)).To(Succeed())
 				Expect(imageStreamObjects.Items).To(HaveLen(1))
 
 				is := imageStreamObjects.Items[0]
@@ -431,8 +421,7 @@ var _ = Describe("imageStream tests", func() {
 				Expect(res.Updated).To(BeTrue())
 
 				imageStreamObjects := &imagev1.ImageStreamList{}
-				err := cli.List(context.TODO(), imageStreamObjects)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), imageStreamObjects)).To(Succeed())
 				Expect(imageStreamObjects.Items).To(HaveLen(1))
 
 				is := imageStreamObjects.Items[0]
@@ -501,8 +490,7 @@ var _ = Describe("imageStream tests", func() {
 				Expect(res.Updated).To(BeFalse()) // <=== should not update the imageStream
 
 				imageStreamObjects := &imagev1.ImageStreamList{}
-				err := cli.List(context.TODO(), imageStreamObjects)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), imageStreamObjects)).To(Succeed())
 				Expect(imageStreamObjects.Items).To(HaveLen(1))
 
 				is := imageStreamObjects.Items[0]
@@ -571,8 +559,7 @@ var _ = Describe("imageStream tests", func() {
 				Expect(res.Updated).To(BeFalse()) // <=== should not update the imageStream
 
 				imageStreamObjects := &imagev1.ImageStreamList{}
-				err := cli.List(context.TODO(), imageStreamObjects)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), imageStreamObjects)).To(Succeed())
 				Expect(imageStreamObjects.Items).To(HaveLen(1))
 
 				is := imageStreamObjects.Items[0]
@@ -642,8 +629,7 @@ var _ = Describe("imageStream tests", func() {
 				Expect(res.Updated).To(BeFalse()) // <=== should not update the imageStream
 
 				imageStreamObjects := &imagev1.ImageStreamList{}
-				err := cli.List(context.TODO(), imageStreamObjects)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), imageStreamObjects)).To(Succeed())
 				Expect(imageStreamObjects.Items).To(HaveLen(1))
 
 				is := imageStreamObjects.Items[0]
@@ -712,8 +698,7 @@ var _ = Describe("imageStream tests", func() {
 				Expect(res.Updated).To(BeTrue())
 
 				imageStreamObjects := &imagev1.ImageStreamList{}
-				err := cli.List(context.TODO(), imageStreamObjects)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), imageStreamObjects)).To(Succeed())
 				Expect(imageStreamObjects.Items).To(HaveLen(1))
 
 				is := imageStreamObjects.Items[0]

--- a/controllers/operands/imageStream_test.go
+++ b/controllers/operands/imageStream_test.go
@@ -168,7 +168,7 @@ var _ = Describe("imageStream tests", func() {
 			ImageStreamObjects = &imagev1.ImageStreamList{}
 			err = cli.List(context.TODO(), ImageStreamObjects)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ImageStreamObjects.Items).To(HaveLen(0))
+			Expect(ImageStreamObjects.Items).To(BeEmpty())
 
 			By("check that the delete event was emitted")
 			expectedEvents := []commonTestUtils.MockEvent{

--- a/controllers/operands/operand_test.go
+++ b/controllers/operands/operand_test.go
@@ -84,8 +84,10 @@ var _ = Describe("Test operator.go", func() {
 				},
 			}
 
-			err := applyAnnotationPatch(obj, `[{"op": "add", "path": "/spec/config/filesystemOverhead/global", "value": "55"}]`)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(
+				applyAnnotationPatch(obj, `[{"op": "add", "path": "/spec/config/filesystemOverhead/global", "value": "55"}]`),
+			).To(Succeed())
+
 			Expect(obj.Spec.Config).NotTo(BeNil())
 			Expect(obj.Spec.Config.FilesystemOverhead).NotTo(BeNil())
 			Expect(obj.Spec.Config.FilesystemOverhead.Global).Should(BeEquivalentTo("55"))
@@ -118,8 +120,7 @@ var _ = Describe("Test operator.go", func() {
 			}
 
 			operand := genericOperand{Scheme: scheme.Scheme}
-			err := operand.addCrToTheRelatedObjectList(req, found)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(operand.addCrToTheRelatedObjectList(req, found)).To(Succeed())
 
 			foundRef, err := reference.GetReference(operand.Scheme, found)
 			Expect(err).ToNot(HaveOccurred())
@@ -143,16 +144,14 @@ var _ = Describe("Test operator.go", func() {
 			}
 
 			operand := genericOperand{Scheme: scheme.Scheme}
-			err := operand.addCrToTheRelatedObjectList(req, found)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(operand.addCrToTheRelatedObjectList(req, found)).To(Succeed())
 
 			oldRef, err := reference.GetReference(operand.Scheme, found)
 			Expect(err).ToNot(HaveOccurred())
 
 			// update resource version
 			found.ResourceVersion = newVersion
-			err = operand.addCrToTheRelatedObjectList(req, found)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(operand.addCrToTheRelatedObjectList(req, found)).To(Succeed())
 
 			newRef, err := reference.GetReference(operand.Scheme, found)
 			Expect(err).ToNot(HaveOccurred())

--- a/controllers/operands/quickStart_test.go
+++ b/controllers/operands/quickStart_test.go
@@ -42,8 +42,7 @@ var _ = Describe("QuickStart tests", func() {
 		It("should return true if CRD exists, with no error", func() {
 			cli := commonTestUtils.InitClient([]runtime.Object{qsCrd})
 
-			err := checkCrdExists(context.TODO(), cli, logger)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(checkCrdExists(context.TODO(), cli, logger)).To(Succeed())
 		})
 	})
 
@@ -68,8 +67,7 @@ var _ = Describe("QuickStart tests", func() {
 				Expect(handlers).To(BeEmpty())
 			})
 
-			err := os.Mkdir(dir, 0744)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(os.Mkdir(dir, 0744)).To(Succeed())
 			defer os.RemoveAll(dir)
 
 			By("folder is empty", func() {
@@ -96,8 +94,7 @@ var _ = Describe("QuickStart tests", func() {
 				Expect(handlers).To(BeEmpty())
 			})
 
-			err = commonTestUtils.CopyFile(path.Join(dir, "quickStart.yaml"), path.Join(testFilesLocation, "quickstart.yaml"))
-			Expect(err).ToNot(HaveOccurred())
+			Expect(commonTestUtils.CopyFile(path.Join(dir, "quickStart.yaml"), path.Join(testFilesLocation, "quickstart.yaml"))).To(Succeed())
 
 			By("yaml file exists", func() {
 				cli := commonTestUtils.InitClient([]runtime.Object{qsCrd})
@@ -159,8 +156,7 @@ var _ = Describe("QuickStart tests", func() {
 				Expect(res.Created).To(BeTrue())
 
 				quickstartObjects := &consolev1.ConsoleQuickStartList{}
-				err := cli.List(context.TODO(), quickstartObjects)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), quickstartObjects)).To(Succeed())
 				Expect(quickstartObjects.Items).To(HaveLen(1))
 				Expect(quickstartObjects.Items[0].Name).Should(Equal("test-quick-start"))
 			})
@@ -187,8 +183,7 @@ var _ = Describe("QuickStart tests", func() {
 				Expect(res.Updated).To(BeTrue())
 
 				quickstartObjects := &consolev1.ConsoleQuickStartList{}
-				err := cli.List(context.TODO(), quickstartObjects)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cli.List(context.TODO(), quickstartObjects)).To(Succeed())
 				Expect(quickstartObjects.Items).To(HaveLen(1))
 				Expect(quickstartObjects.Items[0].Name).Should(Equal("test-quick-start"))
 				// check that the existing object was reconciled

--- a/controllers/operands/ssp_test.go
+++ b/controllers/operands/ssp_test.go
@@ -614,8 +614,7 @@ var _ = Describe("SSP Operands", func() {
 				Expect(dataImportCronTemplateHardCodedMap).To(BeEmpty())
 
 				By("file does not exist - no error")
-				err := os.Mkdir(dir, os.ModePerm)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(os.Mkdir(dir, os.ModePerm)).To(Succeed())
 				defer func() { _ = os.RemoveAll(dir) }()
 
 				Expect(readDataImportCronTemplatesFromFile()).To(Succeed())
@@ -624,15 +623,13 @@ var _ = Describe("SSP Operands", func() {
 				destFile := path.Join(dir, "dataImportCronTemplates.yaml")
 
 				By("valid file exits")
-				err = commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml"))
-				Expect(err).ToNot(HaveOccurred())
+				Expect(commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml"))).To(Succeed())
 				defer os.Remove(destFile)
 				Expect(readDataImportCronTemplatesFromFile()).To(Succeed())
 				Expect(dataImportCronTemplateHardCodedMap).To(HaveLen(2))
 
 				By("the file is wrong")
-				err = commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "wrongDataImportCronTemplates.yaml"))
-				Expect(err).ToNot(HaveOccurred())
+				Expect(commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "wrongDataImportCronTemplates.yaml"))).To(Succeed())
 				defer os.Remove(destFile)
 				Expect(readDataImportCronTemplatesFromFile()).To(HaveOccurred())
 				Expect(dataImportCronTemplateHardCodedMap).To(BeEmpty())
@@ -904,13 +901,11 @@ var _ = Describe("SSP Operands", func() {
 				})
 
 				It("should return an the hard coded list if there is a file, but no list in the HyperConverged CR", func() {
-					err := os.Mkdir(dir, os.ModePerm)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(os.Mkdir(dir, os.ModePerm)).To(Succeed())
 					defer func() { _ = os.RemoveAll(dir) }()
 					destFile := path.Join(dir, "dataImportCronTemplates.yaml")
 
-					err = commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml"))
-					Expect(err).ToNot(HaveOccurred())
+					Expect(commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml"))).To(Succeed())
 					defer os.Remove(destFile)
 					Expect(readDataImportCronTemplatesFromFile()).To(Succeed())
 
@@ -924,13 +919,13 @@ var _ = Describe("SSP Operands", func() {
 				})
 
 				It("should return a combined list if there is a file and a list in the HyperConverged CR", func() {
-					err := os.Mkdir(dir, os.ModePerm)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(os.Mkdir(dir, os.ModePerm)).To(Succeed())
 					defer func() { _ = os.RemoveAll(dir) }()
 					destFile := path.Join(dir, "dataImportCronTemplates.yaml")
 
-					err = commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml"))
-					Expect(err).ToNot(HaveOccurred())
+					Expect(
+						commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml")),
+					).To(Succeed())
 					defer os.Remove(destFile)
 					Expect(readDataImportCronTemplatesFromFile()).To(Succeed())
 
@@ -954,13 +949,13 @@ var _ = Describe("SSP Operands", func() {
 				})
 
 				It("Should not add a common DIC template if it marked as disabled", func() {
-					err := os.Mkdir(dir, os.ModePerm)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(os.Mkdir(dir, os.ModePerm)).To(Succeed())
 					defer func() { _ = os.RemoveAll(dir) }()
 					destFile := path.Join(dir, "dataImportCronTemplates.yaml")
 
-					err = commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml"))
-					Expect(err).ToNot(HaveOccurred())
+					Expect(
+						commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml")),
+					).To(Succeed())
 					defer os.Remove(destFile)
 					Expect(readDataImportCronTemplatesFromFile()).To(Succeed())
 
@@ -984,13 +979,13 @@ var _ = Describe("SSP Operands", func() {
 				})
 
 				It("Should reject if the CR list contain DIC template with the same name, and there are also common DIC templates", func() {
-					err := os.Mkdir(dir, os.ModePerm)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(os.Mkdir(dir, os.ModePerm)).To(Succeed())
 					defer func() { _ = os.RemoveAll(dir) }()
 					destFile := path.Join(dir, "dataImportCronTemplates.yaml")
 
-					err = commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml"))
-					Expect(err).ToNot(HaveOccurred())
+					Expect(
+						commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml")),
+					).To(Succeed())
 					defer os.Remove(destFile)
 					Expect(readDataImportCronTemplatesFromFile()).To(Succeed())
 
@@ -1040,13 +1035,13 @@ var _ = Describe("SSP Operands", func() {
 				})
 
 				It("should not return the common templates, if feature gate is false", func() {
-					err := os.Mkdir(dir, os.ModePerm)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(os.Mkdir(dir, os.ModePerm)).To(Succeed())
 					defer func() { _ = os.RemoveAll(dir) }()
 					destFile := path.Join(dir, "dataImportCronTemplates.yaml")
 
-					err = commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml"))
-					Expect(err).ToNot(HaveOccurred())
+					Expect(
+						commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml")),
+					).To(Succeed())
 					defer os.Remove(destFile)
 					Expect(readDataImportCronTemplatesFromFile()).To(Succeed())
 
@@ -1062,13 +1057,13 @@ var _ = Describe("SSP Operands", func() {
 				})
 
 				It("should modify a common dic if it exist in the HyperConverged CR", func() {
-					err := os.Mkdir(dir, os.ModePerm)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(os.Mkdir(dir, os.ModePerm)).To(Succeed())
 					defer func() { _ = os.RemoveAll(dir) }()
 					destFile := path.Join(dir, "dataImportCronTemplates.yaml")
 
-					err = commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml"))
-					Expect(err).ToNot(HaveOccurred())
+					Expect(
+						commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml")),
+					).To(Succeed())
 					defer os.Remove(destFile)
 					Expect(readDataImportCronTemplatesFromFile()).To(Succeed())
 
@@ -1179,11 +1174,11 @@ var _ = Describe("SSP Operands", func() {
 			Context("test data import cron templates in Status", func() {
 				var destFile string
 				BeforeEach(func() {
-					err := os.Mkdir(dir, os.ModePerm)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(os.Mkdir(dir, os.ModePerm)).To(Succeed())
 					destFile = path.Join(dir, "dataImportCronTemplates.yaml")
-					err = commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml"))
-					Expect(err).ToNot(HaveOccurred())
+					Expect(
+						commonTestUtils.CopyFile(destFile, path.Join(testFilesLocation, "dataImportCronTemplates.yaml")),
+					).To(Succeed())
 					Expect(readDataImportCronTemplatesFromFile()).To(Succeed())
 				})
 

--- a/controllers/webhooks/controller_test.go
+++ b/controllers/webhooks/controller_test.go
@@ -40,7 +40,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(ok).To(BeTrue())
 
 				// we should have no runnable before registering the controller
-				Expect(mockmgr.GetRunnables()).To(HaveLen(0))
+				Expect(mockmgr.GetRunnables()).To(BeEmpty())
 
 				// we should have one runnable after registering it on Openshift
 				err = RegisterReconciler(mgr, ci)
@@ -61,12 +61,12 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(ok).To(BeTrue())
 
 				// we should have no runnable before registering the controller
-				Expect(mockmgr.GetRunnables()).To(HaveLen(0))
+				Expect(mockmgr.GetRunnables()).To(BeEmpty())
 
 				// we should have still no runnable after registering if not on Openshift
 				err = RegisterReconciler(mgr, ci)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(mockmgr.GetRunnables()).To(HaveLen(0))
+				Expect(mockmgr.GetRunnables()).To(BeEmpty())
 			})
 
 		})

--- a/controllers/webhooks/controller_test.go
+++ b/controllers/webhooks/controller_test.go
@@ -43,8 +43,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(mockmgr.GetRunnables()).To(BeEmpty())
 
 				// we should have one runnable after registering it on Openshift
-				err = RegisterReconciler(mgr, ci)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(RegisterReconciler(mgr, ci)).To(Succeed())
 				Expect(mockmgr.GetRunnables()).To(HaveLen(1))
 			})
 
@@ -64,8 +63,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(mockmgr.GetRunnables()).To(BeEmpty())
 
 				// we should have still no runnable after registering if not on Openshift
-				err = RegisterReconciler(mgr, ci)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(RegisterReconciler(mgr, ci)).To(Succeed())
 				Expect(mockmgr.GetRunnables()).To(BeEmpty())
 			})
 
@@ -140,8 +138,7 @@ var _ = Describe("HyperconvergedController", func() {
 				resources := []runtime.Object{clusterVersion, infrastructure, ingress, apiServer, dns}
 				cl := commonTestUtils.InitClient(resources)
 
-				err := hcoutil.GetClusterInfo().Init(context.TODO(), cl, logger)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(hcoutil.GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
 				ci := hcoutil.GetClusterInfo()
 				// We should have corrctly mocked all the Openshift resources needed by clusterInfo
 				Expect(ci.IsOpenshift()).To(BeTrue())
@@ -168,8 +165,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 				// Update ApiServer CR
 				apiServer.Spec.TLSSecurityProfile = customTLSSecurityProfile
-				err = cl.Update(context.TODO(), apiServer)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cl.Update(context.TODO(), apiServer)).To(Succeed())
 				Expect(hcoutil.GetClusterInfo().GetTLSSecurityProfile(nil)).To(Equal(initialTLSSecurityProfile), "should still return the cached value (initial value)")
 
 				// Reconcile again to refresh ApiServer CR in memory

--- a/pkg/webhooks/mutator/virt-launcher-mutator_test.go
+++ b/pkg/webhooks/mutator/virt-launcher-mutator_test.go
@@ -64,8 +64,7 @@ var _ = Describe("virt-launcher webhook mutator", func() {
 		}
 
 		launcherPod.Spec.Containers[0].Resources = podResources
-		err := mutator.handleVirtLauncherCreation(launcherPod, hco, true, true)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(mutator.handleVirtLauncherCreation(launcherPod, hco, true, true)).To(Succeed())
 
 		resources := launcherPod.Spec.Containers[0].Resources
 		Expect(resources.Limits[k8sv1.ResourceCPU].Equal(expectedResources.Limits[k8sv1.ResourceCPU])).To(BeTrue())
@@ -151,8 +150,7 @@ var _ = Describe("virt-launcher webhook mutator", func() {
 			launcherPod := getFakeLauncherPod()
 			mutator := getVirtLauncherMutator()
 
-			err := mutator.setResourceRatio(launcherPod, ratio, resourceAnnotationKey, resourceName)
-			Expect(err).To(HaveOccurred())
+			Expect(mutator.setResourceRatio(launcherPod, ratio, resourceAnnotationKey, resourceName)).ToNot(Succeed())
 		},
 			Entry("zero ratio", "0", k8sv1.ResourceCPU),
 			Entry("negative ratio", "-1.2", k8sv1.ResourceMemory),
@@ -195,11 +193,9 @@ var _ = Describe("virt-launcher webhook mutator", func() {
 			}
 
 			const ratio = "1.23"
-			err := mutator.setResourceRatio(launcherPod, ratio, resourceAnnotationKey, k8sv1.ResourceCPU)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(mutator.setResourceRatio(launcherPod, ratio, resourceAnnotationKey, k8sv1.ResourceCPU)).To(Succeed())
 
-			err = mutator.setResourceRatio(launcherPod, ratio, resourceAnnotationKey, k8sv1.ResourceMemory)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(mutator.setResourceRatio(launcherPod, ratio, resourceAnnotationKey, k8sv1.ResourceMemory)).To(Succeed())
 
 			Expect(launcherPod.Spec.Containers[0].Resources.Requests).To(BeEmpty())
 		})

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -1515,7 +1515,7 @@ var _ = Describe("webhooks validator", func() {
 					Expect(minTypedTLSVersion).Should(Equal(midExpected))
 
 					apiServer.Spec.TLSSecurityProfile = finApiTlsSecurityProfile
-					err = cl.Update(context.TODO(), apiServer)
+					Expect(cl.Update(context.TODO(), apiServer)).To(Succeed())
 					hcoTlsConfigCache = finHCOTlsSecurityProfile
 
 					Expect(util.GetClusterInfo().RefreshAPIServerCR(context.TODO(), cl)).To(Succeed())


### PR DESCRIPTION
Prepare to the next version of the ginkgolinter that will force this change.

Also, improve error checks in tests

When checking error from function, only to check if it succeeded (and
not checking the error itself), replace:
```go
err := funcRetErr()
Expect(err).ToNot(HaveOccurred())
```

with
```go
Expect(funcRetErr()).To(Succeed())
```

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

