### PR TITLE
[release-1.10] add the virt-artifacts-server image to CSV

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -64,6 +64,7 @@ jobs:
         run: |
           export HCO_OPERATOR_IMAGE=$(tools/digester/digester --image="quay.io/kubevirt/hyperconverged-cluster-operator:${CSV_VERSION}")
           export HCO_WEBHOOK_IMAGE=$(tools/digester/digester --image="quay.io/kubevirt/hyperconverged-cluster-webhook:${CSV_VERSION}")
+          export HCO_DOWNLOADS_IMAGE=$(tools/digester/digester --image="quay.io/kubevirt/virt-artifacts-server:${CSV_VERSION}")
           ./hack/build-manifests.sh
           sed -i "/^ \+replaces:/d" ${PACKAGE_DIR}/${CSV_VERSION}/manifests/kubevirt-hyperconverged-operator.v${CSV_VERSION}.clusterserviceversion.yaml
       - name: Get opm client

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.10.7/manifests/kubevirt-hyperconverged-operator.v1.10.7.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.10.7/manifests/kubevirt-hyperconverged-operator.v1.10.7.clusterserviceversion.yaml
@@ -4378,6 +4378,8 @@ spec:
     name: ssp-operator
   - image: quay.io/kubevirt/virt-api@sha256:707003b221496b4432da2f507d1e36e528b45888b5d321e06d460f0678da44ae
     name: virt-api
+  - image: +ARTIFACTS_SERVER_IMAGE_TO_REPLACE+
+    name: virt-artifacts-server
   - image: quay.io/kubevirt/virt-controller@sha256:0789fafed2913b35a771e3db882748502b3250be04ece86d97f30201779b4e54
     name: virt-controller
   - image: quay.io/kubevirt/virt-exportproxy@sha256:f14444b0200a85efb4b3c176caefe70aabba7d295e33d2af14027a59ce297e24

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.7/manifests/kubevirt-hyperconverged-operator.v1.10.7.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.10.7/manifests/kubevirt-hyperconverged-operator.v1.10.7.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.10.7-unstable
-    createdAt: "2024-02-08 15:51:32"
+    createdAt: "2024-02-09 11:52:37"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -4378,6 +4378,8 @@ spec:
     name: ssp-operator
   - image: quay.io/kubevirt/virt-api@sha256:707003b221496b4432da2f507d1e36e528b45888b5d321e06d460f0678da44ae
     name: virt-api
+  - image: quay.io/kubevirt/virt-artifacts-server:1.10.7-unstable
+    name: virt-artifacts-server
   - image: quay.io/kubevirt/virt-controller@sha256:0789fafed2913b35a771e3db882748502b3250be04ece86d97f30201779b4e54
     name: virt-controller
   - image: quay.io/kubevirt/virt-exportproxy@sha256:f14444b0200a85efb4b3c176caefe70aabba7d295e33d2af14027a59ce297e24

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -41,7 +41,7 @@ source "${PROJECT_ROOT}"/deploy/images.env
 HCO_OPERATOR_IMAGE=${HCO_OPERATOR_IMAGE:-quay.io/kubevirt/hyperconverged-cluster-operator:${CSV_VERSION}-unstable}
 HCO_WEBHOOK_IMAGE=${HCO_WEBHOOK_IMAGE:-quay.io/kubevirt/hyperconverged-cluster-webhook:${CSV_VERSION}-unstable}
 HCO_DOWNLOADS_IMAGE=${HCO_DOWNLOADS_IMAGE:-quay.io/kubevirt/virt-artifacts-server:${CSV_VERSION}-unstable}
-DIGEST_LIST="${DIGEST_LIST},${HCO_OPERATOR_IMAGE}|hyperconverged-cluster-operator,${HCO_WEBHOOK_IMAGE}|hyperconverged-cluster-webhook"
+DIGEST_LIST="${DIGEST_LIST},${HCO_OPERATOR_IMAGE}|hyperconverged-cluster-operator,${HCO_WEBHOOK_IMAGE}|hyperconverged-cluster-webhook,${HCO_DOWNLOADS_IMAGE}|virt-artifacts-server"
 
 DEPLOY_DIR="${PROJECT_ROOT}/deploy"
 CRD_DIR="${DEPLOY_DIR}/crds"


### PR DESCRIPTION
## What this PR does / why we need it
the virt-artifacts-server image is missing from the CSV related images. It's also set with tag istead of digest in when releasing to the community hub.

This PR fixes these two issues

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the CSV: properly add the virt-artifacts-server image
```
