### PR TITLE
Dynamically configure CSV disable-operand-delete annotation

### DIFF
--- a/controllers/commontestutils/testUtils.go
+++ b/controllers/commontestutils/testUtils.go
@@ -162,6 +162,7 @@ func GetScheme() *runtime.Scheme {
 		operatorv1.Install,
 		openshiftconfigv1.Install,
 		mtqv1alpha1.AddToScheme,
+		csvv1alpha1.AddToScheme,
 	} {
 		Expect(f(testScheme)).ToNot(HaveOccurred())
 	}
@@ -226,6 +227,9 @@ var ( // own resources
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      RSName,
 			Namespace: Namespace,
+			Annotations: map[string]string{
+				components.DisableOperandDeletionAnnotation: "true",
+			},
 		},
 	}
 

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -249,7 +249,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 				// Check conditions
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(22))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(23))
 				expectedRef := corev1.ObjectReference{
 					Kind:            "PrometheusRule",
 					Namespace:       namespace,
@@ -335,7 +335,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 				// Check conditions
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(23))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(24))
 				expectedRef := corev1.ObjectReference{
 					Kind:            "MTQ",
 					Name:            "mtq-kubevirt-hyperconverged",

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -144,8 +144,9 @@ var _ = Describe("HyperconvergedController", func() {
 					DeployTektonTaskResources: pointer.Bool(true),
 				}
 
-				cl := commontestutils.InitClient([]client.Object{hcoNamespace, hco})
-				monitoringReconciler := alerts.NewMonitoringReconciler(hcoutil.GetClusterInfo(), cl, commontestutils.NewEventEmitterMock(), commontestutils.GetScheme())
+				ci := hcoutil.GetClusterInfo()
+				cl := commontestutils.InitClient([]client.Object{hcoNamespace, hco, ci.GetCSV()})
+				monitoringReconciler := alerts.NewMonitoringReconciler(ci, cl, commontestutils.NewEventEmitterMock(), commontestutils.GetScheme())
 
 				r := initReconciler(cl, nil)
 				r.monitoringReconciler = monitoringReconciler
@@ -249,7 +250,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 				// Check conditions
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(23))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(22))
 				expectedRef := corev1.ObjectReference{
 					Kind:            "PrometheusRule",
 					Namespace:       namespace,
@@ -269,8 +270,9 @@ var _ = Describe("HyperconvergedController", func() {
 					EnableManagedTenantQuota:  pointer.Bool(true),
 				}
 
-				cl := commontestutils.InitClient([]client.Object{hcoNamespace, hco})
-				monitoringReconciler := alerts.NewMonitoringReconciler(hcoutil.GetClusterInfo(), cl, commontestutils.NewEventEmitterMock(), commontestutils.GetScheme())
+				ci := hcoutil.GetClusterInfo()
+				cl := commontestutils.InitClient([]client.Object{hcoNamespace, hco, ci.GetCSV()})
+				monitoringReconciler := alerts.NewMonitoringReconciler(ci, cl, commontestutils.NewEventEmitterMock(), commontestutils.GetScheme())
 
 				r := initReconciler(cl, nil)
 				r.monitoringReconciler = monitoringReconciler
@@ -335,7 +337,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 				// Check conditions
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(24))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(23))
 				expectedRef := corev1.ObjectReference{
 					Kind:            "MTQ",
 					Name:            "mtq-kubevirt-hyperconverged",
@@ -1157,6 +1159,7 @@ var _ = Describe("HyperconvergedController", func() {
 				expected := getBasicDeployment()
 				Expect(expected.hco.Spec.TLSSecurityProfile).To(BeNil())
 
+				expected.csv = commontestutils.ClusterInfoMock{}.GetCSV()
 				resources := expected.toArray()
 				resources = append(resources, clusterVersion, infrastructure, ingress, apiServer, dns, ipv4network)
 				cl := commontestutils.InitClient(resources)

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -11,6 +11,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -130,6 +131,7 @@ type BasicExpected struct {
 	consoleProxySvc      *corev1.Service
 	consolePlugin        *consolev1.ConsolePlugin
 	consoleConfig        *operatorv1.Console
+	csv                  *csvv1alpha1.ClusterServiceVersion
 }
 
 func (be BasicExpected) toArray() []client.Object {
@@ -156,6 +158,7 @@ func (be BasicExpected) toArray() []client.Object {
 		be.consoleProxySvc,
 		be.consolePlugin,
 		be.consoleConfig,
+		be.csv,
 	}
 }
 
@@ -303,6 +306,9 @@ func getBasicDeployment() *BasicExpected {
 		},
 	}
 	res.hcoCRD = hcoCrd
+
+	csv := hcoutil.GetClusterInfo().GetCSV()
+	res.csv = csv
 
 	return res
 }

--- a/controllers/operands/csv.go
+++ b/controllers/operands/csv.go
@@ -1,0 +1,82 @@
+package operands
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+type csvHandler genericOperand
+
+func newCsvHandler(Client client.Client, Scheme *runtime.Scheme, ci hcoutil.ClusterInfo) *csvHandler {
+	return &csvHandler{
+		Client:                 Client,
+		Scheme:                 Scheme,
+		crType:                 "CSV",
+		setControllerReference: false,
+		hooks: &csvHooks{
+			ci: ci,
+		},
+	}
+}
+
+type csvHooks struct {
+	ci hcoutil.ClusterInfo
+}
+
+func (c csvHooks) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+	csv := c.ci.GetCSV()
+	csv.Annotations[components.DisableOperandDeletionAnnotation] = "true"
+	if hc.Spec.UninstallStrategy == hcov1beta1.HyperConvergedUninstallStrategyRemoveWorkloads {
+		csv.Annotations[components.DisableOperandDeletionAnnotation] = "false"
+	}
+	return csv, nil
+}
+
+func (c csvHooks) getEmptyCr() client.Object { return &csvv1alpha1.ClusterServiceVersion{} }
+
+func (c csvHooks) updateCr(req *common.HcoRequest, cli client.Client, exists runtime.Object, required runtime.Object) (bool, bool, error) {
+	found, ok1 := exists.(*csvv1alpha1.ClusterServiceVersion)
+	csv, ok2 := required.(*csvv1alpha1.ClusterServiceVersion)
+	if !ok1 || !ok2 {
+		return false, false, errors.New("can't convert to CSV")
+	}
+
+	foundDisableOperandDeletion := found.Annotations[components.DisableOperandDeletionAnnotation]
+	csvDisableOperandDeletion := csv.Annotations[components.DisableOperandDeletionAnnotation]
+
+	if csvDisableOperandDeletion != foundDisableOperandDeletion {
+		if req.HCOTriggered {
+			req.Logger.Info("Updating existing CSV disable-operand-delete annotation to new opinionated values")
+		} else {
+			req.Logger.Info("Reconciling an externally updated CSV disable-operand-delete annotation to its opinionated values")
+		}
+
+		patch := fmt.Sprintf(
+			"[{\"op\": \"replace\",\"path\": \"/metadata/annotations/%s\",\"value\": \"%s\"}]\n",
+			strings.ReplaceAll(components.DisableOperandDeletionAnnotation, "/", "~1"),
+			csvDisableOperandDeletion,
+		)
+		err := cli.Patch(req.Ctx, found, client.RawPatch(types.JSONPatchType, []byte(patch)))
+		if err != nil {
+			req.Logger.Error(err, "Failed to update CSV disable-operand-delete annotation")
+			return false, false, err
+		}
+		req.Logger.Info("Updated CSV disable-operand-delete annotation")
+		return true, false, nil
+	}
+
+	return false, false, nil
+}
+
+func (c csvHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }

