### PR TITLE
Remove redundant variables

### DIFF
--- a/controllers/alerts/alerts.go
+++ b/controllers/alerts/alerts.go
@@ -17,6 +17,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -188,7 +189,6 @@ func createUnsafeModificationAlertRule() monitoringv1.Rule {
 }
 
 func createInstallationNotCompletedAlertRule() monitoringv1.Rule {
-	var hour1 monitoringv1.Duration = "1h"
 	return monitoringv1.Rule{
 		Alert: installationNotCompletedAlert,
 		Expr:  intstr.FromString("kubevirt_hco_hyperconverged_cr_exists == 0"),
@@ -196,7 +196,7 @@ func createInstallationNotCompletedAlertRule() monitoringv1.Rule {
 			"description": "the installation was not completed; the HyperConverged custom resource is missing. In order to complete the installation of the Hyperconverged Cluster Operator you should create the HyperConverged custom resource.",
 			"summary":     "the installation was not completed; to complete the installation, create a HyperConverged custom resource.",
 		},
-		For: &hour1,
+		For: ptr.To[monitoringv1.Duration]("1h"),
 		Labels: map[string]string{
 			severityAlertLabelKey:     "info",
 			healthImpactAlertLabelKey: "critical",

--- a/controllers/operands/cliDownload.go
+++ b/controllers/operands/cliDownload.go
@@ -13,6 +13,7 @@ import (
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
@@ -193,7 +194,6 @@ func (*cliDownloadsRouteHooks) updateCr(req *common.HcoRequest, Client client.Cl
 func (cliDownloadsRouteHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func NewCliDownloadsRoute(hc *hcov1beta1.HyperConverged) *routev1.Route {
-	weight := int32(100)
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cliDownloadsServiceName,
@@ -211,7 +211,7 @@ func NewCliDownloadsRoute(hc *hcov1beta1.HyperConverged) *routev1.Route {
 			To: routev1.RouteTargetReference{
 				Kind:   "Service",
 				Name:   cliDownloadsServiceName,
-				Weight: &weight,
+				Weight: ptr.To[int32](100),
 			},
 		},
 	}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
@@ -191,7 +192,7 @@ var (
 
 // KubeVirt containerDisk verification memory usage limit
 var (
-	kvDiskVerificationMemoryLimit, _ = resource.ParseQuantity("2G")
+	kvDiskVerificationMemoryLimit = resource.MustParse("2G")
 )
 
 // ************  KubeVirt Handler  **************
@@ -670,11 +671,10 @@ func getKVDevConfig(hc *hcov1beta1.HyperConverged) *kubevirtcorev1.DeveloperConf
 
 // Static for now, could be configured in the HCO CR in the future
 func getKVSeccompConfig() *kubevirtcorev1.SeccompConfiguration {
-	kubevirtProfile := "kubevirt/kubevirt.json"
 	return &kubevirtcorev1.SeccompConfiguration{
 		VirtualMachineInstanceProfile: &kubevirtcorev1.VirtualMachineInstanceProfile{
 			CustomProfile: &kubevirtcorev1.CustomProfile{
-				LocalhostProfile: &kubevirtProfile,
+				LocalhostProfile: ptr.To("kubevirt/kubevirt.json"),
 			},
 		},
 	}
@@ -697,8 +697,7 @@ func hcoConfig2KvConfig(hcoConfig hcov1beta1.HyperConvergedConfig, infrastructur
 
 	kvConfig := &kubevirtcorev1.ComponentConfig{}
 	if !infrastructureHighlyAvailable {
-		var singleReplica uint8 = 1
-		kvConfig.Replicas = &singleReplica
+		kvConfig.Replicas = ptr.To[uint8](1)
 	}
 
 	if hcoConfig.NodePlacement != nil {

--- a/controllers/operands/kubevirtConsolePlugin_test.go
+++ b/controllers/operands/kubevirtConsolePlugin_test.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"reflect"
 
-	"k8s.io/utils/ptr"
-
-	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	consolev1 "github.com/openshift/api/console/v1"
@@ -17,7 +13,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/reference"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
@@ -442,9 +441,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingResource := deploymentManifestor(hco)
 
 				// now, modify HCO's node placement
-				seconds34 := int64(34)
 				hco.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, v1.Toleration{
-					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: &seconds34,
+					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: ptr.To[int64](34),
 				})
 				hco.Spec.Infra.NodePlacement.NodeSelector["key3"] = "something entirely else"
 
@@ -491,9 +489,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				req.HCOTriggered = false
 
 				// now, modify deployment Kubevirt Console Plugin Deployment node placement
-				seconds34 := int64(34)
 				existingResource.Spec.Template.Spec.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, v1.Toleration{
-					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: &seconds34,
+					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: ptr.To[int64](34),
 				})
 				existingResource.Spec.Template.Spec.NodeSelector["key3"] = "BADvalue3"
 

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -6,12 +6,9 @@ import (
 	"os"
 	"time"
 
-	openshiftconfigv1 "github.com/openshift/api/config/v1"
-
-	"k8s.io/utils/ptr"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -19,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/reference"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
@@ -334,17 +332,13 @@ Version: 1.2.3`)
 			existKv.Spec.Configuration.EmulatedMachines = []string{"wrong"}
 
 			// LiveMigration Configurations
-			bandwidthPerMigration := resource.MustParse("16Mi")
-			wrongNumeric64Value := int64(0)
-			wrongNumeric32Value := uint32(0)
-			network := "testNetwork"
 			existKv.Spec.Configuration.MigrationConfiguration = &kubevirtcorev1.MigrationConfiguration{
-				BandwidthPerMigration:             &bandwidthPerMigration,
-				CompletionTimeoutPerGiB:           &wrongNumeric64Value,
-				ParallelMigrationsPerCluster:      &wrongNumeric32Value,
-				ParallelOutboundMigrationsPerNode: &wrongNumeric32Value,
-				ProgressTimeout:                   &wrongNumeric64Value,
-				Network:                           &network,
+				BandwidthPerMigration:             ptr.To(resource.MustParse("16Mi")),
+				CompletionTimeoutPerGiB:           ptr.To[int64](0),
+				ParallelMigrationsPerCluster:      ptr.To[uint32](0),
+				ParallelOutboundMigrationsPerNode: ptr.To[uint32](0),
+				ProgressTimeout:                   ptr.To[int64](0),
+				Network:                           ptr.To("testNetwork"),
 				AllowAutoConverge:                 ptr.To(false),
 				AllowPostCopy:                     ptr.To(false),
 			}
@@ -415,8 +409,7 @@ Version: 1.2.3`)
 		})
 
 		It("should fail if the Spec.LiveMigrationConfig.BandwidthPerMigration is wrongly formatted", func() {
-			wrongFormat := "Wrong Format"
-			hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &wrongFormat
+			hco.Spec.LiveMigrationConfig.BandwidthPerMigration = ptr.To("Wrong Format")
 
 			_, err := NewKubeVirt(hco, commontestutils.Namespace)
 			Expect(err).To(HaveOccurred())
@@ -519,19 +512,21 @@ Version: 1.2.3`)
 			existKv, err := NewKubeVirt(hco)
 			Expect(err).ToNot(HaveOccurred())
 
-			bandwidthPerMigration := "16Mi"
-			completionTimeoutPerGiB := int64(100)
-			parallelOutboundMigrationsPerNode := uint32(7)
-			parallelMigrationsPerCluster := uint32(18)
-			progressTimeout := int64(5000)
-			network := "testNetwork"
+			const (
+				bandwidthPerMigration             = "16Mi"
+				completionTimeoutPerGiB           = int64(100)
+				parallelOutboundMigrationsPerNode = uint32(7)
+				parallelMigrationsPerCluster      = uint32(18)
+				progressTimeout                   = int64(5000)
+				network                           = "testNetwork"
+			)
 
-			hco.Spec.LiveMigrationConfig.BandwidthPerMigration = &bandwidthPerMigration
-			hco.Spec.LiveMigrationConfig.CompletionTimeoutPerGiB = &completionTimeoutPerGiB
-			hco.Spec.LiveMigrationConfig.ParallelOutboundMigrationsPerNode = &parallelOutboundMigrationsPerNode
-			hco.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster = &parallelMigrationsPerCluster
-			hco.Spec.LiveMigrationConfig.ProgressTimeout = &progressTimeout
-			hco.Spec.LiveMigrationConfig.Network = &network
+			hco.Spec.LiveMigrationConfig.BandwidthPerMigration = ptr.To(bandwidthPerMigration)
+			hco.Spec.LiveMigrationConfig.CompletionTimeoutPerGiB = ptr.To(completionTimeoutPerGiB)
+			hco.Spec.LiveMigrationConfig.ParallelOutboundMigrationsPerNode = ptr.To(parallelOutboundMigrationsPerNode)
+			hco.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster = ptr.To(parallelMigrationsPerCluster)
+			hco.Spec.LiveMigrationConfig.ProgressTimeout = ptr.To(progressTimeout)
+			hco.Spec.LiveMigrationConfig.Network = ptr.To(network)
 			hco.Spec.LiveMigrationConfig.AllowAutoConverge = ptr.To(true)
 			hco.Spec.LiveMigrationConfig.AllowPostCopy = ptr.To(true)
 
@@ -552,14 +547,14 @@ Version: 1.2.3`)
 
 			mc := foundResource.Spec.Configuration.MigrationConfiguration
 			Expect(mc).ToNot(BeNil())
-			Expect(*mc.BandwidthPerMigration).To(Equal(resource.MustParse(bandwidthPerMigration)))
-			Expect(*mc.CompletionTimeoutPerGiB).To(Equal(completionTimeoutPerGiB))
-			Expect(*mc.ParallelOutboundMigrationsPerNode).To(Equal(parallelOutboundMigrationsPerNode))
-			Expect(*mc.ParallelMigrationsPerCluster).To(Equal(parallelMigrationsPerCluster))
-			Expect(*mc.ProgressTimeout).To(Equal(progressTimeout))
-			Expect(*mc.Network).To(Equal(network))
-			Expect(*mc.AllowAutoConverge).To(BeTrue())
-			Expect(*mc.AllowPostCopy).To(BeTrue())
+			Expect(mc.BandwidthPerMigration).To(HaveValue(Equal(resource.MustParse(bandwidthPerMigration))))
+			Expect(mc.CompletionTimeoutPerGiB).To(HaveValue(Equal(completionTimeoutPerGiB)))
+			Expect(mc.ParallelOutboundMigrationsPerNode).To(HaveValue(Equal(parallelOutboundMigrationsPerNode)))
+			Expect(mc.ParallelMigrationsPerCluster).To(HaveValue(Equal(parallelMigrationsPerCluster)))
+			Expect(mc.ProgressTimeout).To(HaveValue(Equal(progressTimeout)))
+			Expect(mc.Network).To(HaveValue(Equal(network)))
+			Expect(mc.AllowAutoConverge).To(HaveValue(BeTrue()))
+			Expect(mc.AllowPostCopy).To(HaveValue(BeTrue()))
 
 			// ObjectReference should have been updated
 			Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
@@ -1249,11 +1244,14 @@ Version: 1.2.3`)
 				existKv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				oldKVCPUmodel := "oldKVCPUmodel"
+				const (
+					oldKVCPUmodel = "oldKVCPUmodel"
+					testCPUModel  = "testValue"
+				)
+
 				existKv.Spec.Configuration.CPUModel = oldKVCPUmodel
 
-				testCPUModel := "testValue"
-				hco.Spec.DefaultCPUModel = &testCPUModel
+				hco.Spec.DefaultCPUModel = ptr.To(testCPUModel)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existKv})
 
@@ -1292,9 +1290,7 @@ Version: 1.2.3`)
 							foundResource),
 					).To(Succeed())
 
-					kvCPUModel := foundResource.Spec.Configuration.CPUModel
-					Expect(kvCPUModel).ToNot(BeNil())
-					Expect(kvCPUModel).To(Equal(testCPUModel))
+					Expect(foundResource.Spec.Configuration.CPUModel).To(Equal(testCPUModel))
 				})
 
 			})
