### PR TITLE
Fix gomega expressions without assertions

### DIFF
--- a/controllers/operands/cliDownload_test.go
+++ b/controllers/operands/cliDownload_test.go
@@ -75,7 +75,7 @@ var _ = Describe("CLI Download", func() {
 
 			key := client.ObjectKeyFromObject(expectedResource)
 			foundResource := &consolev1.ConsoleCLIDownload{}
-			Expect(cl.Get(context.TODO(), key, foundResource))
+			Expect(cl.Get(context.TODO(), key, foundResource)).To(Succeed())
 			Expect(reflect.DeepEqual(expectedResource.Spec, foundResource.Spec)).To(BeTrue())
 
 			// ObjectReference should have been updated
@@ -159,7 +159,7 @@ var _ = Describe("Downloads Service", func() {
 
 			key := client.ObjectKeyFromObject(expectedResource)
 			foundResource := &corev1.Service{}
-			Expect(cl.Get(context.TODO(), key, foundResource))
+			Expect(cl.Get(context.TODO(), key, foundResource)).To(Succeed())
 			Expect(hasServiceRightFields(foundResource, expectedResource)).To(BeTrue())
 
 			// ObjectReference should have been updated
@@ -239,7 +239,7 @@ var _ = Describe("Cli Downloads Route", func() {
 
 			key := client.ObjectKeyFromObject(expectedResource)
 			foundResource := &routev1.Route{}
-			Expect(cl.Get(context.TODO(), key, foundResource))
+			Expect(cl.Get(context.TODO(), key, foundResource)).To(Succeed())
 			Expect(hasRouteRightFields(foundResource, expectedResource)).To(BeTrue())
 
 			// ObjectReference should have been updated

--- a/controllers/operands/kubevirtConsolePlugin_test.go
+++ b/controllers/operands/kubevirtConsolePlugin_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 
-			Expect(reflect.DeepEqual(foundResource.Labels, expectedResource.Labels))
+			Expect(reflect.DeepEqual(foundResource.Labels, expectedResource.Labels)).To(BeTrue())
 		})
 
 		It("should reconcile plugin labels to default if added", func() {
@@ -163,7 +163,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 
-			Expect(reflect.DeepEqual(foundResource.Labels, expectedResource.Labels))
+			Expect(reflect.DeepEqual(foundResource.Labels, expectedResource.Labels)).To(BeTrue())
 		})
 
 		It("should reconcile plugin labels to default if deleted", func() {
@@ -188,7 +188,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 
-			Expect(reflect.DeepEqual(foundResource.Labels, expectedResource.Labels))
+			Expect(reflect.DeepEqual(foundResource.Labels, expectedResource.Labels)).To(BeTrue())
 		})
 	})
 

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -84,7 +84,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			expectedResource := NewKubeVirtPriorityClass(hco)
 			key := client.ObjectKeyFromObject(expectedResource)
 			foundResource := &schedulingv1.PriorityClass{}
-			Expect(cl.Get(context.TODO(), key, foundResource))
+			Expect(cl.Get(context.TODO(), key, foundResource)).To(Succeed())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
 			Expect(foundResource.Value).To(Equal(expectedResource.Value))
 			Expect(foundResource.GlobalDefault).To(Equal(expectedResource.GlobalDefault))


### PR DESCRIPTION
Ran ginkgolinter v0.12.0 with the new "missing assetion" rule. Found several places where the assertion method is missing, and fixed them.

e.g.:
```go
Expect(cl.Get(context.TODO(), key, foundResource))
```
Should be:
```go
Expect(cl.Get(context.TODO(), key, foundResource)).To(Succeed())
```

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
