### PR TITLE
Fix link text for virtctl ARM 64 binaries

### DIFF
--- a/controllers/operands/cliDownload.go
+++ b/controllers/operands/cliDownload.go
@@ -94,7 +94,7 @@ func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLID
 				},
 				{
 					Href: baseURL + "/arm64/linux/virtctl.tar.gz",
-					Text: "Download virtctl for Linux for arm64",
+					Text: "Download virtctl for Linux for ARM 64",
 				},
 				{
 					Href: baseURL + "/amd64/mac/virtctl.zip",
@@ -102,7 +102,7 @@ func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLID
 				},
 				{
 					Href: baseURL + "/arm64/mac/virtctl.zip",
-					Text: "Download virtctl for Mac for arm64",
+					Text: "Download virtctl for Mac for ARM 64",
 				},
 				{
 					Href: baseURL + "/amd64/windows/virtctl.zip",
@@ -110,7 +110,7 @@ func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLID
 				},
 				{
 					Href: baseURL + "/arm64/windows/virtctl.zip",
-					Text: "Download virtctl for Windows for arm64",
+					Text: "Download virtctl for Windows for ARM 64",
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
amend the link text for virtctl binaries
on OCP/OKD to improve the consistency
with oc ones.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2216330

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-30133
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
