### PR TITLE
[func-test] simplify vmi test

### DIFF
--- a/tests/func-tests/virtual_machines_test.go
+++ b/tests/func-tests/virtual_machines_test.go
@@ -2,7 +2,6 @@ package tests_test
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -20,7 +19,6 @@ import (
 const (
 	timeout         = 10 * time.Minute
 	pollingInterval = 10 * time.Second
-	vmiSamplingSize = 5
 )
 
 var _ = Describe("[rfe_id:273][crit:critical][vendor:cnv-qe@redhat.com][level:system]Virtual Machine", func() {
@@ -36,12 +34,9 @@ var _ = Describe("[rfe_id:273][crit:critical][vendor:cnv-qe@redhat.com][level:sy
 	})
 
 	It("[test_id:5696] should create, verify and delete VMIs", func() {
-		for i := 0; i < vmiSamplingSize; i++ {
-			fmt.Fprintf(GinkgoWriter, "Run %d/%d\n", i+1, vmiSamplingSize)
-			vmiName := verifyVMICreation(client)
-			verifyVMIRunning(client, vmiName)
-			verifyVMIDeletion(client, vmiName)
-		}
+		vmiName := verifyVMICreation(client)
+		verifyVMIRunning(client, vmiName)
+		verifyVMIDeletion(client, vmiName)
 	})
 })
 
@@ -62,8 +57,7 @@ func verifyVMIRunning(client kubecli.KubevirtClient, vmiName string) *kubevirtco
 		var err error
 		vmi, err = client.VirtualMachineInstance(kvtutil.NamespaceTestDefault).Get(context.Background(), vmiName, &k8smetav1.GetOptions{})
 		g.Expect(err).ToNot(HaveOccurred())
-		GinkgoWriter.Printf("VMI's status.phase: %s\n", vmi.Status.Phase)
-		GinkgoWriter.Printf("Reason: %s\n\n", vmi.Status.Reason)
+		Expect(vmi.Status.Phase).ShouldNot(Equal(kubevirtcorev1.Failed), "vmi scheduling failed: %v\n", vmi.Status)
 		return vmi.Status.Phase == kubevirtcorev1.Running
 	}, timeout, pollingInterval).Should(BeTrue(), "failed to get the vmi Running")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Curently we are trying to execute
test [test_id:5696] 5 times in a row
and we mark it a failed if the
VMI is not able to reach the Running
phase.
Let's execute it only once.

On failures we run must-gather but at collection
time the VM got already deleted as part of test
teardown.

Let's print out more status info on failures (failing earlier)
to help troubleshooting this on the next failures.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
