### PR TITLE
feat: Switch common-instancetypes deployment to virt-operator

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -214,6 +214,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"HotplugNICs",
 					"VMPersistentState",
 					"NetworkBindingPlugins",
+					"CommonInstancetypesDeploymentGate",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -111,6 +111,9 @@ const (
 
 	// Enable using a plugin to bind the pod and the VM network
 	kvHNetworkBindingPluginsGate = "NetworkBindingPlugins"
+
+	// Deploy common-instancetypes using virt-operator
+	kvDeployCommonInstancetypes = "CommonInstancetypesDeploymentGate"
 )
 
 const (
@@ -137,6 +140,7 @@ var (
 		kvHotplugNicsGate,
 		kvVMPersistentState,
 		kvHNetworkBindingPluginsGate,
+		kvDeployCommonInstancetypes,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of

--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -167,9 +167,8 @@ func NewSSP(hc *hcov1beta1.HyperConverged, opts ...string) (*sspv1beta2.SSP, []h
 		spec.FeatureGates.DeployVmConsoleProxy = *hc.Spec.FeatureGates.DeployVMConsoleProxy
 	}
 
-	// This feature gate is set to true in 4.15.
-	// TODO(4.16): Set it to false, and set a similar feature gate on kubevirt CR.
-	spec.FeatureGates.DeployCommonInstancetypes = ptr.To(true)
+	// Disable common-instancetypes deployment by SSP from 4.16, now handled by virt-operator
+	spec.FeatureGates.DeployCommonInstancetypes = ptr.To(false)
 
 	// Default value is the operator namespace
 	pipelinesNamespace := getNamespace(hc.Namespace, opts)

--- a/controllers/operands/ssp_test.go
+++ b/controllers/operands/ssp_test.go
@@ -204,13 +204,13 @@ var _ = Describe("SSP Operands", func() {
 			Expect(expectedResource.Spec.FeatureGates.DeployVmConsoleProxy).To(BeTrue())
 		})
 
-		It("should create with deployCommonInstancetypes feature gate", func() {
+		It("should create with deployCommonInstancetypes feature gate disabled", func() {
 			hco := commontestutils.NewHco()
 
 			expectedResource, _, err := NewSSP(hco)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(expectedResource.Spec.FeatureGates.DeployCommonInstancetypes).To(HaveValue(BeTrue()))
+			Expect(expectedResource.Spec.FeatureGates.DeployCommonInstancetypes).To(HaveValue(BeFalse()))
 		})
 
 		Context("Node placement", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This change disables the deployment of common-instancetypes by the ssp-operator and enables it instead through virt-operator.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-39071
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
