### PR TITLE
Fix the golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,9 @@ linters:
 linters-settings:
   ginkgolinter:
     forbid-focus-container: true
-  revive:
-    rules:
-    - name: dot-imports
-      disabled: true
+issues:
+  exclude-rules:
+  - linters:
+    - revive
+    source: ". \"github.com/onsi/(ginkgo/v2|gomega)\""
+    text: "dot-imports: should not use dot imports"

--- a/tests/.golangci.yml
+++ b/tests/.golangci.yml
@@ -5,7 +5,9 @@ linters:
 linters-settings:
   ginkgolinter:
     forbid-focus-container: true
-  revive:
-    rules:
-      - name: dot-imports
-        disabled: true
+issues:
+  exclude-rules:
+  - linters:
+    - revive
+    source: ". \"github.com/onsi/(ginkgo/v2|gomega)\""
+    text: "dot-imports: should not use dot imports"


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the golangci-lang configuration, to allow dot-importing of ginkgo and gomega. This is instead of completly disable the dot-import rule in the revive linter.

**Jira Ticket**:
```jira-ticket
None
```

**Release note**:
```release-note
None
```
