### PR TITLE
Consume nmap-7.94 in check_tlsprofile.sh

### DIFF
--- a/hack/check_tlsprofile.sh
+++ b/hack/check_tlsprofile.sh
@@ -57,9 +57,9 @@ fi
 
 if ! which nmap ; then
     echo "Try to install nmap"
-    rpm -vhU --nodeps https://nmap.org/dist/nmap-7.92-1.x86_64.rpm
-    rpm -vhU https://nmap.org/dist/ncat-7.92-1.x86_64.rpm
-    rpm -vhU https://nmap.org/dist/nping-0.7.92-1.x86_64.rpm
+    rpm -vhU --nodeps https://nmap.org/dist/nmap-7.94-1.x86_64.rpm
+    rpm -vhU https://nmap.org/dist/ncat-7.94-1.x86_64.rpm
+    rpm -vhU https://nmap.org/dist/nping-0.7.94-1.x86_64.rpm
 fi
 
 if [ -n "${OPENSHIFT_BUILD_NAMESPACE:-}" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Consume up to date nmap binaries in
TLS tests.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
