### PR TITLE
[release-1.11] fix the publish github action

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -68,11 +68,12 @@ jobs:
           sed -i "/^ \+replaces:/d" ${PACKAGE_DIR}/${CSV_VERSION}/manifests/kubevirt-hyperconverged-operator.v${CSV_VERSION}.clusterserviceversion.yaml
       - name: Get opm client
         run: |
-          wget https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm
-          chmod +x linux-amd64-opm
+          mkdir -p _out
+          wget "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm" -O _out/opm
+          chmod +x _out/opm
       - name: Build and Push the Index Image
         run: |
-          export OPM=$(pwd)/linux-amd64-opm
+          export OPM=$(pwd)/_out/opm
           ./hack/build-index-image.sh ${{ env.CSV_VERSION }}
       - name: Run Publisher script
         run: |
@@ -115,8 +116,9 @@ jobs:
           sed -i -E "s|(quay.io/kubevirt/hyperconverged-cluster-bundle:).*|\1${CSV_VERSION}|g" deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-release.yaml
           sed -i -E "s|(quay.io/kubevirt/hyperconverged-cluster-bundle:).*|\1${CSV_VERSION}|g" deploy/olm-catalog/community-kubevirt-hyperconverged/index-template-unstable.yaml
           git add ./deploy/
+          echo "CHANGED=true" >> $GITHUB_ENV
 
-      - uses: peter-evans/create-pull-request@v3
+      - uses: peter-evans/create-pull-request@v5
         if: ${{ env.CHANGED }}
         with:
           token: ${{ secrets.HCO_BOT_TOKEN }}
@@ -131,7 +133,6 @@ jobs:
             ```release-note
             Prepare version ${{ env.NEW_VERSION }}
             ```
-          assignees: tiraboschi,orenc1,nunnatsa
-          reviewers: tiraboschi,orenc1,nunnatsa
-          team-reviewers: owners, maintainers
+          assignees: tiraboschi,orenc1,nunnatsa,machadovilaca,dharmit
+          reviewers: tiraboschi,orenc1,nunnatsa,machadovilaca,dharmit
           branch: prepare_version_${{ env.NEW_VERSION }}

--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -90,7 +90,6 @@ jobs:
             ```release-note
             Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}
             ```
-          assignees: tiraboschi,orenc1,nunnatsa
-          reviewers: tiraboschi,orenc1,nunnatsa
-          team-reviewers: owners, maintainers
+          assignees: tiraboschi,orenc1,nunnatsa,machadovilaca,dharmit
+          reviewers: tiraboschi,orenc1,nunnatsa,machadovilaca,dharmit
           branch: bump_${{ env.UPDATED_COMPONENT }}_${{ env.UPDATED_VERSION }}_${{ matrix.branches.branch }}


### PR DESCRIPTION
## What this PR does / why we need it
* Make sure to create a new PR for the next version, if everything went well.
* Avoid error message from the peter-evans/create-pull-request action, by not using non-existing teams
* avoid pushing the opm binary to git

### Jira Ticket
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
