### PR TITLE
[release-1.10] Improve the creation of index-image

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -19,14 +19,14 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       REGISTRY_NAMESPACE: kubevirt
-      OPM_VERSION: v1.26.2
+      OPM_VERSION: v1.35.0
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.19'
       - name: Get latest version
@@ -40,7 +40,6 @@ jobs:
         run: |
           echo "IMAGE_TAG=${CSV_VERSION}-unstable" >> $GITHUB_ENV
           echo "UNSTABLE=UNSTABLE" >> $GITHUB_ENV
-          echo "FBCUNSTABLE=FBCUNSTABLE" >> $GITHUB_ENV
 
       - name: Build Applications Images
         env:
@@ -73,5 +72,4 @@ jobs:
       - name: Build and Push the Index Image
         run: |
           export OPM=$(pwd)/linux-amd64-opm
-          ./hack/build-index-image.sh ${{ env.IMAGE_TAG }} ${{ env.UNSTABLE }}
-          ./hack/build-index-image.sh ${{ env.IMAGE_TAG }} ${{ env.FBCUNSTABLE }}
+          ./hack/build-index-image.sh latest ${{ env.UNSTABLE }}

--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -13,7 +13,7 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       REGISTRY_NAMESPACE: kubevirt
-      OPM_VERSION: v1.26.2
+      OPM_VERSION: v1.35.0
     steps:
       - name: resolve the correct branch of the tag
         run: |
@@ -114,6 +114,8 @@ jobs:
           sed -i -E "s|(ARG INITIAL_VERSION=).*|\1${CSV_VERSION}|g;s|(ARG INITIAL_VERSION_SED=).*|\1\"${VERSION_4_SED}\"|g" deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
           sed -i -E "s|(ARG VERSION=).*|\1${CSV_VERSION}|g" deploy/olm-catalog/bundle.Dockerfile
           sed -i -E "s|(ARG INITIAL_VERSION=).*|\1${CSV_VERSION}|g;s|(ARG INITIAL_VERSION_SED=).*|\1\"${VERSION_4_SED}\"|g" deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
+          sed -i -E "s|(quay.io/kubevirt/hyperconverged-cluster-bundle:).*|\1${CSV_VERSION}|g" deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-release.yaml
+          echo "    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:${CSV_VERSION}" >> deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-unstable.yaml
           git add ./deploy/
 
       - uses: peter-evans/create-pull-request@v3

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-release.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-release.yaml
@@ -1,0 +1,7 @@
+Schema: olm.semver
+GenerateMajorChannels: true
+GenerateMinorChannels: true
+DefaultChannelTypePreference: minor
+Stable:
+  Bundles:
+    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.10.2

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-unstable.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-unstable.yaml
@@ -1,0 +1,11 @@
+Schema: olm.semver
+GenerateMajorChannels: true
+GenerateMinorChannels: true
+DefaultChannelTypePreference: minor
+Candidate:
+  Bundles:
+    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.6.0
+    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.7.0
+    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.8.0
+    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.9.0
+    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.10.2


### PR DESCRIPTION
1. fix bug that when creating index image for the first time for a version, the script fails.
2. build the index image from scratch, instead of building it from an existing index image, using opm.
3. simplify the script.
4. upgrade opm to v1.35.0

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
