### PR TITLE
Fix bug in the deploy/deploy.sh script

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -56,7 +56,7 @@ function update_nodes {
         for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
             nodes+=("node$(printf "%02d" ${i})")
         done
-        pull_command="docker"
+        pull_command="crictl"
     fi
 
     ${_cri_bin} ps -a

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -33,6 +33,7 @@ kubectl apply ${LABEL_SELECTOR_ARG} -f https://raw.githubusercontent.com/kubevir
 kubectl apply ${LABEL_SELECTOR_ARG} -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/kubevirt00.crd.yaml
 kubectl apply ${LABEL_SELECTOR_ARG} -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/hostpath-provisioner00.crd.yaml
 kubectl apply ${LABEL_SELECTOR_ARG} -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/scheduling-scale-performance00.crd.yaml
+kubectl apply ${LABEL_SELECTOR_ARG} -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/managed-tenant-quota00.crd.yaml
 
 # Deploy cert-manager for webhook certificates
 kubectl apply ${LABEL_SELECTOR_ARG} -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/cert-manager.yaml


### PR DESCRIPTION
## What this PR does / why we need it
The current script lacks the applying of the MTQ CRD, causing the HCO deployment to fail, and the HCO pod to exit with error.

This PR adds the missing CRD.

Also, `make sync` is broken because kubevirtci started use crictl instead of podman. This PR changes the cli to `crictl` in `hack/sync.sh`.

Fixes #2672 

### Reviewer Checklist
- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

### Jira Ticket
```jira-ticket
None
```

### Release note
```release-note
Fix bug in deploy/deploy.sh script. Add missing CRD.
```
