### PR TITLE
Move the default values test to golang

### DIFF
--- a/hack/check_defaults.sh
+++ b/hack/check_defaults.sh
@@ -51,10 +51,8 @@ FGPATHS=(
 LMPATHS=(
     "/spec/liveMigrationConfig/parallelMigrationsPerCluster"
     "/spec/liveMigrationConfig/parallelOutboundMigrationsPerNode"
-    "/spec/liveMigrationConfig/bandwidthPerMigration"
     "/spec/liveMigrationConfig/completionTimeoutPerGiB"
     "/spec/liveMigrationConfig/progressTimeout"
-    "/spec/liveMigrationConfig/network"
     "/spec/liveMigrationConfig/allowAutoConverge"
     "/spec/liveMigrationConfig/allowPostCopy"
     "/spec/liveMigrationConfig"

--- a/hack/check_tlsprofile.sh
+++ b/hack/check_tlsprofile.sh
@@ -124,3 +124,5 @@ if [ -n "$PF_PID" ]; then
   echo "Terminating port forwarding"
   kill ${PF_PID}
 fi
+
+check_ssp_up

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -44,9 +44,6 @@ sleep 60
 
 ./hack/retry.sh 10 30 "KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_labels.sh"
 
-# Check the defaulting mechanism
-KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_defaults.sh
-
 # Check golden images
 KUBECTL_BINARY=${KUBECTL_BINARY} ./hack/check_golden_images.sh
 

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -1,0 +1,197 @@
+package tests_test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	"kubevirt.io/client-go/kubecli"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
+)
+
+const (
+	removePathPatchTmplt = `[{"op": "remove", "path": %q}]`
+)
+
+var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
+	var (
+		cli kubecli.KubevirtClient
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		cli, err = kubecli.GetKubevirtClient()
+		Expect(cli).ToNot(BeNil())
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx = context.Background()
+	})
+
+	restoreDefaults := func(cli kubecli.KubevirtClient) error {
+		return tests.PatchHCO(ctx, cli, []byte(`[{"op": "replace", "path": "/spec", "value": {}}]`))
+	}
+
+	Context("certConfig defaults", func() {
+		defaultCertConfig := v1beta1.HyperConvergedCertConfig{
+			CA: v1beta1.CertRotateConfigCA{
+				Duration:    &metav1.Duration{Duration: time.Hour * 48},
+				RenewBefore: &metav1.Duration{Duration: time.Hour * 24},
+			},
+			Server: v1beta1.CertRotateConfigServer{
+				Duration:    &metav1.Duration{Duration: time.Hour * 24},
+				RenewBefore: &metav1.Duration{Duration: time.Hour * 12},
+			},
+		}
+
+		DescribeTable("Check that certConfig defaults are behaving as expected", func(path string) {
+			Expect(restoreDefaults(cli)).To(Succeed())
+
+			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			Eventually(func() error {
+				return tests.PatchHCO(ctx, cli, patch)
+			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				hc := tests.GetHCO(ctx, cli)
+				g.Expect(reflect.DeepEqual(hc.Spec.CertConfig, defaultCertConfig)).Should(BeTrue(), "certConfig should be equal to default")
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+		},
+			Entry("when removing /spec/certConfig/ca/duration", "/spec/certConfig/ca/duration"),
+			Entry("when removing /spec/certConfig/ca/renewBefore", "/spec/certConfig/ca/renewBefore"),
+			Entry("when removing /spec/certConfig/ca", "/spec/certConfig/ca"),
+			Entry("when removing /spec/certConfig/server/duration", "/spec/certConfig/server/duration"),
+			Entry("when removing /spec/certConfig/server/renewBefore", "/spec/certConfig/server/renewBefore"),
+			Entry("when removing /spec/certConfig/server", "/spec/certConfig/server"),
+			Entry("when removing /spec/certConfig", "/spec/certConfig"),
+			Entry("when removing /spec", "/spec"),
+		)
+	})
+
+	Context("feature gate defaults", func() {
+		defaultFeatureGates := v1beta1.HyperConvergedFeatureGates{
+			DeployKubeSecondaryDNS:      pointer.Bool(false),
+			DeployTektonTaskResources:   pointer.Bool(false),
+			DisableMDevConfiguration:    pointer.Bool(false),
+			EnableCommonBootImageImport: pointer.Bool(true),
+			PersistentReservation:       pointer.Bool(false),
+			Root:                        pointer.Bool(false),
+			WithHostPassthroughCPU:      pointer.Bool(false),
+		}
+
+		DescribeTable("Check that featureGates defaults are behaving as expected", func(path string) {
+			Expect(restoreDefaults(cli)).To(Succeed())
+
+			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			Eventually(func() error {
+				return tests.PatchHCO(ctx, cli, patch)
+			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				hc := tests.GetHCO(ctx, cli)
+				g.Expect(reflect.DeepEqual(hc.Spec.FeatureGates, defaultFeatureGates)).Should(BeTrue(), "featureGates should be equal to default")
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+		},
+			Entry("when removing /spec/featureGates/deployKubeSecondaryDNS", "/spec/featureGates/deployKubeSecondaryDNS"),
+			Entry("when removing /spec/featureGates/deployTektonTaskResources", "/spec/featureGates/deployTektonTaskResources"),
+			Entry("when removing /spec/featureGates/disableMDevConfiguration", "/spec/featureGates/disableMDevConfiguration"),
+			Entry("when removing /spec/featureGates/enableCommonBootImageImport", "/spec/featureGates/enableCommonBootImageImport"),
+			Entry("when removing /spec/featureGates/persistentReservation", "/spec/featureGates/persistentReservation"),
+			Entry("when removing /spec/featureGates/root", "/spec/featureGates/root"),
+			Entry("when removing /spec/featureGates/withHostPassthroughCPU", "/spec/featureGates/withHostPassthroughCPU"),
+			Entry("when removing /spec/featureGates", "/spec/featureGates"),
+			Entry("when removing /spec", "/spec"),
+		)
+	})
+
+	Context("liveMigrationConfig defaults", func() {
+		defaultLiveMigrationConfig := v1beta1.LiveMigrationConfigurations{
+			AllowAutoConverge:                 pointer.Bool(false),
+			AllowPostCopy:                     pointer.Bool(false),
+			CompletionTimeoutPerGiB:           pointer.Int64(800),
+			ParallelMigrationsPerCluster:      pointer.Uint32(5),
+			ParallelOutboundMigrationsPerNode: pointer.Uint32(2),
+			ProgressTimeout:                   pointer.Int64(150),
+		}
+
+		DescribeTable("Check that liveMigrationConfig defaults are behaving as expected", func(path string) {
+			Expect(restoreDefaults(cli)).To(Succeed())
+
+			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			Eventually(func() error {
+				return tests.PatchHCO(ctx, cli, patch)
+			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				hc := tests.GetHCO(ctx, cli)
+				g.Expect(reflect.DeepEqual(hc.Spec.LiveMigrationConfig, defaultLiveMigrationConfig)).Should(BeTrue(), "liveMigrationConfig should be equal to default")
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+		},
+			Entry("when removing /spec/liveMigrationConfig/allowAutoConverge", "/spec/liveMigrationConfig/allowAutoConverge"),
+			Entry("when removing /spec/liveMigrationConfig/allowPostCopy", "/spec/liveMigrationConfig/allowPostCopy"),
+			Entry("when removing /spec/liveMigrationConfig/completionTimeoutPerGiB", "/spec/liveMigrationConfig/completionTimeoutPerGiB"),
+			Entry("when removing /spec/liveMigrationConfig/parallelMigrationsPerCluster", "/spec/liveMigrationConfig/parallelMigrationsPerCluster"),
+			Entry("when removing /spec/liveMigrationConfig/parallelOutboundMigrationsPerNode", "/spec/liveMigrationConfig/parallelOutboundMigrationsPerNode"),
+			Entry("when removing /spec/liveMigrationConfig/progressTimeout", "/spec/liveMigrationConfig/progressTimeout"),
+			Entry("when removing /spec/liveMigrationConfig", "/spec/liveMigrationConfig"),
+			Entry("when removing /spec", "/spec"),
+		)
+	})
+
+	Context("workloadUpdateStrategy defaults", func() {
+		defaultWorkloadUpdateStrategy := v1beta1.HyperConvergedWorkloadUpdateStrategy{
+			BatchEvictionInterval: &metav1.Duration{Duration: time.Minute},
+			BatchEvictionSize:     pointer.Int(10),
+			WorkloadUpdateMethods: []string{"LiveMigrate"},
+		}
+
+		DescribeTable("Check that workloadUpdateStrategy defaults are behaving as expected", func(path string) {
+			Expect(restoreDefaults(cli)).To(Succeed())
+
+			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			Eventually(func() error {
+				return tests.PatchHCO(ctx, cli, patch)
+			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				hc := tests.GetHCO(ctx, cli)
+				g.Expect(reflect.DeepEqual(hc.Spec.WorkloadUpdateStrategy, defaultWorkloadUpdateStrategy)).Should(BeTrue(), "workloadUpdateStrategy should be equal to default")
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+		},
+			Entry("when removing /spec/workloadUpdateStrategy/batchEvictionInterval", "/spec/workloadUpdateStrategy/batchEvictionInterval"),
+			Entry("when removing /spec/workloadUpdateStrategy/batchEvictionSize", "/spec/workloadUpdateStrategy/batchEvictionSize"),
+			Entry("when removing /spec/workloadUpdateStrategy/workloadUpdateMethods", "/spec/workloadUpdateStrategy/workloadUpdateMethods"),
+			Entry("when removing /spec/workloadUpdateStrategy", "/spec/workloadUpdateStrategy"),
+			Entry("when removing /spec", "/spec"),
+		)
+	})
+
+	Context("uninstallStrategy defaults", func() {
+		const defaultUninstallStrategy = `BlockUninstallIfWorkloadsExist`
+
+		DescribeTable("Check that uninstallStrategy default is behaving as expected", func(path string) {
+			Expect(restoreDefaults(cli)).To(Succeed())
+
+			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			Eventually(func() error {
+				return tests.PatchHCO(ctx, cli, patch)
+			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				hc := tests.GetHCO(ctx, cli)
+				g.Expect(hc.Spec.UninstallStrategy).Should(Equal(v1beta1.HyperConvergedUninstallStrategy(defaultUninstallStrategy)), "uninstallStrategy should be equal to default")
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+		},
+			Entry("when removing /spec/uninstallStrategy", "/spec/uninstallStrategy"),
+			Entry("when removing /spec", "/spec"),
+		)
+	})
+})

--- a/tests/func-tests/utils.go
+++ b/tests/func-tests/utils.go
@@ -8,24 +8,24 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	"kubevirt.io/kubevirt/tests/flags"
-
 	"github.com/onsi/ginkgo/v2"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	. "github.com/onsi/gomega" //nolint dot-imports
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests/flags"
 	kvtutil "kubevirt.io/kubevirt/tests/util"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 var KubeVirtStorageClassLocal string
@@ -183,4 +183,12 @@ func UpdateHCO(ctx context.Context, client kubecli.KubevirtClient, input *v1beta
 		return nil, err
 	}
 	return output, nil
+}
+
+// PatchHCO updates the HCO CR using a DynamicClient, it can return errors on failures
+func PatchHCO(ctx context.Context, cl kubecli.KubevirtClient, patch []byte) error {
+	hcoGVR := schema.GroupVersionResource{Group: v1beta1.SchemeGroupVersion.Group, Version: v1beta1.SchemeGroupVersion.Version, Resource: resource}
+
+	_, err := cl.DynamicClient().Resource(hcoGVR).Namespace(flags.KubeVirtInstallNamespace).Patch(ctx, hcoutil.HyperConvergedName, types.JSONPatchType, patch, metav1.PatchOptions{})
+	return err
 }


### PR DESCRIPTION
The default values e2e test is written in bash. This PR replace the existing test bash script with golang implementation

Also, fix the current bash script to remove old pathes that are not the
default anymore. (we still need the old default test for the upgrade
lanes; will implement e2e there later).

The test now is much faster - takes less than a second.
**Jira Ticket**:
```jira-ticket
None
```

**Release note**:
```release-note
None
```
