### PR TITLE
[release-1.11] fix the publish action

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -85,7 +85,7 @@ jobs:
         env:
           CSV_VERSION: ${{ env.CSV_VERSION }}
         run: |
-          NEW_VERSION=./hack/get-next-version.sh "${CSV_VERSION}"
+          NEW_VERSION=$(./hack/get-next-version.sh "${CSV_VERSION}")
           NEW_IMAGE_TAG="${NEW_VERSION}-unstable"
           echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
           echo "NEW_IMAGE_TAG=${NEW_IMAGE_TAG}" >> $GITHUB_ENV
@@ -113,7 +113,7 @@ jobs:
           sed -i -E "s|(ARG VERSION=).*|\1${CSV_VERSION}|g" deploy/olm-catalog/bundle.Dockerfile
           sed -i -E "s|(ARG INITIAL_VERSION=).*|\1${CSV_VERSION}|g;s|(ARG INITIAL_VERSION_SED=).*|\1\"${VERSION_4_SED}\"|g" deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
           sed -i -E "s|(quay.io/kubevirt/hyperconverged-cluster-bundle:).*|\1${CSV_VERSION}|g" deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-release.yaml
-          echo "    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:${CSV_VERSION}" >> deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-unstable.yaml
+          sed -i -E "s|(quay.io/kubevirt/hyperconverged-cluster-bundle:).*|\1${CSV_VERSION}|g" deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-unstable.yaml
           git add ./deploy/
 
       - uses: peter-evans/create-pull-request@v3

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-unstable.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-unstable.yaml
@@ -4,9 +4,4 @@ GenerateMinorChannels: true
 DefaultChannelTypePreference: minor
 Candidate:
   Bundles:
-    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.6.0
-    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.7.0
-    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.8.0
-    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.9.0
-    - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.10.1
     - Image: quay.io/kubevirt/hyperconverged-cluster-bundle:1.11.0


### PR DESCRIPTION
## What this PR does / why we need it
* Fix a bug in the publish github action.
* leave only one version in the unstable index image
* don't generate major version in the index image

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