--- a/controllers/operands/csv_test.go
+++ b/controllers/operands/csv_test.go
@@ -1,0 +1,91 @@
+package operands
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+var _ = Describe("CSV Operand", func() {
+	var (
+		hco *hcov1beta1.HyperConverged
+		req *common.HcoRequest
+		ci  *commontestutils.ClusterInfoMock
+	)
+
+	BeforeEach(func() {
+		hco = commontestutils.NewHco()
+		req = commontestutils.NewReq(hco)
+		ci = &commontestutils.ClusterInfoMock{}
+	})
+
+	Context("UninstallStrategy is missing", func() {
+		It("should set console.openshift.io/disable-operand-delete to true", func() {
+			foundResource := ensure(req, hco, ci)
+			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "true"))
+		})
+	})
+
+	Context("UninstallStrategy is BlockUninstallIfWorkloadsExist", func() {
+		It("should set console.openshift.io/disable-operand-delete to true", func() {
+			hco.Spec.UninstallStrategy = hcov1beta1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
+			foundResource := ensure(req, hco, ci)
+			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "true"))
+		})
+
+		It("should set console.openshift.io/disable-operand-delete to true on changing from RemoveWorkloads", func() {
+			hco.Spec.UninstallStrategy = hcov1beta1.HyperConvergedUninstallStrategyRemoveWorkloads
+			foundResource := ensure(req, hco, ci)
+			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "false"))
+
+			hco.Spec.UninstallStrategy = hcov1beta1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
+			foundResource = ensure(req, hco, ci)
+			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "true"))
+		})
+	})
+
+	Context("UninstallStrategy is RemoveWorkloads", func() {
+		It("should set console.openshift.io/disable-operand-delete to false", func() {
+			hco.Spec.UninstallStrategy = hcov1beta1.HyperConvergedUninstallStrategyRemoveWorkloads
+			foundResource := ensure(req, hco, ci)
+			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "false"))
+		})
+
+		It("should set console.openshift.io/disable-operand-delete to false on changing from BlockUninstallIfWorkloadsExist", func() {
+			hco.Spec.UninstallStrategy = hcov1beta1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
+			foundResource := ensure(req, hco, ci)
+			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "true"))
+
+			hco.Spec.UninstallStrategy = hcov1beta1.HyperConvergedUninstallStrategyRemoveWorkloads
+			foundResource = ensure(req, hco, ci)
+			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "false"))
+		})
+	})
+})
+
+func ensure(req *common.HcoRequest, hco *hcov1beta1.HyperConverged, ci hcoutil.ClusterInfo) *csvv1alpha1.ClusterServiceVersion {
+	cl := commontestutils.InitClient([]client.Object{hco, ci.GetCSV()})
+	handler := (*genericOperand)(newCsvHandler(cl, commontestutils.GetScheme(), ci))
+	res := handler.ensure(req)
+	Expect(res.UpgradeDone).To(BeFalse())
+	Expect(res.Err).ToNot(HaveOccurred())
+
+	foundResource := &csvv1alpha1.ClusterServiceVersion{}
+	Expect(
+		cl.Get(context.TODO(),
+			types.NamespacedName{Name: ci.GetCSV().Name, Namespace: ci.GetCSV().Namespace},
+			foundResource),
+	).To(Succeed())
+	return foundResource
+}

