### PR TITLE
Propagate nodeplacement to kubevirt-console-plugin deployment

### DIFF
--- a/controllers/operands/deploymentHandler.go
+++ b/controllers/operands/deploymentHandler.go
@@ -87,7 +87,10 @@ func hasCorrectDeploymentFields(found *appsv1.Deployment, required *appsv1.Deplo
 		reflect.DeepEqual(found.Spec.Replicas, required.Spec.Replicas) &&
 		reflect.DeepEqual(found.Spec.Template.Spec.Containers, required.Spec.Template.Spec.Containers) &&
 		reflect.DeepEqual(found.Spec.Template.Spec.ServiceAccountName, required.Spec.Template.Spec.ServiceAccountName) &&
-		reflect.DeepEqual(found.Spec.Template.Spec.PriorityClassName, required.Spec.Template.Spec.PriorityClassName)
+		reflect.DeepEqual(found.Spec.Template.Spec.PriorityClassName, required.Spec.Template.Spec.PriorityClassName) &&
+		reflect.DeepEqual(found.Spec.Template.Spec.Affinity, required.Spec.Template.Spec.Affinity) &&
+		reflect.DeepEqual(found.Spec.Template.Spec.NodeSelector, required.Spec.Template.Spec.NodeSelector) &&
+		reflect.DeepEqual(found.Spec.Template.Spec.Tolerations, required.Spec.Template.Spec.Tolerations)
 }
 
 func shouldRecreate(found, required *appsv1.Deployment) bool {

--- a/controllers/operands/kubevirtConsolePlugin_test.go
+++ b/controllers/operands/kubevirtConsolePlugin_test.go
@@ -344,6 +344,159 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			// let's check the object UID to ensure that the object get really deleted and recreated
 			Expect(foundResource.GetUID()).ToNot(Equal(types.UID("oldObjectUID")))
 		})
