### PR TITLE
[release-1.9] Expose DisableMDEVConfiguration feature gate on HCO API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ sanity: generate generate-doc validate-no-offensive-lang goimport
 	go mod tidy -v
 	go mod vendor
 	./hack/build-manifests.sh
+	(cd tests && go mod tidy -v && go mod vendor)
 	git add -N vendor
 	git difftool -y --trust-exit-code --extcmd=./hack/diff-csv.sh
 

--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -329,6 +329,12 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=true
 	// +default=true
 	NonRoot *bool `json:"nonRoot,omitempty"`
+
+	// Disable mediated devices handling on KubeVirt
+	// +optional
+	// +kubebuilder:default=false
+	// +default=false
+	DisableMDevConfiguration *bool `json:"disableMDevConfiguration,omitempty"`
 }
 
 // PermittedHostDevices holds information about devices allowed for passthrough

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -235,6 +235,11 @@ func (in *HyperConvergedFeatureGates) DeepCopyInto(out *HyperConvergedFeatureGat
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisableMDevConfiguration != nil {
+		in, out := &in.DisableMDevConfiguration, &out.DisableMDevConfiguration
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1beta1/zz_generated.defaults.go
+++ b/api/v1beta1/zz_generated.defaults.go
@@ -60,6 +60,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = true
 		in.Spec.FeatureGates.NonRoot = &ptrVar1
 	}
+	if in.Spec.FeatureGates.DisableMDevConfiguration == nil {
+		var ptrVar1 bool = false
+		in.Spec.FeatureGates.DisableMDevConfiguration = &ptrVar1
+	}
 	if in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster == nil {
 		var ptrVar1 uint32 = 5
 		in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster = &ptrVar1

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -235,6 +235,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 							Format:      "",
 						},
 					},
+					"disableMDevConfiguration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Disable mediated devices handling on KubeVirt",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -561,6 +569,13 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 									},
 								},
 							},
+						},
+					},
+					"systemHealthStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SystemHealthStatus reflects the health of HCO and its secondary resources, based on the aggregated conditions.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -1021,6 +1021,10 @@ spec:
                     description: deploy resources (kubevirt tekton tasks and example
                       pipelines) in Tekton tasks operator
                     type: boolean
+                  disableMDevConfiguration:
+                    default: false
+                    description: Disable mediated devices handling on KubeVirt
+                    type: boolean
                   enableCommonBootImageImport:
                     default: true
                     description: 'Opt-in to automatic delivery/updates of the common

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -143,6 +143,7 @@ var (
 const (
 	kvWithHostPassthroughCPU = "WithHostPassthroughCPU"
 	kvRoot                   = "Root"
+	kvDisableMDevConfig      = "DisableMDEVConfiguration"
 )
 
 // CPU Plugin default values
@@ -641,6 +642,10 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) [
 
 	if featureGates.NonRoot != nil && !*featureGates.NonRoot {
 		fgs = append(fgs, kvRoot)
+	}
+
+	if featureGates.DisableMDevConfiguration != nil && *featureGates.DisableMDevConfiguration {
+		fgs = append(fgs, kvDisableMDevConfig)
 	}
 
 	return fgs

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -1411,6 +1411,45 @@ Version: 1.2.3`)
 					})
 				})
 
+				It("should add the DisableMDevConfiguration feature gate if DisableMDevConfiguration is true in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						DisableMDevConfiguration: pointer.Bool(true),
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the DisableMDevConfiguration feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvDisableMDevConfig))
+					})
+				})
+
+				It("should not add the DisableMDevConfiguration feature gate if DisableMDevConfiguration is not set in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						DisableMDevConfiguration: nil,
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the DisableMDevConfiguration feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvDisableMDevConfig))
+					})
+				})
+
+				It("should not add the DisableMDevConfiguration feature gate if DisableMDevConfiguration is false in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						DisableMDevConfiguration: pointer.Bool(false),
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the DisableMDevConfiguration feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvDisableMDevConfig))
+					})
+				})
+
 				It("should not add the feature gates if FeatureGates field is empty", func() {
 					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{}
@@ -1445,7 +1484,8 @@ Version: 1.2.3`)
 					Expect(err).ToNot(HaveOccurred())
 
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						WithHostPassthroughCPU: pointer.Bool(true),
+						WithHostPassthroughCPU:   pointer.Bool(true),
+						DisableMDevConfiguration: pointer.Bool(true),
 					}
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
@@ -1475,7 +1515,8 @@ Version: 1.2.3`)
 					Expect(err).ToNot(HaveOccurred())
 
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						WithHostPassthroughCPU: pointer.Bool(false),
+						WithHostPassthroughCPU:   pointer.Bool(false),
+						DisableMDevConfiguration: pointer.Bool(false),
 					}
 
 					cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
@@ -2576,7 +2617,7 @@ Version: 1.2.3`)
 
 				hco.Spec.TuningPolicy = hcov1beta1.HyperConvergedAnnotationTuningPolicy
 				hco.Annotations = make(map[string]string, 1)
