### PR TITLE
Fix BZ 2215756: Failed kubevirt-plugin

### DIFF
--- a/controllers/operands/kubevirtConsolePlugin_test.go
+++ b/controllers/operands/kubevirtConsolePlugin_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
 			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
 			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
-			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentDeployment)))
+			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentUIPlugin)))
 			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelManagedBy, hcoutil.OperatorName))
 			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelVersion, hcoutil.GetHcoKvIoVersion()))
 			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelPartOf, hcoutil.HyperConvergedCluster))

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -79,5 +79,5 @@ const (
 	AppComponentMonitoring AppComponent = "monitoring"
 	AppComponentSchedule   AppComponent = "schedule"
 	AppComponentDeployment AppComponent = "deployment"
-	AppComponentTekton     AppComponent = "tekton"
+	AppComponentUIPlugin   AppComponent = "kubevirt-console-plugin"
 )

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/consts.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/consts.go
@@ -79,5 +79,5 @@ const (
 	AppComponentMonitoring AppComponent = "monitoring"
 	AppComponentSchedule   AppComponent = "schedule"
 	AppComponentDeployment AppComponent = "deployment"
-	AppComponentTekton     AppComponent = "tekton"
+	AppComponentUIPlugin   AppComponent = "kubevirt-console-plugin"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
The UI plugin pod labels were changed, while the service selector wasn't.

This PR fixes that, by replacing the "component" label of the deployment, service, pod, and configMap to "kubevirt-console-plugin", and modify the service's selector to use the component label instead of the app label.


**Reviewer Checklist**
- [x] PR Message
- [X] Commit Messages
- [ ] How to test
- [x] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-30034
```

**Release note**:
```release-note
Fix BZ 2215756: Failed kubevirt-plugin
```
