### PR TITLE
Fix SSP validating webhook path

### DIFF
--- a/deploy/webhooks.yaml
+++ b/deploy/webhooks.yaml
@@ -135,7 +135,7 @@ webhooks:
     service:
       name: ssp-operator-service
       namespace: kubevirt-hyperconverged
-      path: /validate-ssp-kubevirt-io-v1beta1-ssp
+      path: /validate-ssp-kubevirt-io-v1beta2-ssp
       port: 9443
   failurePolicy: Fail
   matchPolicy: Equivalent


### PR DESCRIPTION
**What this PR does / why we need it**:
The latest version of SSP has updated the apiGroup version from `v1betav1` to `v1betav2`. It also implies that validating webhook path needs to be updated.  Nevertheless, the path is still pointing to `v1betav1`, which makes the HCO deployment on environments like CRC to fail.

Fix: [https://github.com/kubevirt/hyperconverged-cluster-operator/issues/2530](https://github.com/kubevirt/hyperconverged-cluster-operator/issues/2530)
**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
