### PR TITLE
cnao: Deploy linux bridge only for non Openshift

### DIFF
--- a/controllers/operands/networkAddons.go
+++ b/controllers/operands/networkAddons.go
@@ -140,8 +140,11 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged, opts ...string) (*networkad
 
 	cnaoSpec := networkaddonsshared.NetworkAddonsConfigSpec{
 		Multus:      &networkaddonsshared.Multus{},
-		LinuxBridge: &networkaddonsshared.LinuxBridge{},
 		KubeMacPool: &networkaddonsshared.KubeMacPool{},
+	}
+
+	if !hcoutil.GetClusterInfo().IsOpenshift() {
+		cnaoSpec.LinuxBridge = &networkaddonsshared.LinuxBridge{}
 	}
 
 	nameServerIP, err := getKSDNameServerIP(hc.Spec.KubeSecondaryDNSNameServerIP)

--- a/controllers/operands/networkAddons_test.go
+++ b/controllers/operands/networkAddons_test.go
@@ -595,6 +595,12 @@ var _ = Describe("CNA Operand", func() {
 					expectedBaseDomain: "",
 				}),
 			)
+
+			It("Should deploy linux-bridge", func() {
+				existingCNAO, err := NewNetworkAddons(hco)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(existingCNAO.Spec.LinuxBridge).ToNot(BeNil(), "Linux Bridge spec should be added")
+			})
 		})
 
 		Context("With Openshift Mock", func() {
@@ -633,6 +639,13 @@ var _ = Describe("CNA Operand", func() {
 					expectedBaseDomain: "",
 				}),
 			)
+
+			It("Should not deploy linux-bridge", func() {
+				existingCNAO, err := NewNetworkAddons(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(existingCNAO.Spec.LinuxBridge).To(BeNil(), "Linux Bridge spec should not be added")
+			})
 		})
 
 		It("should handle conditions", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
We used to have two bridge CNIs,
bridge which is the official, and cnv-bridge which we maintained for additional features.
Since there is only one now, in case it is already exists, we don't need to deploy it (as long as there is a softlink
between bridge and cnv-bridge, for backward compability). 
For Openshift it is already deployed, so skip deployment in such case.

**Reviewer Checklist**

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
