### PR TITLE
Add `kubevirt_hyperconverged_operator_health_status` recording rule

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -11,6 +11,8 @@ Count of out-of-band modifications overwritten by HCO. Type: Counter.
 Indicates whether the system health status is healthy (0), warning (1), or error (2), by aggregating the conditions of HCO and its secondary resources. Type: Gauge.
 ### kubevirt_hco_unsafe_modification_count
 Count of unsafe modifications in the HyperConverged annotations. Type: Gauge.
+### kubevirt_hyperconverged_operator_health_status
+Indicates whether HCO and its secondary resources health status is healthy (0), warning (1) or critical (2), based both on the firing alerts that impact the operator health, and on kubevirt_hco_system_health_status metric. Type: Gauge.
 ## Developing new metrics
 After developing new metrics or changing old ones, please run `make generate-doc` to regenerate this document.
 

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -581,3 +581,89 @@ tests:
     exp_samples:
     - labels: 'cluster:vmi_request_cpu_cores:sum{}'
       value: 0.12
+
+# Test kubevirt_hyperconverged_operator_health_status recording rule
+- interval: 1m
+  input_series:
+  - series: 'kubevirt_hco_system_health_status'
+    # time:  0     1     2     3     4     5     6     7     8     9     10     11
+    values: "0     0     0     0     1     1     1     1     2     2      2      2"
+  - series: 'ALERTS{kubernetes_operator_component="kubevirt", alertstate="firing", operator_health_impact="warning"}'
+    # time:  0     1     2     3     4     5     6     7     8     9     10     11
+    values: "1     1   stale stale   1     1   stale stale   1     1    stale  stale"
+  - series: 'ALERTS{kubernetes_operator_component="kubevirt", alertstate="firing", operator_health_impact="critical"}'
+    # time:  0     1     2     3     4     5     6     7     8     9     10     11
+    values: "1   stale   1   stale   1   stale   1   stale   1   stale    1    stale"
+  promql_expr_test:
+  # kubevirt_hco_system_health_status = 0 and both warning and critical alerts are firing at 0m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 0m
+    exp_samples:
+    - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+      value: 2
+  # kubevirt_hco_system_health_status = 0 and only a warning alert is firing at 1m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 1m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 1
+  # kubevirt_hco_system_health_status = 0 and a critical alert is firing at 2m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 2m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 2
+  # kubevirt_hco_system_health_status = 0 and no alerts are firing at 3m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 3m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 0
+  # kubevirt_hco_system_health_status = 1 and both warning and critical alerts are firing at 4m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 4m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 2
+  # kubevirt_hco_system_health_status = 1 and only a warning alert is firing at 5m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 5m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 1
+  # kubevirt_hco_system_health_status = 1 and a critical alert is firing at 6m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 6m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 2
+  # kubevirt_hco_system_health_status = 1 and no alerts are firing at 7m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 7m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 1
+  # kubevirt_hco_system_health_status = 2 and both warning and critical alerts are firing at 8m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 8m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 2
+  # kubevirt_hco_system_health_status = 2 and only a warning alert is firing at 9m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 9m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 2
+  # kubevirt_hco_system_health_status = 2 and a critical alert is firing at 10m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 10m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 2
+  # kubevirt_hco_system_health_status = 2 and no alerts are firing at 11m
+  - expr: 'kubevirt_hyperconverged_operator_health_status'
+    eval_time: 11m
+    exp_samples:
+      - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
+        value: 2

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -114,6 +114,13 @@ var HcoMetrics = func() hcoMetrics {
 	}
 }()
 
+var hcoRecordingRules = []MetricDescription{
+	{`kubevirt_hyperconverged_operator_health_status`,
+		"Indicates whether HCO and its secondary resources health status is healthy (0), warning (1) or critical (2), based both on the firing alerts that impact the operator health, and on kubevirt_hco_system_health_status metric",
+		"Gauge",
+	},
+}
+
 // hcoMetrics holds all HCO metrics
 type hcoMetrics struct {
 	// overwrittenModifications counts out-of-band modifications overwritten by HCO
@@ -279,6 +286,8 @@ func (hm hcoMetrics) GetMetricDesc() []MetricDescription {
 	for _, md := range hm.metricDescList {
 		res = append(res, MetricDescription{FqName: md.fqName, Help: md.help, Type: md.mType})
 	}
+	res = append(res, hcoRecordingRules...)
+
 	return res
 }
 


### PR DESCRIPTION
This PR adds a new recording rule - `kubevirt_hyperconverged_operator_health_status` with the label `name=kubevirt-hyperconvered`. 
This recording rule indicates the total health of HCO and its secondary resources, based on the following:
- The firing alerts impact on the operator's health, by using their `operator_health_impact` label.
- The conditions which are reported by the different components, by using `kubevirt_hco_system_health_status` metric which aggregates this.

Its value is set according to the following logic:
-  If there are firing alerts with `operator_health_impact = critical` or `kubevirt_hco_system_health_status = 2`:
`kubevirt_hyperconverged_operator_health_status = 2`
-  Else, if there are firing alerts with `operator_health_impact = warning` or `kubevirt_hco_system_health_status = 1`:
`kubevirt_hyperconverged_operator_health_status = 1`
- Else, `kubevirt_hyperconverged_operator_health_status = 0`

jira-ticket: [CNV-14700](https://issues.redhat.com/browse/CNV-14700)

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `kubevirt_hyperconverged_operator_health_status` recording rule 
```

