### PR TITLE
Improve e2e test stabilization

### DIFF
--- a/tests/func-tests/cluster_eviction_strategy_test.go
+++ b/tests/func-tests/cluster_eviction_strategy_test.go
@@ -8,9 +8,9 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
 
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
-	"kubevirt.io/client-go/kubecli"
 )
 
 var _ = Describe("Cluster level evictionStrategy default value", func() {

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -56,7 +56,7 @@ var (
 	imageNamespace = defaultImageNamespace
 )
 
-var _ = Describe("golden image test", Label("data-import-coron"), Serial, func() {
+var _ = Describe("golden image test", Label("data-import-coron"), Serial, Ordered, func() {
 	var (
 		cli kubecli.KubevirtClient
 		ctx context.Context
@@ -115,7 +115,7 @@ var _ = Describe("golden image test", Label("data-import-coron"), Serial, func()
 				g.Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, is)).To(Succeed())
 
 				return is.GetLabels()
-			}).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).ShouldNot(HaveKey("test-label"))
+			}).WithTimeout(time.Second * 15).WithPolling(time.Millisecond * 100).ShouldNot(HaveKey("test-label"))
 		},
 			Entry("check the centos8 imagestream", "centos8"),
 		)

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -6,23 +6,20 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	"kubevirt.io/kubevirt/tests/flags"
-
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"kubevirt.io/client-go/kubecli"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
+	"kubevirt.io/kubevirt/tests/flags"
 	kvtutil "kubevirt.io/kubevirt/tests/util"
 
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
-	"kubevirt.io/client-go/kubecli"
 )
 
 const (
@@ -31,7 +28,7 @@ const (
 	workloads = "workloads"
 )
 
-var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:system]Node Placement", Ordered, func() {
+var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:system]Node Placement", Ordered, Serial, func() {
 	ctx := context.TODO()
 	tests.FlagParse()
 	hco := &hcov1beta1.HyperConverged{}

--- a/tests/func-tests/update_priority_class_test.go
+++ b/tests/func-tests/update_priority_class_test.go
@@ -16,7 +16,7 @@ import (
 
 const priorityClassName = "kubevirt-cluster-critical"
 
-var _ = Describe("check update priorityClass", Ordered, func() {
+var _ = Describe("check update priorityClass", Ordered, Serial, func() {
 	var (
 		cli                 kubecli.KubevirtClient
 		ctx                 context.Context
@@ -66,12 +66,12 @@ var _ = Describe("check update priorityClass", Ordered, func() {
 		Eventually(func(g Gomega) {
 			By("make sure a new priority class was created, by checking its UID")
 			pc, err := cli.SchedulingV1().PriorityClasses().Get(ctx, priorityClassName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			g.Expect(err).ToNot(HaveOccurred())
 
 			newUID = pc.UID
 			g.Expect(string(newUID)).ShouldNot(Or(Equal(""), Equal(oldPriorityClassUID)))
 			g.Expect(pc.GetLabels()).ShouldNot(HaveKey("test"))
-		}).WithTimeout(10 * time.Second).
+		}).WithTimeout(30 * time.Second).
 			WithPolling(100 * time.Millisecond).
 			Should(Succeed())
 

--- a/tests/func-tests/validation_test.go
+++ b/tests/func-tests/validation_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Check CR validation", Label("validation"), Serial, func() {
 				hc.Spec.ResourceRequirements = requirements
 				_, err = tests.UpdateHCO(ctx, cli, hc)
 				return err
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(outcome)
+			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(outcome)
 		},
 			Entry("succeed when VMI CPU allocation is nil", nil, Succeed()),
 			Entry("fail when VMI CPU allocation is 1", pointer.Int(1), MatchError(ContainSubstring("Automatic CPU limits are incompatible with a VMI CPU allocation ratio of 1"))),


### PR DESCRIPTION
## What does this PR do / why we need it
Some of the e2e tests randomly fail. The reason may be that these tests are running in parallel with other tests that maybe change some settings in HCO, causing some unexpected results.

This PR moves several tests to run serially, so no test will run in parallel with them. Also, this PR added the `Ordered` spec in some cases, and adds some debug info to the vm test"

### Jira Ticket
```jira-ticket
None
```

### Release note
```release-note
None
```
