### PR TITLE
Fix FBC index build

### DIFF
--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -27,17 +27,17 @@ UNSTABLE=$2
 function create_index_image() {
   CURRENT_VERSION=$1
   PREV_VERSION=$2
-  if [[ "${UNSTABLE}" == "UNSTABLE" ]]; then
+  INITIAL_VERSION=${CURRENT_VERSION}
+  if [[ "${UNSTABLE}" == "UNSTABLE" ]] || [[ "${UNSTABLE}" == "FBCUNSTABLE" ]]; then
     mv ${PACKAGE_NAME}/${CURRENT_VERSION} ${PACKAGE_NAME}/${CURRENT_VERSION}-unstable
     CURRENT_VERSION=${CURRENT_VERSION}-unstable
     PREV_VERSION=${PREV_VERSION}-unstable
-  elif [[ "${UNSTABLE}" == "FBCUNSTABLE" ]]; then
-    mv ${PACKAGE_NAME}/${CURRENT_VERSION} ${PACKAGE_NAME}/${CURRENT_VERSION}-fbc-unstable
-    CURRENT_VERSION=${CURRENT_VERSION}-fbc-unstable
-    PREV_VERSION=${PREV_VERSION}-fbc-unstable
   fi
   BUNDLE_IMAGE_NAME="${IMAGE_REGISTRY}/${REGISTRY_NAMESPACE}/${BUNDLE_REGISTRY_IMAGE_NAME}:${CURRENT_VERSION}"
   INDEX_IMAGE_NAME="${IMAGE_REGISTRY}/${REGISTRY_NAMESPACE}/${INDEX_REGISTRY_IMAGE_NAME}:${CURRENT_VERSION}"
+  if [[ "${UNSTABLE}" == "FBCUNSTABLE" ]]; then
+    INDEX_IMAGE_NAME="${IMAGE_REGISTRY}/${REGISTRY_NAMESPACE}/${INDEX_REGISTRY_IMAGE_NAME}:${INITIAL_VERSION}-fbc-unstable"
+  fi
 
   podman build -t "${BUNDLE_IMAGE_NAME}" -f bundle.Dockerfile --build-arg "VERSION=${CURRENT_VERSION}" .
   podman push "${BUNDLE_IMAGE_NAME}"
@@ -60,6 +60,8 @@ function create_index_image() {
   fi
 
   podman push "${INDEX_IMAGE_NAME}"
+
+  mv ${PACKAGE_NAME}/${CURRENT_VERSION} ${PACKAGE_NAME}/${INITIAL_VERSION}
 }
 
 function create_file_based_catalog() {


### PR DESCRIPTION
- ensure that DB and FBC index can be built in a row restoring the initial folder struct
- add -fbc- prefix only to the FBC based index image but not to the bundle

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
