### PR TITLE
Fix diff tool

### DIFF
--- a/hack/diff-csv.sh
+++ b/hack/diff-csv.sh
@@ -4,4 +4,4 @@
 #     git difftool -y --extcmd=hacks/diff-csv.sh
 #
 # currently used for make sanity
-diff --unified=1 --ignore-matching-lines='^\s*createdAt:' $@
+diff --unified=1 --ignore-matching-lines='^\s*createdAt:' --ignore-matching-lines='^\s*\* Copyright [0-9]\{4\} Red Hat, Inc\.' $@


### PR DESCRIPTION
## What this PR does / why we need it
PRs now fails on sanity check, when performing git diff. The auto generated files include the text "Copyright <year>". **What this PR does / why we need it**:
Moving to a new year (2024), the git diff fails on sanity.

This PR fixes the git diff so it won't fail for these lines.

### Jira Ticket
```jira-ticket
None
```

### Release note
```release-note
None
```
