### PR TITLE
dataImportCronTemplates: Move default-instancetype to n.medium

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -4,7 +4,7 @@
     name: centos-stream8-image-cron
     labels:
       instancetype.kubevirt.io/default-preference: centos.8.stream
-      instancetype.kubevirt.io/default-instancetype: server.medium
+      instancetype.kubevirt.io/default-instancetype: n.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -24,7 +24,7 @@
     name: centos-stream9-image-cron
     labels:
       instancetype.kubevirt.io/default-preference: centos.9.stream
-      instancetype.kubevirt.io/default-instancetype: server.medium
+      instancetype.kubevirt.io/default-instancetype: n.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -44,7 +44,7 @@
     name: fedora-image-cron
     labels:
       instancetype.kubevirt.io/default-preference: fedora
-      instancetype.kubevirt.io/default-instancetype: server.medium
+      instancetype.kubevirt.io/default-instancetype: n.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -64,7 +64,7 @@
     name: centos-7-image-cron
     labels:
       instancetype.kubevirt.io/default-preference: centos.7
-      instancetype.kubevirt.io/default-instancetype: server.medium
+      instancetype.kubevirt.io/default-instancetype: n.medium
   spec:
     schedule: "0 */12 * * *"
     template:


### PR DESCRIPTION
**What this PR does / why we need it**:

The common-templates based server and highperformance instance types are deprecated and will be removed in a future release of common-instancetypes:

Deprecate the legacy instance types
https://github.com/kubevirt/common-instancetypes/pull/36

This change moves the dataImportCronTemplates supplied by HCO to the SSP operator over to using the equivalent hyperscale like generic N family of instance types.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-26869
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
