### PR TITLE
fix the MTQ links in the release bumper

### DIFF
--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -95,7 +95,7 @@ function get_updated_versions {
     ["SSP"]="kubevirt/ssp-operator"
     ["HPPO"]="kubevirt/hostpath-provisioner-operator"
     ["HPP"]="kubevirt/hostpath-provisioner"
-    ["MTQ"]="kubevirt/mtq_operator"
+    ["MTQ"]="kubevirt/managed-tenant-quota"
     ["KUBEVIRT_CONSOLE_PLUGIN"]="kubevirt-ui/kubevirt-plugin"
     ["KUBEVIRT_CONSOLE_PROXY"]="kubevirt-ui/kubevirt-apiserver-proxy"
   )
@@ -105,6 +105,7 @@ function get_updated_versions {
     ["CDI"]="kubevirt.io/containerized-data-importer-api"
     ["NETWORK_ADDONS"]="kubevirt/cluster-network-addons-operator"
     ["SSP"]="kubevirt.io/ssp-operator/api"
+    ["MTQ"]="kubevirt.io/managed-tenant-quota"
   )
 
   UPDATED_VERSIONS=()


### PR DESCRIPTION
## What this PR does / why we need it
The release bump automation is not working and always fails.

The release bump bot used the old MTQ links to check the version and to import the source code (in go.mod).

This PR fixes these links to the new ones.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
