### PR TITLE
Expose SCSI persistent reservation FG

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -356,6 +356,15 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=false
 	// +default=false
 	DisableMDevConfiguration *bool `json:"disableMDevConfiguration,omitempty"`
+
+	// Enable persistent reservation of a LUN through the SCSI Persistent Reserve commands on Kubevirt.
+	// In order to issue privileged SCSI ioctls, the VM requires activation of the persistent reservation flag.
+	// Once this feature gate is enabled, then the additional container with the qemu-pr-helper is deployed inside the virt-handler pod.
+	// Enabling (or removing) the feature gate causes the redeployment of the virt-handler pod.
+	// +optional
+	// +kubebuilder:default=false
+	// +default=false
+	PersistentReservation *bool `json:"persistentReservation,omitempty"`
 }
 
 // PermittedHostDevices holds information about devices allowed for passthrough

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -245,6 +245,11 @@ func (in *HyperConvergedFeatureGates) DeepCopyInto(out *HyperConvergedFeatureGat
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PersistentReservation != nil {
+		in, out := &in.PersistentReservation, &out.PersistentReservation
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1beta1/zz_generated.defaults.go
+++ b/api/v1beta1/zz_generated.defaults.go
@@ -60,6 +60,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.FeatureGates.DisableMDevConfiguration = &ptrVar1
 	}
+	if in.Spec.FeatureGates.PersistentReservation == nil {
+		var ptrVar1 bool = false
+		in.Spec.FeatureGates.PersistentReservation = &ptrVar1
+	}
 	if in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster == nil {
 		var ptrVar1 uint32 = 5
 		in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster = &ptrVar1

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -249,6 +249,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 							Format:      "",
 						},
 					},
+					"persistentReservation": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Enable persistent reservation of a LUN through the SCSI Persistent Reserve commands on Kubevirt. In order to issue privileged SCSI ioctls, the VM requires activation of the persistent reservation flag. Once this feature gate is enabled, then the additional container with the qemu-pr-helper is deployed inside the virt-handler pod. Enabling (or removing) the feature gate causes the redeployment of the virt-handler pod.",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -1076,6 +1076,16 @@ spec:
                     description: "Enables rootless virt-launcher. \n Deprecated: please
                       use the root FG."
                     type: boolean
+                  persistentReservation:
+                    default: false
+                    description: Enable persistent reservation of a LUN through the
+                      SCSI Persistent Reserve commands on Kubevirt. In order to issue
+                      privileged SCSI ioctls, the VM requires activation of the persistent
+                      reservation flag. Once this feature gate is enabled, then the
+                      additional container with the qemu-pr-helper is deployed inside
+                      the virt-handler pod. Enabling (or removing) the feature gate
+                      causes the redeployment of the virt-handler pod.
+                    type: boolean
                   root:
                     description: 'Enable root virt-launcher (default: false).'
                     type: boolean

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -153,6 +153,7 @@ const (
 	kvWithHostPassthroughCPU = "WithHostPassthroughCPU"
 	kvRoot                   = "Root"
 	kvDisableMDevConfig      = "DisableMDEVConfiguration"
+	kvPersistentReservation  = "PersistentReservation"
 )
 
 // CPU Plugin default values
