### PR TITLE
Support ApplyOptions on upgradePatches

### DIFF
--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -1,16 +1,6 @@
 {
   "hcoCRPatchList": [
     {
-      "semverRange": ">=1.4.0 <=1.5.0",
-      "jsonPatch": [
-        {
-          "op": "replace",
-          "path": "/spec/featureGates/sriovLiveMigration",
-          "value": true
-        }
-      ]
-    },
-    {
       "semverRange": ">=1.4.0 <1.5.0",
       "jsonPatch": [
         {

--- a/controllers/hyperconverged/test-files/upgradePatches/badPatches4.json
+++ b/controllers/hyperconverged/test-files/upgradePatches/badPatches4.json
@@ -1,0 +1,13 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "remove",
+          "path": "/spec/badUnexistingKey1/badUnexistingKey2"
+        }
+      ]
+    }
+  ]
+}

--- a/controllers/hyperconverged/test-files/upgradePatches/badPatches5.json
+++ b/controllers/hyperconverged/test-files/upgradePatches/badPatches5.json
@@ -1,0 +1,16 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "remove",
+          "path": "/spec/badUnexistingKey1/badUnexistingKey2"
+        }
+      ],
+      "jsonPatchApplyOptions": {
+	   "allowMissingPathOnRemove": true
+      }
+    }
+  ]
+}

--- a/controllers/hyperconverged/test-files/upgradePatches/badPatches6.json
+++ b/controllers/hyperconverged/test-files/upgradePatches/badPatches6.json
@@ -1,0 +1,14 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "add",
+          "path": "/spec/mediatedDevicesConfiguration/mediatedDeviceTypes",
+          "value": ["nvidia-222"]
+        }
+      ]
+    }
+  ]
+}

--- a/controllers/hyperconverged/test-files/upgradePatches/badPatches7.json
+++ b/controllers/hyperconverged/test-files/upgradePatches/badPatches7.json
@@ -1,0 +1,17 @@
+{
+  "hcoCRPatchList": [
+    {
+      "semverRange": ">=1.4.0 <=1.5.0",
+      "jsonPatch": [
+        {
+          "op": "add",
+          "path": "/spec/mediatedDevicesConfiguration/mediatedDeviceTypes",
+          "value": ["nvidia-222"]
+        }
+      ],
+      "jsonPatchApplyOptions": {
+        "ensurePathExistsOnAdd": true
+      }
+    }
+  ]
+}

--- a/controllers/hyperconverged/upgradePatches_test.go
+++ b/controllers/hyperconverged/upgradePatches_test.go
@@ -95,6 +95,45 @@ var _ = Describe("upgradePatches", func() {
 				),
 			)
 
