### PR TITLE
Prepare for the new version of the ginkgolinter

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          version: v1.51.2
           skip-pkg-cache: true
           args: --timeout=5m --out-${NO_FUTURE}format line-number
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ WEBHOOK_IMAGE      ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-webhook
 FUNC_TEST_IMAGE    ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-functest
 VIRT_ARTIFACTS_SERVER ?= $(REGISTRY_NAMESPACE)/virt-artifacts-server
 LDFLAGS            ?= -w -s
+GOLANDCI_LINT_VERSION ?= v1.51.2
 
 
 
@@ -36,10 +37,9 @@ goimport:
 
 
 lint:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANDCI_LINT_VERSION}
 	golangci-lint run
-	go install github.com/nunnatsa/ginkgolinter/cmd/ginkgolinter@latest
-	ginkgolinter ./...
-	(cd tests && ginkgolinter ./...)
+	(cd tests && golangci-lint run)
 
 build: build-operator build-csv-merger build-webhook
 

--- a/controllers/operands/cdi_test.go
+++ b/controllers/operands/cdi_test.go
@@ -1192,12 +1192,12 @@ var _ = Describe("CDI Operand", func() {
 				Expect(handler.hooks.(*cdiHooks).cache).ToNot(BeNil())
 
 				By("compare pointers to make sure cache is working", func() {
-					Expect(handler.hooks.(*cdiHooks).cache == cr).Should(BeTrue())
+					Expect(handler.hooks.(*cdiHooks).cache).Should(BeIdenticalTo(cr))
 
 					cdi1, err := handler.hooks.getFullCr(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(cdi1).ToNot(BeNil())
-					Expect(cr == cdi1).Should(BeTrue())
+					Expect(cr).Should(BeIdenticalTo(cdi1))
 				})
 			})
 
@@ -1220,9 +1220,9 @@ var _ = Describe("CDI Operand", func() {
 				Expect(crII).ToNot(BeNil())
 				Expect(handler.hooks.(*cdiHooks).cache).ToNot(BeNil())
 
-				Expect(crI == crII).To(BeFalse())
-				Expect(handler.hooks.(*cdiHooks).cache == crI).To(BeFalse())
-				Expect(handler.hooks.(*cdiHooks).cache == crII).To(BeTrue())
+				Expect(crI).ToNot(BeIdenticalTo(crII))
+				Expect(handler.hooks.(*cdiHooks).cache).ToNot(BeIdenticalTo(crI))
+				Expect(handler.hooks.(*cdiHooks).cache).To(BeIdenticalTo(crII))
 			})
 		})
 

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -2843,12 +2843,12 @@ Version: 1.2.3`)
 				Expect(handler.hooks.(*kubevirtHooks).cache).ToNot(BeNil())
 
 				By("compare pointers to make sure cache is working", func() {
-					Expect(handler.hooks.(*kubevirtHooks).cache == cr).Should(BeTrue())
+					Expect(handler.hooks.(*kubevirtHooks).cache).Should(BeIdenticalTo(cr))
 
 					crII, err := handler.hooks.getFullCr(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(crII).ToNot(BeNil())
-					Expect(cr == crII).Should(BeTrue())
+					Expect(cr).Should(BeIdenticalTo(crII))
 				})
 			})
 
@@ -2871,9 +2871,9 @@ Version: 1.2.3`)
 				Expect(crII).ToNot(BeNil())
 				Expect(handler.hooks.(*kubevirtHooks).cache).ToNot(BeNil())
 
-				Expect(crI == crII).To(BeFalse())
-				Expect(handler.hooks.(*kubevirtHooks).cache == crI).To(BeFalse())
-				Expect(handler.hooks.(*kubevirtHooks).cache == crII).To(BeTrue())
+				Expect(crI).ToNot(BeIdenticalTo(crII))
+				Expect(handler.hooks.(*kubevirtHooks).cache).ToNot(BeIdenticalTo(crI))
+				Expect(handler.hooks.(*kubevirtHooks).cache).To(BeIdenticalTo(crII))
 			})
 		})
 

