### PR TITLE
[release-1.9] Fix labels for console plugin resources

### DIFF
--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
-export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+# TODO: pin to a specific kubevirtci tag due to an issue in latest. see: https://github.com/kubevirt/kubevirt/pull/10103#issuecomment-1637077797 for details
+# export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+export KUBEVIRTCI_TAG=2307121202-6724dec
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -275,11 +275,11 @@ func getBasicDeployment() *BasicExpected {
 	expectedVirtioWinRoleBinding := operands.NewVirtioWinCmReaderRoleBinding(hco)
 	res.virtioWinRoleBinding = expectedVirtioWinRoleBinding
 
-	expectedConsolePluginDeployment, err := operands.NewKvUiPluginDeplymnt(hco)
+	expectedConsolePluginDeployment, err := operands.NewKvUIPluginDeplymnt(hco)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	res.consolePluginDeploy = expectedConsolePluginDeployment
 
-	expectedConsolePluginService := operands.NewKvUiPluginSvc(hco)
+	expectedConsolePluginService := operands.NewKvUIPluginSvc(hco)
 	res.consolePluginSvc = expectedConsolePluginService
 
 	expectedConsolePlugin := operands.NewKvConsolePlugin(hco)

--- a/controllers/operands/kubevirtConsolePlugin_test.go
+++ b/controllers/operands/kubevirtConsolePlugin_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		It("should create plugin CR if not present", func() {
 			expectedResource := NewKvConsolePlugin(hco)
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler, err := newKvUiPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+			handler, err := newKvUIPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			res := handler[0].ensure(req)
@@ -68,7 +68,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			expectedResource := NewKvConsolePlugin(hco)
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource, expectedConsoleConfig})
-			handler, err := newKvUiPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+			handler, err := newKvUIPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			res := handler[0].ensure(req)
@@ -91,7 +91,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Spec.DisplayName = "fake plugin name"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource, expectedConsoleConfig})
-			handler, err := newKvUiPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+			handler, err := newKvUIPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			res := handler[0].ensure(req)
@@ -125,7 +125,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Labels[hcoutil.AppLabel] = "changed"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource, expectedConsoleConfig})
-			handler, err := newKvUiPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+			handler, err := newKvUIPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			res := handler[0].ensure(req)
@@ -150,7 +150,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Labels["fake_label"] = "something"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource, expectedConsoleConfig})
-			handler, err := newKvUiPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+			handler, err := newKvUIPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			res := handler[0].ensure(req)
@@ -175,7 +175,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			delete(outdatedResource.Labels, hcoutil.AppLabel)
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource, expectedConsoleConfig})
-			handler, err := newKvUiPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+			handler, err := newKvUIPluginCRHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			res := handler[0].ensure(req)
@@ -204,11 +204,11 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should create if not present", func() {
-			expectedResource, err := NewKvUiPluginDeplymnt(hco)
+			expectedResource, err := NewKvUIPluginDeplymnt(hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+			handler, err := newKvUIPluginDeploymentHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			res := handler[0].ensure(req)
@@ -224,7 +224,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
 			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commonTestUtils.Name))
 			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commonTestUtils.Name))
-			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentDeployment)))
+			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentUIPlugin)))
 			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelManagedBy, hcoutil.OperatorName))
 			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelVersion, hcoutil.GetHcoKvIoVersion()))
 			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelPartOf, hcoutil.HyperConvergedCluster))
