### PR TITLE
Extend ConsoleCLIDownload to contain also links for arm64 binaries

### DIFF
--- a/build/Dockerfile.artifacts
+++ b/build/Dockerfile.artifacts
@@ -16,10 +16,13 @@ RUN eval $(cat /tmp/config  |grep KUBEVIRT_VERSION=) && \
     echo "KUBEVIRT_VERSION: $KUBEVIRT_VERSION" && \
     curl -v --fail -L -o virtctl "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-amd64" && \
     mkdir -p ./amd64/linux && tar -zhcf ./amd64/linux/virtctl.tar.gz virtctl && rm virtctl && \
+    ( curl -v --fail -L -o virtctl "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-arm64" && mkdir -p ./arm64/linux && tar -zhcf ./amd64/linux/virtctl.tar.gz virtctl && rm virtctl ) || true && \
     curl -v --fail -L -o virtctl "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-darwin-amd64" && \
     mkdir -p ./amd64/mac && zip -r -q ./amd64/mac/virtctl.zip virtctl && rm virtctl && \
+    ( curl -v --fail -L -o virtctl "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-darwin-arm64" && mkdir -p ./arm64/mac && zip -r -q ./amd64/mac/virtctl.zip virtctl && rm virtctl ) || true && \
     curl -v --fail -L -o virtctl.exe "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-windows-amd64.exe" && \
-    mkdir -p ./amd64/windows && zip -r -q ./amd64/windows/virtctl.zip virtctl.exe && rm virtctl.exe
+    mkdir -p ./amd64/windows && zip -r -q ./amd64/windows/virtctl.zip virtctl.exe && rm virtctl.exe && \
+    ( curl -v --fail -L -o virtctl.exe "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-windows-arm64.exe" && mkdir -p ./arm64/windows && zip -r -q ./arm64/windows/virtctl.zip virtctl.exe && rm virtctl.exe ) || true
 
 
 ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git

--- a/controllers/operands/cliDownload.go
+++ b/controllers/operands/cliDownload.go
@@ -93,12 +93,24 @@ func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLID
 					Text: "Download virtctl for Linux for x86_64",
 				},
 				{
+					Href: baseURL + "/arm64/linux/virtctl.tar.gz",
+					Text: "Download virtctl for Linux for arm64",
+				},
+				{
 					Href: baseURL + "/amd64/mac/virtctl.zip",
 					Text: "Download virtctl for Mac for x86_64",
 				},
 				{
+					Href: baseURL + "/arm64/mac/virtctl.zip",
+					Text: "Download virtctl for Mac for arm64",
+				},
+				{
 					Href: baseURL + "/amd64/windows/virtctl.zip",
 					Text: "Download virtctl for Windows for x86_64",
+				},
+				{
+					Href: baseURL + "/arm64/windows/virtctl.zip",
+					Text: "Download virtctl for Windows for arm64",
 				},
 			},
 		},

--- a/controllers/operands/cliDownload_test.go
+++ b/controllers/operands/cliDownload_test.go
@@ -43,7 +43,7 @@ var _ = Describe("CLI Download", func() {
 			Expect(cl.Get(context.TODO(), key, foundResource)).ToNot(HaveOccurred())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
 			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
-			Expect(foundResource.Spec.Links).Should(HaveLen(3))
+			Expect(foundResource.Spec.Links).Should(HaveLen(6))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 

--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"net/http"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -63,7 +64,7 @@ func checkConsoleCliDownloadSpec(client kubecli.KubevirtClient) {
 		Timeout(10*time.Second).
 		Do(context.TODO()).Into(&ccd)).To(Succeed())
 
-	ExpectWithOffset(1, ccd.Spec.Links).Should(HaveLen(3))
+	ExpectWithOffset(1, ccd.Spec.Links).Should(HaveLen(6))
 
 	for _, link := range ccd.Spec.Links {
 		By("Checking links. Link:" + link.Href)
@@ -71,7 +72,12 @@ func checkConsoleCliDownloadSpec(client kubecli.KubevirtClient) {
 			// ssl of the route is irrelevant
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}}
-		resp, err := client.Get(link.Href)
+		// TODO: virtctl binaries for arm64 are still not available,
+		// checking the amd64 ones twice.
+		// Remove this once arm64 binaries get properly released in the next Kubevirt release.
+		// resp, err := client.Get(link.Href)
+		resp, err := client.Get(strings.Replace(link.Href, "arm64", "amd64", -1))
+		///////
 		_ = resp.Body.Close()
 
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
Extend ConsoleCLIDownload to contain also links
for arm64.
Try to download virtctl binaries also for arm64
without failing virt-artifacts-server build if
they are still not available.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-26832
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Extend ConsoleCLIDownload to contain also links for arm64 binaries
```
