### PR TITLE
fix some gomega errors

### DIFF
--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -595,7 +595,7 @@ Version: 1.2.3`)
 				Expect(mdevConf).ToNot(BeNil())
 				Expect(mdevConf.MediatedDeviceTypes).To(HaveLen(2))
 				Expect(mdevConf.MediatedDeviceTypes).To(ContainElements("nvidia-222", "nvidia-230"))
-				Expect(mdevConf.MediatedDevicesTypes).To(HaveLen(0)) //nolint SA1019
+				Expect(mdevConf.MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
 
 			})
 
@@ -626,7 +626,7 @@ Version: 1.2.3`)
 				Expect(mdevConf).ToNot(BeNil())
 				Expect(mdevConf.MediatedDeviceTypes).To(HaveLen(2))
 				Expect(mdevConf.MediatedDeviceTypes).To(ContainElements("nvidia-222", "nvidia-230"))
-				Expect(mdevConf.MediatedDevicesTypes).To(HaveLen(0)) //nolint SA1019
+				Expect(mdevConf.MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
 
 			})
 
@@ -675,14 +675,14 @@ Version: 1.2.3`)
 				Expect(mdevConf).ToNot(BeNil())
 				Expect(mdevConf.MediatedDeviceTypes).To(HaveLen(2))
 				Expect(mdevConf.MediatedDeviceTypes).To(ContainElements("nvidia-222", "nvidia-230"))
-				Expect(mdevConf.MediatedDevicesTypes).To(HaveLen(0)) //nolint SA1019
+				Expect(mdevConf.MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
 				Expect(mdevConf.NodeMediatedDeviceTypes).To(HaveLen(2))
 				Expect(mdevConf.NodeMediatedDeviceTypes[0].MediatedDeviceTypes).To(ContainElements("nvidia-223"))
 				Expect(mdevConf.NodeMediatedDeviceTypes[0].NodeSelector).To(HaveKeyWithValue("testLabel1", "true"))
-				Expect(mdevConf.NodeMediatedDeviceTypes[0].MediatedDevicesTypes).To(HaveLen(0)) //nolint SA1019
+				Expect(mdevConf.NodeMediatedDeviceTypes[0].MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
 				Expect(mdevConf.NodeMediatedDeviceTypes[1].MediatedDeviceTypes).To(ContainElements("nvidia-229"))
 				Expect(mdevConf.NodeMediatedDeviceTypes[1].NodeSelector).To(HaveKeyWithValue("testLabel2", "true"))
-				Expect(mdevConf.NodeMediatedDeviceTypes[1].MediatedDevicesTypes).To(HaveLen(0)) //nolint SA1019
+				Expect(mdevConf.NodeMediatedDeviceTypes[1].MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
 
 			})
 			It("should propagate the mediated devices configuration from the HC with node selectors - mediatedDeviceTypes", func() {
@@ -730,14 +730,14 @@ Version: 1.2.3`)
 				Expect(mdevConf).ToNot(BeNil())
 				Expect(mdevConf.MediatedDeviceTypes).To(HaveLen(2))
 				Expect(mdevConf.MediatedDeviceTypes).To(ContainElements("nvidia-222", "nvidia-230"))
-				Expect(mdevConf.MediatedDevicesTypes).To(HaveLen(0)) //nolint SA1019
+				Expect(mdevConf.MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
 				Expect(mdevConf.NodeMediatedDeviceTypes).To(HaveLen(2))
 				Expect(mdevConf.NodeMediatedDeviceTypes[0].MediatedDeviceTypes).To(ContainElements("nvidia-223"))
 				Expect(mdevConf.NodeMediatedDeviceTypes[0].NodeSelector).To(HaveKeyWithValue("testLabel1", "true"))
-				Expect(mdevConf.NodeMediatedDeviceTypes[0].MediatedDevicesTypes).To(HaveLen(0)) //nolint SA1019
+				Expect(mdevConf.NodeMediatedDeviceTypes[0].MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
 				Expect(mdevConf.NodeMediatedDeviceTypes[1].MediatedDeviceTypes).To(ContainElements("nvidia-229"))
 				Expect(mdevConf.NodeMediatedDeviceTypes[1].NodeSelector).To(HaveKeyWithValue("testLabel2", "true"))
-				Expect(mdevConf.NodeMediatedDeviceTypes[1].MediatedDevicesTypes).To(HaveLen(0)) //nolint SA1019
+				Expect(mdevConf.NodeMediatedDeviceTypes[1].MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
 
 			})
 			It("should update the permitted host devices configuration from the HC - mediatedDeviceTypes", func() {

--- a/tests/func-tests/update_priority_class_test.go
+++ b/tests/func-tests/update_priority_class_test.go
@@ -69,7 +69,7 @@ var _ = Describe("check update priorityClass", Ordered, Serial, func() {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			newUID = pc.UID
-			g.Expect(string(newUID)).ShouldNot(Or(Equal(""), Equal(oldPriorityClassUID)))
+			g.Expect(newUID).ShouldNot(Or(Equal(types.UID("")), Equal(oldPriorityClassUID)))
 			g.Expect(pc.GetLabels()).ShouldNot(HaveKey("test"))
 		}).WithTimeout(30 * time.Second).
 			WithPolling(100 * time.Millisecond).


### PR DESCRIPTION
The next version of ginkgolinter will check comparison of value from different types. We have one case like this in our functional test.

In addition, fix several `HavelLen(0)`, change them to `BeEmpty()`. They all were hidden by a `//nolint` comment.


**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
