### PR TITLE
fix wrong mkdir flag in upgrade-test-operator-sdk.sh

### DIFF
--- a/hack/compare_scc.sh
+++ b/hack/compare_scc.sh
@@ -22,40 +22,29 @@ set -ex
 OUTPUT_DIR=${OUTPUT_DIR:-_out}
 SCC_OUTPUT_DIR="${OUTPUT_DIR}/scc"
 
-BEFORE_DIR="${SCC_OUTPUT_DIR}/before"
-AFTER_DIR="${SCC_OUTPUT_DIR}/after"
+SCC_BEFORE_SUFFIX=.yaml.before
+SCC_AFTER_SUFFIX=.yaml.after
 
-SUFFIX=.json
-
-function dump_sccs() {
-  TARGET_DIR=$1
-  if [ "${CMD}" == "oc" ] && [ "${KUBEVIRT_PROVIDER}" != "external" ]; then
-    mkdir -p "${TARGET_DIR}"
-    for SCCNAME in $( ${CMD} get scc -o custom-columns=:metadata.name); do
+function dump_sccs_before(){
+    if [ "${CMD}" == "oc" ]; then
+        mkdir -pv "${SCC_OUTPUT_DIR}"
+        for SCCNAME in $( ${CMD} get scc -o custom-columns=:metadata.name )
+        do
       echo -e "\n--- SCC ${SCCNAME} ---"
-      ${CMD} get scc "${SCCNAME}" -o json | jq 'del(.metadata.resourceVersion,.metadata.generation,.metadata.labels,.metadata.annotations)' > "${TARGET_DIR}/${SCCNAME}${SUFFIX}" || true
+          ${CMD} get scc ${SCCNAME} -o yaml > "${SCC_OUTPUT_DIR}/${SCCNAME}${SCC_BEFORE_SUFFIX}" || true
     done
   else
     echo "Ignoring SCCs on k8s"
   fi
 }
 
-function dump_sccs_before() {
-  dump_sccs "${BEFORE_DIR}"
-}
-
-function dump_sccs_after() {
-  dump_sccs "${AFTER_DIR}"
-
-  compare_sccs
-}
-
-function compare_sccs() {
+function dump_sccs_after(){
   if [ "${CMD}" == "oc" ] && [ "${KUBEVIRT_PROVIDER}" != "external" ]; then
-    for f in "${BEFORE_DIR}"/*"${SUFFIX}"; do
-      SCCNAME=$(basename --suffix="${SUFFIX}" "$f")
-      echo -e "\n--- comparing SCC ${SCCNAME} ---"
-      diff "${BEFORE_DIR}/${SCCNAME}${SUFFIX}" "${AFTER_DIR}/${SCCNAME}${SUFFIX}"
+        for f in "${SCC_OUTPUT_DIR}"/*"${SCC_BEFORE_SUFFIX}"; do
+           SCCNAME=$(basename --suffix=${SCC_BEFORE_SUFFIX} "$f")
+           echo -e "\n--- SCC ${SCCNAME} ---"
+           ${CMD} get scc ${SCCNAME} -o yaml > "${SCC_OUTPUT_DIR}/${SCCNAME}${SCC_AFTER_SUFFIX}" || true
+           diff -I '^\s*generation:.*$' -I '^\s*resourceVersion:.*$' -I '^\s*time:.*$' "${SCC_OUTPUT_DIR}/${SCCNAME}${SCC_BEFORE_SUFFIX}" "${SCC_OUTPUT_DIR}/${SCCNAME}${SCC_AFTER_SUFFIX}"
     done
   else
     echo "Ignoring SCCs on k8s"

--- a/hack/upgrade-test-operator-sdk.sh
+++ b/hack/upgrade-test-operator-sdk.sh
@@ -68,7 +68,6 @@ function cleanup() {
 trap "cleanup" INT TERM EXIT
 
 source hack/compare_scc.sh
-OUTPUT_DIR=${OUTPUT_DIR} dump_sccs_before
 
 CSV=$( ${CMD} get csv -o name -n ${HCO_NAMESPACE} | grep "kubevirt-hyperconverged-operator")
 
@@ -304,12 +303,13 @@ VIRTIOWIN_IMAGE_CM=$(${CMD} get cm virtio-win -n ${HCO_NAMESPACE} -o jsonpath='{
 [[ "${VIRTIOWIN_IMAGE_CSV}" == "${VIRTIOWIN_IMAGE_CM}" ]]
 
 Msg "Read the HCO operator log before it been deleted"
-mkdir -f "${OUTPUT_DIR}/logs"
+LOG_DIR="${ARTIFACT_DIR}/logs"
+mkdir -p "${LOG_DIR}"
 HCO_POD=$( ${CMD} get -n ${HCO_NAMESPACE} pods -l "name=hyperconverged-cluster-operator" -o name)
-${CMD} logs -n ${HCO_NAMESPACE} "${HCO_POD}" > "${OUTPUT_DIR}/logs/hyperconverged-cluster-operator.log"
+${CMD} logs -n ${HCO_NAMESPACE} "${HCO_POD}" > "${LOG_DIR}/hyperconverged-cluster-operator.log"
 
 Msg "Read the HCO webhook log before it been deleted"
 WH_POD=$( ${CMD} get -n ${HCO_NAMESPACE} pods -l "name=hyperconverged-cluster-webhook" -o name)
-${CMD} logs -n ${HCO_NAMESPACE} "${WH_POD}" > "${OUTPUT_DIR}/logs/hyperconverged-cluster-webhook.log"
+${CMD} logs -n ${HCO_NAMESPACE} "${WH_POD}" > "${LOG_DIR}/hyperconverged-cluster-webhook.log"
 
 echo "upgrade-test completed successfully."


### PR DESCRIPTION
## What this PR does / why we need it
Fix several issues with the upgrade-test-operator-sdk script, including:
* `mkdir -f` ==> `mkdir -p`
* restore the compare_scc script, and use the shared dir for the output files.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
