### PR TITLE
Consume virt images with full URL

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/kubevirt-hyperconverged-operator.v1.10.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/kubevirt-hyperconverged-operator.v1.10.0.clusterserviceversion.yaml
@@ -3069,20 +3069,20 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                - name: VIRT_API_SHASUM
-                  value: sha256:ddb0442f62fd68ad99b611a7015e7a711411f34b3dfe5825d4c4458a23e71afe
-                - name: VIRT_CONTROLLER_SHASUM
-                  value: sha256:37d81eb640cac4f21a0867bfe44ca8282aba34e8263235286a7bf126d079562e
-                - name: VIRT_HANDLER_SHASUM
-                  value: sha256:cf36d0df3b019e86a747eea4cdfd62ab78f8109481d4cac28a383b308825d945
-                - name: VIRT_LAUNCHER_SHASUM
-                  value: sha256:49ed398374b0a94a5d67cc99051117a9a422a3972aed0c9f87c0eb115ddf2249
-                - name: VIRT_EXPORTPROXY_SHASUM
-                  value: sha256:d7ef7c80f2dd44da1b5d9c4e0e2313764fc6c502112552fe5b6eb063d0494113
-                - name: VIRT_EXPORTSERVER_SHASUM
-                  value: sha256:7e6b2e3bf53f3ae533f71776572a76a67a4a828f459d0271e720bb27d8787d64
-                - name: GS_SHASUM
-                  value: sha256:b923e8050ebc386505bc587a066a36dd70fa49df57789e86e77d28b1035045d3
+                - name: VIRT_API_IMAGE
+                  value: quay.io/kubevirt/virt-api@sha256:ddb0442f62fd68ad99b611a7015e7a711411f34b3dfe5825d4c4458a23e71afe
+                - name: VIRT_CONTROLLER_IMAGE
+                  value: quay.io/kubevirt/virt-controller@sha256:37d81eb640cac4f21a0867bfe44ca8282aba34e8263235286a7bf126d079562e
+                - name: VIRT_HANDLER_IMAGE
+                  value: quay.io/kubevirt/virt-handler@sha256:cf36d0df3b019e86a747eea4cdfd62ab78f8109481d4cac28a383b308825d945
+                - name: VIRT_LAUNCHER_IMAGE
+                  value: quay.io/kubevirt/virt-launcher@sha256:49ed398374b0a94a5d67cc99051117a9a422a3972aed0c9f87c0eb115ddf2249
+                - name: VIRT_EXPORTPROXY_IMAGE
+                  value: quay.io/kubevirt/virt-exportproxy@sha256:d7ef7c80f2dd44da1b5d9c4e0e2313764fc6c502112552fe5b6eb063d0494113
+                - name: VIRT_EXPORTSERVER_IMAGE
+                  value: quay.io/kubevirt/virt-exportserver@sha256:7e6b2e3bf53f3ae533f71776572a76a67a4a828f459d0271e720bb27d8787d64
+                - name: GS_IMAGE
+                  value: quay.io/kubevirt/libguestfs-tools@sha256:b923e8050ebc386505bc587a066a36dd70fa49df57789e86e77d28b1035045d3
                 - name: KUBEVIRT_VERSION
                   value: v1.0.0-alpha.0
                 image: quay.io/kubevirt/virt-operator@sha256:31542e77456b84d4763d2b01c64e3eb9220e56992e13b4efc80fab8dcc36783c

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/kubevirt-hyperconverged-operator.v1.10.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/kubevirt-hyperconverged-operator.v1.10.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.10.0-unstable
-    createdAt: "2023-04-29 05:12:35"
+    createdAt: "2023-05-04 12:01:59"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
@@ -3069,20 +3069,20 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                - name: VIRT_API_SHASUM
-                  value: sha256:ddb0442f62fd68ad99b611a7015e7a711411f34b3dfe5825d4c4458a23e71afe
-                - name: VIRT_CONTROLLER_SHASUM
-                  value: sha256:37d81eb640cac4f21a0867bfe44ca8282aba34e8263235286a7bf126d079562e
-                - name: VIRT_HANDLER_SHASUM
-                  value: sha256:cf36d0df3b019e86a747eea4cdfd62ab78f8109481d4cac28a383b308825d945
-                - name: VIRT_LAUNCHER_SHASUM
-                  value: sha256:49ed398374b0a94a5d67cc99051117a9a422a3972aed0c9f87c0eb115ddf2249
-                - name: VIRT_EXPORTPROXY_SHASUM
-                  value: sha256:d7ef7c80f2dd44da1b5d9c4e0e2313764fc6c502112552fe5b6eb063d0494113
-                - name: VIRT_EXPORTSERVER_SHASUM
-                  value: sha256:7e6b2e3bf53f3ae533f71776572a76a67a4a828f459d0271e720bb27d8787d64
-                - name: GS_SHASUM
-                  value: sha256:b923e8050ebc386505bc587a066a36dd70fa49df57789e86e77d28b1035045d3
+                - name: VIRT_API_IMAGE
+                  value: quay.io/kubevirt/virt-api@sha256:ddb0442f62fd68ad99b611a7015e7a711411f34b3dfe5825d4c4458a23e71afe
+                - name: VIRT_CONTROLLER_IMAGE
+                  value: quay.io/kubevirt/virt-controller@sha256:37d81eb640cac4f21a0867bfe44ca8282aba34e8263235286a7bf126d079562e
+                - name: VIRT_HANDLER_IMAGE
+                  value: quay.io/kubevirt/virt-handler@sha256:cf36d0df3b019e86a747eea4cdfd62ab78f8109481d4cac28a383b308825d945
+                - name: VIRT_LAUNCHER_IMAGE
+                  value: quay.io/kubevirt/virt-launcher@sha256:49ed398374b0a94a5d67cc99051117a9a422a3972aed0c9f87c0eb115ddf2249
+                - name: VIRT_EXPORTPROXY_IMAGE
+                  value: quay.io/kubevirt/virt-exportproxy@sha256:d7ef7c80f2dd44da1b5d9c4e0e2313764fc6c502112552fe5b6eb063d0494113
+                - name: VIRT_EXPORTSERVER_IMAGE
+                  value: quay.io/kubevirt/virt-exportserver@sha256:7e6b2e3bf53f3ae533f71776572a76a67a4a828f459d0271e720bb27d8787d64
+                - name: GS_IMAGE
+                  value: quay.io/kubevirt/libguestfs-tools@sha256:b923e8050ebc386505bc587a066a36dd70fa49df57789e86e77d28b1035045d3
                 - name: KUBEVIRT_VERSION
                   value: v1.0.0-alpha.0
                 image: quay.io/kubevirt/virt-operator@sha256:31542e77456b84d4763d2b01c64e3eb9220e56992e13b4efc80fab8dcc36783c

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -405,20 +405,20 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
-        - name: VIRT_API_SHASUM
-          value: sha256:ddb0442f62fd68ad99b611a7015e7a711411f34b3dfe5825d4c4458a23e71afe
-        - name: VIRT_CONTROLLER_SHASUM
-          value: sha256:37d81eb640cac4f21a0867bfe44ca8282aba34e8263235286a7bf126d079562e
-        - name: VIRT_HANDLER_SHASUM
-          value: sha256:cf36d0df3b019e86a747eea4cdfd62ab78f8109481d4cac28a383b308825d945
-        - name: VIRT_LAUNCHER_SHASUM
-          value: sha256:49ed398374b0a94a5d67cc99051117a9a422a3972aed0c9f87c0eb115ddf2249
-        - name: VIRT_EXPORTPROXY_SHASUM
-          value: sha256:d7ef7c80f2dd44da1b5d9c4e0e2313764fc6c502112552fe5b6eb063d0494113
-        - name: VIRT_EXPORTSERVER_SHASUM
-          value: sha256:7e6b2e3bf53f3ae533f71776572a76a67a4a828f459d0271e720bb27d8787d64
-        - name: GS_SHASUM
-          value: sha256:b923e8050ebc386505bc587a066a36dd70fa49df57789e86e77d28b1035045d3
+        - name: VIRT_API_IMAGE
+          value: quay.io/kubevirt/virt-api@sha256:ddb0442f62fd68ad99b611a7015e7a711411f34b3dfe5825d4c4458a23e71afe
+        - name: VIRT_CONTROLLER_IMAGE
+          value: quay.io/kubevirt/virt-controller@sha256:37d81eb640cac4f21a0867bfe44ca8282aba34e8263235286a7bf126d079562e
+        - name: VIRT_HANDLER_IMAGE
+          value: quay.io/kubevirt/virt-handler@sha256:cf36d0df3b019e86a747eea4cdfd62ab78f8109481d4cac28a383b308825d945
+        - name: VIRT_LAUNCHER_IMAGE
+          value: quay.io/kubevirt/virt-launcher@sha256:49ed398374b0a94a5d67cc99051117a9a422a3972aed0c9f87c0eb115ddf2249
+        - name: VIRT_EXPORTPROXY_IMAGE
+          value: quay.io/kubevirt/virt-exportproxy@sha256:d7ef7c80f2dd44da1b5d9c4e0e2313764fc6c502112552fe5b6eb063d0494113
+        - name: VIRT_EXPORTSERVER_IMAGE
+          value: quay.io/kubevirt/virt-exportserver@sha256:7e6b2e3bf53f3ae533f71776572a76a67a4a828f459d0271e720bb27d8787d64
+        - name: GS_IMAGE
+          value: quay.io/kubevirt/libguestfs-tools@sha256:b923e8050ebc386505bc587a066a36dd70fa49df57789e86e77d28b1035045d3
         - name: KUBEVIRT_VERSION
           value: v1.0.0-alpha.0
         image: quay.io/kubevirt/virt-operator@sha256:31542e77456b84d4763d2b01c64e3eb9220e56992e13b4efc80fab8dcc36783c

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -96,18 +96,6 @@ function gen_csv() {
 }
 
 function create_virt_csv() {
-  local apiSha
-  local controllerSha
-  local launcherSha
-  local handlerSha
-
-  apiSha="${KUBEVIRT_API_IMAGE/*@/}"
-  controllerSha="${KUBEVIRT_CONTROLLER_IMAGE/*@/}"
-  launcherSha="${KUBEVIRT_LAUNCHER_IMAGE/*@/}"
-  handlerSha="${KUBEVIRT_HANDLER_IMAGE/*@/}"
-  exportProxySha="${KUBEVIRT_EXPORTPROXY_IMAGE/*@/}"
-  exportServerSha="${KUBEVIRT_EXPORSERVER_IMAGE/*@/}"
-
   local operatorName="kubevirt"
   local dumpCRDsArg="--dumpCRDs"
   local operatorArgs
@@ -115,15 +103,15 @@ function create_virt_csv() {
     --namespace=${OPERATOR_NAMESPACE} \
     --csvVersion=${CSV_VERSION} \
     --operatorImageVersion=${KUBEVIRT_OPERATOR_IMAGE/*@/} \
-    --dockerPrefix=${KUBEVIRT_OPERATOR_IMAGE%\/*} \
     --kubeVirtVersion=${KUBEVIRT_VERSION} \
-    --apiSha=${apiSha} \
-    --controllerSha=${controllerSha} \
-    --handlerSha=${handlerSha} \
-    --launcherSha=${launcherSha} \
-    --exportProxySha=${exportProxySha} \
-    --exportServerSha=${exportServerSha} \
-    --gsSha=${KUBEVIRT_LIBGUESTFS_TOOLS_IMAGE/*@/} \
+    --virt-api-image="${KUBEVIRT_API_IMAGE}" \
+    --virt-controller-image="${KUBEVIRT_CONTROLLER_IMAGE}" \
+    --virt-handler-image="${KUBEVIRT_HANDLER_IMAGE}" \
+    --virt-launcher-image="${KUBEVIRT_LAUNCHER_IMAGE}" \
+    --virt-export-proxy-image="${KUBEVIRT_EXPORTPROXY_IMAGE}" \
+    --virt-export-server-image="${KUBEVIRT_EXPORSERVER_IMAGE}" \
+    --gs-image="${KUBEVIRT_LIBGUESTFS_TOOLS_IMAGE}" \
+    --virt-operator-image="${KUBEVIRT_OPERATOR_IMAGE}"
   "
 
   gen_csv "${DEFAULT_CSV_GENERATOR}" "${operatorName}" "${KUBEVIRT_OPERATOR_IMAGE}" "${dumpCRDsArg}" "${operatorArgs}"


### PR DESCRIPTION
**What this PR does / why we need it**:

After
https://github.com/kubevirt/kubevirt/pull/8673
passing only the sha digest of virt images
is deprecated.
Let's switch to the new mechanism.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Consume virt images with full URL
```
