### PR TITLE
Add static rate limit profile `highBurst`

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -29,7 +29,10 @@ type HyperConvergedTuningPolicy string
 
 // HyperConvergedAnnotationTuningPolicy defines a static configuration of the kubevirt query per seconds (qps) and burst values
 // through annotation values.
-const HyperConvergedAnnotationTuningPolicy HyperConvergedTuningPolicy = "annotation"
+const (
+	HyperConvergedAnnotationTuningPolicy HyperConvergedTuningPolicy = "annotation"
+	HyperConvergedHighBurstProfile       HyperConvergedTuningPolicy = "highBurst"
+)
 
 // HyperConvergedSpec defines the desired state of HyperConverged
 // +k8s:openapi-gen=true
@@ -45,7 +48,7 @@ type HyperConvergedSpec struct {
 	// If TuningPolicy is not present the default kubevirt values are used.
 	// It can be set to `annotation` for fine-tuning the kubevirt queryPerSeconds (qps) and burst values.
 	// Qps and burst values are taken from the annotation hco.kubevirt.io/tuningPolicy
-	// +kubebuilder:validation:Enum=annotation
+	// +kubebuilder:validation:Enum=annotation;highBurst
 	// +optional
 	TuningPolicy HyperConvergedTuningPolicy `json:"tuningPolicy,omitempty"`
 

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2439,6 +2439,7 @@ spec:
                   Qps and burst values are taken from the annotation hco.kubevirt.io/tuningPolicy
                 enum:
                 - annotation
+                - highBurst
                 type: string
               uninstallStrategy:
                 default: BlockUninstallIfWorkloadsExist

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2439,6 +2439,7 @@ spec:
                   Qps and burst values are taken from the annotation hco.kubevirt.io/tuningPolicy
                 enum:
                 - annotation
+                - highBurst
                 type: string
               uninstallStrategy:
                 default: BlockUninstallIfWorkloadsExist

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -2439,6 +2439,7 @@ spec:
                   Qps and burst values are taken from the annotation hco.kubevirt.io/tuningPolicy
                 enum:
                 - annotation
+                - highBurst
                 type: string
               uninstallStrategy:
                 default: BlockUninstallIfWorkloadsExist

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -2439,6 +2439,7 @@ spec:
                   Qps and burst values are taken from the annotation hco.kubevirt.io/tuningPolicy
                 enum:
                 - annotation
+                - highBurst
                 type: string
               uninstallStrategy:
                 default: BlockUninstallIfWorkloadsExist

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -1058,7 +1058,13 @@ Kubevirt API clients come with a token bucket rate limiter which avoids to conge
 The rate limiters are configurable through `burst` and `Query Per Second (QPS)` parameters.
 Whilst the rate limiter may avoid congestion, it may also limit the number of VMs that can be deployed in the cluster.
 Therefore, HCO enables the feature `tuningPolicy` for allowing to tune the rate limiters parameters.
-The `tuningPolicy` field can be set as `annotation`.
+Currently, there are two profiles supported: `annotation` and `highBurst`.
+
+### Annotation Profile
+
+The `tuningPolicy` profile `annotation` is intended for arbitrary `burst` and `QPS` values, i.e. the values are fully
+configurable with the desired ones.
+By using this profile, the user is responsible for setting the values more appropriated to its particular scenario.
 
 > **_Note_:** If no `tuningPolicy` is configured or the `tuningPolicy` feature is not well configured, Kubevirt will use the
 > [default](https://github.com/kubevirt/kubevirt/blob/a3e92eb499636cbab46763fbdd1dbccaca716c29/pkg/virt-config/virt-config.go#L78-L86) rate limiter values.
@@ -1093,4 +1099,18 @@ The `tuningPolicy` feature can be enabled using the following patch:
 
 ```bash
 kubectl patch -n kubevirt-hyperconverged hco kubevirt-hyperconverged --type=json -p='[{"op": "add", "path": "/spec/tuningPolicy", "value": "annotation"}]'
+```
+
+### HighBurst Profile
+
+The `highBurst` profile is intended for high load scenarios where the user expect to create and maintain a high number of VMs
+in the same cluster.
+The profile configures internally the more suitable `burst` and `QPS` values for the most common high load scenarios. 
+Nevertheless, the specific configuration of those values is hidden to the user.
+Also, the values may change over time since they are based on an experimentation process.
+
+To enable this `tuningPolicy` profile, the following patch may be applied:
+
+```bash
+kubectl patch -n kubevirt-hyperconverged hco kubevirt-hyperconverged --type=json -p='[{"op": "add", "path": "/spec/tuningPolicy", "value": "highBurst"}]'
 ```


### PR DESCRIPTION
This PR adds the rate limit profile `highBurst`. This profile hides the configuration values `Query Per Second (QPS)` and `burst` of KubeVirt components: `API`, `Webhook`, `Controller` and `Handler`.

**What this PR does / why we need it**:
Currently, in order to set up these values, it is required to use the following path:

```
$ oc patch hco -n openshift-cnv kubevirt-hyperconverged --type=merge -p '{"metadata":{"annotations":{"kubevirt.kubevirt.io/jsonpatch":"[{\"op\":\"add\",\"path\":\"/spec/configuration\",\"value\":{\"apiConfiguration\":{\"restClient\":{\"rateLimiter\":{\"tokenBucketRateLimiter\":{\"burst\":200,\"qps\":100}}}},\"controllerConfiguration\":{\"restClient\":{\"rateLimiter\":{\"tokenBucketRateLimiter\":{\"burst\":400,\"qps\":200}}}},\"handlerConfiguration\":{\"restClient\":{\"rateLimiter\":{\"tokenBucketRateLimiter\":{\"burst\":400,\"qps\":200}}}},\"webhookConfiguration\":{\"restClient\":{\"rateLimiter\":{\"tokenBucketRateLimiter\":{\"burst\":400,\"qps\":200}}}}}}]"}}}'
```
or use the `tuningPolicy: annotation` profile. However, this profile has two main downsides: requires users to know the best suitable values for their use-case and it does not allow to configure the values of each component.
This new feature solves both problems while avoiding the use of the patch.

Implements: https://github.com/kubevirt/hyperconverged-cluster-operator/issues/2295
**Reviewer Checklist**

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:

```jira-ticket
https://issues.redhat.com/browse/CNV-14170
```

**Release note**:

```release-note
KubeVirt rate limit profile `highBurst`. This profile helps to create and maintain a high number of VMs in the same cluster.
```
