### PR TITLE
Fix runbook URL test

### DIFF
--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -68,8 +68,10 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 				if rule.Alert != "" {
 					Expect(rule.Annotations).To(HaveKeyWithValue("summary", Not(BeEmpty())),
 						"%s summary is missing or empty", rule.Alert)
-					Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", ContainSubstring(rule.Alert)),
-						"%s runbook_url is missing or doesn't contain alert name", rule.Alert)
+					Expect(rule.Annotations).To(HaveKey("runbook_url"),
+						"%s runbook_url is missing", rule.Alert)
+					Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", HaveSuffix(rule.Alert)),
+						"%s runbook_url is not equal to alert name", rule.Alert)
 					checkRunbookURLAvailability(rule)
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix `runbook_url` test to expect it to have the alert name as a suffix. 

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
