### PR TITLE
Add Jira Ticket section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
+-->
+
+**What this PR does / why we need it**:
+
 **Reviewer Checklist**
 <!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,15 @@
 - [ ] Uninstallation Scenario
 - [ ] Backward Compatibility
 - [ ] Troubleshooting Friendly
-  
+
+**Jira Ticket**:
+<!--  Write the link to the Jira ticket:
+If the task is not tracked by a Jira ticket, just write "NONE".
+-->
+```jira-ticket
+
+```
+
 **Release note**:
 <!--  Write your release note:
 1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
@@ -23,4 +31,3 @@
 ```release-note
 
 ```
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Usually, there is a tendency to forget to link the URL for the Jira ticket. In this PR, we add a section to the PR template to remember both the author and the reviewer of the Jira URL.

I also used the PR to add a header section with the `**What this PR does / why we need it**:` as we have in other KubeVirt org repositories. I think it makes sense and its useful.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-26405
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
