### PR TITLE
[release-1.10] Do not require nodemediatedDeviceTypes to prevent broken upgrades (#2534)

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -458,7 +458,9 @@ type MediatedHostDevice struct {
 
 // MediatedDevicesConfiguration holds information about MDEV types to be defined, if available
 // +k8s:openapi-gen=true
+// +kubebuilder:validation:XValidation:rule="(has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0) || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)",message="for mediatedDevicesConfiguration a non-empty mediatedDeviceTypes or mediatedDevicesTypes(deprecated) is required"
 type MediatedDevicesConfiguration struct {
+	// +optional
 	// +listType=atomic
 	MediatedDeviceTypes []string `json:"mediatedDeviceTypes"`
 
@@ -474,18 +476,21 @@ type MediatedDevicesConfiguration struct {
 
 // NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specific node that matches the NodeSelector field.
 // +k8s:openapi-gen=true
+// +kubebuilder:validation:XValidation:rule="(has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0) || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)",message="for nodeMediatedDeviceTypes a non-empty mediatedDeviceTypes or mediatedDevicesTypes(deprecated) is required"
 type NodeMediatedDeviceTypesConfig struct {
+
 	// NodeSelector is a selector which must be true for the vmi to fit on a node.
 	// Selector which must match a node's labels for the vmi to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 	NodeSelector map[string]string `json:"nodeSelector"`
 
 	// +listType=atomic
+	// +optional
 	MediatedDeviceTypes []string `json:"mediatedDeviceTypes"`
 
 	// Deprecated: please use mediatedDeviceTypes instead.
-	// +optional
 	// +listType=atomic
+	// +optional
 	MediatedDevicesTypes []string `json:"mediatedDevicesTypes"`
 }
 

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -857,7 +857,6 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_MediatedDevices
 						},
 					},
 				},
-				Required: []string{"mediatedDeviceTypes"},
 			},
 		},
 		Dependencies: []string{
@@ -972,7 +971,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_NodeMediatedDev
 						},
 					},
 				},
-				Required: []string{"nodeSelector", "mediatedDeviceTypes"},
+				Required: []string{"nodeSelector"},
 			},
 		},
 	}

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2260,14 +2260,21 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                           type: object
                       required:
-                      - mediatedDeviceTypes
                       - nodeSelector
                       type: object
+                      x-kubernetes-validations:
+                      - message: for nodeMediatedDeviceTypes a non-empty mediatedDeviceTypes
+                          or mediatedDevicesTypes(deprecated) is required
+                        rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
+                          || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
                     type: array
                     x-kubernetes-list-type: atomic
-                required:
-                - mediatedDeviceTypes
                 type: object
+                x-kubernetes-validations:
+                - message: for mediatedDevicesConfiguration a non-empty mediatedDeviceTypes
+                    or mediatedDevicesTypes(deprecated) is required
+                  rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
+                    || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2260,14 +2260,21 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                           type: object
                       required:
-                      - mediatedDeviceTypes
                       - nodeSelector
                       type: object
+                      x-kubernetes-validations:
+                      - message: for nodeMediatedDeviceTypes a non-empty mediatedDeviceTypes
+                          or mediatedDevicesTypes(deprecated) is required
+                        rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
+                          || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
                     type: array
                     x-kubernetes-list-type: atomic
-                required:
-                - mediatedDeviceTypes
                 type: object
+                x-kubernetes-validations:
+                - message: for mediatedDevicesConfiguration a non-empty mediatedDeviceTypes
+                    or mediatedDevicesTypes(deprecated) is required
+                  rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
+                    || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -2260,14 +2260,21 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                           type: object
                       required:
-                      - mediatedDeviceTypes
                       - nodeSelector
                       type: object
+                      x-kubernetes-validations:
+                      - message: for nodeMediatedDeviceTypes a non-empty mediatedDeviceTypes
+                          or mediatedDevicesTypes(deprecated) is required
+                        rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
+                          || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
                     type: array
                     x-kubernetes-list-type: atomic
