### PR TITLE
webhook: disable HTTP/2 as a remediation for CVE-2023-44487

### DIFF
--- a/cmd/hyperconverged-cluster-webhook/main.go
+++ b/cmd/hyperconverged-cluster-webhook/main.go
@@ -185,6 +185,10 @@ func MutateTLSConfig(cfg *tls.Config) {
 	// This callback executes on each client call returning a new config to be used
 	// please be aware that the APIServer is using http keepalive so this is going to
 	// be executed only after a while for fresh connections and not on existing ones
+
+	// Disable HTTP/2 as a remediation for CVE-2023-44487
+	cfg.NextProtos = []string{"http/1.1"}
+
 	cfg.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
 		cipherNames, minTypedTLSVersion := validator.SelectCipherSuitesAndMinTLSVersion()
 		cfg.CipherSuites = crypto.CipherSuitesOrDie(crypto.OpenSSLToIANACipherSuites(cipherNames))


### PR DESCRIPTION
**What this PR does / why we need it**:
webhook: disable HTTP/2 as a remediation for CVE-2023-44487

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
webhook: disable HTTP/2 as a remediation for CVE-2023-44487
```
