### PR TITLE
Fix node placement for kubevirt-console-plugin

### DIFF
--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -173,7 +173,7 @@ func getKvUIDeployment(hc *hcov1beta1.HyperConverged, deploymentName string, ima
 	}
 
 	if hc.Spec.Infra.NodePlacement != nil {
-		if hc.Spec.Infra.NodePlacement.Affinity != nil {
+		if hc.Spec.Infra.NodePlacement.NodeSelector != nil {
 			deployment.Spec.Template.Spec.NodeSelector = make(map[string]string)
 			for key, value := range hc.Spec.Infra.NodePlacement.NodeSelector {
 				deployment.Spec.Template.Spec.NodeSelector[key] = value


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes a bug with the placement of kubevirt-console-plugin deployment.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-27446
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix node placement for kubevirt-console-plugin
```