@@ -233,11 +233,11 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should find plugin deployment if present", func() {
-			expectedResource, err := NewKvUiPluginDeplymnt(hco)
+			expectedResource, err := NewKvUIPluginDeplymnt(hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+			handler, err := newKvUIPluginDeploymentHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			res := handler[0].ensure(req)
@@ -260,8 +260,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should reconcile deployment to default if changed", func() {
-			expectedResource, _ := NewKvUiPluginDeplymnt(hco)
-			outdatedResource, _ := NewKvUiPluginDeplymnt(hco)
+			expectedResource, _ := NewKvUIPluginDeplymnt(hco)
+			outdatedResource, _ := NewKvUIPluginDeplymnt(hco)
 			outdatedResource.ObjectMeta.UID = "oldObjectUID"
 			outdatedResource.ObjectMeta.ResourceVersion = "1234"
 
@@ -269,7 +269,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Spec.Template.Spec.Containers[0].Image = "quay.io/fake/image:latest"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource})
-			handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+			handler, err := newKvUIPluginDeploymentHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 			res := handler[0].ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -302,8 +302,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should reconcile deployment to default if changed - (immutable fields)", func() {
-			expectedResource, _ := NewKvUiPluginDeplymnt(hco)
-			outdatedResource, _ := NewKvUiPluginDeplymnt(hco)
+			expectedResource, _ := NewKvUIPluginDeplymnt(hco)
+			outdatedResource, _ := NewKvUIPluginDeplymnt(hco)
 
 			outdatedResource.ObjectMeta.UID = "oldObjectUID"
 			outdatedResource.ObjectMeta.ResourceVersion = "1234"
