### PR TITLE
feat: add virtio-image flag to TTO csv manifest generator

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
@@ -3105,6 +3105,7 @@ spec:
                 - name: WAIT_FOR_VMI_STATUS_IMG
                 - name: GENERATE_SSH_KEYS_IMG
                 - name: VIRTIO_IMG
+                  value: quay.io/kubevirt/virtio-container-disk@sha256:5b99c78ed831401048e72d72f9ec805710ee7625131fd9ad277b38ab1e67cfb9
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -3790,6 +3791,8 @@ spec:
     name: virt-launcher
   - image: quay.io/kubevirt/virt-operator@sha256:c66cca19eefafb12d5ecf1d1e0e8c403792744c2031ed8cb4701a9cbd90f112f
     name: virt-operator
+  - image: quay.io/kubevirt/virtio-container-disk@sha256:5b99c78ed831401048e72d72f9ec805710ee7625131fd9ad277b38ab1e67cfb9
+    name: virtio-container
   - image: quay.io/kubevirt/virtio-container-disk@sha256:5b99c78ed831401048e72d72f9ec805710ee7625131fd9ad277b38ab1e67cfb9
     name: virtio-container-disk
   replaces: kubevirt-hyperconverged-operator.v1.8.0

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/kubevirt-hyperconverged-operator.v1.9.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.9.0-unstable
-    createdAt: "2023-02-17 05:13:53"
+    createdAt: "2023-02-20 12:57:22"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -3105,6 +3105,7 @@ spec:
                 - name: WAIT_FOR_VMI_STATUS_IMG
                 - name: GENERATE_SSH_KEYS_IMG
                 - name: VIRTIO_IMG
+                  value: quay.io/kubevirt/virtio-container-disk@sha256:5b99c78ed831401048e72d72f9ec805710ee7625131fd9ad277b38ab1e67cfb9
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -3790,6 +3791,8 @@ spec:
     name: virt-launcher
   - image: quay.io/kubevirt/virt-operator@sha256:c66cca19eefafb12d5ecf1d1e0e8c403792744c2031ed8cb4701a9cbd90f112f
     name: virt-operator
+  - image: quay.io/kubevirt/virtio-container-disk@sha256:5b99c78ed831401048e72d72f9ec805710ee7625131fd9ad277b38ab1e67cfb9
+    name: virtio-container
   - image: quay.io/kubevirt/virtio-container-disk@sha256:5b99c78ed831401048e72d72f9ec805710ee7625131fd9ad277b38ab1e67cfb9
     name: virtio-container-disk
   replaces: kubevirt-hyperconverged-operator.v1.8.0

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -607,6 +607,7 @@ spec:
         - name: WAIT_FOR_VMI_STATUS_IMG
         - name: GENERATE_SSH_KEYS_IMG
         - name: VIRTIO_IMG
+          value: quay.io/kubevirt/virtio-container-disk@sha256:5b99c78ed831401048e72d72f9ec805710ee7625131fd9ad277b38ab1e67cfb9
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -174,6 +174,7 @@ function create_tto_csv() {
     --csv-version=${CSV_VERSION} \
     --operator-image=${TTO_OPERATOR_IMAGE} \
     --operator-version=${TTO_VERSION} \
+    --virtio-image=${KUBEVIRT_VIRTIO_IMAGE} \
   "
 
   gen_csv ${TTO_CSV_GENERATOR} ${operatorName} "${TTO_OPERATOR_IMAGE}" ${dumpCRDsArg} ${operatorArgs}


### PR DESCRIPTION
Add virtio-image flag for TTO csv manifest generator. This change should prevent usage of wrong virtio image version.
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2155796

**Reviewer Checklist**

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
```
Add virtio-image flag for TTO csv manifest generator
```

