### PR TITLE
For tests, use imagePullPolicy=Always

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -66,7 +66,7 @@ spec:
         - name: KV_CONSOLE_PLUGIN_IMAGE
         - name: KV_CONSOLE_PROXY_IMAGE
         image: quay.io/kubevirt/hyperconverged-cluster-operator:1.11.0-unstable
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 1
           httpGet:
@@ -143,7 +143,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.11.0-unstable
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 1
           httpGet:
@@ -216,7 +216,7 @@ spec:
     spec:
       containers:
       - image: quay.io/kubevirt/virt-artifacts-server:1.11.0-unstable
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: server
         ports:
         - containerPort: 8080

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"sort"
 	"strconv"
+	"strings"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 
@@ -445,6 +446,12 @@ func writeOperatorDeploymentsAndServices(deployments []appsv1.Deployment, servic
 	check(err)
 	defer operatorYaml.Close()
 	for _, deployment := range deployments {
+		if strings.HasPrefix(deployment.Name, "hyperconverged-cluster-") {
+			for i := range deployment.Spec.Template.Spec.Containers {
+				deployment.Spec.Template.Spec.Containers[i].ImagePullPolicy = corev1.PullAlways
+			}
+		}
+
 		check(util.MarshallObject(deployment, operatorYaml))
 	}
 


### PR DESCRIPTION
In order to redeploy HCO with `make cluster-sync`, change the pull policy for HCO images to Always.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
