### PR TITLE
Use env `RUNBOOK_URL_TEMPLATE` for the runbooks URL template

### DIFF
--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -67,9 +67,9 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			for _, rule := range group.Rules {
 				if rule.Alert != "" {
 					Expect(rule.Annotations).To(HaveKeyWithValue("summary", Not(BeEmpty())),
-						fmt.Sprintf("%s summary is missing or empty", rule.Alert))
+						"%s summary is missing or empty", rule.Alert)
 					Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", Not(BeEmpty())),
-						fmt.Sprintf("%s runbook_url is missing or empty", rule.Alert))
+						"%s runbook_url is missing or empty", rule.Alert)
 					checkRunbookUrlAvailability(rule)
 				}
 			}
@@ -81,13 +81,13 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			for _, rule := range group.Rules {
 				if rule.Alert != "" {
 					Expect(rule.Labels).To(HaveKeyWithValue("severity", BeElementOf("info", "warning", "critical")),
-						fmt.Sprintf("%s severity label is missing or not valid", rule.Alert))
+						"%s severity label is missing or not valid", rule.Alert)
 					Expect(rule.Labels).To(HaveKeyWithValue("kubernetes_operator_part_of", "kubevirt"),
-						fmt.Sprintf("%s kubernetes_operator_part_of label is missing or not valid", rule.Alert))
+						"%s kubernetes_operator_part_of label is missing or not valid", rule.Alert)
 					Expect(rule.Labels).To(HaveKeyWithValue("kubernetes_operator_component", "hyperconverged-cluster-operator"),
-						fmt.Sprintf("%s kubernetes_operator_component label is missing or not valid", rule.Alert))
+						"%s kubernetes_operator_component label is missing or not valid", rule.Alert)
 					Expect(rule.Labels).To(HaveKeyWithValue("operator_health_impact", BeElementOf("none", "warning", "critical")),
-						fmt.Sprintf("%s operator_health_impact label is missing or not valid", rule.Alert))
+						"%s operator_health_impact label is missing or not valid", rule.Alert)
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When `RUNBOOK_URL_TEMPLATE` env variable is set, its value will be used as the runbooks URL template. Otherwise, keep using the default runbook URL template `https://kubevirt.io/monitoring/runbooks/%s`. 
This allows using different runbooks versions, in accordance with the installation.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-14383
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use env RUNURL_TEMPLATE as the runbooks URL template
```
