### PR TITLE
Add flag to csv-merger to pass the test images NVRs

### DIFF
--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -124,7 +124,8 @@ var (
 		"Comma separated list of CSVs that can be skipped (read replaced) by this version")
 	olmSkipRange = flag.String("olm-skip-range", "",
 		"Semver range expression for CSVs that can be skipped (read replaced) by this version")
-	mgImage = flag.String("mg-image", "quay.io/kubevirt/must-gather", "Operator suggested must-gather image")
+	mgImage        = flag.String("mg-image", "quay.io/kubevirt/must-gather", "Operator suggested must-gather image")
+	testImagesNVRs = flag.String("test-images-nvrs", "", "Test Images NVRs")
 
 	envVars EnvVarFlags
 )
@@ -332,6 +333,8 @@ func getHcoCsv() {
 	applyOverrides(csvBase)
 
 	csvBase.Spec.RelatedImages = sortRelatedImages(csvBase.Spec.RelatedImages)
+
+	csvBase.ObjectMeta.Annotations["test-images-nvrs"] = *testImagesNVRs
 
 	panicOnError(util.MarshallObject(csvBase, os.Stdout))
 }

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -327,15 +327,16 @@ func getHcoCsv() {
 	if *mgImage != "" {
 		csvBase.Annotations[mgImageAnnotation] = *mgImage
 	}
+	if *testImagesNVRs != "" {
+		csvBase.ObjectMeta.Annotations["test-images-nvrs"] = *testImagesNVRs
+	}
 
 	setSupported(csvBase)
 
 	applyOverrides(csvBase)
 
 	csvBase.Spec.RelatedImages = sortRelatedImages(csvBase.Spec.RelatedImages)
-
-	csvBase.ObjectMeta.Annotations["test-images-nvrs"] = *testImagesNVRs
-
+	
 	panicOnError(util.MarshallObject(csvBase, os.Stdout))
 }
 

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -336,7 +336,6 @@ func getHcoCsv() {
 	applyOverrides(csvBase)
 
 	csvBase.Spec.RelatedImages = sortRelatedImages(csvBase.Spec.RelatedImages)
-	
 	panicOnError(util.MarshallObject(csvBase, os.Stdout))
 }
 


### PR DESCRIPTION
We need a new flag in the csv-merger to be able to pass the test images NVRs as a parameter when creating the CSV

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We are in the process of creating test images for some kubevirt components. These images contain test code only meant to be used internally for testing purposes. Right now the pull urls of these images appears in the CSV relatedImages field, and we decided it's preferrable to only have the NVR of these images in an annotation. Therefore we want to create this new flag in the csv-merger, in order to pass the test images NVRs and create an annotation with them.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