@@ -1391,9 +1387,8 @@ Version: 1.2.3`)
 				Expect(err).ToNot(HaveOccurred())
 
 				// now, modify HCO's node placement
-				seconds3 := int64(3)
 				hco.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
-					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: &seconds3,
+					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
 
 				hco.Spec.Workloads.NodePlacement.NodeSelector["key1"] = "something else"
@@ -1441,12 +1436,11 @@ Version: 1.2.3`)
 				req.HCOTriggered = false
 
 				// now, modify KV's node placement
-				seconds3 := int64(3)
 				existingResource.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
-					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: &seconds3,
+					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
 				existingResource.Spec.Workloads.NodePlacement.Tolerations = append(hco.Spec.Workloads.NodePlacement.Tolerations, corev1.Toleration{
-					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: &seconds3,
+					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
 
 				existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"] = "BADvalue1"
@@ -2397,7 +2391,8 @@ Version: 1.2.3`)
 		})
 
 		Context("Workload Update Strategy", func() {
-			defaultBatchEvictionSize := 10
+			const defaultBatchEvictionSize = 10
+
 			getClusterInfo := hcoutil.GetClusterInfo
 
 			BeforeEach(func() {
@@ -2417,7 +2412,7 @@ Version: 1.2.3`)
 				hco.Spec.WorkloadUpdateStrategy = hcov1beta1.HyperConvergedWorkloadUpdateStrategy{
 					WorkloadUpdateMethods: []string{"aaa", "bbb"},
 					BatchEvictionInterval: &metav1.Duration{Duration: time.Minute * 1},
-					BatchEvictionSize:     &defaultBatchEvictionSize,
+					BatchEvictionSize:     ptr.To(defaultBatchEvictionSize),
 				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
@@ -2437,7 +2432,7 @@ Version: 1.2.3`)
 				Expect(foundResource.Spec.WorkloadUpdateStrategy).ToNot(BeNil())
 				kvUpdateStrategy := foundResource.Spec.WorkloadUpdateStrategy
 				Expect(kvUpdateStrategy.BatchEvictionInterval.Duration.String()).Should(Equal("1m0s"))
-				Expect(*kvUpdateStrategy.BatchEvictionSize).Should(Equal(defaultBatchEvictionSize))
+				Expect(kvUpdateStrategy.BatchEvictionSize).Should(HaveValue(Equal(defaultBatchEvictionSize)))
 				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(HaveLen(2))
 				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(ContainElements(kubevirtcorev1.WorkloadUpdateMethod("aaa"), kubevirtcorev1.WorkloadUpdateMethod("bbb")))
 
@@ -2464,7 +2459,7 @@ Version: 1.2.3`)
 				Expect(foundResource.Spec.WorkloadUpdateStrategy).ToNot(BeNil())
 				kvUpdateStrategy := foundResource.Spec.WorkloadUpdateStrategy
 				Expect(kvUpdateStrategy.BatchEvictionInterval.Duration.String()).Should(Equal("1m0s"))
-				Expect(*kvUpdateStrategy.BatchEvictionSize).Should(Equal(defaultBatchEvictionSize))
+				Expect(kvUpdateStrategy.BatchEvictionSize).Should(HaveValue(Equal(defaultBatchEvictionSize)))
 				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(HaveLen(1))
 				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(
 					ContainElements(
@@ -2480,10 +2475,10 @@ Version: 1.2.3`)
 				existingKv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				modifiedBatchEvictionSize := 5
+				const modifiedBatchEvictionSize = 5
 				hco.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []string{"aaa", "bbb", "ccc"}
 				hco.Spec.WorkloadUpdateStrategy.BatchEvictionInterval = &metav1.Duration{Duration: time.Minute * 3}
-				hco.Spec.WorkloadUpdateStrategy.BatchEvictionSize = &modifiedBatchEvictionSize
+				hco.Spec.WorkloadUpdateStrategy.BatchEvictionSize = ptr.To(modifiedBatchEvictionSize)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingKv})
 				handler := (*genericOperand)(newKubevirtHandler(cl, commontestutils.GetScheme()))
@@ -2508,19 +2503,19 @@ Version: 1.2.3`)
 					),
 				)
 
