### PR TITLE
Fix junit output from tests

### DIFF
--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -28,7 +28,8 @@ fi
 source ./hack/check_operator_condition.sh
 printOperatorCondition
 
-${TEST_OUT_PATH}/func-tests.test -ginkgo.v -junit-output="${TEST_OUT_PATH}/output/junit.xml" -installed-namespace="${INSTALLED_NAMESPACE}" -cdi-namespace="${INSTALLED_NAMESPACE}" "$@" "${KUBECONFIG_FLAG}"
+mkdir "${TEST_OUT_PATH}/output"
+${TEST_OUT_PATH}/func-tests.test -ginkgo.v --ginkgo.junit-report="${TEST_OUT_PATH}/output/junit.xml" -installed-namespace="${INSTALLED_NAMESPACE}" -cdi-namespace="${INSTALLED_NAMESPACE}" "$@" "${KUBECONFIG_FLAG}"
 
 # wait a minute to allow all VMs to be deleted before attempting to change node placement configuration
 sleep 60

--- a/tests/func-tests/main_test.go
+++ b/tests/func-tests/main_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -19,19 +17,7 @@ import (
 
 func TestTests(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Tests Suite", NewReporters())
-}
-
-// NewReporters is a function to gather new ginkgo test reporters
-func NewReporters() []Reporter {
-	reporters := make([]Reporter, 0)
-	if ginkgo_reporters.Polarion.Run {
-		reporters = append(reporters, &ginkgo_reporters.Polarion)
-	}
-	if ginkgo_reporters.JunitOutput != "" {
-		reporters = append(reporters, ginkgo_reporters.NewJunitReporter())
-	}
-	return reporters
+	RunSpecs(t, "Tests Suite")
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
The custom reporter are deprecated in ginkgo and are ignore. As result, the report files are not created.

This PR restores the junit report, as it supported by ginkgo.

Polarian report can't work for now. Future solution will be to add json report and translate it to polarion.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

