### PR TITLE
kubevirt: Network binding plugin

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -220,6 +220,11 @@ type HyperConvergedSpec struct {
 	// the enabling the KSM in the nodes (if available).
 	// +optional
 	KSMConfiguration *v1.KSMConfiguration `json:"ksmConfiguration,omitempty"`
+
+	// NetworkBinding defines the network binding plugins.
+	// Those bindings can be used when defining virtual machine interfaces.
+	// +optional
+	NetworkBinding map[string]v1.InterfaceBindingPlugin `json:"networkBinding,omitempty"`
 }
 
 // CertRotateConfigCA contains the tunables for TLS certificates.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -448,6 +448,13 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 		*out = new(corev1.KSMConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NetworkBinding != nil {
+		in, out := &in.NetworkBinding, &out.NetworkBinding
+		*out = make(map[string]corev1.InterfaceBindingPlugin, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -548,11 +548,26 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 							Ref:         ref("kubevirt.io/api/core/v1.KSMConfiguration"),
 						},
 					},
+					"networkBinding": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NetworkBinding defines the network binding plugins. Those bindings can be used when defining virtual machine interfaces.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("kubevirt.io/api/core/v1.InterfaceBindingPlugin"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.DataImportCronTemplate", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedCertConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedFeatureGates", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedObsoleteCPUs", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedWorkloadUpdateStrategy", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LiveMigrationConfigurations", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LogVerbosityConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.MediatedDevicesConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.OperandResourceRequirements", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.PermittedHostDevices", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.StorageImportConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.VirtualMachineOptions", "github.com/openshift/api/config/v1.TLSSecurityProfile", "kubevirt.io/api/core/v1.KSMConfiguration", "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.FilesystemOverhead"},
+			"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.DataImportCronTemplate", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedCertConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedFeatureGates", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedObsoleteCPUs", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedWorkloadUpdateStrategy", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LiveMigrationConfigurations", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LogVerbosityConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.MediatedDevicesConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.OperandResourceRequirements", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.PermittedHostDevices", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.StorageImportConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.VirtualMachineOptions", "github.com/openshift/api/config/v1.TLSSecurityProfile", "kubevirt.io/api/core/v1.InterfaceBindingPlugin", "kubevirt.io/api/core/v1.KSMConfiguration", "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.FilesystemOverhead"},
 	}
 }
 

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2361,6 +2361,23 @@ spec:
                     or mediatedDevicesTypes(deprecated) is required
                   rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
                     || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
+              networkBinding:
+                additionalProperties:
+                  properties:
+                    networkAttachmentDefinition:
+                      description: 'NetworkAttachmentDefinition references to a NetworkAttachmentDefinition
+                        CR object. Format: <name>, <namespace>/<name>. If namespace
+                        is not specified, VMI namespace is assumed. version: 1alphav1'
+                      type: string
+                    sidecarImage:
+                      description: 'SidecarImage references a container image that
+                        runs in the virt-launcher pod. The sidecar handles (libvirt)
+                        domain configuration and optional services. version: 1alphav1'
+                      type: string
+                  type: object
+                description: NetworkBinding defines the network binding plugins. Those
+                  bindings can be used when defining virtual machine interfaces.
+                type: object
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -219,6 +219,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"KubevirtSeccompProfile",
 					"HotplugNICs",
 					"VMPersistentState",
