### PR TITLE
Bump golangci-lint to v1.56.0

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.1
+          version: v1.56.0
           skip-pkg-cache: true
           args: --timeout=5m --out-${NO_FUTURE}format line-number
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,9 +7,10 @@ linters:
 linters-settings:
   ginkgolinter:
     forbid-focus-container: true
-issues:
-  exclude-rules:
-  - linters:
-    - revive
-    source: ". \"github.com/onsi/(ginkgo/v2|gomega)\""
-    text: "dot-imports: should not use dot imports"
+  revive:
+    rules:
+    - name: dot-imports
+      arguments:
+      - allowedPackages:
+        - github.com/onsi/ginkgo/v2
+        - github.com/onsi/gomega

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ WEBHOOK_IMAGE      ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-webhook
 FUNC_TEST_IMAGE    ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-functest
 VIRT_ARTIFACTS_SERVER ?= $(REGISTRY_NAMESPACE)/virt-artifacts-server
 LDFLAGS            ?= -w -s
-GOLANDCI_LINT_VERSION ?= v1.55.1
+GOLANDCI_LINT_VERSION ?= v1.56.0
 
 
 

--- a/tests/.golangci.yml
+++ b/tests/.golangci.yml
@@ -5,9 +5,10 @@ linters:
 linters-settings:
   ginkgolinter:
     forbid-focus-container: true
-issues:
-  exclude-rules:
-  - linters:
-    - revive
-    source: ". \"github.com/onsi/(ginkgo/v2|gomega)\""
-    text: "dot-imports: should not use dot imports"
+  revive:
+    rules:
+      - name: dot-imports
+        arguments:
+          - allowedPackages:
+              - github.com/onsi/ginkgo/v2
+              - github.com/onsi/gomega


### PR DESCRIPTION
Use the new revive linter configuration to allow dot import of ginkgo and gomega.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
