### PR TITLE
Preparation for running functional test after upgrade

### DIFF
--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -119,3 +119,6 @@ echo "Exiting... Exit code: $exitCode"
 # exit non-zero if exit code of functest is not zero
 [[ "${exitCode}" == "0" ]]
 
+# Brutally delete HCO removing the namespace where it's running"
+source hack/test_delete_ns.sh
+test_delete_ns

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -59,6 +59,3 @@ sleep 10
 [[ $(${KUBECTL_BINARY} get priorityclass kubevirt-cluster-critical -o=jsonpath='{.metadata.labels.app}') == 'kubevirt-hyperconverged' ]]
 
 ./hack/check_update_priority_class.sh
-
-# Check the webhook, to see if it allow deleting of the HyperConverged CR
-./hack/retry.sh 10 30 "${KUBECTL_BINARY} delete hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged"

--- a/hack/upgrade-test-index-image.sh
+++ b/hack/upgrade-test-index-image.sh
@@ -292,12 +292,6 @@ Msg "Check that OVS is deployed or not deployed according to deployOVS annotatio
 Msg "Ensure that console plugin deployment and service has been renamed successfully"
 KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} ./hack/check_upgrade_console_plugin.sh
 
-Msg "Check that managed objects has correct labels"
-./hack/retry.sh 10 30 "KUBECTL_BINARY=${CMD} ./hack/check_labels.sh"
-
-Msg "Check the defaulting mechanism"
-KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} ./hack/check_defaults.sh
-
 Msg "Check that the v2v CRDs and deployments were removed"
 if ${CMD} get crd | grep -q v2v.kubevirt.io; then
     echo "The v2v CRDs should not be found; they had to be removed."
@@ -336,9 +330,6 @@ else
     echo "TTO reference removed from .status.relatedObjects"
 fi
 
-Msg "check golden images"
-KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} ./hack/check_golden_images.sh
-
 Msg "check virtio-win image is in configmap"
 VIRTIOWIN_IMAGE_CSV=$(${CMD} get ${CSV} -n ${HCO_NAMESPACE} \
   -o jsonpath='{.spec.install.spec.deployments[?(@.name=="hco-operator")].spec.template.spec.containers[0].env[?(@.name=="VIRTIOWIN_CONTAINER")].value}')
@@ -353,9 +344,5 @@ ${CMD} logs -n ${HCO_NAMESPACE} "${HCO_POD}"
 Msg "Read the HCO webhook log before it been deleted"
 WH_POD=$( ${CMD} get -n ${HCO_NAMESPACE} pods -l "name=hyperconverged-cluster-webhook" -o name)
 ${CMD} logs -n ${HCO_NAMESPACE} "${WH_POD}"
-
-Msg "Brutally delete HCO removing the namespace where it's running"
-source hack/test_delete_ns.sh
-test_delete_ns
 
 echo "upgrade-test completed successfully."


### PR DESCRIPTION
Currently, many e2e tests are implemented by bash files. We want to move them to golang. But some of these tests are also running on the upgrade test lanes, so this PR removes these bash tests from the upgrade test, and add the full e2e test instead. That will allow us to move most of the bash tests to golang.

This PR remove several tests from the upgrade lanes. These test will be called from the lane configurations in openshift/release, as implemented in https://github.com/openshift/release/pull/40643.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
