### PR TITLE
Add CR option to specify which storage class to use for VM persistent state

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -180,6 +180,11 @@ type HyperConvergedSpec struct {
 	// +kubebuilder:validation:Enum=None;LiveMigrate;External
 	// +optional
 	EvictionStrategy *v1.EvictionStrategy `json:"evictionStrategy,omitempty"`
+
+	// VMStateStorageClass is the name of the storage class to use for the PVCs created to preserve VM state, like TPM.
+	// The storage class must support RWX in filesystem mode.
+	// +optional
+	VMStateStorageClass *string `json:"vmStateStorageClass,omitempty"`
 }
 
 // CertRotateConfigCA contains the tunables for TLS certificates.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -403,6 +403,11 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 		*out = new(corev1.EvictionStrategy)
 		**out = **in
 	}
+	if in.VMStateStorageClass != nil {
+		in, out := &in.VMStateStorageClass, &out.VMStateStorageClass
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -482,6 +482,13 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 							Format:      "",
 						},
 					},
+					"vmStateStorageClass": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VMStateStorageClass is the name of the storage class to use for the PVCs created to preserve VM state, like TPM. The storage class must support RWX in filesystem mode.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2504,6 +2504,11 @@ spec:
                 description: VDDK Init Image eventually used to import VMs from external
                   providers
                 type: string
+              vmStateStorageClass:
+                description: VMStateStorageClass is the name of the storage class
+                  to use for the PVCs created to preserve VM state, like TPM. The
+                  storage class must support RWX in filesystem mode.
+                type: string
               workloadUpdateStrategy:
                 default:
                   batchEvictionInterval: 1m0s

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -428,6 +428,10 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		config.CPUModel = *hc.Spec.DefaultCPUModel
 	}
 
+	if hc.Spec.VMStateStorageClass != nil {
+		config.VMStateStorageClass = *hc.Spec.VMStateStorageClass
+	}
+
 	return config, nil
 }
 

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -2655,6 +2655,36 @@ Version: 1.2.3`)
 			})
 		})
 
+		Context("VM state storage class", func() {
+			It("should modify storage class according to HCO CR", func() {
+				existingResource, err := NewKubeVirt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Modify HCO's VM state storage class configuration")
+				hco.Spec.VMStateStorageClass = pointer.String("rook-cephfs")
+
+				cl := commontestutils.InitClient([]runtime.Object{hco, existingResource})
+				handler := (*genericOperand)(newKubevirtHandler(cl, commontestutils.GetScheme()))
+				res := handler.ensure(req)
+				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.Updated).To(BeTrue())
+				Expect(res.Err).ToNot(HaveOccurred())
+
+				foundResource := &kubevirtcorev1.KubeVirt{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+						foundResource),
+				).ToNot(HaveOccurred())
+
+				Expect(existingResource.Spec.Configuration.VMStateStorageClass).To(BeEmpty())
+
+				Expect(foundResource.Spec.Configuration.VMStateStorageClass).To(Equal("rook-cephfs"))
+
+				Expect(req.Conditions).To(BeEmpty())
+			})
+		})
+
 		It("should handle conditions", func() {
 			expectedResource, err := NewKubeVirt(hco, commontestutils.Namespace)
 			Expect(err).ToNot(HaveOccurred())

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2504,6 +2504,11 @@ spec:
                 description: VDDK Init Image eventually used to import VMs from external
                   providers
                 type: string
+              vmStateStorageClass:
+                description: VMStateStorageClass is the name of the storage class
+                  to use for the PVCs created to preserve VM state, like TPM. The
+                  storage class must support RWX in filesystem mode.
+                type: string
               workloadUpdateStrategy:
                 default:
                   batchEvictionInterval: 1m0s

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -2504,6 +2504,11 @@ spec:
                 description: VDDK Init Image eventually used to import VMs from external
                   providers
                 type: string
+              vmStateStorageClass:
+                description: VMStateStorageClass is the name of the storage class
+                  to use for the PVCs created to preserve VM state, like TPM. The
+                  storage class must support RWX in filesystem mode.
+                type: string
               workloadUpdateStrategy:
                 default:
                   batchEvictionInterval: 1m0s

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -2504,6 +2504,11 @@ spec:
                 description: VDDK Init Image eventually used to import VMs from external
                   providers
                 type: string
+              vmStateStorageClass:
+                description: VMStateStorageClass is the name of the storage class
+                  to use for the PVCs created to preserve VM state, like TPM. The
+                  storage class must support RWX in filesystem mode.
+                type: string
               workloadUpdateStrategy:
                 default:
                   batchEvictionInterval: 1m0s

--- a/docs/api.md
+++ b/docs/api.md
@@ -189,6 +189,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | tektonPipelinesNamespace | TektonPipelinesNamespace defines namespace in which example pipelines will be deployed. | *string |  | false |
 | kubeSecondaryDNSNameServerIP | KubeSecondaryDNSNameServerIP defines name server IP used by KubeSecondaryDNS | *string |  | false |
 | evictionStrategy | EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific field is set it overrides the cluster level one. | *v1.EvictionStrategy | LiveMigrate | false |
+| vmStateStorageClass | VMStateStorageClass is the name of the storage class to use for the PVCs created to preserve VM state, like TPM. The storage class must support RWX in filesystem mode. | *string |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -806,6 +806,20 @@ Possible values:
 `LiveMigrate` is the default behaviour.
 
 
+## VM state storage class
+
+`VMStateStorageClass` defines the [Kubernetes Storage Class](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+to be used for creating persistent state PVCs for VMs, used for example for persisting the state of the vTPM.
+The storage class must be of type "filesystem" and support the ReadWriteMany (RWX) access mode.
+This option should be set simply to the storage class name. Example:
+```yaml
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  vmStateStorageClass: "rook-cephfs"
+```
+
 ## Hyperconverged Kubevirt cluster-wide Crypto Policy API
 
 Starting from OCP/OKD 4.6, a [cluster-wide API](https://github.com/openshift/enhancements/blob/master/enhancements/kube-apiserver/tls-config.md) is available for cluster administrators to set TLS profiles for OCP/OKD core components.

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
@@ -180,6 +180,11 @@ type HyperConvergedSpec struct {
 	// +kubebuilder:validation:Enum=None;LiveMigrate;External
 	// +optional
 	EvictionStrategy *v1.EvictionStrategy `json:"evictionStrategy,omitempty"`
+
+	// VMStateStorageClass is the name of the storage class to use for the PVCs created to preserve VM state, like TPM.
+	// The storage class must support RWX in filesystem mode.
+	// +optional
+	VMStateStorageClass *string `json:"vmStateStorageClass,omitempty"`
 }
 
 // CertRotateConfigCA contains the tunables for TLS certificates.

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
@@ -403,6 +403,11 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 		*out = new(corev1.EvictionStrategy)
 		**out = **in
 	}
+	if in.VMStateStorageClass != nil {
+		in, out := &in.VMStateStorageClass, &out.VMStateStorageClass
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
@@ -482,6 +482,13 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 							Format:      "",
 						},
 					},
+					"vmStateStorageClass": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VMStateStorageClass is the name of the storage class to use for the PVCs created to preserve VM state, like TPM. The storage class must support RWX in filesystem mode.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is needed to enable the use of the persistent vTPM VM feature.
Admins should use this new option to specify which RWX FS storage class should be use to store the VM persistent state.
Once enabled, users will be able to create VMs with vTPM persistence enabled.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-28387
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New CR option to specify which storage class to use for storing VM state, needed for vTPM persistence.
```
