### PR TITLE
[release-1.8] Expose DisableMDEVConfiguration feature gate on HCO API…

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -274,6 +274,11 @@ type HyperConvergedFeatureGates struct {
 	// +optional
 	// +kubebuilder:default=true
 	NonRoot bool `json:"nonRoot"`
+
+	// Disable mediated devices handling on KubeVirt
+	// +optional
+	// +kubebuilder:default=false
+	DisableMDevConfiguration bool `json:"disableMDevConfiguration"`
 }
 
 // PermittedHostDevices holds information about devices allowed for passthrough

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2022 Red Hat, Inc.
+ * Copyright 2023 Red Hat, Inc.
  *
  */
 

--- a/api/v1beta1/zz_generated.defaults.go
+++ b/api/v1beta1/zz_generated.defaults.go
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2022 Red Hat, Inc.
+ * Copyright 2023 Red Hat, Inc.
  *
  */
 

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2022 Red Hat, Inc.
+ * Copyright 2023 Red Hat, Inc.
  *
  */
 
@@ -218,6 +218,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 					"nonRoot": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Enables rootless virt-launcher.",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"disableMDevConfiguration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Disable mediated devices handling on KubeVirt",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -875,6 +875,10 @@ spec:
                     description: deploy resources (kubevirt tekton tasks and example
                       pipelines) in Tekton tasks operator
                     type: boolean
+                  disableMDevConfiguration:
+                    default: false
+                    description: Disable mediated devices handling on KubeVirt
+                    type: boolean
                   enableCommonBootImageImport:
                     default: true
                     description: 'Opt-in to automatic delivery/updates of the common

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -138,6 +138,7 @@ var (
 const (
 	kvWithHostPassthroughCPU = "WithHostPassthroughCPU"
 	kvNonRoot                = "NonRoot"
+	kvDisableMDevConfig      = "DisableMDEVConfiguration"
 )
 
 // CPU Plugin default values
@@ -571,6 +572,10 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) [
 
 	if featureGates.NonRoot {
 		fgs = append(fgs, kvNonRoot)
+	}
+
+	if featureGates.DisableMDevConfiguration {
+		fgs = append(fgs, kvDisableMDevConfig)
 	}
 
 	return fgs

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -1392,6 +1392,32 @@ Version: 1.2.3`)
 					})
 				})
 
+				It("should add the DisableMDevConfiguration feature gate if DisableMDevConfiguration is true in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						DisableMDevConfiguration: true,
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the DisableMDevConfiguration feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvDisableMDevConfig))
+					})
+				})
+
+				It("should not add the DisableMDevConfiguration feature gate if DisableMDevConfiguration is false in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						DisableMDevConfiguration: false,
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the DisableMDevConfiguration feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvDisableMDevConfig))
+					})
+				})
+
 				It("should not add the feature gates if FeatureGates field is empty", func() {
 					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{}
@@ -1426,7 +1452,8 @@ Version: 1.2.3`)
 					Expect(err).ToNot(HaveOccurred())
 
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						WithHostPassthroughCPU: true,
+						WithHostPassthroughCPU:   true,
+						DisableMDevConfiguration: true,
 					}
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
@@ -1456,7 +1483,8 @@ Version: 1.2.3`)
 					Expect(err).ToNot(HaveOccurred())
 
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						WithHostPassthroughCPU: false,
+						WithHostPassthroughCPU:   false,
+						DisableMDevConfiguration: false,
 					}
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -875,6 +875,10 @@ spec:
                     description: deploy resources (kubevirt tekton tasks and example
                       pipelines) in Tekton tasks operator
                     type: boolean
+                  disableMDevConfiguration:
+                    default: false
+                    description: Disable mediated devices handling on KubeVirt
+                    type: boolean
                   enableCommonBootImageImport:
                     default: true
                     description: 'Opt-in to automatic delivery/updates of the common

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -13,6 +13,7 @@ spec:
       renewBefore: 12h0m0s
   featureGates:
     deployTektonTaskResources: false
+    disableMDevConfiguration: false
     enableCommonBootImageImport: false
     nonRoot: true
     withHostPassthroughCPU: false

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
@@ -875,6 +875,10 @@ spec:
                     description: deploy resources (kubevirt tekton tasks and example
                       pipelines) in Tekton tasks operator
                     type: boolean
+                  disableMDevConfiguration:
+                    default: false
+                    description: Disable mediated devices handling on KubeVirt
+                    type: boolean
                   enableCommonBootImageImport:
                     default: true
                     description: 'Opt-in to automatic delivery/updates of the common

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.8.0/manifests/hco00.crd.yaml
@@ -875,6 +875,10 @@ spec:
                     description: deploy resources (kubevirt tekton tasks and example
                       pipelines) in Tekton tasks operator
                     type: boolean
+                  disableMDevConfiguration:
+                    default: false
+                    description: Disable mediated devices handling on KubeVirt
+                    type: boolean
                   enableCommonBootImageImport:
                     default: true
                     description: 'Opt-in to automatic delivery/updates of the common

--- a/docs/api.md
+++ b/docs/api.md
@@ -130,6 +130,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | enableCommonBootImageImport | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | bool | true | true |
 | deployTektonTaskResources | deploy resources (kubevirt tekton tasks and example pipelines) in Tekton tasks operator | bool | false | true |
 | nonRoot | Enables rootless virt-launcher. | bool | true | true |
+| disableMDevConfiguration | Disable mediated devices handling on KubeVirt | bool | false | true |
 
 [Back to TOC](#table-of-contents)
 

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -22,7 +22,7 @@ echo "Read the CR's spec before starting the test"
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o json | jq '.spec'
 
 CERTCONFIGDEFAULTS='{"ca":{"duration":"48h0m0s","renewBefore":"24h0m0s"},"server":{"duration":"24h0m0s","renewBefore":"12h0m0s"}}'
-FGDEFAULTS='{"deployTektonTaskResources":false,"enableCommonBootImageImport":true,"nonRoot":true,"withHostPassthroughCPU":false}'
+FGDEFAULTS='{"deployTektonTaskResources":false,"disableMDevConfiguration":false,"enableCommonBootImageImport":true,"nonRoot":true,"withHostPassthroughCPU":false}'
 LMDEFAULTS='{"completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'
@@ -41,6 +41,7 @@ CERTCONFIGPATHS=(
 )
 
 FGPATHS=(
+    "/spec/featureGates/disableMDevConfiguration"
     "/spec/featureGates/enableCommonBootImageImport"
     "/spec/featureGates/withHostPassthroughCPU"
     "/spec/featureGates"
@@ -96,7 +97,7 @@ for JPATH in "${FGPATHS[@]}"; do
     sleep 2
 done
 
-echo "Check that featureGates defaults are behaving as expected"
+echo "Check that liveMigrationConfig defaults are behaving as expected"
 
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": /spec, \"value\": {} }]'"
 for JPATH in "${LMPATHS[@]}"; do

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -60,7 +60,7 @@ var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 			expectedWorkloadsPods := map[string]bool{
 				"bridge-marker": false,
 				"cni-plugins":   false,
-				//"kube-multus":     false,
+				// "kube-multus":     false,
 				"ovs-cni-marker": false,
 				"virt-handler":   false,
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
* Expose DisableMDEVConfiguration feature gate on HCO API

This is a manual cherry pick of #2320

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2184440


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-27890
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
expose DisableMDEVConfiguration feature gate in HCO CR.
```
