### PR TITLE
fix CRModification alert in upgrade

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -285,7 +285,7 @@ func (r *ReconcileHyperConverged) Reconcile(ctx context.Context, request reconci
 		r.operandHandler.Reset()
 	}
 
-	err = r.monitoringReconciler.Reconcile(hcoRequest)
+	err = r.monitoringReconciler.Reconcile(hcoRequest, r.firstLoop)
 	if err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
The KubevirtHyperconvergedClusterOperatorCRModification alert is triggered on upgrade for some resource metrics.

This PR fixes this bug and prevents these alerts.

**Reviewer Checklist**
- [x] PR Message
- [x] Commit Messages
- [ ] How to test
- [x] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [x] Upgrade Scenario
- [ ] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-22746
```

**Release note**:
```release-note
Fix bug [https://issues.redhat.com/browse/CNV-22746] - should not trigger alerts during upgrade
```
