### PR TITLE
silence confusing warning in the functest log

### DIFF
--- a/tests/func-tests/utils.go
+++ b/tests/func-tests/utils.go
@@ -165,6 +165,7 @@ func UpdateHCO(ctx context.Context, client kubecli.KubevirtClient, input *v1beta
 	hco.ObjectMeta.Annotations = input.ObjectMeta.Annotations
 	hco.ObjectMeta.Finalizers = input.ObjectMeta.Finalizers
 	hco.ObjectMeta.Labels = input.ObjectMeta.Labels
+	hco.Status = v1beta1.HyperConvergedStatus{} // to silence warning about unknown fields.
 
 	object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&hco)
 	if err != nil {


### PR DESCRIPTION
Each time the functional test updates the HyperConverged CR, the test log shows lines like these:
```
W0711 14:00:40.704447      58 warnings.go:70] unknown field "status.dataImportCronTemplates[0].metadata.creationTimestamp"
W0711 14:00:40.704465      58 warnings.go:70] unknown field "status.dataImportCronTemplates[0].spec.template.metadata.creationTimestamp"
W0711 14:00:40.704468      58 warnings.go:70] unknown field "status.dataImportCronTemplates[1].metadata.creationTimestamp"
W0711 14:00:40.704470      58 warnings.go:70] unknown field "status.dataImportCronTemplates[1].spec.template.metadata.creationTimestamp"
W0711 14:00:40.704472      58 warnings.go:70] unknown field "status.dataImportCronTemplates[2].metadata.creationTimestamp"
W0711 14:00:40.704474      58 warnings.go:70] unknown field "status.dataImportCronTemplates[2].spec.template.metadata.creationTimestamp"
W0711 14:00:40.704476      58 warnings.go:70] unknown field "status.dataImportCronTemplates[3].metadata.creationTimestamp"
W0711 14:00:40.704479      58 warnings.go:70] unknown field "status.dataImportCronTemplates[3].spec.template.metadata.creationTimestamp"
W0711 14:00:40.704481      58 warnings.go:70] unknown field "status.dataImportCronTemplates[4].metadata.creationTimestamp"
W0711 14:00:40.704482      58 warnings.go:70] unknown field "status.dataImportCronTemplates[4].spec.template.metadata.creationTimestamp"
W0711 14:00:41.767113      58 warnings.go:70] unknown field "status.dataImportCronTemplates[0].metadata.creationTimestamp"
W0711 14:00:41.767131      58 warnings.go:70] unknown field "status.dataImportCronTemplates[0].spec.template.metadata.creationTimestamp"
W0711 14:00:41.767137      58 warnings.go:70] unknown field "status.dataImportCronTemplates[1].metadata.creationTimestamp"
W0711 14:00:41.767141      58 warnings.go:70] unknown field "status.dataImportCronTemplates[1].spec.template.metadata.creationTimestamp"
W0711 14:00:41.767144      58 warnings.go:70] unknown field "status.dataImportCronTemplates[2].metadata.creationTimestamp"
W0711 14:00:41.767146      58 warnings.go:70] unknown field "status.dataImportCronTemplates[2].spec.template.metadata.creationTimestamp"
W0711 14:00:41.767148      58 warnings.go:70] unknown field "status.dataImportCronTemplates[3].metadata.creationTimestamp"
W0711 14:00:41.767149      58 warnings.go:70] unknown field "status.dataImportCronTemplates[3].spec.template.metadata.creationTimestamp"
W0711 14:00:41.767151      58 warnings.go:70] unknown field "status.dataImportCronTemplates[4].metadata.creationTimestamp"
W0711 14:00:41.767153      58 warnings.go:70] unknown field "status.dataImportCronTemplates[4].spec.template.metadata.creationTimestamp"
```
This noise makes it harder to read the test log, to debug the test and so on. 

This PR removes the status field from the HyperConverged object before using it for update. That way we skip the unknown field warning printouts.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
