### PR TITLE
Fix the golden image test

### DIFF
--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -83,6 +83,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 	if expectedImagesFromConfig := tests.GetConfig().DataImportCron.ExpectedDataImportCrons; len(expectedImagesFromConfig) > 0 {
 		expectedImages = expectedImagesFromConfig
 	}
+	sort.Strings(expectedImages)
 
 	if expectedISFromConfig := tests.GetConfig().DataImportCron.ExpectedImageStream; len(expectedISFromConfig) > 0 {
 		expectedImageStreams = expectedISFromConfig
@@ -147,12 +148,12 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		It("should propagate the DICT to SSP", func() {
 			Eventually(func(g Gomega) []string {
 				unstructured, err := cli.DynamicClient().Resource(sspGVR).Namespace(flags.KubeVirtInstallNamespace).Get(ctx, "ssp-kubevirt-hyperconverged", metav1.GetOptions{})
-				Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(err).ShouldNot(HaveOccurred())
 
 				ssp := &v1beta2.SSP{}
-				Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, ssp)).To(Succeed())
+				g.Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, ssp)).To(Succeed())
 
-				Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(len(expectedImages)))
+				g.Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(len(expectedImages)))
 
 				imageNames := make([]string, len(expectedImages))
 				for i, image := range ssp.Spec.CommonTemplates.DataImportCronTemplates {
@@ -167,7 +168,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			Eventually(func(g Gomega) []string {
 				hco := tests.GetHCO(ctx, cli)
 
-				Expect(hco.Status.DataImportCronTemplates).Should(HaveLen(len(expectedImages)))
+				g.Expect(hco.Status.DataImportCronTemplates).Should(HaveLen(len(expectedImages)))
 
 				imageNames := make([]string, len(expectedImages))
 				for i, image := range hco.Status.DataImportCronTemplates {


### PR DESCRIPTION
**What this PR does / why we need it**:
The test compared two string slices. One with the expected golden image names, and one with the actual ones. This is failing when the order is not the same.

This fix changes the assetion to check that both slice have the same length and the same ites, regardless their order.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
