### PR TITLE
fix the index-template file

### DIFF
--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-unstable.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-unstable.yaml
@@ -9,5 +9,6 @@ Candidate:
     - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.8.0
     - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.9.0
     - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.10.1
-    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.11.0-unstable # todo set to 1.11.0 after this released
+      # todo set to 1.11.0 after v1.11.0 released
+    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.11.0-unstable
     - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.12.0


### PR DESCRIPTION
## What this PR does / why we need it
The fix in #2752 wasn't enough. We have a todo comment in one of the image files. That causes error in digester. This fix moves the comment up to a new line. Now the build-index-image.sh script is running.


**Jira Ticket**:
```jira-ticket
None
```

**Release note**:
```release-note
None
```
