### PR TITLE
Expose HCO monitoring on plain k8s

### DIFF
--- a/controllers/alerts/metrics_test.go
+++ b/controllers/alerts/metrics_test.go
@@ -587,7 +587,7 @@ var _ = Describe("alert tests", func() {
 
 		It("should update the labels if modified", func() {
 			owner := getDeploymentReference(ci.GetDeployment())
-			existRB := newRoleBinding(owner, commontestutils.Namespace)
+			existRB := newRoleBinding(owner, commontestutils.Namespace, ci)
 			existRB.Labels = map[string]string{
 				"wrongKey1": "wrongValue1",
 				"wrongKey2": "wrongValue2",
@@ -608,7 +608,7 @@ var _ = Describe("alert tests", func() {
 
 		It("should update the labels if it's missing", func() {
 			owner := getDeploymentReference(ci.GetDeployment())
-			existRB := newRoleBinding(owner, commontestutils.Namespace)
+			existRB := newRoleBinding(owner, commontestutils.Namespace, ci)
 			existRB.Labels = nil
 
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
@@ -632,7 +632,7 @@ var _ = Describe("alert tests", func() {
 				BlockOwnerDeletion: pointer.Bool(true),
 				UID:                "0987654321",
 			}
-			existRB := newRoleBinding(owner, commontestutils.Namespace)
+			existRB := newRoleBinding(owner, commontestutils.Namespace, ci)
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
@@ -663,7 +663,7 @@ var _ = Describe("alert tests", func() {
 				BlockOwnerDeletion: pointer.Bool(true),
 				UID:                "0987654321",
 			}
-			existRB := newRoleBinding(owner, commontestutils.Namespace)
+			existRB := newRoleBinding(owner, commontestutils.Namespace, ci)
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
@@ -693,7 +693,7 @@ var _ = Describe("alert tests", func() {
 
 		It("should update the referenceOwner if missing", func() {
 			owner := metav1.OwnerReference{}
-			existRB := newRoleBinding(owner, commontestutils.Namespace)
+			existRB := newRoleBinding(owner, commontestutils.Namespace, ci)
 			existRB.OwnerReferences = nil
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
@@ -716,7 +716,7 @@ var _ = Describe("alert tests", func() {
 
 		It("should update the RoleRef if modified", func() {
 			owner := getDeploymentReference(ci.GetDeployment())
-			existRB := newRoleBinding(owner, commontestutils.Namespace)
+			existRB := newRoleBinding(owner, commontestutils.Namespace, ci)
 
 			existRB.RoleRef = rbacv1.RoleRef{
 				APIGroup: "wrongAPIGroup",
@@ -740,7 +740,7 @@ var _ = Describe("alert tests", func() {
 
 		It("should update the RoleRef if it's missing", func() {
 			owner := getDeploymentReference(ci.GetDeployment())
-			existRB := newRoleBinding(owner, commontestutils.Namespace)
+			existRB := newRoleBinding(owner, commontestutils.Namespace, ci)
 
 			existRB.RoleRef = rbacv1.RoleRef{}
 
@@ -760,7 +760,7 @@ var _ = Describe("alert tests", func() {
 
 		It("should update the Subjects if modified", func() {
 			owner := getDeploymentReference(ci.GetDeployment())
-			existRB := newRoleBinding(owner, commontestutils.Namespace)
+			existRB := newRoleBinding(owner, commontestutils.Namespace, ci)
 
 			existRB.Subjects = []rbacv1.Subject{
 				{
@@ -784,7 +784,7 @@ var _ = Describe("alert tests", func() {
 			Expect(rb.Subjects).Should(HaveLen(1))
 			Expect(rb.Subjects[0].Kind).Should(Equal(rbacv1.ServiceAccountKind))
 			Expect(rb.Subjects[0].Name).Should(Equal("prometheus-k8s"))
-			Expect(rb.Subjects[0].Namespace).Should(Equal(monitoringNamespace))
+			Expect(rb.Subjects[0].Namespace).Should(Equal(getMonitoringNamespace(ci)))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
 			Expect(metrics.HcoMetrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric))
@@ -792,7 +792,7 @@ var _ = Describe("alert tests", func() {
 
 		It("should update the Subjects if it's missing", func() {
 			owner := getDeploymentReference(ci.GetDeployment())
-			existRB := newRoleBinding(owner, commontestutils.Namespace)
+			existRB := newRoleBinding(owner, commontestutils.Namespace, ci)
 
 			existRB.Subjects = nil
 
@@ -806,7 +806,7 @@ var _ = Describe("alert tests", func() {
 			Expect(rb.Subjects).Should(HaveLen(1))
 			Expect(rb.Subjects[0].Kind).Should(Equal(rbacv1.ServiceAccountKind))
 			Expect(rb.Subjects[0].Name).Should(Equal("prometheus-k8s"))
-			Expect(rb.Subjects[0].Namespace).Should(Equal(monitoringNamespace))
+			Expect(rb.Subjects[0].Namespace).Should(Equal(getMonitoringNamespace(ci)))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
 			Expect(metrics.HcoMetrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric))

--- a/controllers/alerts/reconciler.go
+++ b/controllers/alerts/reconciler.go
@@ -45,7 +45,7 @@ func NewMonitoringReconciler(ci hcoutil.ClusterInfo, cl client.Client, ee hcouti
 		reconcilers: []MetricReconciler{
 			newAlertRuleReconciler(namespace, owner),
 			newRoleReconciler(namespace, owner),
-			newRoleBindingReconciler(namespace, owner),
+			newRoleBindingReconciler(namespace, owner, ci),
 			newMetricServiceReconciler(namespace, owner),
 			newServiceMonitorReconciler(namespace, owner),
 		},

--- a/controllers/commontestutils/testUtils.go
+++ b/controllers/commontestutils/testUtils.go
@@ -296,6 +296,9 @@ func (ClusterInfoMock) GetBaseDomain() string {
 func (c ClusterInfoMock) IsConsolePluginImageProvided() bool {
 	return true
 }
+func (c ClusterInfoMock) IsMonitoringAvailable() bool {
+	return true
+}
 func (c ClusterInfoMock) GetPod() *corev1.Pod {
 	return pod
 }
@@ -364,8 +367,10 @@ func (ClusterInfoSNOMock) GetTLSSecurityProfile(_ *openshiftconfigv1.TLSSecurity
 func (ClusterInfoSNOMock) RefreshAPIServerCR(_ context.Context, _ client.Client) error {
 	return nil
 }
-
 func (ClusterInfoSNOMock) IsConsolePluginImageProvided() bool {
+	return true
+}
+func (c ClusterInfoSNOMock) IsMonitoringAvailable() bool {
 	return true
 }
 
@@ -408,6 +413,9 @@ func (ClusterInfoSRCPHAIMock) GetBaseDomain() string {
 	return BaseDomain
 }
 func (ClusterInfoSRCPHAIMock) IsConsolePluginImageProvided() bool {
+	return true
+}
+func (ClusterInfoSRCPHAIMock) IsMonitoringAvailable() bool {
 	return true
 }
 func (ClusterInfoSRCPHAIMock) GetTLSSecurityProfile(_ *openshiftconfigv1.TLSSecurityProfile) *openshiftconfigv1.TLSSecurityProfile {

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -122,7 +122,7 @@ func newReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo, upgradeableCond 
 		upgradeableCondition: upgradeableCond,
 	}
 
-	if ci.IsOpenshift() {
+	if ci.IsMonitoringAvailable() {
 		r.monitoringReconciler = alerts.NewMonitoringReconciler(ci, r.client, hcoutil.GetEventEmitter(), r.scheme)
 	}
 
@@ -185,12 +185,16 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo) er
 		&rbacv1.Role{},
 		&rbacv1.RoleBinding{},
 	}
+	if ci.IsMonitoringAvailable() {
+		secondaryResources = append(secondaryResources, []client.Object{
+			&monitoringv1.ServiceMonitor{},
+			&monitoringv1.PrometheusRule{},
+		}...)
+	}
 	if ci.IsOpenshift() {
 		secondaryResources = append(secondaryResources, []client.Object{
 			&sspv1beta1.SSP{},
 			&corev1.Service{},
-			&monitoringv1.ServiceMonitor{},
-			&monitoringv1.PrometheusRule{},
 			&routev1.Route{},
 			&consolev1.ConsoleCLIDownload{},
 			&consolev1.ConsoleQuickStart{},

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -16,6 +16,8 @@ const (
 	KVUIPluginImageEnvV              = "KV_CONSOLE_PLUGIN_IMAGE"
 	HcoValidatingWebhook             = "validate-hco.kubevirt.io"
 	HcoMutatingWebhookNS             = "mutate-ns-hco.kubevirt.io"
+	PrometheusRuleCRDName            = "prometheusrules.monitoring.coreos.com"
+	ServiceMonitorCRDName            = "servicemonitors.monitoring.coreos.com"
 	HcoMutatingWebhookHyperConverged = "mutate-hyperconverged-hco.kubevirt.io"
 	AppLabel                         = "app"
 	UndefinedNamespace               = ""

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/consts.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/consts.go
@@ -16,6 +16,8 @@ const (
 	KVUIPluginImageEnvV              = "KV_CONSOLE_PLUGIN_IMAGE"
 	HcoValidatingWebhook             = "validate-hco.kubevirt.io"
 	HcoMutatingWebhookNS             = "mutate-ns-hco.kubevirt.io"
+	PrometheusRuleCRDName            = "prometheusrules.monitoring.coreos.com"
+	ServiceMonitorCRDName            = "servicemonitors.monitoring.coreos.com"
 	HcoMutatingWebhookHyperConverged = "mutate-hyperconverged-hco.kubevirt.io"
 	AppLabel                         = "app"
 	UndefinedNamespace               = ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
**What this PR does / why we need it**:
Right now we are creating HCO monitoring-related resources only in OpenShift clusters, and thus HCO metrics and alerts are created and exposed to Prometheus only on these clusters. On plain k8s clusters, HCO only implements metrics, but they are not exposed to Prometheus, and alerts are not created or reconciled at all.
This PR exposes metrics and alerts also on k8s clusters, by enabling the creation and reconciliation of required monitoring-related resources (e.g. `PrometheusRule`,`ServiceMonitor`), as long as Prometheus is installed on the cluster. 


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**: https://issues.redhat.com/browse/CNV-26009
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose HCO monitoring on plain k8s
```
