### PR TITLE
Fix documentation of deployVmConsoleProxy feature gate

### DIFF
--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -161,11 +161,8 @@ reverted back to false.
 **Default**: `false`
 
 ### deployVmConsoleProxy Feature Gate
-Set the `deployVmConsoleProxy` feature gate to true to allow SSP operator to deploy its resources. SSP operator will 
-deploy a proxy that provides an access to the VNC console of a KubeVirt Virtual Machine (VM).
-
-**Note**: Once `deployVmConsoleProxy` is set to true, SSP operator will not delete deployed resources if `deployVmConsoleProxy` is 
-reverted back to false.
+Set the `deployVmConsoleProxy` feature gate to `true` to allow SSP operator to deploy its resources. SSP operator will 
+deploy a service that provides new API to generate a time limited token to access the VNC console of a KubeVirt Virtual Machine (VM).
 
 **Default**: `false`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Setting the feature gate to `false` or nil, will remove the `vm-console-proxy`.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly


**Release note**:
```release-note
Fix documentation for feature gate "deployVmConsoleProxy".
```
