### PR TITLE
Properly consume kubevirt test binaries

### DIFF
--- a/hack/kv-smoke-tests.sh
+++ b/hack/kv-smoke-tests.sh
@@ -14,15 +14,7 @@ export BIN_DIR
 
 TESTS_BINARY="$BIN_DIR/kv_smoke_tests.test"
 
-######
-# hack to run a fixed version of Kubevirt tests
-# please remove this hack once
-# - https://github.com/kubevirt/kubevirt/pull/9683
-# - https://github.com/kubevirt/kubevirt/pull/9684
-# are properly consumed
-#curl -Lo "$TESTS_BINARY" "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/tests.test"
-curl -Lo "$TESTS_BINARY" "https://github.com/tiraboschi/kubevirt/releases/download/v1.0.0-alpha.0-fix/tests.test"
-######
+curl -Lo "$TESTS_BINARY" "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/tests.test"
 chmod +x "$TESTS_BINARY"
 
 echo "create testing infrastructure"


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2326 we had to introduce a temporary hack to consume a patched version of kubevirt test binary with additional fixes that now landed in the released version of Kubevirt. Let's remove the hack.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
