### PR TITLE
Set DeployCommonInstancetypes feature gate on SSP

### DIFF
--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -13,6 +13,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -166,6 +167,10 @@ func NewSSP(hc *hcov1beta1.HyperConverged, opts ...string) (*sspv1beta2.SSP, []h
 	if hc.Spec.FeatureGates.DeployVMConsoleProxy != nil {
 		spec.FeatureGates.DeployVmConsoleProxy = *hc.Spec.FeatureGates.DeployVMConsoleProxy
 	}
+
+	// This feature gate is set to true in 4.15.
+	// TODO(4.16): Set it to false, and set a similar feature gate on kubevirt CR.
+	spec.FeatureGates.DeployCommonInstancetypes = ptr.To(true)
 
 	// Default value is the operator namespace
 	pipelinesNamespace := getNamespace(hc.Namespace, opts)

--- a/controllers/operands/ssp_test.go
+++ b/controllers/operands/ssp_test.go
@@ -137,6 +137,15 @@ var _ = Describe("SSP Operands", func() {
 			Expect(expectedResource.Spec.FeatureGates.DeployVmConsoleProxy).To(BeTrue())
 		})
 
+		It("should create with deployCommonInstancetypes feature gate", func() {
+			hco := commontestutils.NewHco()
+
+			expectedResource, _, err := NewSSP(hco)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(expectedResource.Spec.FeatureGates.DeployCommonInstancetypes).To(HaveValue(BeTrue()))
+		})
+
 		Context("Node placement", func() {
 
 			It("should add node placement if missing", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
in CNV 4.15, the common instance types should be deployed by SSP operator. So this feature gate is set to "true"

Later in 4.16, it will be set to "false".

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-31875
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