--- a/controllers/operands/networkAddons_test.go
+++ b/controllers/operands/networkAddons_test.go
@@ -960,12 +960,12 @@ var _ = Describe("CNA Operand", func() {
 				Expect(handler.hooks.(*cnaHooks).cache).ToNot(BeNil())
 
 				By("compare pointers to make sure cache is working", func() {
-					Expect(handler.hooks.(*cnaHooks).cache == cr).Should(BeTrue())
+					Expect(handler.hooks.(*cnaHooks).cache).Should(BeIdenticalTo(cr))
 
 					crII, err := handler.hooks.getFullCr(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(crII).ToNot(BeNil())
-					Expect(cr == crII).Should(BeTrue())
+					Expect(cr).Should(BeIdenticalTo(crII))
 				})
 			})
 
@@ -988,9 +988,9 @@ var _ = Describe("CNA Operand", func() {
 				Expect(crII).ToNot(BeNil())
 				Expect(handler.hooks.(*cnaHooks).cache).ToNot(BeNil())
 
-				Expect(crI == crII).To(BeFalse())
-				Expect(handler.hooks.(*cnaHooks).cache == crI).To(BeFalse())
-				Expect(handler.hooks.(*cnaHooks).cache == crII).To(BeTrue())
+				Expect(crI).ToNot(BeIdenticalTo(crII))
+				Expect(handler.hooks.(*cnaHooks).cache).ToNot(BeIdenticalTo(crI))
+				Expect(handler.hooks.(*cnaHooks).cache).To(BeIdenticalTo(crII))
 			})
 
 			Context("Requested components", func() {

--- a/controllers/operands/ssp_test.go
+++ b/controllers/operands/ssp_test.go
@@ -462,12 +462,12 @@ var _ = Describe("SSP Operands", func() {
 				Expect(handler.hooks.(*sspHooks).cache).ToNot(BeNil())
 
 				By("compare pointers to make sure cache is working", func() {
-					Expect(handler.hooks.(*sspHooks).cache == cr).Should(BeTrue())
+					Expect(handler.hooks.(*sspHooks).cache).Should(BeIdenticalTo(cr))
 
 					cdi1, err := handler.hooks.getFullCr(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(cdi1).ToNot(BeNil())
-					Expect(cr == cdi1).Should(BeTrue())
+					Expect(cr).Should(BeIdenticalTo(cdi1))
 				})
 			})
 
@@ -490,9 +490,9 @@ var _ = Describe("SSP Operands", func() {
 				Expect(crII).ToNot(BeNil())
 				Expect(handler.hooks.(*sspHooks).cache).ToNot(BeNil())
 
-				Expect(crI == crII).To(BeFalse())
-				Expect(handler.hooks.(*sspHooks).cache == crI).To(BeFalse())
-				Expect(handler.hooks.(*sspHooks).cache == crII).To(BeTrue())
+				Expect(crI).ToNot(BeIdenticalTo(crII))
+				Expect(handler.hooks.(*sspHooks).cache).ToNot(BeIdenticalTo(crI))
+				Expect(handler.hooks.(*sspHooks).cache).To(BeIdenticalTo(crII))
 			})
 		})
 

--- a/controllers/operands/tto_test.go
+++ b/controllers/operands/tto_test.go
@@ -122,12 +122,12 @@ var _ = Describe("TTO Operands", func() {
 				Expect(handler.hooks.(*ttoHooks).cache).ToNot(BeNil())
 
 				By("compare pointers to make sure cache is working", func() {
-					Expect(handler.hooks.(*ttoHooks).cache == cr).Should(BeTrue())
+					Expect(handler.hooks.(*ttoHooks).cache).Should(BeIdenticalTo(cr))
 
 					tto1, err := handler.hooks.getFullCr(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(tto1).ToNot(BeNil())
-					Expect(cr == tto1).Should(BeTrue())
+					Expect(cr).Should(BeIdenticalTo(tto1))
 				})
 			})
 
@@ -150,9 +150,9 @@ var _ = Describe("TTO Operands", func() {
 				Expect(crII).ToNot(BeNil())
 				Expect(handler.hooks.(*ttoHooks).cache).ToNot(BeNil())
 
-				Expect(crI == crII).To(BeFalse())
-				Expect(handler.hooks.(*ttoHooks).cache == crI).To(BeFalse())
-				Expect(handler.hooks.(*ttoHooks).cache == crII).To(BeTrue())
+				Expect(crI).ToNot(BeIdenticalTo(crII))
+				Expect(handler.hooks.(*ttoHooks).cache).ToNot(BeIdenticalTo(crI))
+				Expect(handler.hooks.(*ttoHooks).cache).To(BeIdenticalTo(crII))
 			})
 		})
 	})

--- a/tests/.golangci.yml
+++ b/tests/.golangci.yml
@@ -1,0 +1,3 @@
+linters:
+  enable:
+  - ginkgolinter

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -99,7 +99,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 
 		By("Updating kubevirt object with a new label")
 		kubevirt.Labels["test-label"] = "test-label-value"
-		kubevirt, err = virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Update(kubevirt)
+		_, err = virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Update(kubevirt)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		verifyAlertExists(promClient, "KubevirtHyperconvergedClusterOperatorCRModification", 60*time.Second)


### PR DESCRIPTION
Fix new linter warnings for wrong boolean comparisons; e.g.

`Expect(x == 10).Equal(true)` should be `Expect(x).Equal(10)`

Also, set the golangci-lint version to `v1.51.2` (current latest) so we won't be surprised by new linter rules, but we'll can control when we adopt them.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

