### PR TITLE
[release-1.8] Consume latest kubevirtci image

### DIFF
--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -13,18 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.24'}
-######
-# workaround for https://github.com/kubevirt/kubevirt/issues/9434
-# we started setting SELinux boolean for chardev access
-# with https://github.com/kubevirt/kubevirtci/pull/968
-# but it got reverted with https://github.com/kubevirt/kubevirtci/pull/975
-# altough it's still needed with Kubevirt v0.58.1
-# TODO: let's remove this once https://github.com/kubevirt/kubevirt/issues/9434
-# is fixed
-#
-# export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
-export KUBEVIRTCI_TAG=2302221824-e1cf770
-######
+export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
 
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'


### PR DESCRIPTION
**What this PR does / why we need it**:
with
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2287 we also pinned a specific tag on kubevirtci
as a workaround for https://github.com/kubevirt/kubevirt/issues/9434 Let's revert to the usual behaviour once the
root cause is properly fixed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