-				//burst is missing
+				// burst is missing
 				hco.Annotations["hco.kubevirt.io/tuningPolicy"] = `{"qps": 100}`
 
 				kv, err := NewKubeVirt(hco)

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1021,6 +1021,10 @@ spec:
                     description: deploy resources (kubevirt tekton tasks and example
                       pipelines) in Tekton tasks operator
                     type: boolean
+                  disableMDevConfiguration:
+                    default: false
+                    description: Disable mediated devices handling on KubeVirt
+                    type: boolean
                   enableCommonBootImageImport:
                     default: true
                     description: 'Opt-in to automatic delivery/updates of the common

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -14,6 +14,7 @@ spec:
   featureGates:
     deployKubeSecondaryDNS: false
     deployTektonTaskResources: false
+    disableMDevConfiguration: false
     enableCommonBootImageImport: true
     nonRoot: true
     withHostPassthroughCPU: false

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
@@ -1021,6 +1021,10 @@ spec:
                     description: deploy resources (kubevirt tekton tasks and example
                       pipelines) in Tekton tasks operator
                     type: boolean
+                  disableMDevConfiguration:
+                    default: false
+                    description: Disable mediated devices handling on KubeVirt
+                    type: boolean
                   enableCommonBootImageImport:
                     default: true
                     description: 'Opt-in to automatic delivery/updates of the common

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.9.0/manifests/hco00.crd.yaml
@@ -1021,6 +1021,10 @@ spec:
                     description: deploy resources (kubevirt tekton tasks and example
                       pipelines) in Tekton tasks operator
                     type: boolean
+                  disableMDevConfiguration:
+                    default: false
+                    description: Disable mediated devices handling on KubeVirt
+                    type: boolean
                   enableCommonBootImageImport:
                     default: true
                     description: 'Opt-in to automatic delivery/updates of the common

--- a/docs/api.md
+++ b/docs/api.md
@@ -131,6 +131,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | deployTektonTaskResources | deploy resources (kubevirt tekton tasks and example pipelines) in Tekton tasks operator | *bool | false | false |
 | deployKubeSecondaryDNS | Deploy KubeSecondaryDNS by CNAO | *bool | false | false |
 | nonRoot | Enables rootless virt-launcher. | *bool | true | false |
+| disableMDevConfiguration | Disable mediated devices handling on KubeVirt | *bool | false | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -22,7 +22,7 @@ echo "Read the CR's spec before starting the test"
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o json | jq '.spec'
 
 CERTCONFIGDEFAULTS='{"ca":{"duration":"48h0m0s","renewBefore":"24h0m0s"},"server":{"duration":"24h0m0s","renewBefore":"12h0m0s"}}'
-FGDEFAULTS='{"deployKubeSecondaryDNS":false,"deployTektonTaskResources":false,"enableCommonBootImageImport":true,"nonRoot":true,"withHostPassthroughCPU":false}'
+FGDEFAULTS='{"deployKubeSecondaryDNS":false,"deployTektonTaskResources":false,"disableMDevConfiguration":false,"enableCommonBootImageImport":true,"nonRoot":true,"withHostPassthroughCPU":false}'
 LMDEFAULTS='{"allowAutoConverge":false,"allowPostCopy":false,"completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'
