### PR TITLE
Start bumping golang to go1.21

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.20.10 AS builder
+FROM docker.io/golang:1.21.6 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.20.10 AS builder
+FROM docker.io/golang:1.21.6 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.functest.ci
+++ b/build/Dockerfile.functest.ci
@@ -1,5 +1,5 @@
-# registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
+# registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.20.10 AS builder
+FROM docker.io/golang:1.21.6 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .


### PR DESCRIPTION
## What this PR does / why we need it
Starting by bumping the Dockerfiles, as the openshift/release bot override any chnage we do there because of these Dockerfiles. This is why we need to perform the bump in three phases:
1. this one, to bump the base images
2. ci in openshift/release
3. all the rest (e.g. go.mod, scripts and so on)

### Reviewer Checklist
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

### Jira Ticket
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump Dockerfiles base images to go1.21
```