+			DescribeTable(
+				"should handle MissingPathOnRemove according to jsonPatchApplyOptions",
+				func(filename string, expectedErr bool, message string) {
+					Expect(copyTestFile(filename)).To(Succeed())
+
+					err := validateUpgradePatches(req)
+					if expectedErr {
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).Should(HavePrefix(message))
+					} else {
+						Expect(err).ToNot(HaveOccurred())
+					}
+				},
+				Entry(
+					"without jsonPatchApplyOptions",
+					"badPatches4.json",
+					true,
+					"remove operation does not apply: doc is missing path: ",
+				),
+				Entry(
+					"with AllowMissingPathOnRemove on jsonPatchApplyOptions",
+					"badPatches5.json",
+					false,
+					"",
+				),
+				Entry(
+					"without jsonPatchApplyOptions",
+					"badPatches6.json",
+					true,
+					"add operation does not apply: doc is missing path: ",
+				),
+				Entry(
+					"with EnsurePathExistsOnAdd on jsonPatchApplyOptions",
+					"badPatches7.json",
+					false,
+					"",
+				),
+			)
+
 		})
 
 		Context("objectsToBeRemoved", func() {

--- a/controllers/operands/operand.go
+++ b/controllers/operands/operand.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	dario.cat/mergo v1.0.0
 	github.com/blang/semver/v4 v4.0.0
-	github.com/evanphx/json-patch v5.7.0+incompatible
+	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v1.2.4
 	github.com/google/uuid v1.3.1
@@ -50,7 +50,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
-	github.com/evanphx/json-patch/v5 v5.7.0 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ2tG6yudJd8LBksgI=
-github.com/evanphx/json-patch v5.7.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.7.0 h1:nJqP7uwL84RJInrohHfW0Fx3awjbm8qZeFv0nW9SYGc=
 github.com/evanphx/json-patch/v5 v5.7.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -210,7 +210,7 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ2tG6yudJd8LBksgI=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch/v5 v5.7.0 h1:nJqP7uwL84RJInrohHfW0Fx3awjbm8qZeFv0nW9SYGc=
 github.com/evanphx/json-patch/v5 v5.7.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW64qjjJq8M2u4dxNaBiDfKK+z/3eGDpXEQhc=

--- a/vendor/github.com/evanphx/json-patch/README.md
+++ b/vendor/github.com/evanphx/json-patch/README.md
@@ -4,7 +4,7 @@
 well as for calculating & applying [RFC7396 JSON merge patches](https://tools.ietf.org/html/rfc7396).
 
 [![GoDoc](https://godoc.org/github.com/evanphx/json-patch?status.svg)](http://godoc.org/github.com/evanphx/json-patch)
-[![Build Status](https://github.com/evanphx/json-patch/actions/workflows/go.yml/badge.svg)](https://github.com/evanphx/json-patch/actions/workflows/go.yml)
+[![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)
 [![Report Card](https://goreportcard.com/badge/github.com/evanphx/json-patch)](https://goreportcard.com/report/github.com/evanphx/json-patch)
 
 # Get It!
@@ -314,4 +314,4 @@ go test -cover ./...
 ```
 
 Builds for pull requests are tested automatically 
-using [GitHub Actions](https://github.com/evanphx/json-patch/actions/workflows/go.yml).
+using [TravisCI](https://travis-ci.org/evanphx/json-patch).

--- a/vendor/github.com/evanphx/json-patch/patch.go
+++ b/vendor/github.com/evanphx/json-patch/patch.go
@@ -359,7 +359,7 @@ func findObject(pd *container, path string) (container, string) {
 
 		next, ok := doc.get(decodePatchKey(part))
 
-		if next == nil || ok != nil || next.raw == nil {
+		if next == nil || ok != nil {
 			return nil, ""
 		}
 
@@ -568,29 +568,6 @@ func (p Patch) replace(doc *container, op Operation) error {
 		return errors.Wrapf(err, "replace operation failed to decode path")
 	}
 
-	if path == "" {
-		val := op.value()
-
-		if val.which == eRaw {
-			if !val.tryDoc() {
-				if !val.tryAry() {
-					return errors.Wrapf(err, "replace operation value must be object or array")
-				}
-			}
-		}
-
-		switch val.which {
-		case eAry:
-			*doc = &val.ary
-		case eDoc:
-			*doc = &val.doc
-		case eRaw:
-			return errors.Wrapf(err, "replace operation hit impossible case")
-		}
-
-		return nil
-	}
-
 	con, key := findObject(doc, path)
 
 	if con == nil {
@@ -657,25 +634,6 @@ func (p Patch) test(doc *container, op Operation) error {
 		return errors.Wrapf(err, "test operation failed to decode path")
 	}
 
-	if path == "" {
-		var self lazyNode
-
-		switch sv := (*doc).(type) {
-		case *partialDoc:
-			self.doc = *sv
-			self.which = eDoc
-		case *partialArray:
-			self.ary = *sv
-			self.which = eAry
-		}
-
-		if self.equal(op.value()) {
-			return nil
-		}
-
-		return errors.Wrapf(ErrTestFailed, "testing value %s failed", path)
-	}
-
 	con, key := findObject(doc, path)
 
 	if con == nil {
@@ -688,7 +646,7 @@ func (p Patch) test(doc *container, op Operation) error {
 	}
 
 	if val == nil {
-		if op.value() == nil || op.value().raw == nil {
+		if op.value().raw == nil {
 			return nil
 		}
 		return errors.Wrapf(ErrTestFailed, "testing value %s failed", path)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -17,7 +17,7 @@ github.com/davecgh/go-spew/spew
 ## explicit; go 1.13
 github.com/emicklei/go-restful/v3
 github.com/emicklei/go-restful/v3/log
-# github.com/evanphx/json-patch v5.7.0+incompatible
+# github.com/evanphx/json-patch v5.6.0+incompatible
 ## explicit
 github.com/evanphx/json-patch
 # github.com/evanphx/json-patch/v5 v5.7.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for optional ApplyOptions
(AllowMissingPathOnRemove/EnsurePathExistsOnAdd/...) on upgradePatches from github.com/evanphx/json-patch/v5. Bump it to v5 everywhere.

Add unit tests for allowMissingPathOnRemove and ensurePathExistsOnAdd.

Avoid trying to update featureGates/sriovLiveMigration since it got removed with #2067.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
