### PR TITLE
Fix bug where installing HCO on kubernetes+OLM, fails

### DIFF
--- a/pkg/util/own_resources.go
+++ b/pkg/util/own_resources.go
@@ -68,7 +68,7 @@ func findOwnResources(ctx context.Context, cl client.Reader, logger logr.Logger)
 			logger.Error(err, "Can't get deployment")
 			return
 		}
-		if GetClusterInfo().IsOpenshift() {
+		if GetClusterInfo().IsManagedByOLM() {
 			var err error
 			or.csv, err = getCSVFromDeployment(or.deployment, cl, operatorNs, logger)
 			if err != nil {

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/own_resources.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/own_resources.go
@@ -68,7 +68,7 @@ func findOwnResources(ctx context.Context, cl client.Reader, logger logr.Logger)
 			logger.Error(err, "Can't get deployment")
 			return
 		}
-		if GetClusterInfo().IsOpenshift() {
+		if GetClusterInfo().IsManagedByOLM() {
 			var err error
 			or.csv, err = getCSVFromDeployment(or.deployment, cl, operatorNs, logger)
 			if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it
In this case, we miss the CSV, as HCO currenlty only read it on openshift. That eventually causes nil pointer error, and the HCO pod is in crash loop.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix issue 2703 where installing HCO on kubernetes+OLM
```

this PR is not enough to  fix issue 2703. We need first to cherry pick it to the release-1.10 branch, then to release a new version.