### PR TITLE
Fix local execution on OCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ hack/cloud-init.sh
 hack/test_ssh*
 tools/release-notes/vendor/
 tools/release-notes/git/vendor/
+upgradePatches.json

--- a/hack/make_local.sh
+++ b/hack/make_local.sh
@@ -21,6 +21,8 @@ sed -i "s|-f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-o
 
 chmod +x _local/deploy.sh
 
+ln -s assets/upgradePatches.json upgradePatches.json
+
 kubectl config set-context --current --namespace=${hco_namespace}
 _local/deploy.sh
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When we deploy locally, HCO binary
is executed without a pod (by design) so we cannot
get a reference to its deployment and to
the owning CSV starting from the pod we are
running in.
On the other side, when deploying locally,
we know in advance the name of the deployment
object (with replica=0) and the expected
namespace from an environmental variable.
Let's get the deployment object from there.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
