### PR TITLE
dataImportCronTemplates: Move default-instancetype to u1.medium

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -4,7 +4,7 @@
     name: centos-stream8-image-cron
     labels:
       instancetype.kubevirt.io/default-preference: centos.8.stream
-      instancetype.kubevirt.io/default-instancetype: n.medium
+      instancetype.kubevirt.io/default-instancetype: u1.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -24,7 +24,7 @@
     name: centos-stream9-image-cron
     labels:
       instancetype.kubevirt.io/default-preference: centos.9.stream
-      instancetype.kubevirt.io/default-instancetype: n.medium
+      instancetype.kubevirt.io/default-instancetype: u1.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -44,7 +44,7 @@
     name: fedora-image-cron
     labels:
       instancetype.kubevirt.io/default-preference: fedora
-      instancetype.kubevirt.io/default-instancetype: n.medium
+      instancetype.kubevirt.io/default-instancetype: u1.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -64,7 +64,7 @@
     name: centos-7-image-cron
     labels:
       instancetype.kubevirt.io/default-preference: centos.7
-      instancetype.kubevirt.io/default-instancetype: n.medium
+      instancetype.kubevirt.io/default-instancetype: u1.medium
   spec:
     schedule: "0 */12 * * *"
     template:


### PR DESCRIPTION
**What this PR does / why we need it**:

common-instancetypes v0.3.0 as deployed by SSP operator v0.18.1 renames the N neutral instance type class to U for universal ahead of new network related classes being introduced in a future release.

This change moves the dataImportCronTemplates used by the SSP operator over to this new class. It also corrects a previous mistake, using the correct `u1.medium` name of the resource. A follow up change will provide some basic functional testing of this to ensure a mistake like this isn't able to merge in the future.

This change is backwardly compatible, any previous users of the N instance type class either directly through their VirtualMachine definition or indirectly inferred through these default labels will not be impacted with their VirtualMachines continuing to use the original N instance type class.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