-				Expect(*foundKv.Spec.WorkloadUpdateStrategy.BatchEvictionInterval).Should(Equal(metav1.Duration{Duration: time.Minute * 3}))
-				Expect(*foundKv.Spec.WorkloadUpdateStrategy.BatchEvictionSize).Should(Equal(modifiedBatchEvictionSize))
+				Expect(foundKv.Spec.WorkloadUpdateStrategy.BatchEvictionInterval).Should(HaveValue(Equal(metav1.Duration{Duration: time.Minute * 3})))
+				Expect(foundKv.Spec.WorkloadUpdateStrategy.BatchEvictionSize).Should(HaveValue(Equal(modifiedBatchEvictionSize)))
 			})
 
 			It("should overwrite Workload Update Strategy if directly set on KV CR", func() {
-
-				hcoModifiedBatchEvictionSize := 5
-				kvModifiedBatchEvictionSize := 7
-
+				const (
+					hcoModifiedBatchEvictionSize = 5
+					kvModifiedBatchEvictionSize  = 7
+				)
 				hco.Spec.WorkloadUpdateStrategy = hcov1beta1.HyperConvergedWorkloadUpdateStrategy{
 					WorkloadUpdateMethods: []string{"LiveMigrate"},
 					BatchEvictionInterval: &metav1.Duration{Duration: time.Minute * 5},
-					BatchEvictionSize:     &hcoModifiedBatchEvictionSize,
+					BatchEvictionSize:     ptr.To(hcoModifiedBatchEvictionSize),
 				}
 
 				existingKV, err := NewKubeVirt(hco)
@@ -2531,7 +2526,7 @@ Version: 1.2.3`)
 
 				By("Modify KV's Workload Update Strategy configuration")
 				existingKV.Spec.WorkloadUpdateStrategy.BatchEvictionInterval = &metav1.Duration{Duration: 3 * time.Minute}
-				existingKV.Spec.WorkloadUpdateStrategy.BatchEvictionSize = &kvModifiedBatchEvictionSize
+				existingKV.Spec.WorkloadUpdateStrategy.BatchEvictionSize = ptr.To(kvModifiedBatchEvictionSize)
 				existingKV.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []kubevirtcorev1.WorkloadUpdateMethod{kubevirtcorev1.WorkloadUpdateMethodEvict}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingKV})
@@ -2564,7 +2559,7 @@ Version: 1.2.3`)
 				Expect(foundUpdateStrategy.WorkloadUpdateMethods).Should(ContainElements(
 					kubevirtcorev1.WorkloadUpdateMethodLiveMigrate,
 				))
-				Expect(*foundUpdateStrategy.BatchEvictionSize).Should(Equal(hcoModifiedBatchEvictionSize))
+				Expect(foundUpdateStrategy.BatchEvictionSize).Should(HaveValue(Equal(hcoModifiedBatchEvictionSize)))
 				Expect(foundUpdateStrategy.BatchEvictionInterval.Duration.String()).Should(Equal("5m0s"))
 			})
 
