### PR TITLE
Use ECDSA for the test VM on upgrade tests

### DIFF
--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -121,7 +121,7 @@ KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} printOperatorConditio
 ### Create a VM ###
 Msg "Create a simple VM on the previous version cluster, before the upgrade"
 ${CMD} create namespace ${VMS_NAMESPACE}
-ssh-keygen -f ./hack/test_ssh -q -N ""
+ssh-keygen -t ecdsa -f ./hack/test_ssh -q -N ""
 cat << END > ./hack/cloud-init.sh
 #!/bin/sh
 export NEW_USER="cirros"


### PR DESCRIPTION
The DEFAULT system-wide cryptographic policy
in CentOS Stream 9/RHEL9 doesn't allow
anymore RSA with key size < 2048 bits
(was < 1024 bits in RHEL 8).
Move to ECDSA to be ready to
work with CentOS Stream 9/UBI9 images.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly
  
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

