### PR TITLE
fix sanity test

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.19' # The Go version to download (if necessary) and use.
 
@@ -34,7 +34,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.52.2
           skip-pkg-cache: true
           args: --timeout=5m --out-${NO_FUTURE}format line-number
 

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -11,24 +11,27 @@ k8s.io/code-generator/cmd/openapi-gen@${K8S_VER}
 
 deepcopy-gen \
 	--go-header-file "${PROJECT_ROOT}/hack/boilerplate.go.txt" \
-	--output-base "${PROJECT_ROOT}/../../.." \
+	--output-base "${PROJECT_ROOT}" \
 	--output-file-base zz_generated.deepcopy \
 	--input-dirs github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1 \
-	--output-package github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1
+	--output-package github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1 \
+        --trim-path-prefix="${PROJECT_ROOT}/github.com/kubevirt/hyperconverged-cluster-operator/"
 
 defaulter-gen \
 	--go-header-file "${PROJECT_ROOT}/hack/boilerplate.go.txt" \
-	--output-base "${PROJECT_ROOT}/../../.." \
+	--output-base "${PROJECT_ROOT}" \
 	--output-file-base zz_generated.defaults \
 	--input-dirs github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1 \
-	--output-package github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1
+	--output-package github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1 \
+  --trim-path-prefix="${PROJECT_ROOT}/github.com/kubevirt/hyperconverged-cluster-operator/"
 
 openapi-gen \
 	--go-header-file "${PROJECT_ROOT}/hack/boilerplate.go.txt" \
-	--output-base "${PROJECT_ROOT}/../../.." \
+	--output-base "${PROJECT_ROOT}" \
 	--output-file-base zz_generated.openapi \
 	--input-dirs github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1 \
-	--output-package github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1
+	--output-package github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1 \
+        --trim-path-prefix="${PROJECT_ROOT}/github.com/kubevirt/hyperconverged-cluster-operator/"
 
 go fmt api/v1beta1/zz_generated.deepcopy.go
 go fmt api/v1beta1/zz_generated.defaults.go


### PR DESCRIPTION
## What this PR does / why we need it
Before this PR, running `make generate` in the CI, generates the files in the wrong place, and so the `git diff` missed the changes if the author forgot to regenerate before opening the PR. The result is that we could push API changes without regenerate, and the sanity test missed that.

This PR fixes this issue. Now the files are generated at the right place, and so the sanity test does check the auto generated files.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