--- a/controllers/operands/csv_test.go
+++ b/controllers/operands/csv_test.go
@@ -76,9 +76,9 @@ var _ = Describe("CSV Operand", func() {
 
 func ensure(req *common.HcoRequest, hco *hcov1beta1.HyperConverged, ci hcoutil.ClusterInfo) *csvv1alpha1.ClusterServiceVersion {
 	cl := commontestutils.InitClient([]client.Object{hco, ci.GetCSV()})
-	handler := (*genericOperand)(newCsvHandler(cl, commontestutils.GetScheme(), ci))
+	handler := newCsvHandler(cl, ci)
 	res := handler.ensure(req)
-	Expect(res.UpgradeDone).To(BeFalse())
+	Expect(res.UpgradeDone).To(BeTrue())
 	Expect(res.Err).ToNot(HaveOccurred())
 
 	foundResource := &csvv1alpha1.ClusterServiceVersion{}

--- a/controllers/operands/imageStream_test.go
+++ b/controllers/operands/imageStream_test.go
@@ -132,7 +132,7 @@ var _ = Describe("imageStream tests", func() {
 			hco.Spec.FeatureGates.EnableCommonBootImageImport = pointer.Bool(true)
 			eventEmitter := commontestutils.NewEventEmitterMock()
 			ci := commontestutils.ClusterInfoMock{}
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco})
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco, ci.GetCSV()})
 			handler := NewOperandHandler(cli, commontestutils.GetScheme(), ci, eventEmitter)
 			handler.FirstUseInitiation(commontestutils.GetScheme(), ci, hco)
 
@@ -191,10 +191,10 @@ var _ = Describe("imageStream tests", func() {
 
 			hcoNamespace := commontestutils.NewHcoNamespace()
 			hco := commontestutils.NewHco()
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco})
+			ci := commontestutils.ClusterInfoMock{}
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
-			ci := commontestutils.ClusterInfoMock{}
 			handler := NewOperandHandler(cli, commontestutils.GetScheme(), ci, eventEmitter)
 			handler.FirstUseInitiation(commontestutils.GetScheme(), ci, hco)
 

--- a/controllers/operands/operandHandler.go
+++ b/controllers/operands/operandHandler.go
@@ -74,7 +74,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 	}
 
 	if ci.IsManagedByOLM() {
-		operands = append(operands, (*genericOperand)(newCsvHandler(client, scheme, ci)))
+		operands = append(operands, newCsvHandler(client, ci))
 	}
 
 	return &OperandHandler{

--- a/controllers/operands/operandHandler.go
+++ b/controllers/operands/operandHandler.go
@@ -73,6 +73,10 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 		operands = append(operands, (*genericOperand)(newServiceHandler(client, scheme, NewKvUIProxySvc)))
 	}
 
