### PR TITLE
Force runbooks names to include alerts names

### DIFF
--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -68,8 +68,8 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 				if rule.Alert != "" {
 					Expect(rule.Annotations).To(HaveKeyWithValue("summary", Not(BeEmpty())),
 						"%s summary is missing or empty", rule.Alert)
-					Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", Not(BeEmpty())),
-						"%s runbook_url is missing or empty", rule.Alert)
+					Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", ContainSubstring(rule.Alert)),
+						"%s runbook_url is missing or doesn't contain alert name", rule.Alert)
 					checkRunbookURLAvailability(rule)
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds a check to the alerts rules test, which verifies that the alerts `runbook_url` annotations contain the alerts names.

**Which issue(s) this PR fixes**: https://issues.redhat.com/browse/CNV-30798


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
