### PR TITLE
Allow modifiying operand annotations using json-patch annotation

### DIFF
--- a/controllers/operands/operand.go
+++ b/controllers/operands/operand.go
@@ -2,10 +2,8 @@ package operands
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
@@ -400,17 +398,6 @@ func applyAnnotationPatch(obj runtime.Object, annotation string) error {
 	patches, err := jsonpatch.DecodePatch([]byte(annotation))
 	if err != nil {
 		return err
-	}
-
-	for _, patch := range patches {
-		path, err := patch.Path()
-		if err != nil {
-			return err
-		}
-
-		if !strings.HasPrefix(path, "/spec/") {
-			return errors.New("can only modify spec fields")
-		}
 	}
 
 	specBytes, err := json.Marshal(obj)


### PR DESCRIPTION
## What this PR does / why we need it
PR #2685 sets a new annotation to the KV CR. Currently, the user can't remove this annotation using the HCO json-patch annotation, in order to remove this new annotation in case it causes issues in their clusters, because HCO rejects json-patch annotations if they are trying to modify fieds that are not under `/spec`.

This PR removes this limitation, allowing the users to modify also annotations.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
