### PR TITLE
expose VM live update configuration bits in the HCO API

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -227,6 +227,10 @@ type HyperConvergedSpec struct {
 	// Those bindings can be used when defining virtual machine interfaces.
 	// +optional
 	NetworkBinding map[string]v1.InterfaceBindingPlugin `json:"networkBinding,omitempty"`
+
+	// Configuration of the VM live update features
+	// +optional
+	VMLiveUpdateConfiguration *v1.LiveUpdateConfiguration `json:"vmLiveUpdateConfiguration,omitempty"`
 }
 
 // CertRotateConfigCA contains the tunables for TLS certificates.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -455,6 +455,11 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.VMLiveUpdateConfiguration != nil {
+		in, out := &in.VMLiveUpdateConfiguration, &out.VMLiveUpdateConfiguration
+		*out = new(corev1.LiveUpdateConfiguration)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -564,11 +564,17 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 							},
 						},
 					},
+					"vmLiveUpdateConfiguration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Configuration of the VM live update features",
+							Ref:         ref("kubevirt.io/api/core/v1.LiveUpdateConfiguration"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.DataImportCronTemplate", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedCertConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedFeatureGates", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedObsoleteCPUs", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedWorkloadUpdateStrategy", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LiveMigrationConfigurations", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LogVerbosityConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.MediatedDevicesConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.OperandResourceRequirements", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.PermittedHostDevices", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.StorageImportConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.VirtualMachineOptions", "github.com/openshift/api/config/v1.TLSSecurityProfile", "kubevirt.io/api/core/v1.InterfaceBindingPlugin", "kubevirt.io/api/core/v1.KSMConfiguration", "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.FilesystemOverhead"},
+			"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.DataImportCronTemplate", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedCertConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedFeatureGates", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedObsoleteCPUs", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedWorkloadUpdateStrategy", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LiveMigrationConfigurations", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LogVerbosityConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.MediatedDevicesConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.OperandResourceRequirements", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.PermittedHostDevices", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.StorageImportConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.VirtualMachineOptions", "github.com/openshift/api/config/v1.TLSSecurityProfile", "kubevirt.io/api/core/v1.InterfaceBindingPlugin", "kubevirt.io/api/core/v1.KSMConfiguration", "kubevirt.io/api/core/v1.LiveUpdateConfiguration", "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.FilesystemOverhead"},
 	}
 }
 

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2770,6 +2770,32 @@ spec:
                       for the VM.
                     type: boolean
                 type: object
+              vmLiveUpdateConfiguration:
+                description: Configuration of the VM live update features
+                properties:
+                  maxCpuSockets:
+                    description: MaxCpuSockets holds the maximum amount of sockets
+                      that can be hotplugged
+                    format: int32
+                    type: integer
+                  maxGuest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxGuest defines the maximum amount memory that can
+                      be allocated to the guest using hotplug.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxHotplugRatio:
+                    description: 'MaxHotplugRatio is the ratio used to define the
+                      max amount of a hotplug resource that can be made available
+                      to a VM when the specific Max* setting is not defined (MaxCpuSockets,
+                      MaxGuest) Example: VM is configured with 512Mi of guest memory,
+                      if MaxGuest is not defined and MaxHotplugRatio is 2 then MaxGuest
+                      = 1Gi defaults to 4'
+                    format: int32
+                    type: integer
+                type: object
               vmStateStorageClass:
                 description: VMStateStorageClass is the name of the storage class
                   to use for the PVCs created to preserve VM state, like TPM. The

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -215,6 +215,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"HotplugNICs",
 					"VMPersistentState",
 					"NetworkBindingPlugins",
