### PR TITLE
[release-1.11] Fix data import cron templates

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -3,7 +3,7 @@
       cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: centos-stream8-image-cron
     labels:
-      instancetype.kubevirt.io/default-preference: centos.8.stream
+      instancetype.kubevirt.io/default-preference: centos.stream8
       instancetype.kubevirt.io/default-instancetype: u1.medium
   spec:
     schedule: "0 */12 * * *"
@@ -23,7 +23,7 @@
       cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: centos-stream9-image-cron
     labels:
-      instancetype.kubevirt.io/default-preference: centos.9.stream
+      instancetype.kubevirt.io/default-preference: centos.stream9
       instancetype.kubevirt.io/default-instancetype: u1.medium
   spec:
     schedule: "0 */12 * * *"


### PR DESCRIPTION
Set the `instancetype.kubevirt.io/default-preference` labels in centos 8 & 9 to the right value.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix data import cron templates
```