-                required:
-                - mediatedDeviceTypes
                 type: object
+                x-kubernetes-validations:
+                - message: for mediatedDevicesConfiguration a non-empty mediatedDeviceTypes
+                    or mediatedDevicesTypes(deprecated) is required
+                  rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
+                    || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.0/manifests/hco00.crd.yaml
@@ -2260,14 +2260,21 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                           type: object
                       required:
-                      - mediatedDeviceTypes
                       - nodeSelector
                       type: object
+                      x-kubernetes-validations:
+                      - message: for nodeMediatedDeviceTypes a non-empty mediatedDeviceTypes
+                          or mediatedDevicesTypes(deprecated) is required
+                        rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
+                          || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
                     type: array
                     x-kubernetes-list-type: atomic
-                required:
-                - mediatedDeviceTypes
                 type: object
+                x-kubernetes-validations:
+                - message: for mediatedDevicesConfiguration a non-empty mediatedDeviceTypes
+                    or mediatedDevicesTypes(deprecated) is required
+                  rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
+                    || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
@@ -458,7 +458,9 @@ type MediatedHostDevice struct {
 
 // MediatedDevicesConfiguration holds information about MDEV types to be defined, if available
 // +k8s:openapi-gen=true
+// +kubebuilder:validation:XValidation:rule="(has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0) || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)",message="for mediatedDevicesConfiguration a non-empty mediatedDeviceTypes or mediatedDevicesTypes(deprecated) is required"
 type MediatedDevicesConfiguration struct {
+	// +optional
 	// +listType=atomic
 	MediatedDeviceTypes []string `json:"mediatedDeviceTypes"`
 
@@ -474,18 +476,21 @@ type MediatedDevicesConfiguration struct {
 
 // NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specific node that matches the NodeSelector field.
 // +k8s:openapi-gen=true
+// +kubebuilder:validation:XValidation:rule="(has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0) || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)",message="for nodeMediatedDeviceTypes a non-empty mediatedDeviceTypes or mediatedDevicesTypes(deprecated) is required"
 type NodeMediatedDeviceTypesConfig struct {
+
 	// NodeSelector is a selector which must be true for the vmi to fit on a node.
 	// Selector which must match a node's labels for the vmi to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 	NodeSelector map[string]string `json:"nodeSelector"`
 
 	// +listType=atomic
+	// +optional
 	MediatedDeviceTypes []string `json:"mediatedDeviceTypes"`
 
 	// Deprecated: please use mediatedDeviceTypes instead.
-	// +optional
 	// +listType=atomic
+	// +optional
 	MediatedDevicesTypes []string `json:"mediatedDevicesTypes"`
 }
 

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
@@ -857,7 +857,6 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_MediatedDevices
 						},
 					},
 				},
-				Required: []string{"mediatedDeviceTypes"},
 			},
 		},
 		Dependencies: []string{
@@ -972,7 +971,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_NodeMediatedDev
 						},
 					},
 				},
-				Required: []string{"nodeSelector", "mediatedDeviceTypes"},
+				Required: []string{"nodeSelector"},
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
With #2402 we deprecated MediatedDevicesTypes and
NodeMediatedDeviceTypes.MediatedDevicesTypes for
MediatedDeviceTypes and NodeMediatedDeviceTypes.MediatedDeviceTypes. We also introduced a mutating webhook to handle the conversion. Unfortunately make the two new names mandatory is breaking the validation of the new version of the CRD on OLM upgrades since only the previous names were there with the old CRD.

We already have func test covering this area,
but they are fooled by the mutating webhook that
instead is not involved into the CRD validation process on the OLM side.
On the other side, add an additional upgrade lane just for this is probably too expensive.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2241327

This is a manual cherry-pick of #2534

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-33570
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Do not require nodemediatedDeviceTypes to prevent broken upgrades
```