@@ -41,6 +41,7 @@ CERTCONFIGPATHS=(
 )
 
 FGPATHS=(
+    "/spec/featureGates/disableMDevConfiguration"
     "/spec/featureGates/enableCommonBootImageImport"
     "/spec/featureGates/withHostPassthroughCPU"
     "/spec/featureGates"
@@ -99,7 +100,7 @@ for JPATH in "${FGPATHS[@]}"; do
     sleep 2
 done
 
-echo "Check that featureGates defaults are behaving as expected"
+echo "Check that liveMigrationConfig defaults are behaving as expected"
 
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": /spec, \"value\": {} }]'"
 for JPATH in "${LMPATHS[@]}"; do

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -60,7 +60,7 @@ var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 			expectedWorkloadsPods := map[string]bool{
 				"bridge-marker": false,
 				"cni-plugins":   false,
-				//"kube-multus":     false,
+				// "kube-multus":     false,
 				"ovs-cni-marker": false,
 				"virt-handler":   false,
 				"secondary-dns":  false,

--- a/tests/func-tests/virtual_machines_test.go
+++ b/tests/func-tests/virtual_machines_test.go
@@ -59,6 +59,7 @@ func verifyVMIRunning(client kubecli.KubevirtClient, vmiName string) *kubevirtco
 		var err error
 		vmi, err = client.VirtualMachineInstance(kvtutil.NamespaceTestDefault).Get(context.Background(), vmiName, &k8smetav1.GetOptions{})
 		g.Expect(err).ToNot(HaveOccurred())
+		fmt.Fprintf(GinkgoWriter, "VMI's status.phase: %s", vmi.Status.Phase)
 		return vmi.Status.Phase == kubevirtcorev1.Running
 	}, timeout, pollingInterval).Should(BeTrue(), "failed to get the vmi Running")
 

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -139,6 +139,7 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.4.0 h1:y9YHcjnjynCd/DVbg5j9L/33jQM3MxJlbj/zWskzfGU=

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
@@ -329,6 +329,12 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=true
 	// +default=true
 	NonRoot *bool `json:"nonRoot,omitempty"`
+
+	// Disable mediated devices handling on KubeVirt
+	// +optional
+	// +kubebuilder:default=false
+	// +default=false
+	DisableMDevConfiguration *bool `json:"disableMDevConfiguration,omitempty"`
 }
 
 // PermittedHostDevices holds information about devices allowed for passthrough

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
@@ -235,6 +235,11 @@ func (in *HyperConvergedFeatureGates) DeepCopyInto(out *HyperConvergedFeatureGat
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisableMDevConfiguration != nil {
+		in, out := &in.DisableMDevConfiguration, &out.DisableMDevConfiguration
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.defaults.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.defaults.go
@@ -60,6 +60,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = true
 		in.Spec.FeatureGates.NonRoot = &ptrVar1
 	}
+	if in.Spec.FeatureGates.DisableMDevConfiguration == nil {
+		var ptrVar1 bool = false
+		in.Spec.FeatureGates.DisableMDevConfiguration = &ptrVar1
+	}
 	if in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster == nil {
 		var ptrVar1 uint32 = 5
 		in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster = &ptrVar1

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
@@ -235,6 +235,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 							Format:      "",
 						},
 					},
+					"disableMDevConfiguration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Disable mediated devices handling on KubeVirt",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -561,6 +569,13 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 									},
 								},
 							},
+						},
+					},
+					"systemHealthStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SystemHealthStatus reflects the health of HCO and its secondary resources, based on the aggregated conditions.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
* Expose DisableMDEVConfiguration feature gate on HCO API

This is a manual cherry pick of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2320
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2184439

Signed-off-by: Oren Cohen <ocohen@redhat.com>
Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-27889
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
expose DisableMDEVConfiguration feature gate in HCO CR.
```
