### PR TITLE
Effectively download and test arm64 virtctl binaries

### DIFF
--- a/build/Dockerfile.artifacts
+++ b/build/Dockerfile.artifacts
@@ -5,7 +5,7 @@ WORKDIR /opt/app-root/src
 COPY hack/config /tmp/config
 
 USER 0
-RUN dnf -y install zip && \
+RUN dnf -y install zip file && \
     sed '/^\s*listen\s*\[::\]:8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv4 && \
     sed '/^\s*listen\s*8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv6
 USER 1001
@@ -14,16 +14,33 @@ ARG download_url=https://github.com/kubevirt/kubevirt/releases/download
 
 RUN eval $(cat /tmp/config  |grep KUBEVIRT_VERSION=) && \
     echo "KUBEVIRT_VERSION: $KUBEVIRT_VERSION" && \
-    curl -v --fail -L -o virtctl "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-amd64" && \
-    mkdir -p ./amd64/linux && tar -zhcf ./amd64/linux/virtctl.tar.gz virtctl && rm virtctl && \
-    ( curl -v --fail -L -o virtctl "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-arm64" && mkdir -p ./arm64/linux && tar -zhcf ./amd64/linux/virtctl.tar.gz virtctl && rm virtctl ) || true && \
-    curl -v --fail -L -o virtctl "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-darwin-amd64" && \
-    mkdir -p ./amd64/mac && zip -r -q ./amd64/mac/virtctl.zip virtctl && rm virtctl && \
-    ( curl -v --fail -L -o virtctl "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-darwin-arm64" && mkdir -p ./arm64/mac && zip -r -q ./amd64/mac/virtctl.zip virtctl && rm virtctl ) || true && \
-    curl -v --fail -L -o virtctl.exe "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-windows-amd64.exe" && \
-    mkdir -p ./amd64/windows && zip -r -q ./amd64/windows/virtctl.zip virtctl.exe && rm virtctl.exe && \
-    ( curl -v --fail -L -o virtctl.exe "${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-windows-arm64.exe" && mkdir -p ./arm64/windows && zip -r -q ./arm64/windows/virtctl.zip virtctl.exe && rm virtctl.exe ) || true
-
+    for arch in amd64 arm64; do \
+        for os in linux darwin windows; do \
+            if [[ ${os} == "windows" && ${arch} == "arm64" ]]; then \
+                printf "\n\n### Skipping virctl for Windows on ARM64\n"; \
+            else \
+                extension=""; \
+                archive_extension=".zip"; \
+                archive_command="zip -r -q"; \
+                if [ "${os}" = "windows" ]; then \
+                    extension=".exe"; \
+                fi; \
+                l_os="${os}"; \
+                if [ "${os}" = "darwin" ]; then \
+                    l_os="mac"; \
+                fi; \
+                if [ "${os}" = "linux" ]; then \
+                    archive_extension=".tar.gz"; \
+                    archive_command="tar -zhcf"; \
+                fi; \
+                url="${download_url}/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-${os}-${arch}${extension}"; \
+                printf "\n\n### Downloading ${url}\n"; \
+                curl --fail -L -o virtctl${extension} "${url}" && \
+                file virtctl${extension} && \
+                mkdir -p ./${arch}/${l_os} && ${archive_command} ./${arch}/${l_os}/virtctl${archive_extension} virtctl${extension} && rm virtctl${extension}; \
+            fi; \
+        done; \
+    done
 
 ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git
 ARG git_sha=NONE

--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -67,21 +67,19 @@ func checkConsoleCliDownloadSpec(client kubecli.KubevirtClient) {
 	ExpectWithOffset(1, ccd.Spec.Links).Should(HaveLen(6))
 
 	for _, link := range ccd.Spec.Links {
-		By("Checking links. Link:" + link.Href)
-		client := &http.Client{Transport: &http.Transport{
-			// ssl of the route is irrelevant
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}}
-		// TODO: virtctl binaries for arm64 are still not available,
-		// checking the amd64 ones twice.
-		// Remove this once arm64 binaries get properly released in the next Kubevirt release.
-		// resp, err := client.Get(link.Href)
-		resp, err := client.Get(strings.Replace(link.Href, "arm64", "amd64", -1))
-		///////
-		_ = resp.Body.Close()
+		// virtctl for Windows for ARM 64 is still not shipped, avoid checking it
+		// TODO: remove this once ready
+		if !(strings.Contains(link.Href, "windows") && strings.Contains(link.Href, "arm64")) {
+			By("Checking links. Link:" + link.Href)
+			client := &http.Client{Transport: &http.Transport{
+				// ssl of the route is irrelevant
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}}
+			resp, err := client.Get(link.Href)
+			_ = resp.Body.Close()
 
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		ExpectWithOffset(1, resp).Should(HaveHTTPStatus(http.StatusOK))
-
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, resp).Should(HaveHTTPStatus(http.StatusOK))
+		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2371 we amended ConsoleCLIDownload to contain also the
links for arm64 virtctl binaries that
are going to be available only starting
from the next Kubevirt release.
In order to be able to get #2371 merged
we had to introduce an hack on our tests.
Let's remove it and let's simplify the
download script.

This can be merged only when the next Kubevirt release will be tagged.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-26832
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
