### PR TITLE
Don't trigger build-push-images workflow if renovate.json file updated

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -6,10 +6,11 @@ on:
       - main
       - release-1*
     paths-ignore:
-      - 'docs/**'
-      - 'images/**'
-      - 'automation/**'
-      - 'cluster/**'
+      - "docs/**"
+      - "images/**"
+      - "automation/**"
+      - "cluster/**"
+      - "renovate.json"
 jobs:
   build_push:
     if: (github.repository == 'kubevirt/hyperconverged-cluster-operator')
@@ -28,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: "1.20"
       - name: Get latest version
         run: |
           PACKAGE_DIR="./deploy/olm-catalog/community-kubevirt-hyperconverged"

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -5,9 +5,13 @@ name: Sanity Checks
 # Controls when the action will run.
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+    paths-ignore:
+      - "renovate.json"
   pull_request:
-    branches: [ main ]
+    branches: [main]
+    paths-ignore:
+      - "renovate.json"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -26,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20' # The Go version to download (if necessary) and use.
+          go-version: "1.20" # The Go version to download (if necessary) and use.
 
       - name: Do sanity checks
         run: make sanity


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't trigger build-push-image workflow if renovate.json file updated
```