+					"NetworkBindingPlugins",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -406,6 +406,7 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		DeveloperConfiguration: devConfig,
 		NetworkConfiguration: &kubevirtcorev1.NetworkConfiguration{
 			NetworkInterface: string(kubevirtcorev1.MasqueradeInterface),
+			Binding:          hc.Spec.NetworkBinding,
 		},
 		MigrationConfiguration:       kvLiveMigration,
 		PermittedHostDevices:         toKvPermittedHostDevices(hc.Spec.PermittedHostDevices),

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -107,6 +107,9 @@ const (
 
 	// Enable VM state persistence
 	kvVMPersistentState = "VMPersistentState"
+
+	// Enable using a plugin to bind the pod and the VM network
+	kvHNetworkBindingPluginsGate = "NetworkBindingPlugins"
 )
 
 const (
@@ -132,6 +135,7 @@ var (
 		kvKubevirtSeccompProfile,
 		kvHotplugNicsGate,
 		kvVMPersistentState,
+		kvHNetworkBindingPluginsGate,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -195,6 +195,10 @@ Version: 1.2.3`)
 			hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
 				WithHostPassthroughCPU: ptr.To(true),
 			}
+			bindingPlugins := map[string]kubevirtcorev1.InterfaceBindingPlugin{
+				"binding1": {SidecarImage: "image1", NetworkAttachmentDefinition: "nad1"},
+			}
+			hco.Spec.NetworkBinding = bindingPlugins
 
 			expectedResource, err := NewKubeVirt(hco, commontestutils.Namespace)
 			Expect(err).ToNot(HaveOccurred())
@@ -240,6 +244,7 @@ Version: 1.2.3`)
 
 			Expect(foundResource.Spec.Configuration.NetworkConfiguration).ToNot(BeNil())
 			Expect(foundResource.Spec.Configuration.NetworkConfiguration.NetworkInterface).Should(Equal(string(kubevirtcorev1.MasqueradeInterface)))
+			Expect(foundResource.Spec.Configuration.NetworkConfiguration.Binding).Should(Equal(bindingPlugins))
 
 			// LiveMigration Configurations
 			mc := foundResource.Spec.Configuration.MigrationConfiguration

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2361,6 +2361,23 @@ spec:
                     or mediatedDevicesTypes(deprecated) is required
                   rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
                     || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
+              networkBinding:
+                additionalProperties:
+                  properties:
+                    networkAttachmentDefinition:
+                      description: 'NetworkAttachmentDefinition references to a NetworkAttachmentDefinition
+                        CR object. Format: <name>, <namespace>/<name>. If namespace
+                        is not specified, VMI namespace is assumed. version: 1alphav1'
+                      type: string
+                    sidecarImage:
+                      description: 'SidecarImage references a container image that
+                        runs in the virt-launcher pod. The sidecar handles (libvirt)
+                        domain configuration and optional services. version: 1alphav1'
+                      type: string
+                  type: object
+                description: NetworkBinding defines the network binding plugins. Those
+                  bindings can be used when defining virtual machine interfaces.
+                type: object
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
@@ -2361,6 +2361,23 @@ spec:
                     or mediatedDevicesTypes(deprecated) is required
                   rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
                     || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
+              networkBinding:
+                additionalProperties:
+                  properties:
+                    networkAttachmentDefinition:
+                      description: 'NetworkAttachmentDefinition references to a NetworkAttachmentDefinition
+                        CR object. Format: <name>, <namespace>/<name>. If namespace
+                        is not specified, VMI namespace is assumed. version: 1alphav1'
+                      type: string
+                    sidecarImage:
+                      description: 'SidecarImage references a container image that
+                        runs in the virt-launcher pod. The sidecar handles (libvirt)
+                        domain configuration and optional services. version: 1alphav1'
+                      type: string
+                  type: object
+                description: NetworkBinding defines the network binding plugins. Those
+                  bindings can be used when defining virtual machine interfaces.
+                type: object
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
@@ -2361,6 +2361,23 @@ spec:
                     or mediatedDevicesTypes(deprecated) is required
                   rule: (has(self.mediatedDeviceTypes) && size(self.mediatedDeviceTypes)>0)
                     || (has(self.mediatedDevicesTypes) && size(self.mediatedDevicesTypes)>0)
+              networkBinding:
+                additionalProperties:
+                  properties:
+                    networkAttachmentDefinition:
+                      description: 'NetworkAttachmentDefinition references to a NetworkAttachmentDefinition
+                        CR object. Format: <name>, <namespace>/<name>. If namespace
+                        is not specified, VMI namespace is assumed. version: 1alphav1'
+                      type: string
+                    sidecarImage:
+                      description: 'SidecarImage references a container image that
+                        runs in the virt-launcher pod. The sidecar handles (libvirt)
+                        domain configuration and optional services. version: 1alphav1'
+                      type: string
+                  type: object
+                description: NetworkBinding defines the network binding plugins. Those
+                  bindings can be used when defining virtual machine interfaces.
+                type: object
               obsoleteCPUs:
                 description: ObsoleteCPUs allows avoiding scheduling of VMs for obsolete
                   CPU models

--- a/docs/api.md
+++ b/docs/api.md
@@ -199,6 +199,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | virtualMachineOptions | VirtualMachineOptions holds the cluster level information regarding the virtual machine. | *[VirtualMachineOptions](#virtualmachineoptions) |  | false |
 | commonBootImageNamespace | CommonBootImageNamespace override the default namespace of the common boot images, in order to hide them.\n\nIf not set, HCO won't set any namespace, letting SSP to use the default. If set, use the namespace to create the DataImportCronTemplates and the common image streams, with this namespace. This field is not set by default. | *string |  | false |
 | ksmConfiguration | KSMConfiguration holds the information regarding the enabling the KSM in the nodes (if available). | *v1.KSMConfiguration |  | false |
+| networkBinding | NetworkBinding defines the network binding plugins. Those bindings can be used when defining virtual machine interfaces. | map[string]v1.InterfaceBindingPlugin |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -759,6 +759,25 @@ spec:
   kubeSecondaryDNSNameServerIP: "127.0.0.1"
 ```
 
+## Network Binding plugin
+In order to set NetworkBinding, set it on HyperConverged CR under spec.networkBinding field.
+Default: empty map (no binding plugins).
+
+### Network Binding plugin example
+```yaml
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  networkBinding:
+    custom-binding1:
+      sidecarImage: quay.io/custom-binding1-image
+    custom-binding2:
+      sidecarImage: quay.io/custom-binding2-image
+      networkAttachmentDefinition: customBinding2Nad
+```
+
 ## Modify common golden images
 Golden images are root disk images for commonly used operating systems. HCO provides several common images, but it is possible to modify them, if needed.
 

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
@@ -220,6 +220,11 @@ type HyperConvergedSpec struct {
 	// the enabling the KSM in the nodes (if available).
 	// +optional
 	KSMConfiguration *v1.KSMConfiguration `json:"ksmConfiguration,omitempty"`
+
+	// NetworkBinding defines the network binding plugins.
+	// Those bindings can be used when defining virtual machine interfaces.
+	// +optional
+	NetworkBinding map[string]v1.InterfaceBindingPlugin `json:"networkBinding,omitempty"`
 }
 
 // CertRotateConfigCA contains the tunables for TLS certificates.

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
@@ -448,6 +448,13 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 		*out = new(corev1.KSMConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NetworkBinding != nil {
+		in, out := &in.NetworkBinding, &out.NetworkBinding
+		*out = make(map[string]corev1.InterfaceBindingPlugin, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
@@ -548,11 +548,26 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 							Ref:         ref("kubevirt.io/api/core/v1.KSMConfiguration"),
 						},
 					},
+					"networkBinding": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NetworkBinding defines the network binding plugins. Those bindings can be used when defining virtual machine interfaces.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("kubevirt.io/api/core/v1.InterfaceBindingPlugin"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.DataImportCronTemplate", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedCertConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedFeatureGates", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedObsoleteCPUs", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedWorkloadUpdateStrategy", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LiveMigrationConfigurations", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LogVerbosityConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.MediatedDevicesConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.OperandResourceRequirements", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.PermittedHostDevices", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.StorageImportConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.VirtualMachineOptions", "github.com/openshift/api/config/v1.TLSSecurityProfile", "kubevirt.io/api/core/v1.KSMConfiguration", "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.FilesystemOverhead"},
+			"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.DataImportCronTemplate", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedCertConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedFeatureGates", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedObsoleteCPUs", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedWorkloadUpdateStrategy", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LiveMigrationConfigurations", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LogVerbosityConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.MediatedDevicesConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.OperandResourceRequirements", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.PermittedHostDevices", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.StorageImportConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.VirtualMachineOptions", "github.com/openshift/api/config/v1.TLSSecurityProfile", "kubevirt.io/api/core/v1.InterfaceBindingPlugin", "kubevirt.io/api/core/v1.KSMConfiguration", "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.FilesystemOverhead"},
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Enable NetworkBindingPlugins feature gate by default and propogate the HCO network bindig plugin map to the kubevirt CR.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Propagate networkBinding plugin to kubevirt CR
```
