### PR TITLE
Build also functest image for kubevirtci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ container-build-validate-bundles:
 	podman build -f tools/operator-sdk-validate/Dockerfile -t operator-sdk-validate-hco .
 
 container-build-functest:
-	podman build -f build/Dockerfile.functest -t $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	. "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile.functest -t $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
 container-build-artifacts-server:
 	podman build -f build/Dockerfile.artifacts -t $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
@@ -118,7 +118,7 @@ container-push-webhook:
 	. "hack/cri-bin.sh" && $$CRI_BIN push $$CRI_INSECURE $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
 
 container-push-functest:
-	podman push $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)
+	. "hack/cri-bin.sh" && $$CRI_BIN push $$CRI_INSECURE $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)
 
 container-push-artifacts-server:
 	podman push $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG)

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -41,7 +41,7 @@ function cluster_clean() {
 }
 
 function build() {
-    make container-build-operator container-push-operator container-build-webhook container-push-webhook
+    make container-build-operator container-push-operator container-build-webhook container-push-webhook container-build-functest container-push-functest
 }
 
 function update_nodes {

--- a/tests/func-tests/dashboard_test.go
+++ b/tests/func-tests/dashboard_test.go
@@ -25,6 +25,8 @@ var _ = Describe("[rfe_id:5108][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 		virtCli, err := kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 
+		tests.SkipIfNotOpenShift(virtCli, "Dashboard configmaps")
+
 		client, err := kubecli.GetKubevirtClientFromRESTConfig(virtCli.Config())
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Build also the functest image and push
it to the local registry on kubevirtci
as part of `make cluster-sync`
so then later on it can be directly consumed
with:
`JOB_TYPE=stdci make functest`

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