@@ -313,7 +313,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Spec.Template.Labels[hcoutil.AppLabel] = "wrong label"
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource})
-			handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+			handler, err := newKvUIPluginDeploymentHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 			res := handler[0].ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -347,14 +347,14 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		Context("Node Placement", func() {
 
 			It("should add node placement if missing", func() {
-				existingResource, err := NewKvUiPluginDeplymnt(hco)
+				existingResource, err := NewKvUIPluginDeplymnt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				hco.Spec.Workloads.NodePlacement = commonTestUtils.NewNodePlacement()
 				hco.Spec.Infra.NodePlacement = commonTestUtils.NewOtherNodePlacement()
 
 				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-				handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+				handler, err := newKvUIPluginDeploymentHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 				Expect(err).ToNot(HaveOccurred())
 				res := handler[0].ensure(req)
 				Expect(res.Created).To(BeFalse())
@@ -384,11 +384,11 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				hcoNodePlacement := commonTestUtils.NewHco()
 				hcoNodePlacement.Spec.Workloads.NodePlacement = commonTestUtils.NewNodePlacement()
 				hcoNodePlacement.Spec.Infra.NodePlacement = commonTestUtils.NewOtherNodePlacement()
-				existingResource, err := NewKvUiPluginDeplymnt(hcoNodePlacement)
+				existingResource, err := NewKvUIPluginDeplymnt(hcoNodePlacement)
 				Expect(err).ToNot(HaveOccurred())
 
 				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-				handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+				handler, err := newKvUIPluginDeploymentHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 				Expect(err).ToNot(HaveOccurred())
 				res := handler[0].ensure(req)
 				Expect(res.Created).To(BeFalse())
@@ -417,7 +417,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 				hco.Spec.Workloads.NodePlacement = commonTestUtils.NewNodePlacement()
 				hco.Spec.Infra.NodePlacement = commonTestUtils.NewOtherNodePlacement()
-				existingResource, err := NewKvUiPluginDeplymnt(hco)
+				existingResource, err := NewKvUIPluginDeplymnt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				// now, modify HCO's node placement
@@ -428,7 +428,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				hco.Spec.Infra.NodePlacement.NodeSelector["key3"] = "something entirely else"
 
 				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-				handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+				handler, err := newKvUIPluginDeploymentHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 				Expect(err).ToNot(HaveOccurred())
 				res := handler[0].ensure(req)
 				Expect(res.Created).To(BeFalse())
@@ -458,7 +458,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			It("should overwrite node placement if directly set on Kubevirt Console Plugin Deployment", func() {
 				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewNodePlacement()}
 				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commonTestUtils.NewOtherNodePlacement()}
-				existingResource, err := NewKvUiPluginDeplymnt(hco)
+				existingResource, err := NewKvUIPluginDeplymnt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				// mock a reconciliation triggered by a change in the deployment
@@ -472,7 +472,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingResource.Spec.Template.Spec.NodeSelector["key3"] = "BADvalue3"
 
 				cl := commonTestUtils.InitClient([]runtime.Object{hco, existingResource})
-				handler, err := newKvUiPluginDplymntHandler(logger, cl, commonTestUtils.GetScheme(), hco)
+				handler, err := newKvUIPluginDeploymentHandler(logger, cl, commonTestUtils.GetScheme(), hco)
 				Expect(err).ToNot(HaveOccurred())
 				res := handler[0].ensure(req)
 				Expect(res.UpgradeDone).To(BeFalse())
@@ -508,9 +508,9 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should create plugin service if not present", func() {
-			expectedResource := NewKvUiPluginSvc(hco)
+			expectedResource := NewKvUIPluginSvc(hco)
 			cl := commonTestUtils.InitClient([]runtime.Object{})
-			handler := (*genericOperand)(newServiceHandler(cl, commonTestUtils.GetScheme(), NewKvUiPluginSvc))
+			handler := (*genericOperand)(newServiceHandler(cl, commonTestUtils.GetScheme(), NewKvUIPluginSvc))
 
 			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -528,10 +528,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should find plugin service if present", func() {
-			expectedResource := NewKvUiPluginSvc(hco)
+			expectedResource := NewKvUIPluginSvc(hco)
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, expectedResource})
-			handler := (*genericOperand)(newServiceHandler(cl, commonTestUtils.GetScheme(), NewKvUiPluginSvc))
+			handler := (*genericOperand)(newServiceHandler(cl, commonTestUtils.GetScheme(), NewKvUIPluginSvc))
 
 			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -553,14 +553,14 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should reconcile service to default if changed", func() {
-			expectedResource := NewKvUiPluginSvc(hco)
-			outdatedResource := NewKvUiPluginSvc(hco)
+			expectedResource := NewKvUIPluginSvc(hco)
+			outdatedResource := NewKvUIPluginSvc(hco)
 
 			outdatedResource.ObjectMeta.Labels[hcoutil.AppLabel] = "wrong label"
 			outdatedResource.Spec.Ports[0].Port = 6666
 
 			cl := commonTestUtils.InitClient([]runtime.Object{hco, outdatedResource})
-			handler := (*genericOperand)(newServiceHandler(cl, commonTestUtils.GetScheme(), NewKvUiPluginSvc))
+			handler := (*genericOperand)(newServiceHandler(cl, commonTestUtils.GetScheme(), NewKvUIPluginSvc))
 			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())

--- a/controllers/operands/operandHandler.go
+++ b/controllers/operands/operandHandler.go
@@ -64,7 +64,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 
 	if ci.IsOpenshift() && ci.IsConsolePluginImageProvided() {
 		operands = append(operands, newConsoleHandler(client))
-		operands = append(operands, (*genericOperand)(newServiceHandler(client, scheme, NewKvUiPluginSvc)))
+		operands = append(operands, (*genericOperand)(newServiceHandler(client, scheme, NewKvUIPluginSvc)))
 	}
 
 	return &OperandHandler{
@@ -89,9 +89,9 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 	}
 
 	if ci.IsOpenshift() && ci.IsConsolePluginImageProvided() {
-		h.addOperands(scheme, hc, newKvUiPluginDplymntHandler)
-		h.addOperands(scheme, hc, newKvUiNginxCmHandler)
-		h.addOperands(scheme, hc, newKvUiPluginCRHandler)
+		h.addOperands(scheme, hc, newKvUIPluginDeploymentHandler)
+		h.addOperands(scheme, hc, newKvUINginxCmHandler)
+		h.addOperands(scheme, hc, newKvUIPluginCRHandler)
 	}
 }
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -247,7 +247,7 @@ func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.Deployme
 								Value: params.HppoVersion,
 							},
 							{
-								Name:  util.KvUiPluginImageEnvV,
+								Name:  util.KvUIPluginImageEnvV,
 								Value: params.KvUiPluginImage,
 							},
 						}, params.Env...),

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -79,7 +79,7 @@ func (c *ClusterInfoImp) Init(ctx context.Context, cl client.Client, logger logr
 		return err
 	}
 
