### PR TITLE
Expose vmiCPUAllocationRatio

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -90,6 +90,7 @@ type HyperConvergedSpec struct {
 	CertConfig HyperConvergedCertConfig `json:"certConfig,omitempty"`
 
 	// ResourceRequirements describes the resource requirements for the operand workloads.
+	// +kubebuilder:default={"vmiCPUAllocationRatio": 10}
 	// +optional
 	ResourceRequirements *OperandResourceRequirements `json:"resourceRequirements,omitempty"`
 
@@ -474,6 +475,22 @@ type OperandResourceRequirements struct {
 	// resource
 	// +optional
 	StorageWorkloads *corev1.ResourceRequirements `json:"storageWorkloads,omitempty"`
+
+	// VmiCPUAllocationRatio defines, for each requested virtual CPU,
+	// how much physical CPU to request per VMI from the
+	// hosting node. The value is in fraction of a CPU thread (or
+	// core on non-hyperthreaded nodes).
+	// VMI POD CPU request = number of vCPUs * 1/vmiCPUAllocationRatio
+	// For example, a value of 1 means 1 physical CPU thread per VMI CPU thread.
+	// A value of 100 would be 1% of a physical thread allocated for each
+	// requested VMI thread.
+	// This option has no effect on VMIs that request dedicated CPUs.
+	// Defaults to 10
+	// +kubebuilder:default=10
+	// +kubebuilder:validation:Minimum=1
+	// +default=10
+	// +optional
+	VmiCPUAllocationRatio *int `json:"vmiCPUAllocationRatio,omitempty"`
 }
 
 // HyperConvergedObsoleteCPUs allows avoiding scheduling of VMs for obsolete CPU models
@@ -655,7 +672,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "virtualMachineOptions": {"disableFreePageReporting": true}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "virtualMachineOptions": {"disableFreePageReporting": true}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -674,6 +674,11 @@ func (in *OperandResourceRequirements) DeepCopyInto(out *OperandResourceRequirem
 		*out = new(apicorev1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.VmiCPUAllocationRatio != nil {
+		in, out := &in.VmiCPUAllocationRatio, &out.VmiCPUAllocationRatio
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1beta1/zz_generated.defaults.go
+++ b/api/v1beta1/zz_generated.defaults.go
@@ -112,6 +112,12 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 			panic(err)
 		}
 	}
+	if in.Spec.ResourceRequirements != nil {
+		if in.Spec.ResourceRequirements.VmiCPUAllocationRatio == nil {
+			var ptrVar1 int = 10
+			in.Spec.ResourceRequirements.VmiCPUAllocationRatio = &ptrVar1
+		}
+	}
 	if in.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods == nil {
 		if err := json.Unmarshal([]byte(`["LiveMigrate"]`), &in.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods); err != nil {
 			panic(err)

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -975,6 +975,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_OperandResource
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
+					"vmiCPUAllocationRatio": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VmiCPUAllocationRatio defines, for each requested virtual CPU, how much physical CPU to request per VMI from the hosting node. The value is in fraction of a CPU thread (or core on non-hyperthreaded nodes). VMI POD CPU request = number of vCPUs * 1/vmiCPUAllocationRatio For example, a value of 1 means 1 physical CPU thread per VMI CPU thread. A value of 100 would be 1% of a physical thread allocated for each requested VMI thread. This option has no effect on VMIs that request dedicated CPUs. Defaults to 10",
+							Default:     10,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 			},
 		},

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -64,6 +64,8 @@ spec:
                 parallelMigrationsPerCluster: 5
                 parallelOutboundMigrationsPerNode: 2
                 progressTimeout: 150
+              resourceRequirements:
+                vmiCPUAllocationRatio: 10
               uninstallStrategy: BlockUninstallIfWorkloadsExist
               virtualMachineOptions:
                 disableFreePageReporting: true
@@ -2337,6 +2339,8 @@ spec:
                     x-kubernetes-list-type: map
                 type: object
               resourceRequirements:
+                default:
+                  vmiCPUAllocationRatio: 10
                 description: ResourceRequirements describes the resource requirements
                   for the operand workloads.
                 properties:
@@ -2390,6 +2394,19 @@ spec:
                           Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  vmiCPUAllocationRatio:
+                    default: 10
+                    description: VmiCPUAllocationRatio defines, for each requested
+                      virtual CPU, how much physical CPU to request per VMI from the
+                      hosting node. The value is in fraction of a CPU thread (or core
+                      on non-hyperthreaded nodes). VMI POD CPU request = number of
+                      vCPUs * 1/vmiCPUAllocationRatio For example, a value of 1 means
+                      1 physical CPU thread per VMI CPU thread. A value of 100 would
+                      be 1% of a physical thread allocated for each requested VMI
+                      thread. This option has no effect on VMIs that request dedicated
+                      CPUs. Defaults to 10
+                    minimum: 1
+                    type: integer
                 type: object
               scratchSpaceStorageClass:
                 description: 'Override the storage class used for scratch space during

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -634,6 +634,9 @@ func getKVDevConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.DeveloperCon
 	if lv := hc.Spec.LogVerbosityConfig; lv != nil && lv.Kubevirt != nil {
 		devConf.LogVerbosity = lv.Kubevirt.DeepCopy()
 	}
+	if hc.Spec.ResourceRequirements != nil && hc.Spec.ResourceRequirements.VmiCPUAllocationRatio != nil {
+		devConf.CPUAllocationRatio = *hc.Spec.ResourceRequirements.VmiCPUAllocationRatio
+	}
 
 	return devConf, nil
 }

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -64,6 +64,8 @@ spec:
                 parallelMigrationsPerCluster: 5
                 parallelOutboundMigrationsPerNode: 2
                 progressTimeout: 150
+              resourceRequirements:
+                vmiCPUAllocationRatio: 10
               uninstallStrategy: BlockUninstallIfWorkloadsExist
               virtualMachineOptions:
                 disableFreePageReporting: true
@@ -2337,6 +2339,8 @@ spec:
                     x-kubernetes-list-type: map
                 type: object
               resourceRequirements:
+                default:
+                  vmiCPUAllocationRatio: 10
                 description: ResourceRequirements describes the resource requirements
                   for the operand workloads.
                 properties:
@@ -2390,6 +2394,19 @@ spec:
                           Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  vmiCPUAllocationRatio:
+                    default: 10
+                    description: VmiCPUAllocationRatio defines, for each requested
+                      virtual CPU, how much physical CPU to request per VMI from the
+                      hosting node. The value is in fraction of a CPU thread (or core
+                      on non-hyperthreaded nodes). VMI POD CPU request = number of
+                      vCPUs * 1/vmiCPUAllocationRatio For example, a value of 1 means
+                      1 physical CPU thread per VMI CPU thread. A value of 100 would
+                      be 1% of a physical thread allocated for each requested VMI
+                      thread. This option has no effect on VMIs that request dedicated
+                      CPUs. Defaults to 10
+                    minimum: 1
+                    type: integer
                 type: object
               scratchSpaceStorageClass:
                 description: 'Override the storage class used for scratch space during

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -64,6 +64,8 @@ spec:
                 parallelMigrationsPerCluster: 5
                 parallelOutboundMigrationsPerNode: 2
                 progressTimeout: 150
+              resourceRequirements:
+                vmiCPUAllocationRatio: 10
               uninstallStrategy: BlockUninstallIfWorkloadsExist
               virtualMachineOptions:
                 disableFreePageReporting: true
@@ -2337,6 +2339,8 @@ spec:
                     x-kubernetes-list-type: map
                 type: object
               resourceRequirements:
+                default:
+                  vmiCPUAllocationRatio: 10
                 description: ResourceRequirements describes the resource requirements
                   for the operand workloads.
                 properties:
@@ -2390,6 +2394,19 @@ spec:
                           Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  vmiCPUAllocationRatio:
+                    default: 10
+                    description: VmiCPUAllocationRatio defines, for each requested
+                      virtual CPU, how much physical CPU to request per VMI from the
+                      hosting node. The value is in fraction of a CPU thread (or core
+                      on non-hyperthreaded nodes). VMI POD CPU request = number of
+                      vCPUs * 1/vmiCPUAllocationRatio For example, a value of 1 means
+                      1 physical CPU thread per VMI CPU thread. A value of 100 would
+                      be 1% of a physical thread allocated for each requested VMI
+                      thread. This option has no effect on VMIs that request dedicated
+                      CPUs. Defaults to 10
+                    minimum: 1
+                    type: integer
                 type: object
               scratchSpaceStorageClass:
                 description: 'Override the storage class used for scratch space during

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -64,6 +64,8 @@ spec:
                 parallelMigrationsPerCluster: 5
                 parallelOutboundMigrationsPerNode: 2
                 progressTimeout: 150
+              resourceRequirements:
+                vmiCPUAllocationRatio: 10
               uninstallStrategy: BlockUninstallIfWorkloadsExist
               virtualMachineOptions:
                 disableFreePageReporting: true
@@ -2337,6 +2339,8 @@ spec:
                     x-kubernetes-list-type: map
                 type: object
               resourceRequirements:
+                default:
+                  vmiCPUAllocationRatio: 10
                 description: ResourceRequirements describes the resource requirements
                   for the operand workloads.
                 properties:
@@ -2390,6 +2394,19 @@ spec:
                           Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  vmiCPUAllocationRatio:
+                    default: 10
+                    description: VmiCPUAllocationRatio defines, for each requested
+                      virtual CPU, how much physical CPU to request per VMI from the
+                      hosting node. The value is in fraction of a CPU thread (or core
+                      on non-hyperthreaded nodes). VMI POD CPU request = number of
+                      vCPUs * 1/vmiCPUAllocationRatio For example, a value of 1 means
+                      1 physical CPU thread per VMI CPU thread. A value of 100 would
+                      be 1% of a physical thread allocated for each requested VMI
+                      thread. This option has no effect on VMIs that request dedicated
+                      CPUs. Defaults to 10
+                    minimum: 1
+                    type: integer
                 type: object
               scratchSpaceStorageClass:
                 description: 'Override the storage class used for scratch space during

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,7 +95,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "virtualMachineOptions": {"disableFreePageReporting": true}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "virtualMachineOptions": {"disableFreePageReporting": true}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -174,7 +174,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
 | mediatedDevicesConfiguration | MediatedDevicesConfiguration holds information about MDEV types to be defined on nodes, if available | *[MediatedDevicesConfiguration](#mediateddevicesconfiguration) |  | false |
 | certConfig | certConfig holds the rotation policy for internal, self-signed certificates | [HyperConvergedCertConfig](#hyperconvergedcertconfig) | {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}} | false |
-| resourceRequirements | ResourceRequirements describes the resource requirements for the operand workloads. | *[OperandResourceRequirements](#operandresourcerequirements) |  | false |
+| resourceRequirements | ResourceRequirements describes the resource requirements for the operand workloads. | *[OperandResourceRequirements](#operandresourcerequirements) | {"vmiCPUAllocationRatio": 10} | false |
 | scratchSpaceStorageClass | Override the storage class used for scratch space during transfer operations. The scratch space storage class is determined in the following order: value of scratchSpaceStorageClass, if that doesn't exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space | *string |  | false |
 | vddkInitImage | VDDK Init Image eventually used to import VMs from external providers | *string |  | false |
 | defaultCPUModel | DefaultCPUModel defines a cluster default for CPU model: default CPU model is set when VMI doesn't have any CPU model. When VMI has CPU model set, then VMI's CPU model is preferred. When default CPU model is not set and VMI's CPU model is not set too, host-model will be set. Default CPU model can be changed when kubevirt is running. | *string |  | false |
@@ -296,6 +296,7 @@ OperandResourceRequirements is a list of resource requirements for the operand w
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | storageWorkloads | StorageWorkloads defines the resources requirements for storage workloads. It will propagate to the CDI custom resource | *corev1.ResourceRequirements |  | false |
+| vmiCPUAllocationRatio | VmiCPUAllocationRatio defines, for each requested virtual CPU, how much physical CPU to request per VMI from the hosting node. The value is in fraction of a CPU thread (or core on non-hyperthreaded nodes). VMI POD CPU request = number of vCPUs * 1/vmiCPUAllocationRatio For example, a value of 1 means 1 physical CPU thread per VMI CPU thread. A value of 100 would be 1% of a physical thread allocated for each requested VMI thread. This option has no effect on VMIs that request dedicated CPUs. Defaults to 10 | *int | 10 | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -151,6 +151,30 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 		)
 	})
 
+	Context("resourceRequirements defaults", func() {
+		defaultResourceRequirements := v1beta1.OperandResourceRequirements{
+			VmiCPUAllocationRatio: pointer.Int(10),
+		}
+
+		DescribeTable("Check that resourceRequirements defaults are behaving as expected", func(path string) {
+			restoreDefaults(cli)
+
+			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			Eventually(func() error {
+				return tests.PatchHCO(ctx, cli, patch)
+			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				hc := tests.GetHCO(ctx, cli)
+				g.Expect(reflect.DeepEqual(hc.Spec.ResourceRequirements, &defaultResourceRequirements)).Should(BeTrue(), "resourceRequirements should be equal to default")
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+		},
+			Entry("when removing /spec/resourceRequirements/vmiCPUAllocationRatio", "/spec/resourceRequirements/vmiCPUAllocationRatio"),
+			Entry("when removing /spec/resourceRequirements", "/spec/resourceRequirements"),
+			Entry("when removing /spec", "/spec"),
+		)
+	})
+
 	Context("workloadUpdateStrategy defaults", func() {
 		defaultWorkloadUpdateStrategy := v1beta1.HyperConvergedWorkloadUpdateStrategy{
 			BatchEvictionInterval: &metav1.Duration{Duration: time.Minute},

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
@@ -90,6 +90,7 @@ type HyperConvergedSpec struct {
 	CertConfig HyperConvergedCertConfig `json:"certConfig,omitempty"`
 
 	// ResourceRequirements describes the resource requirements for the operand workloads.
+	// +kubebuilder:default={"vmiCPUAllocationRatio": 10}
 	// +optional
 	ResourceRequirements *OperandResourceRequirements `json:"resourceRequirements,omitempty"`
 
@@ -474,6 +475,22 @@ type OperandResourceRequirements struct {
 	// resource
 	// +optional
 	StorageWorkloads *corev1.ResourceRequirements `json:"storageWorkloads,omitempty"`
+
+	// VmiCPUAllocationRatio defines, for each requested virtual CPU,
+	// how much physical CPU to request per VMI from the
+	// hosting node. The value is in fraction of a CPU thread (or
+	// core on non-hyperthreaded nodes).
+	// VMI POD CPU request = number of vCPUs * 1/vmiCPUAllocationRatio
+	// For example, a value of 1 means 1 physical CPU thread per VMI CPU thread.
+	// A value of 100 would be 1% of a physical thread allocated for each
+	// requested VMI thread.
+	// This option has no effect on VMIs that request dedicated CPUs.
+	// Defaults to 10
+	// +kubebuilder:default=10
+	// +kubebuilder:validation:Minimum=1
+	// +default=10
+	// +optional
+	VmiCPUAllocationRatio *int `json:"vmiCPUAllocationRatio,omitempty"`
 }
 
 // HyperConvergedObsoleteCPUs allows avoiding scheduling of VMs for obsolete CPU models
@@ -655,7 +672,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "virtualMachineOptions": {"disableFreePageReporting": true}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}, "virtualMachineOptions": {"disableFreePageReporting": true}, "featureGates": {"withHostPassthroughCPU": false, "enableCommonBootImageImport": true, "deployTektonTaskResources": false, "deployKubeSecondaryDNS": false, "nonRoot": true}, "liveMigrationConfig": {"completionTimeoutPerGiB": 800, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist"}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
@@ -674,6 +674,11 @@ func (in *OperandResourceRequirements) DeepCopyInto(out *OperandResourceRequirem
 		*out = new(apicorev1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.VmiCPUAllocationRatio != nil {
+		in, out := &in.VmiCPUAllocationRatio, &out.VmiCPUAllocationRatio
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.defaults.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.defaults.go
@@ -112,6 +112,12 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 			panic(err)
 		}
 	}
+	if in.Spec.ResourceRequirements != nil {
+		if in.Spec.ResourceRequirements.VmiCPUAllocationRatio == nil {
+			var ptrVar1 int = 10
+			in.Spec.ResourceRequirements.VmiCPUAllocationRatio = &ptrVar1
+		}
+	}
 	if in.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods == nil {
 		if err := json.Unmarshal([]byte(`["LiveMigrate"]`), &in.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods); err != nil {
 			panic(err)

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
@@ -975,6 +975,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_OperandResource
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
+					"vmiCPUAllocationRatio": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VmiCPUAllocationRatio defines, for each requested virtual CPU, how much physical CPU to request per VMI from the hosting node. The value is in fraction of a CPU thread (or core on non-hyperthreaded nodes). VMI POD CPU request = number of vCPUs * 1/vmiCPUAllocationRatio For example, a value of 1 means 1 physical CPU thread per VMI CPU thread. A value of 100 would be 1% of a physical thread allocated for each requested VMI thread. This option has no effect on VMIs that request dedicated CPUs. Defaults to 10",
+							Default:     10,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Expose vmiCPUAllocationRatio to let the cluster
admin tune CPU request for VMI PODs as
a ratio of the vCPU number.

It got initially introduced on Kubevirt with:
https://github.com/kubevirt/kubevirt/pull/4162
and then converted to int with:
https://github.com/kubevirt/kubevirt/pull/4415

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-15194
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose vmiCPUAllocationRatio
```
