### PR TITLE
Use NodeSelector for kubevirt-console-plugin from HCO CR

### DIFF
--- a/controllers/common/hcoRequest.go
+++ b/controllers/common/hcoRequest.go
@@ -9,7 +9,7 @@ import (
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 )
 
-// hcoRequest - gather data for a specific request
+// HcoRequest - gather data for a specific request
 type HcoRequest struct {
 	reconcile.Request                                     // inheritance of operator request
 	Logger                     logr.Logger                // request logger

--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -61,7 +61,7 @@ func NewKvUiPluginDeplymnt(hc *hcov1beta1.HyperConverged) (*appsv1.Deployment, e
 	// The env var was validated prior to handler creation
 	kvUiPluginImage, _ := os.LookupEnv(hcoutil.KvUiPluginImageEnvV)
 
-	return &appsv1.Deployment{
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIPluginDeploymentName,
 			Labels:    getLabels(hc, hcoutil.AppComponentDeployment),
@@ -144,7 +144,14 @@ func NewKvUiPluginDeplymnt(hc *hcov1beta1.HyperConverged) (*appsv1.Deployment, e
 				},
 			},
 		},
-	}, nil
+	}
+
+	if hc.Spec.Infra.NodePlacement != nil {
+		deployment.Spec.Template.Spec.NodeSelector = hc.Spec.Infra.NodePlacement.NodeSelector
+		deployment.Spec.Template.Spec.Affinity = hc.Spec.Infra.NodePlacement.Affinity
+		deployment.Spec.Template.Spec.Tolerations = hc.Spec.Infra.NodePlacement.Tolerations
+	}
+	return deployment, nil
 }
 
 func NewKvUiPluginSvc(hc *hcov1beta1.HyperConverged) *corev1.Service {

--- a/controllers/operands/kubevirtConsolePlugin_test.go
+++ b/controllers/operands/kubevirtConsolePlugin_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"reflect"
 
+	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	consolev1 "github.com/openshift/api/console/v1"
@@ -202,6 +204,9 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should create if not present", func() {
+			hco.Spec.Infra.NodePlacement = &sdkapi.NodePlacement{
+				NodeSelector: map[string]string{"key": "value"},
+			}
 			expectedResource, err := NewKvUiPluginDeplymnt(hco)
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It would help ensure `kubevirt-console-plugin` Pods respect the `nodeSelector` configuration

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-27446
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Place kubevirt-console-plugin Pod on NodeSelector specified in HCO CR
```
