### PR TITLE
Expose CDI log verbosity to HCO CR

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -659,8 +659,14 @@ type Version struct {
 // LogVerbosityConfiguration configures log verbosity for different components
 // +k8s:openapi-gen=true
 type LogVerbosityConfiguration struct {
+	// Kubevirt is a struct that allows specifying the log verbosity level that controls the amount of information
+	// logged for each Kubevirt component.
 	// +optional
 	Kubevirt *v1.LogVerbosity `json:"kubevirt,omitempty"`
+
+	// CDI indicates the log verbosity level that controls the amount of information logged for CDI components.
+	// +optional
+	CDI *int32 `json:"cdi,omitempty"`
 }
 
 // DataImportCronStatus is the status field of the DIC template

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -596,6 +596,11 @@ func (in *LogVerbosityConfiguration) DeepCopyInto(out *LogVerbosityConfiguration
 		*out = new(corev1.LogVerbosity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CDI != nil {
+		in, out := &in.CDI, &out.CDI
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -801,7 +801,15 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_LogVerbosityCon
 				Properties: map[string]spec.Schema{
 					"kubevirt": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/api/core/v1.LogVerbosity"),
+							Description: "Kubevirt is a struct that allows specifying the log verbosity level that controls the amount of information logged for each Kubevirt component.",
+							Ref:         ref("kubevirt.io/api/core/v1.LogVerbosity"),
+						},
+					},
+					"cdi": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CDI indicates the log verbosity level that controls the amount of information logged for CDI components.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 				},

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2276,9 +2276,15 @@ spec:
                   Kubevirt's different components. The higher the value - the higher
                   the log verbosity.
                 properties:
+                  cdi:
+                    description: CDI indicates the log verbosity level that controls
+                      the amount of information logged for CDI components.
+                    format: int32
+                    type: integer
                   kubevirt:
-                    description: LogVerbosity sets log verbosity level of  various
-                      components
+                    description: Kubevirt is a struct that allows specifying the log
+                      verbosity level that controls the amount of information logged
+                      for each Kubevirt component.
                     properties:
                       nodeVerbosity:
                         additionalProperties:

--- a/controllers/operands/cdi.go
+++ b/controllers/operands/cdi.go
@@ -143,6 +143,10 @@ func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, err
 		hc.Spec.Workloads.NodePlacement.DeepCopyInto(&spec.Workloads)
 	}
 
+	if lv := hc.Spec.LogVerbosityConfig; lv != nil {
+		spec.Config.LogVerbosity = lv.CDI
+	}
+
 	cdi := NewCDIWithNameOnly(hc, opts...)
 	cdi.Spec = spec
 

--- a/controllers/operands/cdi_test.go
+++ b/controllers/operands/cdi_test.go
@@ -515,6 +515,31 @@ var _ = Describe("CDI Operand", func() {
 			})
 		})
 
