### PR TITLE
Fix cluster-wide MachineType

### DIFF
--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -35,6 +35,11 @@ const (
 	machineTypeEnvName  = "MACHINETYPE"
 )
 
+const (
+	DefaultAMD64OVMFPath         = "/usr/share/OVMF"
+	DefaultAMD64EmulatedMachines = "q35*,pc-q35*"
+)
+
 var (
 	useKVMEmulation = false
 )
@@ -426,6 +431,14 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 	if val, ok := os.LookupEnv(machineTypeEnvName); ok {
 		if val = strings.TrimSpace(val); val != "" {
 			config.MachineType = val
+
+			config.ArchitectureConfiguration = &kubevirtcorev1.ArchConfiguration{
+				Amd64: &kubevirtcorev1.ArchSpecificConfiguration{
+					MachineType:      val,
+					OVMFPath:         DefaultAMD64OVMFPath,
+					EmulatedMachines: strings.Split(DefaultAMD64EmulatedMachines, ","),
+				},
+			}
 		}
 	}
 

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -229,6 +229,7 @@ Version: 1.2.3`)
 			Expect(*foundResource.Spec.Configuration.DeveloperConfiguration.DiskVerification.MemoryLimit).Should(Equal(kvDiskVerificationMemoryLimit))
 
 			Expect(foundResource.Spec.Configuration.MachineType).Should(Equal("machine-type"))
+			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).Should(Equal("machine-type"))
 
 			Expect(foundResource.Spec.Configuration.SMBIOSConfig).ToNot(BeNil())
 			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Family).Should(Equal("smbios family"))
@@ -309,6 +310,11 @@ Version: 1.2.3`)
 				FeatureGates: []string{"wrongFG1", "wrongFG2", "wrongFG3"},
 			}
 			existKv.Spec.Configuration.MachineType = "wrong machine type"
+			existKv.Spec.Configuration.ArchitectureConfiguration = &kubevirtcorev1.ArchConfiguration{
+				Amd64: &kubevirtcorev1.ArchSpecificConfiguration{
+					MachineType: "wrong machine type",
+				},
+			}
 			existKv.Spec.Configuration.SMBIOSConfig = &kubevirtcorev1.SMBiosConfiguration{
 				Family:       "wrong family",
 				Product:      "wrong product",
@@ -365,6 +371,7 @@ Version: 1.2.3`)
 			))
 
 			Expect(foundResource.Spec.Configuration.MachineType).Should(Equal("machine-type"))
+			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).Should(Equal("machine-type"))
 
 			Expect(foundResource.Spec.Configuration.SMBIOSConfig).ToNot(BeNil())
 			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Family).Should(Equal("smbios family"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Since https://github.com/kubevirt/kubevirt/pull/8293 there is a new field for setting the cluster-wide MachineType, let's use that along the old one (for compatibility reasons).

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-30288
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cluster-wide machineType
```