@@ -2757,8 +2752,7 @@ Version: 1.2.3`)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				liveMigrateEvictionStrategy := kubevirtcorev1.EvictionStrategyLiveMigrate
-				hco.Spec.EvictionStrategy = &liveMigrateEvictionStrategy
+				hco.Spec.EvictionStrategy = ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrate)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := (*genericOperand)(newKubevirtHandler(cl, commontestutils.GetScheme()))
@@ -2783,14 +2777,12 @@ Version: 1.2.3`)
 
 			It("should modify eviction strategy according to HCO CR", func() {
 
-				evictionStrategyNone := kubevirtcorev1.EvictionStrategyNone
-				hco.Spec.EvictionStrategy = &evictionStrategyNone
+				hco.Spec.EvictionStrategy = ptr.To(kubevirtcorev1.EvictionStrategyNone)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Modify HCO's eviction strategy configuration")
-				evictionStrategyExternal := kubevirtcorev1.EvictionStrategyLiveMigrateIfPossible
-				hco.Spec.EvictionStrategy = &evictionStrategyExternal
+				hco.Spec.EvictionStrategy = ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrateIfPossible)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := (*genericOperand)(newKubevirtHandler(cl, commontestutils.GetScheme()))
@@ -3015,13 +3007,13 @@ Version: 1.2.3`)
 
 		Context("VmiCPUAllocationRatio", func() {
 			It("should add CPUAllocationRatio if missing in KV CR", func() {
-				expectedCPUAllocationRatio := 16
+				const expectedCPUAllocationRatio = 16
 
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				hco.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					VmiCPUAllocationRatio: &expectedCPUAllocationRatio,
+					VmiCPUAllocationRatio: ptr.To(expectedCPUAllocationRatio),
 				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
@@ -3044,11 +3036,11 @@ Version: 1.2.3`)
 			})
 
 			It("should remove CPUAllocationRatio if missing in HCO CR", func() {
-				initialCPUAllocationRatio := 16
+				const initialCPUAllocationRatio = 16
 
 				hcoResourceRequirements := commontestutils.NewHco()
 				hcoResourceRequirements.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					VmiCPUAllocationRatio: &initialCPUAllocationRatio,
+					VmiCPUAllocationRatio: ptr.To(initialCPUAllocationRatio),
 				}
 
 				existingResource, err := NewKubeVirt(hcoResourceRequirements)
@@ -3077,19 +3069,21 @@ Version: 1.2.3`)
 			})
 
 			It("should modify CPUAllocationRatio according to HCO CR", func() {
-				initialCPUAllocationRatio := 16
-				expectedCPUAllocationRatio := 25
+				const (
+					initialCPUAllocationRatio  = 16
+					expectedCPUAllocationRatio = 25
+				)
 				hcoResourceRequirements := commontestutils.NewHco()
 
 				hcoResourceRequirements.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					VmiCPUAllocationRatio: &initialCPUAllocationRatio,
+					VmiCPUAllocationRatio: ptr.To(initialCPUAllocationRatio),
 				}
 
 				existingResource, err := NewKubeVirt(hcoResourceRequirements)
 				Expect(err).ToNot(HaveOccurred())
 
 				hco.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					VmiCPUAllocationRatio: &expectedCPUAllocationRatio,
+					VmiCPUAllocationRatio: ptr.To(expectedCPUAllocationRatio),
 				}
 
 				Expect(existingResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
@@ -3624,8 +3618,8 @@ Version: 1.2.3`)
 		Context("DefaultRuntimeClass", func() {
 
 			It("Should be defined for KubevirtCR if defined in HCO CR", func() {
-				runtimeClass := "myCustomRuntimeClass"
-				hco.Spec.DefaultRuntimeClass = &runtimeClass
+				const runtimeClass = "myCustomRuntimeClass"
+				hco.Spec.DefaultRuntimeClass = ptr.To(runtimeClass)
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -3648,35 +3642,36 @@ Version: 1.2.3`)
 
 	Context("Test hcLiveMigrationToKv", func() {
 
-		bandwidthPerMigration := "64Mi"
-		completionTimeoutPerGiB := int64(100)
-		parallelMigrationsPerCluster := uint32(100)
-		parallelOutboundMigrationsPerNode := uint32(100)
-		progressTimeout := int64(100)
-		network := "testNetwork"
-
+		const (
+			bandwidthPerMigration             = "64Mi"
+			completionTimeoutPerGiB           = int64(100)
+			parallelMigrationsPerCluster      = uint32(100)
+			parallelOutboundMigrationsPerNode = uint32(100)
+			progressTimeout                   = int64(100)
+			network                           = "testNetwork"
+		)
 		It("should create valid KV LM config from a valid HC LM config", func() {
 			lmc := hcov1beta1.LiveMigrationConfigurations{
-				BandwidthPerMigration:             &bandwidthPerMigration,
-				CompletionTimeoutPerGiB:           &completionTimeoutPerGiB,
-				ParallelMigrationsPerCluster:      &parallelMigrationsPerCluster,
-				ParallelOutboundMigrationsPerNode: &parallelOutboundMigrationsPerNode,
-				ProgressTimeout:                   &progressTimeout,
-				Network:                           &network,
+				BandwidthPerMigration:             ptr.To(bandwidthPerMigration),
+				CompletionTimeoutPerGiB:           ptr.To(completionTimeoutPerGiB),
+				ParallelMigrationsPerCluster:      ptr.To(parallelMigrationsPerCluster),
+				ParallelOutboundMigrationsPerNode: ptr.To(parallelOutboundMigrationsPerNode),
+				ProgressTimeout:                   ptr.To(progressTimeout),
+				Network:                           ptr.To(network),
 				AllowAutoConverge:                 ptr.To(true),
 				AllowPostCopy:                     ptr.To(true),
 			}
 			mc, err := hcLiveMigrationToKv(lmc)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(*mc.BandwidthPerMigration).Should(Equal(resource.MustParse(bandwidthPerMigration)))
-			Expect(*mc.CompletionTimeoutPerGiB).Should(Equal(completionTimeoutPerGiB))
-			Expect(*mc.ParallelMigrationsPerCluster).Should(Equal(parallelMigrationsPerCluster))
-			Expect(*mc.ParallelOutboundMigrationsPerNode).Should(Equal(parallelOutboundMigrationsPerNode))
-			Expect(*mc.ProgressTimeout).Should(Equal(progressTimeout))
-			Expect(*mc.Network).Should(Equal(network))
-			Expect(*mc.AllowAutoConverge).Should(BeTrue())
-			Expect(*mc.AllowPostCopy).Should(BeTrue())
+			Expect(mc.BandwidthPerMigration).Should(HaveValue(Equal(resource.MustParse(bandwidthPerMigration))))
+			Expect(mc.CompletionTimeoutPerGiB).Should(HaveValue(Equal(completionTimeoutPerGiB)))
+			Expect(mc.ParallelMigrationsPerCluster).Should(HaveValue(Equal(parallelMigrationsPerCluster)))
+			Expect(mc.ParallelOutboundMigrationsPerNode).Should(HaveValue(Equal(parallelOutboundMigrationsPerNode)))
+			Expect(mc.ProgressTimeout).Should(HaveValue(Equal(progressTimeout)))
+			Expect(mc.Network).Should(HaveValue(Equal(network)))
+			Expect(mc.AllowAutoConverge).Should(HaveValue(BeTrue()))
+			Expect(mc.AllowPostCopy).Should(HaveValue(BeTrue()))
 		})
 
 		It("should create valid empty KV LM config from a valid empty HC LM config", func() {
@@ -3695,14 +3690,13 @@ Version: 1.2.3`)
 		})
 
 		It("should return error if the value of the BandwidthPerMigration field is not valid", func() {
-			wrongBandwidthPerMigration := "Wrong BandwidthPerMigration"
 			lmc := hcov1beta1.LiveMigrationConfigurations{
-				BandwidthPerMigration:             &wrongBandwidthPerMigration,
-				CompletionTimeoutPerGiB:           &completionTimeoutPerGiB,
-				ParallelMigrationsPerCluster:      &parallelMigrationsPerCluster,
-				ParallelOutboundMigrationsPerNode: &parallelOutboundMigrationsPerNode,
-				ProgressTimeout:                   &progressTimeout,
-				Network:                           &network,
+				BandwidthPerMigration:             ptr.To("Wrong BandwidthPerMigration"),
+				CompletionTimeoutPerGiB:           ptr.To(completionTimeoutPerGiB),
+				ParallelMigrationsPerCluster:      ptr.To(parallelMigrationsPerCluster),
+				ParallelOutboundMigrationsPerNode: ptr.To(parallelOutboundMigrationsPerNode),
+				ProgressTimeout:                   ptr.To(progressTimeout),
+				Network:                           ptr.To(network),
 				AllowAutoConverge:                 ptr.To(true),
 				AllowPostCopy:                     ptr.To(true),
 			}

--- a/controllers/operands/mtq.go
+++ b/controllers/operands/mtq.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/reference"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mtqv1alpha1 "kubevirt.io/managed-tenant-quota/staging/src/kubevirt.io/managed-tenant-quota-api/pkg/apis/core/v1alpha1"
@@ -141,7 +142,6 @@ func (*mtqHooks) updateCr(req *common.HcoRequest, Client client.Client, exists r
 func (*mtqHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func NewMTQ(hc *hcov1beta1.HyperConverged, opts ...string) *mtqv1alpha1.MTQ {
-	priorityClassName := mtqv1alpha1.MTQPriorityClass(kvPriorityClass)
 	spec := mtqv1alpha1.MTQSpec{
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		CertConfig: &mtqv1alpha1.MTQCertConfig{
@@ -154,7 +154,7 @@ func NewMTQ(hc *hcov1beta1.HyperConverged, opts ...string) *mtqv1alpha1.MTQ {
 				RenewBefore: hc.Spec.CertConfig.Server.RenewBefore,
 			},
 		},
-		PriorityClass: &priorityClassName,
+		PriorityClass: ptr.To[mtqv1alpha1.MTQPriorityClass](kvPriorityClass),
 	}
 
 	if hc.Spec.Infra.NodePlacement != nil {

--- a/controllers/operands/mtq_test.go
+++ b/controllers/operands/mtq_test.go
@@ -219,12 +219,10 @@ var _ = Describe("MTQ tests", func() {
 	Context("check update", func() {
 
 		It("should update MTQ fields, if not matched to the requirements", func() {
-			wrongPC := mtqv1alpha1.MTQPriorityClass("wrongPC")
-
 			hco.Spec.FeatureGates.EnableManagedTenantQuota = ptr.To(true)
 			mtq := NewMTQWithNameOnly(hco)
 			mtq.Spec.Infra = testNodePlacement
-			mtq.Spec.PriorityClass = &wrongPC
+			mtq.Spec.PriorityClass = ptr.To(mtqv1alpha1.MTQPriorityClass("wrongPC"))
 			mtq.Spec.CertConfig = &mtqv1alpha1.MTQCertConfig{
 				CA: &mtqv1alpha1.CertConfig{
 					Duration:    &metav1.Duration{Duration: time.Hour * 72},

--- a/controllers/operands/networkAddons_test.go
+++ b/controllers/operands/networkAddons_test.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"time"
 
-	openshiftconfigv1 "github.com/openshift/api/config/v1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/reference"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	networkaddonsshared "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
@@ -198,9 +198,8 @@ var _ = Describe("CNA Operand", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// now, modify HCO's node placement
-			seconds3 := int64(3)
 			hco.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
-				Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: &seconds3,
+				Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 			})
 
 			hco.Spec.Workloads.NodePlacement.NodeSelector["key1"] = "something else"
@@ -240,12 +239,11 @@ var _ = Describe("CNA Operand", func() {
 			req.HCOTriggered = false
 
 			// now, modify CNAO node placement
-			seconds3 := int64(3)
 			existingResource.Spec.PlacementConfiguration.Infra.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
-				Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: &seconds3,
+				Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 			})
 			existingResource.Spec.PlacementConfiguration.Workloads.Tolerations = append(hco.Spec.Workloads.NodePlacement.Tolerations, corev1.Toleration{
-				Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: &seconds3,
+				Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 			})
 
 			existingResource.Spec.PlacementConfiguration.Infra.NodeSelector["key1"] = "BADvalue1"
@@ -540,11 +538,10 @@ var _ = Describe("CNA Operand", func() {
 				existingCNAO.Spec.KubeSecondaryDNS = &networkaddonsshared.KubeSecondaryDNS{}
 			}
 
-			kubeSecondaryDNSNameServerIP := "127.0.0.1"
+			const kubeSecondaryDNSNameServerIP = "127.0.0.1"
 			if o.setFeatureGate {
-				deployKubeSecondaryDNS := o.featureGateValue
-				hco.Spec.FeatureGates.DeployKubeSecondaryDNS = &deployKubeSecondaryDNS
-				hco.Spec.KubeSecondaryDNSNameServerIP = &kubeSecondaryDNSNameServerIP
+				hco.Spec.FeatureGates.DeployKubeSecondaryDNS = ptr.To(o.featureGateValue)
+				hco.Spec.KubeSecondaryDNSNameServerIP = ptr.To(kubeSecondaryDNSNameServerIP)
 			}
 
 			cl := commontestutils.InitClient([]client.Object{hco, existingCNAO})
@@ -1075,12 +1072,11 @@ var _ = Describe("CNA Operand", func() {
 	})
 
 	Context("hcoConfig2CnaoPlacement", func() {
-		seconds1, seconds2 := int64(1), int64(2)
 		tolr1 := corev1.Toleration{
-			Key: "key1", Operator: "operator1", Value: "value1", Effect: "effect1", TolerationSeconds: &seconds1,
+			Key: "key1", Operator: "operator1", Value: "value1", Effect: "effect1", TolerationSeconds: ptr.To[int64](1),
 		}
 		tolr2 := corev1.Toleration{
-			Key: "key2", Operator: "operator2", Value: "value2", Effect: "effect2", TolerationSeconds: &seconds2,
+			Key: "key2", Operator: "operator2", Value: "value2", Effect: "effect2", TolerationSeconds: ptr.To[int64](2),
 		}
 
 		It("Should return nil if HCO's input is empty", func() {

--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -29,7 +29,7 @@ const (
 	// This is initially set to 2 replicas, to maintain the behavior of the previous SSP operator.
 	// After SSP implements its defaulting webhook, we can change this to 0 replicas,
 	// and let the webhook set the default.
-	defaultTemplateValidatorReplicas = 2
+	defaultTemplateValidatorReplicas = int32(2)
 
 	defaultCommonTemplatesNamespace = hcoutil.OpenshiftNamespace
 
@@ -124,7 +124,6 @@ func (h *sspHooks) justBeforeComplete(req *common.HcoRequest) {
 }
 
 func NewSSP(hc *hcov1beta1.HyperConverged, opts ...string) (*sspv1beta2.SSP, []hcov1beta1.DataImportCronTemplateStatus, error) {
-	replicas := int32(defaultTemplateValidatorReplicas)
 	templatesNamespace := defaultCommonTemplatesNamespace
 
 	if hc.Spec.CommonTemplatesNamespace != nil {
@@ -145,7 +144,7 @@ func NewSSP(hc *hcov1beta1.HyperConverged, opts ...string) (*sspv1beta2.SSP, []h
 
 	spec := sspv1beta2.SSPSpec{
 		TemplateValidator: &sspv1beta2.TemplateValidator{
-			Replicas: &replicas,
+			Replicas: ptr.To(defaultTemplateValidatorReplicas),
 		},
 		CommonTemplates: sspv1beta2.CommonTemplates{
 			Namespace:               templatesNamespace,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/client-go/discovery"
-
 	"github.com/go-logr/logr"
 	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,7 +19,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/reference"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -159,8 +159,7 @@ func getDeletionOption(dryRun bool, wait bool) *client.DeleteOptions {
 		opts.DryRun = []string{metav1.DryRunAll}
 	}
 	if wait {
-		foreground := metav1.DeletePropagationForeground
-		opts.PropagationPolicy = &foreground
+		opts.PropagationPolicy = ptr.To(metav1.DeletePropagationForeground)
 	}
 	return opts
 }

--- a/pkg/webhooks/mutator/hyperConvergedMutator_test.go
+++ b/pkg/webhooks/mutator/hyperConvergedMutator_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	kubevirtcorev1 "kubevirt.io/api/core/v1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gomodules.xyz/jsonpatch/v2"
@@ -14,8 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kubevirtcorev1 "kubevirt.io/api/core/v1"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
@@ -48,8 +49,7 @@ var _ = Describe("test HyperConverged mutator", func() {
 				},
 				Spec: v1beta1.HyperConvergedSpec{},
 			}
-			evictionStrategy := kubevirtcorev1.EvictionStrategyLiveMigrate
-			cr.Spec.EvictionStrategy = &evictionStrategy
+			cr.Spec.EvictionStrategy = ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrate)
 			cli = commontestutils.InitClient(nil)
 			mutator = initHCMutator(s, cli)
 		})

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -824,8 +824,7 @@ var _ = Describe("webhooks validator", func() {
 				hco.DeepCopyInto(newHco)
 
 				// change something in the LiveMigrationConfig field
-				newVal := int64(200)
-				hco.Spec.LiveMigrationConfig.CompletionTimeoutPerGiB = &newVal
+				hco.Spec.LiveMigrationConfig.CompletionTimeoutPerGiB = ptr.To[int64](200)
 
 				Expect(wh.ValidateUpdate(ctx, dryRun, newHco, hco)).To(Succeed())
 			})
@@ -839,8 +838,7 @@ var _ = Describe("webhooks validator", func() {
 				hco.DeepCopyInto(newHco)
 
 				// change something in the LiveMigrationConfig field
-				wrongVal := "Wrong Value"
-				newHco.Spec.LiveMigrationConfig.BandwidthPerMigration = &wrongVal
+				newHco.Spec.LiveMigrationConfig.BandwidthPerMigration = ptr.To("Wrong Value")
 
 				Expect(
 					wh.ValidateUpdate(ctx, dryRun, newHco, hco),
@@ -1794,7 +1792,6 @@ var _ = Describe("webhooks validator", func() {
 })
 
 func newHyperConvergedConfig() *sdkapi.NodePlacement {
-	seconds1, seconds2 := int64(1), int64(2)
 	return &sdkapi.NodePlacement{
 		NodeSelector: map[string]string{
 			"key1": "value1",
@@ -1819,8 +1816,8 @@ func newHyperConvergedConfig() *sdkapi.NodePlacement {
 			},
 		},
 		Tolerations: []corev1.Toleration{
-			{Key: "key1", Operator: "operator1", Value: "value1", Effect: "effect1", TolerationSeconds: &seconds1},
-			{Key: "key2", Operator: "operator2", Value: "value2", Effect: "effect2", TolerationSeconds: &seconds2},
+			{Key: "key1", Operator: "operator1", Value: "value1", Effect: "effect1", TolerationSeconds: ptr.To[int64](1)},
+			{Key: "key2", Operator: "operator2", Value: "value2", Effect: "effect2", TolerationSeconds: ptr.To[int64](2)},
 		},
 	}
 }

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -377,22 +377,19 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 })
 
 func getDICT() hcov1beta1.DataImportCronTemplate {
-	gcType := cdiv1beta1.DataImportCronGarbageCollectOutdated
-	pullMethod := cdiv1beta1.RegistryPullNode
-
 	return hcov1beta1.DataImportCronTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "custom",
 		},
 		Spec: &cdiv1beta1.DataImportCronSpec{
-			GarbageCollect:    &gcType,
+			GarbageCollect:    ptr.To(cdiv1beta1.DataImportCronGarbageCollectOutdated),
 			ManagedDataSource: "centos7",
 			Schedule:          "18 1/12 * * *",
 			Template: cdiv1beta1.DataVolume{
 				Spec: cdiv1beta1.DataVolumeSpec{
 					Source: &cdiv1beta1.DataVolumeSource{
 						Registry: &cdiv1beta1.DataVolumeSourceRegistry{
-							PullMethod: &pullMethod,
+							PullMethod: ptr.To(cdiv1beta1.RegistryPullNode),
 							URL:        ptr.To("docker://quay.io/containerdisks/centos:7-2009"),
 						},
 					},

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/util.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/util.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/client-go/discovery"
-
 	"github.com/go-logr/logr"
 	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,7 +19,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/reference"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -159,8 +159,7 @@ func getDeletionOption(dryRun bool, wait bool) *client.DeleteOptions {
 		opts.DryRun = []string{metav1.DryRunAll}
 	}
 	if wait {
-		foreground := metav1.DeletePropagationForeground
-		opts.PropagationPolicy = &foreground
+		opts.PropagationPolicy = ptr.To(metav1.DeletePropagationForeground)
 	}
 	return opts
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
use `ptr.To()` instead of defining a variable just to use it's address. That way we can get rid of many variables.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
