### PR TITLE
Remove a workaround needed with old Kubevirt

### DIFF
--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -106,10 +106,6 @@ echo "----- Get virtctl"
 KV_VERSION=$( ${CMD} get kubevirt.kubevirt.io/kubevirt-kubevirt-hyperconverged -n ${HCO_NAMESPACE} -o=jsonpath="{.status.observedKubeVirtVersion}")
 ARCH=$(uname -s | tr A-Z a-z)-$(uname -m | sed 's/x86_64/amd64/') || windows-amd64.exe
 echo ${ARCH}
-### TODO: remove this once we can consume only kubevirt >= v0.55.0
-# --local-ssh-opts needed to bypass host check is available only starting with kubevirt v0.55.0
-KV_VERSION=v0.55.0
-###
 curl -L -o ~/virtctl https://github.com/kubevirt/kubevirt/releases/download/${KV_VERSION}/virtctl-${KV_VERSION}-${ARCH}
 chmod +x ~/virtctl
 ###################


### PR DESCRIPTION
In the past in the upgrade lanes we had
to pin to a specific virtctl version
to consume a new feature not available
in the version of virtctl corresponding to
the installed kubevirt.
Now we can avoid that since we are consuming
fresher versions everywhere.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

