### PR TITLE
Fix a possible bug setting finalizers

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -961,26 +961,6 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.ObjectMeta.Finalizers).Should(Equal([]string{FinalizerName}))
 			})
 
-			It(`should replace a finalizer with a bad name if there`, func() {
-				expected := getBasicDeployment()
-				expected.hco.ObjectMeta.Finalizers = []string{badFinalizerName}
-				cl := expected.initClient()
-				r := initReconciler(cl, nil)
-				res, err := r.Reconcile(context.TODO(), request)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(res.Requeue).To(BeFalse())
-
-				foundResource := &hcov1beta1.HyperConverged{}
-				Expect(
-					cl.Get(context.TODO(),
-						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
-						foundResource),
-				).To(Succeed())
-
-				Expect(foundResource.Status.RelatedObjects).ToNot(BeNil())
-				Expect(foundResource.ObjectMeta.Finalizers).Should(Equal([]string{FinalizerName}))
-			})
-
 			It("Should not be ready if one of the operands is returns error, on create", func() {
 				hco := commontestutils.NewHco()
 				cl := commontestutils.InitClient([]client.Object{hcoNamespace, hco})


### PR DESCRIPTION
**What this PR does / why we need it**:
The code that was adding the finalizer
was not really writing it
if the finalizer was the single change
in the reconciliation loop.
As soon as one of the following reconciliation loops
is touching also something else, the finalizer is really set.

So this is basically not affecting real
world executions but it could potentially
hit unit tests if we verify after a single reconciliation loop.

Only a safer fake client like the
controller-runtime v0.16.2 one is showing this.

Let's also remove obsolete code to remove an old finalizer name
since we can safely assume that upgrades to the latest N
released had enough time to amend it.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
