### PR TITLE
[release-1.9] Fix `verifyOperatorHealthMetricValue()`

### DIFF
--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -181,11 +181,18 @@ func getAlertByName(alerts promApiv1.AlertsResult, alertName string) *promApiv1.
 }
 
 func verifyOperatorHealthMetricValue(promClient promApiv1.API, initialOperatorHealthMetricValue, alertImpact float64) {
-	systemHealthMetricValue := getMetricValue(promClient, "kubevirt_hco_system_health_status")
-	operatorHealthMetricValue := getMetricValue(promClient, "kubevirt_hyperconverged_operator_health_status")
+	Eventually(func(g Gomega) {
+		if alertImpact >= initialOperatorHealthMetricValue {
+			systemHealthMetricValue := getMetricValue(promClient, "kubevirt_hco_system_health_status")
+			operatorHealthMetricValue := getMetricValue(promClient, "kubevirt_hyperconverged_operator_health_status")
+			expectedOperatorHealthMetricValue := math.Max(alertImpact, systemHealthMetricValue)
 
-	expectedOperatorHealthMetricValue := math.Max(alertImpact, math.Max(systemHealthMetricValue, initialOperatorHealthMetricValue))
-	ExpectWithOffset(1, operatorHealthMetricValue).To(Equal(expectedOperatorHealthMetricValue))
+			g.Expect(operatorHealthMetricValue).To(Equal(expectedOperatorHealthMetricValue),
+				"kubevirt_hyperconverged_operator_health_status value is %f, but its expected value is %f, "+
+					"while kubevirt_hco_system_health_status value is %f.",
+				operatorHealthMetricValue, expectedOperatorHealthMetricValue, systemHealthMetricValue)
+		}
+	}, 60*time.Second, 5*time.Second).Should(Succeed())
 }
 
 func getMetricValue(promClient promApiv1.API, metricName string) float64 {


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2379 and https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2342. 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