+					"VMLiveUpdateFeatures",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -110,6 +110,9 @@ const (
 
 	// Enable using a plugin to bind the pod and the VM network
 	kvHNetworkBindingPluginsGate = "NetworkBindingPlugins"
+
+	// Enable VM live update features
+	kvVMLiveUpdateFeatures = "VMLiveUpdateFeatures"
 )
 
 const (
@@ -136,6 +139,7 @@ var (
 		kvHotplugNicsGate,
 		kvVMPersistentState,
 		kvHNetworkBindingPluginsGate,
+		kvVMLiveUpdateFeatures,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of
@@ -418,6 +422,7 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		SeccompConfiguration:         seccompConfig,
 		EvictionStrategy:             hc.Spec.EvictionStrategy,
 		KSMConfiguration:             hc.Spec.KSMConfiguration,
+		LiveUpdateConfiguration:      hc.Spec.VMLiveUpdateConfiguration,
 	}
 
 	if smbiosConfig, ok := os.LookupEnv(smbiosEnvName); ok {

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2770,6 +2770,32 @@ spec:
                       for the VM.
                     type: boolean
                 type: object
+              vmLiveUpdateConfiguration:
+                description: Configuration of the VM live update features
+                properties:
+                  maxCpuSockets:
+                    description: MaxCpuSockets holds the maximum amount of sockets
+                      that can be hotplugged
+                    format: int32
+                    type: integer
+                  maxGuest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxGuest defines the maximum amount memory that can
+                      be allocated to the guest using hotplug.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxHotplugRatio:
+                    description: 'MaxHotplugRatio is the ratio used to define the
+                      max amount of a hotplug resource that can be made available
+                      to a VM when the specific Max* setting is not defined (MaxCpuSockets,
+                      MaxGuest) Example: VM is configured with 512Mi of guest memory,
+                      if MaxGuest is not defined and MaxHotplugRatio is 2 then MaxGuest
+                      = 1Gi defaults to 4'
+                    format: int32
+                    type: integer
+                type: object
               vmStateStorageClass:
                 description: VMStateStorageClass is the name of the storage class
                   to use for the PVCs created to preserve VM state, like TPM. The

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
@@ -2770,6 +2770,32 @@ spec:
                       for the VM.
                     type: boolean
                 type: object
+              vmLiveUpdateConfiguration:
+                description: Configuration of the VM live update features
+                properties:
+                  maxCpuSockets:
+                    description: MaxCpuSockets holds the maximum amount of sockets
+                      that can be hotplugged
+                    format: int32
+                    type: integer
+                  maxGuest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxGuest defines the maximum amount memory that can
+                      be allocated to the guest using hotplug.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxHotplugRatio:
+                    description: 'MaxHotplugRatio is the ratio used to define the
+                      max amount of a hotplug resource that can be made available
+                      to a VM when the specific Max* setting is not defined (MaxCpuSockets,
+                      MaxGuest) Example: VM is configured with 512Mi of guest memory,
+                      if MaxGuest is not defined and MaxHotplugRatio is 2 then MaxGuest
+                      = 1Gi defaults to 4'
+                    format: int32
+                    type: integer
+                type: object
               vmStateStorageClass:
                 description: VMStateStorageClass is the name of the storage class
                   to use for the PVCs created to preserve VM state, like TPM. The

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.11.0/manifests/hco00.crd.yaml
@@ -2770,6 +2770,32 @@ spec:
                       for the VM.
                     type: boolean
                 type: object
+              vmLiveUpdateConfiguration:
+                description: Configuration of the VM live update features
+                properties:
+                  maxCpuSockets:
+                    description: MaxCpuSockets holds the maximum amount of sockets
+                      that can be hotplugged
+                    format: int32
+                    type: integer
+                  maxGuest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxGuest defines the maximum amount memory that can
+                      be allocated to the guest using hotplug.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxHotplugRatio:
+                    description: 'MaxHotplugRatio is the ratio used to define the
+                      max amount of a hotplug resource that can be made available
+                      to a VM when the specific Max* setting is not defined (MaxCpuSockets,
+                      MaxGuest) Example: VM is configured with 512Mi of guest memory,
+                      if MaxGuest is not defined and MaxHotplugRatio is 2 then MaxGuest
+                      = 1Gi defaults to 4'
+                    format: int32
+                    type: integer
+                type: object
               vmStateStorageClass:
                 description: VMStateStorageClass is the name of the storage class
                   to use for the PVCs created to preserve VM state, like TPM. The

--- a/docs/api.md
+++ b/docs/api.md
@@ -200,6 +200,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | commonBootImageNamespace | CommonBootImageNamespace override the default namespace of the common boot images, in order to hide them.\n\nIf not set, HCO won't set any namespace, letting SSP to use the default. If set, use the namespace to create the DataImportCronTemplates and the common image streams, with this namespace. This field is not set by default. | *string |  | false |
 | ksmConfiguration | KSMConfiguration holds the information regarding the enabling the KSM in the nodes (if available). | *v1.KSMConfiguration |  | false |
 | networkBinding | NetworkBinding defines the network binding plugins. Those bindings can be used when defining virtual machine interfaces. | map[string]v1.InterfaceBindingPlugin |  | false |
+| vmLiveUpdateConfiguration | Configuration of the VM live update features | *v1.LiveUpdateConfiguration |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
@@ -227,6 +227,10 @@ type HyperConvergedSpec struct {
 	// Those bindings can be used when defining virtual machine interfaces.
 	// +optional
 	NetworkBinding map[string]v1.InterfaceBindingPlugin `json:"networkBinding,omitempty"`
+
+	// Configuration of the VM live update features
+	// +optional
+	VMLiveUpdateConfiguration *v1.LiveUpdateConfiguration `json:"vmLiveUpdateConfiguration,omitempty"`
 }
 
 // CertRotateConfigCA contains the tunables for TLS certificates.

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.deepcopy.go
@@ -455,6 +455,11 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.VMLiveUpdateConfiguration != nil {
+		in, out := &in.VMLiveUpdateConfiguration, &out.VMLiveUpdateConfiguration
+		*out = new(corev1.LiveUpdateConfiguration)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/zz_generated.openapi.go
@@ -564,11 +564,17 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 							},
 						},
 					},
+					"vmLiveUpdateConfiguration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Configuration of the VM live update features",
+							Ref:         ref("kubevirt.io/api/core/v1.LiveUpdateConfiguration"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.DataImportCronTemplate", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedCertConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedFeatureGates", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedObsoleteCPUs", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedWorkloadUpdateStrategy", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LiveMigrationConfigurations", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LogVerbosityConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.MediatedDevicesConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.OperandResourceRequirements", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.PermittedHostDevices", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.StorageImportConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.VirtualMachineOptions", "github.com/openshift/api/config/v1.TLSSecurityProfile", "kubevirt.io/api/core/v1.InterfaceBindingPlugin", "kubevirt.io/api/core/v1.KSMConfiguration", "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.FilesystemOverhead"},
+			"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.DataImportCronTemplate", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedCertConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedFeatureGates", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedObsoleteCPUs", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HyperConvergedWorkloadUpdateStrategy", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LiveMigrationConfigurations", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.LogVerbosityConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.MediatedDevicesConfiguration", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.OperandResourceRequirements", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.PermittedHostDevices", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.StorageImportConfig", "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.VirtualMachineOptions", "github.com/openshift/api/config/v1.TLSSecurityProfile", "kubevirt.io/api/core/v1.InterfaceBindingPlugin", "kubevirt.io/api/core/v1.KSMConfiguration", "kubevirt.io/api/core/v1.LiveUpdateConfiguration", "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1.FilesystemOverhead"},
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Manage Kubevirt VM live update features with HCO operator


**Release note**:
```release-note
enable the VMLiveUpdateFeatures FG, expose the LiveUpdateConfiguration in HCO API
```