+		Context("Log verbosity", func() {
+
+			It("Should be defined for CDI CR if defined in HCO CR", func() {
+				logVerbosity := int32(4)
+				hco.Spec.LogVerbosityConfig = &hcov1beta1.LogVerbosityConfiguration{CDI: &logVerbosity}
+				cdi, err := NewCDI(hco)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cdi).ToNot(BeNil())
+				Expect(*cdi.Spec.Config.LogVerbosity).To(Equal(logVerbosity))
+			})
+
+			DescribeTable("Should not be defined for CDI CR if not defined in HCO CR", func(logConfig *hcov1beta1.LogVerbosityConfiguration) {
+				hco.Spec.LogVerbosityConfig = logConfig
+				cdi, err := NewCDI(hco)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cdi).ToNot(BeNil())
+				Expect(cdi.Spec.Config.LogVerbosity).To(BeNil())
+			},
+				Entry("nil LogVerbosityConfiguration", nil),
+				Entry("nil CDI logs", &hcov1beta1.LogVerbosityConfiguration{CDI: nil}),
+			)
+		})
+
 		Context("Test ScratchSpaceStorageClass", func() {
 
 			hcoScratchSpaceStorageClassValue := "hcoScratchSpaceStorageClassValue"

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2276,9 +2276,15 @@ spec:
                   Kubevirt's different components. The higher the value - the higher
                   the log verbosity.
                 properties:
+                  cdi:
+                    description: CDI indicates the log verbosity level that controls
+                      the amount of information logged for CDI components.
+                    format: int32
+                    type: integer
                   kubevirt:
-                    description: LogVerbosity sets log verbosity level of  various
-                      components
+                    description: Kubevirt is a struct that allows specifying the log
+                      verbosity level that controls the amount of information logged
+                      for each Kubevirt component.
                     properties:
                       nodeVerbosity:
                         additionalProperties:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
@@ -2276,9 +2276,15 @@ spec:
                   Kubevirt's different components. The higher the value - the higher
                   the log verbosity.
                 properties:
+                  cdi:
+                    description: CDI indicates the log verbosity level that controls
+                      the amount of information logged for CDI components.
+                    format: int32
+                    type: integer
                   kubevirt:
-                    description: LogVerbosity sets log verbosity level of  various
-                      components
+                    description: Kubevirt is a struct that allows specifying the log
+                      verbosity level that controls the amount of information logged
+                      for each Kubevirt component.
                     properties:
                       nodeVerbosity:
                         additionalProperties:

--- a/deploy/kustomize/image_registry/catalog_source.yaml
+++ b/deploy/kustomize/image_registry/catalog_source.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: quay.io/kubevirt/hyperconverged-cluster-index:1.11.0-unstable
+  image: "quay.io/kubevirt/hyperconverged-cluster-index:1.11.0-unstable"
   displayName: KubeVirt HyperConverged
   publisher: KubeVirt Project

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
@@ -2276,9 +2276,15 @@ spec:
                   Kubevirt's different components. The higher the value - the higher
                   the log verbosity.
                 properties:
+                  cdi:
+                    description: CDI indicates the log verbosity level that controls
+                      the amount of information logged for CDI components.
+                    format: int32
+                    type: integer
                   kubevirt:
-                    description: LogVerbosity sets log verbosity level of  various
-                      components
+                    description: Kubevirt is a struct that allows specifying the log
+                      verbosity level that controls the amount of information logged
+                      for each Kubevirt component.
                     properties:
                       nodeVerbosity:
                         additionalProperties:

--- a/docs/api.md
+++ b/docs/api.md
@@ -253,7 +253,8 @@ LogVerbosityConfiguration configures log verbosity for different components
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| kubevirt |  | *v1.LogVerbosity |  | false |
+| kubevirt | Kubevirt is a struct that allows specifying the log verbosity level that controls the amount of information logged for each Kubevirt component. | *v1.LogVerbosity |  | false |
+| cdi | CDI indicates the log verbosity level that controls the amount of information logged for CDI components. | *int32 |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -897,6 +897,22 @@ spec:
 All the values defined [here](https://kubevirt.io/api-reference/master/definitions.html#_v1_logverbosity)
 can be applied.
 
+### Containerized data importer (CDI)
+Different levels of verbosity are used in CDI to control the amount of information that is logged. The verbosity level of logs in CDI can be adjusted using a dedicated field that affect all of its components. 
+This feature enables users to control the amount of detail displayed in logs, ranging from minimal to detailed debugging information.
+
+For example:
+```yaml
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  logVerbosityConfig:
+    cdi: 3
+```
+
+The verbosity levels in CDI typically range from 1 to 3. Level 1 equates to essential log information, while level 3 delves into more detailed logging, providing more specific information.
+
 ## Workloads protection on uninstall
 
 `UninstallStrategy` defines how to proceed on uninstall when workloads (VirtualMachines, DataVolumes) still exist:

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
@@ -659,8 +659,14 @@ type Version struct {
 // LogVerbosityConfiguration configures log verbosity for different components
 // +k8s:openapi-gen=true
 type LogVerbosityConfiguration struct {
+	// Kubevirt is a struct that allows specifying the log verbosity level that controls the amount of information
+	// logged for each Kubevirt component.
 	// +optional
 	Kubevirt *v1.LogVerbosity `json:"kubevirt,omitempty"`
+
+	// CDI indicates the log verbosity level that controls the amount of information logged for CDI components.
+	// +optional
+	CDI *int32 `json:"cdi,omitempty"`
 }
 
 // DataImportCronStatus is the status field of the DIC template

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
@@ -596,6 +596,11 @@ func (in *LogVerbosityConfiguration) DeepCopyInto(out *LogVerbosityConfiguration
 		*out = new(corev1.LogVerbosity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CDI != nil {
+		in, out := &in.CDI, &out.CDI
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
@@ -801,7 +801,15 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_LogVerbosityCon
 				Properties: map[string]spec.Schema{
 					"kubevirt": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/api/core/v1.LogVerbosity"),
+							Description: "Kubevirt is a struct that allows specifying the log verbosity level that controls the amount of information logged for each Kubevirt component.",
+							Ref:         ref("kubevirt.io/api/core/v1.LogVerbosity"),
+						},
+					},
+					"cdi": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CDI indicates the log verbosity level that controls the amount of information logged for CDI components.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 				},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This Pull Request aims to add a new field in the HCO CR to expose CDI log verbosity. This will allow users who deploy CDI with HCO to tweak log verbosity.


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose CDI's log verbosity to HCO CR
```
