### PR TITLE
Workaround for nonRoot FG on Kubevirt

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -321,6 +321,9 @@ type HyperConvergedFeatureGates struct {
 	// +default=false
 	DeployKubeSecondaryDNS *bool `json:"deployKubeSecondaryDNS,omitempty"`
 
+	// TODO: deprecate NonRoot and introduce Root FG with opposite semantic
+	// and a proper conversion logic
+
 	// Enables rootless virt-launcher.
 	// +optional
 	// +kubebuilder:default=true

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -142,7 +142,7 @@ var (
 // KubeVirt feature gates that are exposed in HCO API
 const (
 	kvWithHostPassthroughCPU = "WithHostPassthroughCPU"
-	kvNonRoot                = "NonRoot"
+	kvRoot                   = "Root"
 )
 
 // CPU Plugin default values
@@ -639,8 +639,8 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) [
 		fgs = append(fgs, kvWithHostPassthroughCPU)
 	}
 
-	if featureGates.NonRoot != nil && *featureGates.NonRoot {
-		fgs = append(fgs, kvNonRoot)
+	if featureGates.NonRoot != nil && !*featureGates.NonRoot {
+		fgs = append(fgs, kvRoot)
 	}
 
 	return fgs

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -1372,7 +1372,7 @@ Version: 1.2.3`)
 					})
 				})
 
-				It("should add the NonRoot feature gate if it's set in HyperConverged CR", func() {
+				It("should not add the Root feature gate if NonRoot is true in HyperConverged CR", func() {
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
 						NonRoot: pointer.Bool(true),
 					}
@@ -1381,11 +1381,11 @@ Version: 1.2.3`)
 					Expect(err).ToNot(HaveOccurred())
 					By("KV CR should contain the NonRoot feature gate", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
-						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvNonRoot))
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvRoot))
 					})
 				})
 
-				It("should not add the NonRoot feature gate if it's disabled in HyperConverged CR", func() {
+				It("should add the Root feature gate if NonRoot is false in HyperConverged CR", func() {
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
 						NonRoot: pointer.Bool(false),
 					}
@@ -1394,7 +1394,20 @@ Version: 1.2.3`)
 					Expect(err).ToNot(HaveOccurred())
 					By("KV CR should contain the NonRoot feature gate", func() {
 						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
-						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("NonRoot"))
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvRoot))
+					})
+				})
+
+				It("should not add the Root feature gate if NonRoot is not set in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						NonRoot: nil,
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the NonRoot feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvRoot))
 					})
 				})
 
@@ -1469,7 +1482,7 @@ Version: 1.2.3`)
 					handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
 					res := handler.ensure(req)
 					Expect(res.UpgradeDone).To(BeFalse())
-					Expect(res.Updated).To(BeTrue())
+					Expect(res.Updated).To(BeFalse())
 					Expect(res.Overwritten).To(BeFalse())
 					Expect(res.Err).ToNot(HaveOccurred())
 
@@ -1500,7 +1513,7 @@ Version: 1.2.3`)
 					handler := (*genericOperand)(newKubevirtHandler(cl, commonTestUtils.GetScheme()))
 					res := handler.ensure(req)
 					Expect(res.UpgradeDone).To(BeFalse())
-					Expect(res.Updated).To(BeTrue())
+					Expect(res.Updated).To(BeFalse())
 					Expect(res.Overwritten).To(BeFalse())
 					Expect(res.Err).ToNot(HaveOccurred())
 
@@ -2820,7 +2833,7 @@ Version: 1.2.3`)
 				).ToNot(HaveOccurred())
 
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(mandatoryKvFeatureGates) + 1))
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(mandatoryKvFeatureGates)))
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(hardCodeKvFgs))
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvSRIOVGate))
 				Expect(kv.Spec.Configuration.CPURequest).To(BeNil())


### PR DESCRIPTION
With https://github.com/kubevirt/kubevirt/pull/8563 Kubevirt introduced a new FG named `Root`,
the `nonRoot` FG we are using is still there but
declared as deprecated.

Unfortunately due to bug on Kubevirt the now
deprecated `nonRoot` FG we rely on is
completely ignored so, as a workaround, we will
start internally translating nonRoot -> Root
on Kubevirt with negative logic.

In a future PR the nonRoot FG will be properly deprecated also here and a new Root FG will
be introduced with a proper conversion logic on upgrades.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2175171
JIRA-ticket: https://issues.redhat.com/browse/CNV-26406

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Workaround for nonRoot FG on Kubevirt
```

