### PR TITLE
[release-1.8] fix CRModification alert in upgrade

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -283,7 +283,7 @@ func (r *ReconcileHyperConverged) Reconcile(ctx context.Context, request reconci
 		r.operandHandler.Reset()
 	}
 
-	err = r.monitoringReconciler.Reconcile(hcoRequest)
+	err = r.monitoringReconciler.Reconcile(hcoRequest, r.firstLoop)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -16,7 +16,7 @@ if [ "${JOB_TYPE}" == "stdci" ]; then
     KUBECTL_BINARY="cluster/kubectl.sh"
 fi
 
-if [[ ${JOB_TYPE} = "prow" ]]; then
+if [[ "${JOB_TYPE}" == "prow" || "${JOB_TYPE}" == "presubmit" ]]; then
     KUBECTL_BINARY="oc"
     computed_test_image=${FUNCTEST_IMAGE}
 else


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2305

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2227785

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug [https://issues.redhat.com/browse/CNV-31563] - KubevirtHyperconvergedClusterOperatorCRModification alert in firing state during cnv upgrade (4.12.4->4.12.5)
```