@@ -679,6 +680,9 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) [
 	}
 	if featureGates.DisableMDevConfiguration != nil && *featureGates.DisableMDevConfiguration {
 		fgs = append(fgs, kvDisableMDevConfig)
+	}
+	if featureGates.PersistentReservation != nil && *featureGates.PersistentReservation {
+		fgs = append(fgs, kvPersistentReservation)
 	}
 
 	return fgs

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -1517,6 +1517,45 @@ Version: 1.2.3`)
 					})
 				})
 
+				It("should add the PersistentReservation feature gate if PersistentReservation is true in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						PersistentReservation: pointer.Bool(true),
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the PersistentReservation feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvPersistentReservation))
+					})
+				})
+
+				It("should not add the PersistentReservation feature gate if PersistentReservation is not set in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						PersistentReservation: nil,
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should not contain the PersistentReservation feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvPersistentReservation))
+					})
+				})
+
+				It("should not add the PersistentReservation feature gate if PersistentReservation is false in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						PersistentReservation: pointer.Bool(false),
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should not contain the PersistentReservation feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvPersistentReservation))
+					})
+				})
+
 				It("should not add the feature gates if FeatureGates field is empty", func() {
 					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{}

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1076,6 +1076,16 @@ spec:
                     description: "Enables rootless virt-launcher. \n Deprecated: please
                       use the root FG."
                     type: boolean
+                  persistentReservation:
+                    default: false
+                    description: Enable persistent reservation of a LUN through the
+                      SCSI Persistent Reserve commands on Kubevirt. In order to issue
+                      privileged SCSI ioctls, the VM requires activation of the persistent
+                      reservation flag. Once this feature gate is enabled, then the
+                      additional container with the qemu-pr-helper is deployed inside
+                      the virt-handler pod. Enabling (or removing) the feature gate
+                      causes the redeployment of the virt-handler pod.
+                    type: boolean
                   root:
                     description: 'Enable root virt-launcher (default: false).'
                     type: boolean

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -16,6 +16,7 @@ spec:
     deployTektonTaskResources: false
     disableMDevConfiguration: false
     enableCommonBootImageImport: true
+    persistentReservation: false
     withHostPassthroughCPU: false
   infra: {}
   liveMigrationConfig:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -1076,6 +1076,16 @@ spec:
                     description: "Enables rootless virt-launcher. \n Deprecated: please
                       use the root FG."
                     type: boolean
+                  persistentReservation:
+                    default: false
+                    description: Enable persistent reservation of a LUN through the
+                      SCSI Persistent Reserve commands on Kubevirt. In order to issue
+                      privileged SCSI ioctls, the VM requires activation of the persistent
+                      reservation flag. Once this feature gate is enabled, then the
+                      additional container with the qemu-pr-helper is deployed inside
+                      the virt-handler pod. Enabling (or removing) the feature gate
+                      causes the redeployment of the virt-handler pod.
+                    type: boolean
                   root:
                     description: 'Enable root virt-launcher (default: false).'
                     type: boolean

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -1076,6 +1076,16 @@ spec:
                     description: "Enables rootless virt-launcher. \n Deprecated: please
                       use the root FG."
                     type: boolean
+                  persistentReservation:
+                    default: false
+                    description: Enable persistent reservation of a LUN through the
+                      SCSI Persistent Reserve commands on Kubevirt. In order to issue
+                      privileged SCSI ioctls, the VM requires activation of the persistent
+                      reservation flag. Once this feature gate is enabled, then the
+                      additional container with the qemu-pr-helper is deployed inside
+                      the virt-handler pod. Enabling (or removing) the feature gate
+                      causes the redeployment of the virt-handler pod.
+                    type: boolean
                   root:
                     description: 'Enable root virt-launcher (default: false).'
                     type: boolean

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,6 +133,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | nonRoot | Enables rootless virt-launcher.\n\nDeprecated: please use the root FG. | *bool |  | false |
 | root | Enable root virt-launcher (default: false). | *bool |  | false |
 | disableMDevConfiguration | Disable mediated devices handling on KubeVirt | *bool | false | false |
+| persistentReservation | Enable persistent reservation of a LUN through the SCSI Persistent Reserve commands on Kubevirt. In order to issue privileged SCSI ioctls, the VM requires activation of the persistent reservation flag. Once this feature gate is enabled, then the additional container with the qemu-pr-helper is deployed inside the virt-handler pod. Enabling (or removing) the feature gate causes the redeployment of the virt-handler pod. | *bool | false | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -176,7 +176,25 @@ a mutating webhook is handling the conversion.
 
 **Default**: `false`
 
+### persistentReservation Feature Gate
+Set the `persistentReservation` feature gate to true in order to enable the reservation of a LUN through the SCSI Persistent Reserve commands.
 
+SCSI protocol offers dedicated commands in order to reserve and control access to the LUNs. This can be used to prevent data corruption if the disk is shared by multiple VMs (or more in general processes).
+The SCSI persistent reservation is handled by the qemu-pr-helper. The pr-helper is a privileged daemon that can be either started by libvirt directly or managed externally.
+In case of KubeVirt, the qemu-pr-helper needs to be started externally because it requires high privileges in order to perform the persistent SCSI reservation. Afterward, the pr-helper socket is accessed by the unprivileged virt-launcher pod for enabling the SCSI persistent reservation.
+Once the feature gate is enabled, then the additional container with the qemu-pr-helper is deployed inside the virt-handler pod. Enabling (or removing) the feature gate causes the redeployment of the virt-handler pod.
+
+VMI example:
+```yaml
+    devices:
+      disks:
+      - name: mypvcdisk
+        lun:
+          reservations: true
+```
+**Note**: An important aspect of this feature is that the SCSI persistent reservation doesn't support migration. Even if you apply the reservation to an RWX PVC provisioning SCSI devices, the restriction is due to the reservation done by the initiator on the node. The VM could be migrated but not the reservation.
+
+**Default**: `false`
 
 ### Feature Gates Example
 

--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -22,7 +22,7 @@ echo "Read the CR's spec before starting the test"
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o json | jq '.spec'
 
 CERTCONFIGDEFAULTS='{"ca":{"duration":"48h0m0s","renewBefore":"24h0m0s"},"server":{"duration":"24h0m0s","renewBefore":"12h0m0s"}}'
-FGDEFAULTS='{"deployKubeSecondaryDNS":false,"deployTektonTaskResources":false,"disableMDevConfiguration":false,"enableCommonBootImageImport":true,"root":false,"withHostPassthroughCPU":false}'
+FGDEFAULTS='{"deployKubeSecondaryDNS":false,"deployTektonTaskResources":false,"disableMDevConfiguration":false,"enableCommonBootImageImport":true,"persistentReservation":false,"root":false,"withHostPassthroughCPU":false}'
 LMDEFAULTS='{"allowAutoConverge":false,"allowPostCopy":false,"completionTimeoutPerGiB":800,"parallelMigrationsPerCluster":5,"parallelOutboundMigrationsPerNode":2,"progressTimeout":150}'
 PERMITTED_HOST_DEVICES_DEFAULT1='{"pciDeviceSelector":"10DE:1DB6","resourceName":"nvidia.com/GV100GL_Tesla_V100"}'
 PERMITTED_HOST_DEVICES_DEFAULT2='{"pciDeviceSelector":"10DE:1EB8","resourceName":"nvidia.com/TU104GL_Tesla_T4"}'

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
@@ -356,6 +356,15 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=false
 	// +default=false
 	DisableMDevConfiguration *bool `json:"disableMDevConfiguration,omitempty"`
+
+	// Enable persistent reservation of a LUN through the SCSI Persistent Reserve commands on Kubevirt.
+	// In order to issue privileged SCSI ioctls, the VM requires activation of the persistent reservation flag.
+	// Once this feature gate is enabled, then the additional container with the qemu-pr-helper is deployed inside the virt-handler pod.
+	// Enabling (or removing) the feature gate causes the redeployment of the virt-handler pod.
+	// +optional
+	// +kubebuilder:default=false
+	// +default=false
+	PersistentReservation *bool `json:"persistentReservation,omitempty"`
 }
 
 // PermittedHostDevices holds information about devices allowed for passthrough

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
@@ -245,6 +245,11 @@ func (in *HyperConvergedFeatureGates) DeepCopyInto(out *HyperConvergedFeatureGat
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PersistentReservation != nil {
+		in, out := &in.PersistentReservation, &out.PersistentReservation
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.defaults.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.defaults.go
@@ -60,6 +60,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.FeatureGates.DisableMDevConfiguration = &ptrVar1
 	}
+	if in.Spec.FeatureGates.PersistentReservation == nil {
+		var ptrVar1 bool = false
+		in.Spec.FeatureGates.PersistentReservation = &ptrVar1
+	}
 	if in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster == nil {
 		var ptrVar1 uint32 = 5
 		in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster = &ptrVar1

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
@@ -249,6 +249,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 							Format:      "",
 						},
 					},
+					"persistentReservation": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Enable persistent reservation of a LUN through the SCSI Persistent Reserve commands on Kubevirt. In order to issue privileged SCSI ioctls, the VM requires activation of the persistent reservation flag. Once this feature gate is enabled, then the additional container with the qemu-pr-helper is deployed inside the virt-handler pod. Enabling (or removing) the feature gate causes the redeployment of the virt-handler pod.",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Expose a Feature Gate to configure
SCSI persistent reservation on Kubevirt.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-11239
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose SCSI persistent reservation FG
```
