### PR TITLE
fix github actions

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -73,4 +73,4 @@ jobs:
       - name: Build and Push the Index Image
         run: |
           export OPM=$(pwd)/linux-amd64-opm
-          ./hack/build-index-image.sh ${{ env.IMAGE_TAG }} ${{ env.UNSTABLE }}
+          ./hack/build-index-image.sh latest ${{ env.UNSTABLE }}

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -5,11 +5,11 @@ name: Sanity Checks
 # Controls when the action will run.
 on:
   push:
-    branches: [main]
+    branches: [release-1.11]
     paths-ignore:
       - "renovate.json"
   pull_request:
-    branches: [main]
+    branches: [release-1.11]
     paths-ignore:
       - "renovate.json"
 


### PR DESCRIPTION
## What this PR does / why we need it
1. manual backport Fix the build-push-images action #2747
2. Match actions to branch release-1.11

**Jira Ticket**:
```jira-ticket
None
```

**Release note**:
```release-note
None
```