-	varValue, varExists := os.LookupEnv(KvUiPluginImageEnvV)
+	varValue, varExists := os.LookupEnv(KvUIPluginImageEnvV)
 	c.consolePluginImageProvided = varExists && len(varValue) > 0
 
 	err = c.RefreshAPIServerCR(ctx, cl)

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -14,7 +14,7 @@ const (
 	SspVersionEnvV                   = "SSP_VERSION"
 	TtoVersionEnvV                   = "TTO_VERSION"
 	HppoVersionEnvV                  = "HPPO_VERSION"
-	KvUiPluginImageEnvV              = "KV_CONSOLE_PLUGIN_IMAGE"
+	KvUIPluginImageEnvV              = "KV_CONSOLE_PLUGIN_IMAGE"
 	HcoValidatingWebhook             = "validate-hco.kubevirt.io"
 	HcoMutatingWebhookNS             = "mutate-ns-hco.kubevirt.io"
 	HcoMutatingWebhookHyperConverged = "mutate-hyperconverged-hco.kubevirt.io"
@@ -64,7 +64,7 @@ const (
 	DefaultWebhookCertDir = "/apiserver.local.config/certificates"
 
 	CliDownloadsServerPort       = 8080
-	UiPluginServerPort     int32 = 9443
+	UIPluginServerPort     int32 = 9443
 
 	ApiServerCRName = "cluster"
 
@@ -81,4 +81,5 @@ const (
 	AppComponentSchedule   AppComponent = "schedule"
 	AppComponentDeployment AppComponent = "deployment"
 	AppComponentTekton     AppComponent = "tekton"
+	AppComponentUIPlugin   AppComponent = "kubevirt-console-plugin"
 )

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/cluster.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/cluster.go
@@ -79,7 +79,7 @@ func (c *ClusterInfoImp) Init(ctx context.Context, cl client.Client, logger logr
 		return err
 	}
 
-	varValue, varExists := os.LookupEnv(KvUiPluginImageEnvV)
+	varValue, varExists := os.LookupEnv(KvUIPluginImageEnvV)
 	c.consolePluginImageProvided = varExists && len(varValue) > 0
 
 	err = c.RefreshAPIServerCR(ctx, cl)

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/consts.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/consts.go
@@ -14,7 +14,7 @@ const (
 	SspVersionEnvV                   = "SSP_VERSION"
 	TtoVersionEnvV                   = "TTO_VERSION"
 	HppoVersionEnvV                  = "HPPO_VERSION"
-	KvUiPluginImageEnvV              = "KV_CONSOLE_PLUGIN_IMAGE"
+	KvUIPluginImageEnvV              = "KV_CONSOLE_PLUGIN_IMAGE"
 	HcoValidatingWebhook             = "validate-hco.kubevirt.io"
 	HcoMutatingWebhookNS             = "mutate-ns-hco.kubevirt.io"
 	HcoMutatingWebhookHyperConverged = "mutate-hyperconverged-hco.kubevirt.io"
@@ -64,7 +64,7 @@ const (
 	DefaultWebhookCertDir = "/apiserver.local.config/certificates"
 
 	CliDownloadsServerPort       = 8080
-	UiPluginServerPort     int32 = 9443
+	UIPluginServerPort     int32 = 9443
 
 	ApiServerCRName = "cluster"
 
@@ -81,4 +81,5 @@ const (
 	AppComponentSchedule   AppComponent = "schedule"
 	AppComponentDeployment AppComponent = "deployment"
 	AppComponentTekton     AppComponent = "tekton"
+	AppComponentUIPlugin   AppComponent = "kubevirt-console-plugin"
 )


### PR DESCRIPTION
**This is a manual cherry-pick of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2389**


Currently, the pod selector label of the console plugin service is not targeting the console plugin pod, due to label differences - `app: kubevirt-console-plugin` vs. `app.kubernetes.io/component: deployment`.
We are setting all console-plugin related resources with the label of `app.kubernetes.io/component: kubevirt-console-plugin`.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix kubevirt-console-plugin labels
```
