### PR TITLE
Handle cluster level eviction strategy on SNO as a special case

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -175,8 +175,7 @@ type HyperConvergedSpec struct {
 
 	// EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be
 	// migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific
-	// field is set it overrides the cluster level one.
-	// +kubebuilder:default=LiveMigrate
+	// field is set it overrides the cluster level one. Defaults to LiveMigrate with multiple worker nodes, None on single worker clusters.
 	// +kubebuilder:validation:Enum=None;LiveMigrate;External
 	// +optional
 	EvictionStrategy *v1.EvictionStrategy `json:"evictionStrategy,omitempty"`
@@ -624,7 +623,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "evictionStrategy": "LiveMigrate", "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -485,7 +485,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 					},
 					"evictionStrategy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific field is set it overrides the cluster level one.",
+							Description: "EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific field is set it overrides the cluster level one. Defaults to LiveMigrate with multiple worker nodes, None on single worker clusters.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -51,7 +51,6 @@ spec:
                 server:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
-              evictionStrategy: LiveMigrate
               featureGates:
                 deployKubeSecondaryDNS: false
                 deployTektonTaskResources: false
@@ -1031,11 +1030,11 @@ spec:
                   is running.'
                 type: string
               evictionStrategy:
-                default: LiveMigrate
                 description: EvictionStrategy defines at the cluster level if the
                   VirtualMachineInstance should be migrated instead of shut-off in
                   case of a node drain. If the VirtualMachineInstance specific field
-                  is set it overrides the cluster level one.
+                  is set it overrides the cluster level one. Defaults to LiveMigrate
+                  with multiple worker nodes, None on single worker clusters.
                 enum:
                 - None
                 - LiveMigrate

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -51,7 +51,6 @@ spec:
                 server:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
-              evictionStrategy: LiveMigrate
               featureGates:
                 deployKubeSecondaryDNS: false
                 deployTektonTaskResources: false
@@ -1031,11 +1030,11 @@ spec:
                   is running.'
                 type: string
               evictionStrategy:
-                default: LiveMigrate
                 description: EvictionStrategy defines at the cluster level if the
                   VirtualMachineInstance should be migrated instead of shut-off in
                   case of a node drain. If the VirtualMachineInstance specific field
-                  is set it overrides the cluster level one.
+                  is set it overrides the cluster level one. Defaults to LiveMigrate
+                  with multiple worker nodes, None on single worker clusters.
                 enum:
                 - None
                 - LiveMigrate

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -51,7 +51,6 @@ spec:
                 server:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
-              evictionStrategy: LiveMigrate
               featureGates:
                 deployKubeSecondaryDNS: false
                 deployTektonTaskResources: false
@@ -1031,11 +1030,11 @@ spec:
                   is running.'
                 type: string
               evictionStrategy:
-                default: LiveMigrate
                 description: EvictionStrategy defines at the cluster level if the
                   VirtualMachineInstance should be migrated instead of shut-off in
                   case of a node drain. If the VirtualMachineInstance specific field
-                  is set it overrides the cluster level one.
+                  is set it overrides the cluster level one. Defaults to LiveMigrate
+                  with multiple worker nodes, None on single worker clusters.
                 enum:
                 - None
                 - LiveMigrate

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -51,7 +51,6 @@ spec:
                 server:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
-              evictionStrategy: LiveMigrate
               featureGates:
                 deployKubeSecondaryDNS: false
                 deployTektonTaskResources: false
@@ -1031,11 +1030,11 @@ spec:
                   is running.'
                 type: string
               evictionStrategy:
-                default: LiveMigrate
                 description: EvictionStrategy defines at the cluster level if the
                   VirtualMachineInstance should be migrated instead of shut-off in
                   case of a node drain. If the VirtualMachineInstance specific field
-                  is set it overrides the cluster level one.
+                  is set it overrides the cluster level one. Defaults to LiveMigrate
+                  with multiple worker nodes, None on single worker clusters.
                 enum:
                 - None
                 - LiveMigrate

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,7 +94,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "evictionStrategy": "LiveMigrate", "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -189,7 +189,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | tlsSecurityProfile | TLSSecurityProfile specifies the settings for TLS connections to be propagated to all kubevirt-hyperconverged components. If unset, the hyperconverged cluster operator will consume the value set on the APIServer CR on OCP/OKD or Intermediate if on vanilla k8s. Note that only Old, Intermediate and Custom profiles are currently supported, and the maximum available MinTLSVersions is VersionTLS12. | *openshiftconfigv1.TLSSecurityProfile |  | false |
 | tektonPipelinesNamespace | TektonPipelinesNamespace defines namespace in which example pipelines will be deployed. | *string |  | false |
 | kubeSecondaryDNSNameServerIP | KubeSecondaryDNSNameServerIP defines name server IP used by KubeSecondaryDNS | *string |  | false |
-| evictionStrategy | EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific field is set it overrides the cluster level one. | *v1.EvictionStrategy | LiveMigrate | false |
+| evictionStrategy | EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific field is set it overrides the cluster level one. Defaults to LiveMigrate with multiple worker nodes, None on single worker clusters. | *v1.EvictionStrategy |  | false |
 | vmStateStorageClass | VMStateStorageClass is the name of the storage class to use for the PVCs created to preserve VM state, like TPM. The storage class must support RWX in filesystem mode. | *string |  | false |
 
 [Back to TOC](#table-of-contents)

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -821,7 +821,7 @@ Possible values:
 - `LiveMigrate` migrate the VM on eviction.
 - `External` block eviction and notify an external controller.
 
-`LiveMigrate` is the default behaviour.
+`LiveMigrate` is the default behaviour with multiple worker nodes, `None` on single worker clusters.
 
 
 ## VM state storage class

--- a/pkg/webhooks/mutator/hyperConvergedMutator.go
+++ b/pkg/webhooks/mutator/hyperConvergedMutator.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,6 +15,7 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	kubevirtcorev1 "kubevirt.io/api/core/v1"
 )
 
 var (
@@ -87,6 +90,24 @@ func (hcm *HyperConvergedMutator) mutateHyperConverged(_ context.Context, req ad
 			Path:      "/spec/featureGates/root",
 			Value:     value,
 		})
+	}
+
+	if hc.Spec.EvictionStrategy == nil {
+		ci := hcoutil.GetClusterInfo()
+		if ci.IsInfrastructureHighlyAvailable() {
+			patches = append(patches, jsonpatch.JsonPatchOperation{
+				Operation: "add",
+				Path:      "/spec/evictionStrategy",
+				Value:     kubevirtcorev1.EvictionStrategyLiveMigrate,
+			})
+		} else {
+			patches = append(patches, jsonpatch.JsonPatchOperation{
+				Operation: "add",
+				Path:      "/spec/evictionStrategy",
+				Value:     kubevirtcorev1.EvictionStrategyNone,
+			})
+		}
+
 	}
 
 	if len(patches) > 0 {

--- a/tests/func-tests/cluster_eviction_strategy_test.go
+++ b/tests/func-tests/cluster_eviction_strategy_test.go
@@ -1,0 +1,76 @@
+package tests_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
+	"kubevirt.io/client-go/kubecli"
+)
+
+var _ = Describe("Cluster level evictionStrategy default value", func() {
+	tests.FlagParse()
+	var cli kubecli.KubevirtClient
+	ctx := context.TODO()
+
+	cli, err := kubecli.GetKubevirtClient()
+	Expect(cli).ToNot(BeNil())
+	Expect(err).ToNot(HaveOccurred())
+	var initialEvictionStrategy *v1.EvictionStrategy
+
+	singleworkerCluster, err := isSingleWorkerCluster(cli)
+	Expect(err).ToNot(HaveOccurred())
+
+	BeforeEach(func() {
+		tests.BeforeEach()
+		hc := tests.GetHCO(ctx, cli)
+		initialEvictionStrategy = hc.Spec.EvictionStrategy
+	})
+
+	AfterEach(func() {
+		hc := tests.GetHCO(ctx, cli)
+		hc.Spec.EvictionStrategy = initialEvictionStrategy
+		_ = tests.UpdateHCORetry(ctx, cli, hc)
+	})
+
+	It("Should set spec.evictionStrategy = None by default on single worker clusters", func() {
+		if !singleworkerCluster {
+			Skip("Skipping single worker cluster test having more than one worker node")
+		}
+		hco := tests.GetHCO(ctx, cli)
+		hco.Spec.EvictionStrategy = nil
+		hco = tests.UpdateHCORetry(ctx, cli, hco)
+		noneEvictionStrategy := v1.EvictionStrategyNone
+		Expect(hco.Spec.EvictionStrategy).To(Not(BeNil()))
+		Expect(hco.Spec.EvictionStrategy).To(Equal(&noneEvictionStrategy))
+	})
+
+	It("Should set spec.evictionStrategy = LiveMigrate by default with multiple worker node", func() {
+		if singleworkerCluster {
+			Skip("Skipping not single worker cluster test having a single worker node")
+		}
+		hco := tests.GetHCO(ctx, cli)
+		hco.Spec.EvictionStrategy = nil
+		hco = tests.UpdateHCORetry(ctx, cli, hco)
+		lmEvictionStrategy := v1.EvictionStrategyLiveMigrate
+		Expect(hco.Spec.EvictionStrategy).To(Not(BeNil()))
+		Expect(hco.Spec.EvictionStrategy).To(Equal(&lmEvictionStrategy))
+	})
+
+})
+
+func isSingleWorkerCluster(cli kubecli.KubevirtClient) (bool, error) {
+	workerNodes, err := cli.CoreV1().Nodes().List(context.TODO(), k8smetav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker"})
+	if err != nil {
+		return false, err
+	}
+	if len(workerNodes.Items) == 1 {
+		return true, nil
+	}
+	return false, nil
+}

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
@@ -175,8 +175,7 @@ type HyperConvergedSpec struct {
 
 	// EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be
 	// migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific
-	// field is set it overrides the cluster level one.
-	// +kubebuilder:default=LiveMigrate
+	// field is set it overrides the cluster level one. Defaults to LiveMigrate with multiple worker nodes, None on single worker clusters.
 	// +kubebuilder:validation:Enum=None;LiveMigrate;External
 	// +optional
 	EvictionStrategy *v1.EvictionStrategy `json:"evictionStrategy,omitempty"`
@@ -624,7 +623,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "evictionStrategy": "LiveMigrate", "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
@@ -485,7 +485,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 					},
 					"evictionStrategy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific field is set it overrides the cluster level one.",
+							Description: "EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific field is set it overrides the cluster level one. Defaults to LiveMigrate with multiple worker nodes, None on single worker clusters.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
With #2071 we introduced a knob to let the cluster
admin configure a default EvictionStrategy at
cluster level.
The default value there was `LiveMigrate` for all
the kinds of clusters but this could potentially
introduce side effects (alerts and potentially
also inability to upgrade the cluster without
manually recovery actions) on SNO clusters.

Let's set a different default value (`None`) for
cluster level eviction strategy when we detect
that we are on a cluster with a single worker node
where `LiveMigrate` is not an option.

The code will still honour explicit user choice if there.

Add unit and e2e tests.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2212289

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-29479
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Handle cluster level eviction strategy on SNO as a special case
```
