### PR TITLE
Fix the auto-bump bot

### DIFF
--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -151,7 +151,7 @@ function get_latest_release() {
   major=$(echo $current_version | cut -d. -f1)
   minor=$(echo $current_version | cut -d. -f2)
 
-  RELEASES=$(curl -s -L "https://api.github.com/repos/$repo/releases" | jq -r '.[].tag_name')
+  RELEASES=$(curl -s -L "https://api.github.com/repos/$repo/releases" | jq -r '.[] | select(.tag_name | test("^v?[0-9].*")) | .tag_name')
   releases=(${RELEASES})
 
   semversort "${releases[*]}"

--- a/tools/digester/main.go
+++ b/tools/digester/main.go
@@ -183,7 +183,7 @@ func querySingleImage(ctx context.Context, imageToDigest string, digestOnly bool
 	}
 
 	imgRef, err := docker.ParseReference("//" + imageToDigest)
-	exitOnError(err, "failed to parse container reference")
+	exitOnError(err, fmt.Sprintf("failed to parse container reference: %q", imageToDigest))
 
 	digest, err := docker.GetDigest(ctx, nil, imgRef)
 	exitOnError(err, "failed to get digest from image")
@@ -275,7 +275,7 @@ func readOneDigest(ctx context.Context, image *Image, index int, wg *sync.WaitGr
 	fmt.Println("Reading digest for", fullName)
 
 	imgRef, err := docker.ParseReference(fullName)
-	exitOnError(err, "failed to parse container reference")
+	exitOnError(err, fmt.Sprintf("failed to parse container reference: %q", fullName))
 
 	digest, err := retryGetDigest(ctx, nil, imgRef, 5, 1*time.Second)
 


### PR DESCRIPTION
The auto bump bot reads the release tags from github for each component. Some release tags are not relevant; e.g. `client/v3.6.0`. These tags creates wrong image names, that later failed to be parsed by the digester tool.

To fix that, the auto bump now only accept tags that start with a number, or 'v' followed by a number.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