+	if ci.IsManagedByOLM() {
+		operands = append(operands, (*genericOperand)(newCsvHandler(client, scheme, ci)))
+	}
+
 	return &OperandHandler{
 		client:       client,
 		operands:     operands,

--- a/controllers/operands/operandHandler_test.go
+++ b/controllers/operands/operandHandler_test.go
@@ -38,10 +38,10 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("should create all objects are created", func() {
 			hco := commontestutils.NewHco()
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco})
+			ci := commontestutils.ClusterInfoMock{}
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
-			ci := commontestutils.ClusterInfoMock{}
 
 			handler := NewOperandHandler(cli, commontestutils.GetScheme(), ci, eventEmitter)
 			handler.FirstUseInitiation(commontestutils.GetScheme(), ci, hco)
@@ -177,10 +177,10 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("make sure the all objects are deleted", func() {
 			hco := commontestutils.NewHco()
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco})
+			ci := commontestutils.ClusterInfoMock{}
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
-			ci := commontestutils.ClusterInfoMock{}
 
 			handler := NewOperandHandler(cli, commontestutils.GetScheme(), ci, eventEmitter)
 			handler.FirstUseInitiation(commontestutils.GetScheme(), ci, hco)
@@ -265,10 +265,10 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("delete KV error handling", func() {
 			hco := commontestutils.NewHco()
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco})
+			ci := commontestutils.ClusterInfoMock{}
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
-			ci := commontestutils.ClusterInfoMock{}
 
 			handler := NewOperandHandler(cli, commontestutils.GetScheme(), ci, eventEmitter)
 			handler.FirstUseInitiation(commontestutils.GetScheme(), ci, hco)
@@ -314,10 +314,10 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("delete CDI error handling", func() {
 			hco := commontestutils.NewHco()
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco})
+			ci := commontestutils.ClusterInfoMock{}
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
-			ci := commontestutils.ClusterInfoMock{}
 
 			handler := NewOperandHandler(cli, commontestutils.GetScheme(), ci, eventEmitter)
 			handler.FirstUseInitiation(commontestutils.GetScheme(), ci, hco)
@@ -364,11 +364,11 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("default delete error handling", func() {
 			hco := commontestutils.NewHco()
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco})
+			ci := commontestutils.ClusterInfoMock{}
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
 
 			fakeError := fmt.Errorf("fake CNA deletion error")
 			eventEmitter := commontestutils.NewEventEmitterMock()
-			ci := commontestutils.ClusterInfoMock{}
 
 			handler := NewOperandHandler(cli, commontestutils.GetScheme(), ci, eventEmitter)
 			handler.FirstUseInitiation(commontestutils.GetScheme(), ci, hco)
@@ -414,10 +414,10 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("delete timeout error handling", func() {
 			hco := commontestutils.NewHco()
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco})
+			ci := commontestutils.ClusterInfoMock{}
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
-			ci := commontestutils.ClusterInfoMock{}
 
 			handler := NewOperandHandler(cli, commontestutils.GetScheme(), ci, eventEmitter)
 			handler.FirstUseInitiation(commontestutils.GetScheme(), ci, hco)

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -669,6 +669,8 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
 - apiGroups:
   - scheduling.k8s.io
   resources:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.11.0/manifests/kubevirt-hyperconverged-operator.v1.11.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.11.0/manifests/kubevirt-hyperconverged-operator.v1.11.0.clusterserviceversion.yaml
@@ -391,6 +391,8 @@ spec:
           - get
           - list
           - watch
+          - update
+          - patch
         - apiGroups:
           - scheduling.k8s.io
           resources:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.11.0/manifests/kubevirt-hyperconverged-operator.v1.11.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.11.0/manifests/kubevirt-hyperconverged-operator.v1.11.0.clusterserviceversion.yaml
@@ -391,6 +391,8 @@ spec:
           - get
           - list
           - watch
+          - update
+          - patch
         - apiGroups:
           - scheduling.k8s.io
           resources:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -32,6 +32,8 @@ import (
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
+const DisableOperandDeletionAnnotation = "console.openshift.io/disable-operand-delete"
+
 const (
 	crName              = util.HyperConvergedName
 	packageName         = util.HyperConvergedName
@@ -514,7 +516,7 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		{
 			APIGroups: stringListToSlice("operators.coreos.com"),
 			Resources: stringListToSlice("clusterserviceversions"),
-			Verbs:     stringListToSlice("get", "list", "watch"),
+			Verbs:     stringListToSlice("get", "list", "watch", "update", "patch"),
 		},
 		{
 			APIGroups: stringListToSlice("scheduling.k8s.io"),
@@ -848,16 +850,16 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 			Name:      fmt.Sprintf("%v.v%v", params.Name, params.Version.String()),
 			Namespace: "placeholder",
 			Annotations: map[string]string{
-				"alm-examples":   string(almExamples),
-				"capabilities":   "Deep Insights",
-				"certified":      "false",
-				"categories":     "OpenShift Optional",
-				"containerImage": params.Image,
-				"console.openshift.io/disable-operand-delete": "true",
-				"createdAt":   time.Now().Format("2006-01-02 15:04:05"),
-				"description": params.MetaDescription,
-				"repository":  "https://github.com/kubevirt/hyperconverged-cluster-operator",
-				"support":     "false",
+				"alm-examples":                   string(almExamples),
+				"capabilities":                   "Deep Insights",
+				"certified":                      "false",
+				"categories":                     "OpenShift Optional",
+				"containerImage":                 params.Image,
+				DisableOperandDeletionAnnotation: "true",
+				"createdAt":                      time.Now().Format("2006-01-02 15:04:05"),
+				"description":                    params.MetaDescription,
+				"repository":                     "https://github.com/kubevirt/hyperconverged-cluster-operator",
+				"support":                        "false",
 				"operatorframework.io/suggested-namespace":       params.Namespace,
 				"operators.openshift.io/infrastructure-features": `["disconnected","proxy-aware"]`,
 				"operatorframework.io/initialization-resource":   string(almExamples),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Following the work done in https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1672, this PR communicates to OLM through the `console.openshift.io/disable-operand-delete` if the cascading deletion of all the workloads should be enabled.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-16163
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Dynamically configure CSV disable-operand-delete annotation
```
