### PR TITLE
Use integer values for CPU requests in prom-rules-tests

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -525,12 +525,12 @@ tests:
   input_series:
   # take all containers of running virt-launcher pods
   - series: 'kube_pod_container_resource_requests{pod="virt-launcher-x-y", resource="cpu", container="compute"}'
-    # time:  0   1   2   3   4   5
-    values: "0.1 0.1 0.1 0.1 0.1 0.1"
+    # time:  0 1 2 3 4 5
+    values: "1 1 1 1 1 1"
   # take all containers of running virt-launcher pods
   - series: 'kube_pod_container_resource_requests{pod="virt-launcher-x-y", resource="cpu", container="volumecontainerdisk"}'
-    # time:  0    1    2    3    4    5
-    values: "0.01 0.01 0.01 0.01 0.01 0.01"
+    # time:  0 1 2 3 4 5
+    values: "1 1 1 1 1 1"
   - series: 'kube_pod_labels{label_kubevirt_io="virt-launcher",pod="virt-launcher-x-y"}'
     # time:  0 1 2 3 4 5
     values: "1 1 1 1 1 1"
@@ -549,8 +549,8 @@ tests:
     values: "1 1 1 1 1 1"
   # new VMIs can be created in time
   - series: 'kube_pod_container_resource_requests{pod="virt-launcher-new", resource="cpu", container="volumecontainerdisk"}'
-    # time:  0     1     2     3   4    5
-    values: "stale stale stale 0.01 0.01 0.01"
+    # time:  0     1     2     3 4 5
+    values: "stale stale stale 1 1 1"
   - series: 'kube_pod_labels{label_kubevirt_io="virt-launcher",pod="virt-launcher-new"}'
     # time: 0      1     2     3 4 5
     values: "stale stale stale 1 1 1"
@@ -562,25 +562,25 @@ tests:
     eval_time: 1m
     exp_samples:
     - labels: 'cluster:vmi_request_cpu_cores:sum{}'
-      value: 0.11
+      value: 2
   # update for new pods
   - expr: 'cluster:vmi_request_cpu_cores:sum'
     eval_time: 3m
     exp_samples:
     - labels: 'cluster:vmi_request_cpu_cores:sum{}'
-      value: 0.12
+      value: 3
   # virt-launcher-new is not running at 4m. must exclude it
   - expr: 'cluster:vmi_request_cpu_cores:sum'
     eval_time: 4m
     exp_samples:
     - labels: 'cluster:vmi_request_cpu_cores:sum{}'
-      value: 0.11
+      value: 2
   # virt-launcher-new is back at 5m. must include it
   - expr: 'cluster:vmi_request_cpu_cores:sum'
     eval_time: 5m
     exp_samples:
     - labels: 'cluster:vmi_request_cpu_cores:sum{}'
-      value: 0.12
+      value: 3
 
 # Test kubevirt_hyperconverged_operator_health_status recording rule
 - interval: 1m


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Sanity tests are sometimes failing due to floating point round errors in `prom-rules-tests`. This PR replaces floating point values for `kube_pod_container_resource_requests` with integer values.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
