### PR TITLE
Enable MTQ only at non SNO cluster

### DIFF
--- a/controllers/operands/mtq.go
+++ b/controllers/operands/mtq.go
@@ -24,7 +24,8 @@ type mtqOperand struct {
 }
 
 func (mtq mtqOperand) ensure(req *common.HcoRequest) *EnsureResult {
-	if req.Instance.Spec.FeatureGates.EnableManagedTenantQuota != nil && *req.Instance.Spec.FeatureGates.EnableManagedTenantQuota {
+	if hcoutil.GetClusterInfo().IsInfrastructureHighlyAvailable() && // MTQ is not supported at a single node cluster
+		req.Instance.Spec.FeatureGates.EnableManagedTenantQuota != nil && *req.Instance.Spec.FeatureGates.EnableManagedTenantQuota {
 		// if the FG is set, make sure the MTQ CR is in place and up-to-date
 		return mtq.operand.ensure(req)
 	}

--- a/tests/func-tests/cluster_eviction_strategy_test.go
+++ b/tests/func-tests/cluster_eviction_strategy_test.go
@@ -74,8 +74,6 @@ func isSingleWorkerCluster(cli kubecli.KubevirtClient) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if len(workerNodes.Items) == 1 {
-		return true, nil
-	}
-	return false, nil
+
+	return len(workerNodes.Items) == 1, nil
 }

--- a/tests/func-tests/mtq_test.go
+++ b/tests/func-tests/mtq_test.go
@@ -30,8 +30,9 @@ const (
 var _ = Describe("Test MTQ", Label("MTQ"), Serial, Ordered, func() {
 	tests.FlagParse()
 	var (
-		cli kubecli.KubevirtClient
-		ctx context.Context
+		cli                 kubecli.KubevirtClient
+		ctx                 context.Context
+		singleWorkerCluster bool
 	)
 
 	BeforeEach(func() {
@@ -39,6 +40,9 @@ var _ = Describe("Test MTQ", Label("MTQ"), Serial, Ordered, func() {
 
 		cli, err = kubecli.GetKubevirtClient()
 		Expect(cli).ToNot(BeNil())
+		Expect(err).ToNot(HaveOccurred())
+
+		singleWorkerCluster, err = isSingleWorkerCluster(cli)
 		Expect(err).ToNot(HaveOccurred())
 
 		ctx = context.Background()
@@ -52,6 +56,11 @@ var _ = Describe("Test MTQ", Label("MTQ"), Serial, Ordered, func() {
 
 	When("set the EnableManagedTenantQuota FG", func() {
 		It("should create the MTQ CR and all the pods", func() {
+
+			if singleWorkerCluster {
+				Skip("Don't test MTQ on single node")
+			}
+
 			enableMTQFeatureGate(ctx, cli)
 
 			By("check the MTQ CR")


### PR DESCRIPTION
MTQ is not supported on a single node cluster. This PR adds:
1. validating this use case at the webhook
2. Not creating the MTQ CR on SNO
3. unit tests
4. skip MTQ functional test on SNO

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't create MTQ CR on a single node cluster
```