+
+		Context("Node Placement", func() {
+
+			It("should add node placement if missing", func() {
+				existingResource, err := NewKvUiPluginDeplymnt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				hco.Spec.Workloads.NodePlacement = commonTestUtils.NewNodePlacement()
+				hco.Spec.Infra.NodePlacement = commonTestUtils.NewOtherNodePlacement()
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+				handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+				Expect(err).ToNot(HaveOccurred())
+				res := handler[0].ensure(req)
+				Expect(res.Created).To(BeFalse())
+				Expect(res.Updated).To(BeTrue())
+				Expect(res.Overwritten).To(BeFalse())
+				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.Err).ToNot(HaveOccurred())
+
+				foundResource := &appsv1.Deployment{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+						foundResource),
+				).ToNot(HaveOccurred())
+
+				Expect(existingResource.Spec.Template.Spec.NodeSelector).To(BeZero())
+				Expect(existingResource.Spec.Template.Spec.Affinity).To(BeZero())
+				Expect(existingResource.Spec.Template.Spec.Tolerations).To(BeZero())
+
+				Expect(foundResource.Spec.Template.Spec.NodeSelector).To(BeEquivalentTo(hco.Spec.Infra.NodePlacement.NodeSelector))
+				Expect(foundResource.Spec.Template.Spec.Affinity).To(BeEquivalentTo(hco.Spec.Infra.NodePlacement.Affinity))
+				Expect(foundResource.Spec.Template.Spec.Tolerations).To(BeEquivalentTo(hco.Spec.Infra.NodePlacement.Tolerations))
+			})
+
+			It("should remove node placement if missing in HCO CR", func() {
+
+				hcoNodePlacement := commonTestUtils.NewHco()
+				hcoNodePlacement.Spec.Workloads.NodePlacement = commonTestUtils.NewNodePlacement()
+				hcoNodePlacement.Spec.Infra.NodePlacement = commonTestUtils.NewOtherNodePlacement()
+				existingResource, err := NewKvUiPluginDeplymnt(hcoNodePlacement)
+				Expect(err).ToNot(HaveOccurred())
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+				handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+				Expect(err).ToNot(HaveOccurred())
+				res := handler[0].ensure(req)
+				Expect(res.Created).To(BeFalse())
+				Expect(res.Updated).To(BeTrue())
+				Expect(res.Overwritten).To(BeFalse())
+				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.Err).ToNot(HaveOccurred())
+
+				foundResource := &appsv1.Deployment{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+						foundResource),
+				).ToNot(HaveOccurred())
+
+				Expect(existingResource.Spec.Template.Spec.NodeSelector).ToNot(BeZero())
+				Expect(existingResource.Spec.Template.Spec.Affinity).ToNot(BeZero())
+				Expect(existingResource.Spec.Template.Spec.Tolerations).ToNot(BeZero())
+				Expect(foundResource.Spec.Template.Spec.NodeSelector).To(BeZero())
+				Expect(foundResource.Spec.Template.Spec.Affinity).To(BeZero())
+				Expect(foundResource.Spec.Template.Spec.Tolerations).To(BeZero())
+				Expect(req.Conditions).To(BeEmpty())
+			})
+
+			It("should modify node placement according to HCO CR", func() {
+
+				hco.Spec.Workloads.NodePlacement = commonTestUtils.NewNodePlacement()
+				hco.Spec.Infra.NodePlacement = commonTestUtils.NewOtherNodePlacement()
+				existingResource, err := NewKvUiPluginDeplymnt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				// now, modify HCO's node placement
+				seconds34 := int64(34)
+				hco.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, v1.Toleration{
+					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: &seconds34,
+				})
+				hco.Spec.Infra.NodePlacement.NodeSelector["key3"] = "something entirely else"
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+				handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+				Expect(err).ToNot(HaveOccurred())
+				res := handler[0].ensure(req)
+				Expect(res.Created).To(BeFalse())
+				Expect(res.Updated).To(BeTrue())
+				Expect(res.Overwritten).To(BeFalse())
+				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.Err).ToNot(HaveOccurred())
+
+				foundResource := &appsv1.Deployment{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+						foundResource),
+				).ToNot(HaveOccurred())
+
+				Expect(existingResource.Spec.Template.Spec.Affinity.NodeAffinity).ToNot(BeZero())
+				Expect(existingResource.Spec.Template.Spec.Tolerations).To(HaveLen(2))
+				Expect(existingResource.Spec.Template.Spec.NodeSelector["key3"]).Should(Equal("value3"))
+
+				Expect(foundResource.Spec.Template.Spec.Affinity.NodeAffinity).ToNot(BeNil())
+				Expect(foundResource.Spec.Template.Spec.Tolerations).To(HaveLen(3))
+				Expect(foundResource.Spec.Template.Spec.NodeSelector["key3"]).Should(Equal("something entirely else"))
+
+				Expect(req.Conditions).To(BeEmpty())
+			})
+
+			It("should overwrite node placement if directly set on Kubevirt Console Plugin Deployment", func() {
+				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewNodePlacement()}
+				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewOtherNodePlacement()}
+				existingResource, err := NewKvUiPluginDeplymnt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				// mock a reconciliation triggered by a change in the deployment
+				req.HCOTriggered = false
+
+				// now, modify deployment Kubevirt Console Plugin Deployment node placement
+				seconds34 := int64(34)
+				existingResource.Spec.Template.Spec.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, v1.Toleration{
+					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: &seconds34,
+				})
+				existingResource.Spec.Template.Spec.NodeSelector["key3"] = "BADvalue3"
+
+				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
+				handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+				Expect(err).ToNot(HaveOccurred())
+				res := handler[0].ensure(req)
+				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.Updated).To(BeTrue())
+				Expect(res.Overwritten).To(BeTrue())
+				Expect(res.Err).ToNot(HaveOccurred())
+
+				foundResource := &appsv1.Deployment{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: existingResource.Name, Namespace: existingResource.Namespace},
+						foundResource),
+				).ToNot(HaveOccurred())
+
+				Expect(existingResource.Spec.Template.Spec.Tolerations).To(HaveLen(3))
+				Expect(existingResource.Spec.Template.Spec.NodeSelector["key3"]).Should(Equal("BADvalue3"))
+
+				Expect(foundResource.Spec.Template.Spec.Tolerations).To(HaveLen(2))
+				Expect(foundResource.Spec.Template.Spec.NodeSelector["key3"]).Should(Equal("value3"))
+
+				Expect(req.Conditions).To(BeEmpty())
+			})
+		})
 	})
 
 	Context("Kubevirt Plugin Service", func() {


### PR DESCRIPTION
It would help ensure kubevirt-console-plugin
deployment respect the node placement configuration from the HCO CR.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-27446
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Place kubevirt-console-plugin Pod on NodeSelector specified in HCO CR
```
