### PR TITLE
Revert "Disable PSA for upgrades with kv v0.58 on OCP/OKD (#2281)"

### DIFF
--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -117,18 +117,6 @@ KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} printOperatorConditio
 ### Create a VM ###
 Msg "Create a simple VM on the previous version cluster, before the upgrade"
 ${CMD} create namespace ${VMS_NAMESPACE}
-
-######
-# TODO remove this once OCP/OKD 4.13 will not set PSA enforce=restricted by default
-# excplitly label vm namespace as priviledged to let our VM start there
-# until OCP/OKD will tolerate it can handle it
-# We need it only with Kubevirt <= v0.58.z since Kubevirt v0.59.0 correctly works with PSA.
-if [[ "${RELEASE_DELTA}" == "2" ]]; then
-    echo "----- HACK: explicitly disabling PSA enforce=restricted and scc.podSecurityLabelSync"
-    ${CMD} label namespace ${VMS_NAMESPACE} --overwrite pod-security.kubernetes.io/enforce=privileged security.openshift.io/scc.podSecurityLabelSync=false
-fi
-######
-
 ssh-keygen -t ecdsa -f ./hack/test_ssh -q -N ""
 cat << END > ./hack/cloud-init.sh
 #!/bin/sh


### PR DESCRIPTION
This reverts commit 6adde6252d7c52b2cf00d7e59887fac986a8ad1b.

Not needed starting the upgrade process already with Kubevirt v0.59.z there which is PSA compatible.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
