### PR TITLE
Preparations to ginkgolinter v0.16.0: Expect.Should => Expect.To

### DIFF
--- a/controllers/alerts/metrics_test.go
+++ b/controllers/alerts/metrics_test.go
@@ -90,22 +90,22 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 
 			pr := &monitoringv1.PrometheusRule{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).To(Succeed())
 			svc := &corev1.Service{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).To(Succeed())
 			sm := &monitoringv1.ServiceMonitor{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).To(Succeed())
 			role := &rbacv1.Role{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).To(Succeed())
 			rb := &rbacv1.RoleBinding{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).To(Succeed())
 
 			hco := commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
-			Expect(r.UpdateRelatedObjects(req)).Should(Succeed())
+			Expect(r.UpdateRelatedObjects(req)).To(Succeed())
 			Expect(req.StatusDirty).To(BeTrue())
 			Expect(hco.Status.RelatedObjects).To(HaveLen(5))
 
@@ -162,13 +162,13 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRule})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			pr := &monitoringv1.PrometheusRule{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).To(Succeed())
 
 			Expect(pr.Labels).To(gstruct.MatchKeys(gstruct.IgnoreExtras, commontestutils.KeysFromSSMap(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring))))
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should add the labels if it's missing", func() {
@@ -180,13 +180,13 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRule})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			pr := &monitoringv1.PrometheusRule{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).To(Succeed())
 
-			Expect(pr.Labels).Should(Equal(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)))
+			Expect(pr.Labels).To(Equal(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)))
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the referenceOwner if modified", func() {
@@ -203,20 +203,20 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRule})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			pr := &monitoringv1.PrometheusRule{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(pr.OwnerReferences).Should(HaveLen(1))
-			Expect(pr.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(pr.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(pr.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(pr.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(pr.OwnerReferences).To(HaveLen(1))
+			Expect(pr.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(pr.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(pr.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(pr.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the referenceOwner if modified; not HCO triggered", func() {
@@ -235,17 +235,17 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRule})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			pr := &monitoringv1.PrometheusRule{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(pr.OwnerReferences).Should(HaveLen(1))
-			Expect(pr.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(pr.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(pr.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(pr.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(pr.OwnerReferences).To(HaveLen(1))
+			Expect(pr.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(pr.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(pr.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(pr.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			overrideExpectedEvents := []commontestutils.MockEvent{
 				{
@@ -256,7 +256,7 @@ var _ = Describe("alert tests", func() {
 			}
 
 			Expect(ee.CheckEvents(overrideExpectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).Should(BeEquivalentTo(currentMetric + 1))
+			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).To(BeEquivalentTo(currentMetric + 1))
 		})
 
 		It("should update the referenceOwner if missing", func() {
@@ -267,20 +267,20 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRule})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			pr := &monitoringv1.PrometheusRule{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(pr.OwnerReferences).Should(HaveLen(1))
-			Expect(pr.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(pr.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(pr.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(pr.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(pr.OwnerReferences).To(HaveLen(1))
+			Expect(pr.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(pr.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(pr.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(pr.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the spec if modified", func() {
@@ -299,15 +299,15 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRule})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			pr := &monitoringv1.PrometheusRule{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).To(Succeed())
 			newRule, err := rules.BuildPrometheusRule(commontestutils.Namespace, owner)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pr.Spec).Should(Equal(newRule.Spec))
+			Expect(pr.Spec).To(Equal(newRule.Spec))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the spec if it's missing", func() {
@@ -320,15 +320,15 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRule})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			pr := &monitoringv1.PrometheusRule{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).To(Succeed())
 			newRule, err := rules.BuildPrometheusRule(commontestutils.Namespace, owner)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pr.Spec).Should(Equal(newRule.Spec))
+			Expect(pr.Spec).To(Equal(newRule.Spec))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should use the default runbook URL template when no ENV Variable is set", func() {
@@ -389,11 +389,11 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRule})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, firstLoop)).Should(Succeed())
+			Expect(r.Reconcile(req, firstLoop)).To(Succeed())
 			pr := &monitoringv1.PrometheusRule{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: ruleName}, pr)).To(Succeed())
 
-			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).Should(BeEquivalentTo(currentMetric + expectedCountDelta))
+			Expect(metrics.GetOverwrittenModificationsCount(monitoringv1.PrometheusRuleKind, ruleName)).To(BeEquivalentTo(currentMetric + expectedCountDelta))
 		},
 			Entry("should not increase the counter if it HCO triggered, in upgrade mode and in the first loop", true, true, true, float64(0)), // can't really happen
 			Entry("should not increase the counter if it HCO triggered, not in upgrade mode but in the first loop", true, false, true, float64(0)),
@@ -432,13 +432,13 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRole})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			role := &rbacv1.Role{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).To(Succeed())
 
 			Expect(role.Labels).To(gstruct.MatchKeys(gstruct.IgnoreExtras, commontestutils.KeysFromSSMap(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring))))
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the labels if it's missing", func() {
@@ -449,13 +449,13 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRole})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			role := &rbacv1.Role{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).To(Succeed())
 
-			Expect(role.Labels).Should(Equal(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)))
+			Expect(role.Labels).To(Equal(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)))
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the referenceOwner if modified", func() {
@@ -471,20 +471,20 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRole})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			role := &rbacv1.Role{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(role.OwnerReferences).Should(HaveLen(1))
-			Expect(role.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(role.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(role.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(role.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(role.OwnerReferences).To(HaveLen(1))
+			Expect(role.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(role.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(role.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(role.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the referenceOwner if modified; not HCO triggered", func() {
@@ -502,17 +502,17 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRole})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			role := &rbacv1.Role{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(role.OwnerReferences).Should(HaveLen(1))
-			Expect(role.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(role.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(role.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(role.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(role.OwnerReferences).To(HaveLen(1))
+			Expect(role.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(role.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(role.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(role.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			overrideExpectedEvents := []commontestutils.MockEvent{
 				{
@@ -523,7 +523,7 @@ var _ = Describe("alert tests", func() {
 			}
 
 			Expect(ee.CheckEvents(overrideExpectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).Should(BeEquivalentTo(currentMetric + 1))
+			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).To(BeEquivalentTo(currentMetric + 1))
 		})
 
 		It("should update the referenceOwner if missing", func() {
@@ -533,20 +533,20 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRole})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			role := &rbacv1.Role{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(role.OwnerReferences).Should(HaveLen(1))
-			Expect(role.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(role.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(role.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(role.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(role.OwnerReferences).To(HaveLen(1))
+			Expect(role.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(role.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(role.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(role.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the Rules if modified", func() {
@@ -568,16 +568,16 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRole})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			role := &rbacv1.Role{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).Should(Succeed())
-			Expect(role.Rules).Should(HaveLen(1))
-			Expect(role.Rules[0].APIGroups).Should(Equal([]string{""}))
-			Expect(role.Rules[0].Resources).Should(Equal([]string{"services", "endpoints", "pods"}))
-			Expect(role.Rules[0].Verbs).Should(Equal([]string{"get", "list", "watch"}))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).To(Succeed())
+			Expect(role.Rules).To(HaveLen(1))
+			Expect(role.Rules[0].APIGroups).To(Equal([]string{""}))
+			Expect(role.Rules[0].Resources).To(Equal([]string{"services", "endpoints", "pods"}))
+			Expect(role.Rules[0].Verbs).To(Equal([]string{"get", "list", "watch"}))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the Rules if it's missing", func() {
@@ -589,16 +589,16 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRole})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			role := &rbacv1.Role{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).Should(Succeed())
-			Expect(role.Rules).Should(HaveLen(1))
-			Expect(role.Rules[0].APIGroups).Should(Equal([]string{""}))
-			Expect(role.Rules[0].Resources).Should(Equal([]string{"services", "endpoints", "pods"}))
-			Expect(role.Rules[0].Verbs).Should(Equal([]string{"get", "list", "watch"}))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, role)).To(Succeed())
+			Expect(role.Rules).To(HaveLen(1))
+			Expect(role.Rules[0].APIGroups).To(Equal([]string{""}))
+			Expect(role.Rules[0].Resources).To(Equal([]string{"services", "endpoints", "pods"}))
+			Expect(role.Rules[0].Verbs).To(Equal([]string{"get", "list", "watch"}))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Role", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 	})
 
@@ -627,13 +627,13 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			rb := &rbacv1.RoleBinding{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).To(Succeed())
 
 			Expect(rb.Labels).To(gstruct.MatchKeys(gstruct.IgnoreExtras, commontestutils.KeysFromSSMap(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring))))
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the labels if it's missing", func() {
@@ -644,13 +644,13 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			rb := &rbacv1.RoleBinding{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).To(Succeed())
 
-			Expect(rb.Labels).Should(Equal(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)))
+			Expect(rb.Labels).To(Equal(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)))
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the referenceOwner if modified", func() {
@@ -666,20 +666,20 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			rb := &rbacv1.RoleBinding{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(rb.OwnerReferences).Should(HaveLen(1))
-			Expect(rb.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(rb.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(rb.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(rb.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(rb.OwnerReferences).To(HaveLen(1))
+			Expect(rb.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(rb.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(rb.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(rb.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the referenceOwner if modified; not HCO triggered", func() {
@@ -697,17 +697,17 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			rb := &rbacv1.RoleBinding{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(rb.OwnerReferences).Should(HaveLen(1))
-			Expect(rb.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(rb.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(rb.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(rb.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(rb.OwnerReferences).To(HaveLen(1))
+			Expect(rb.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(rb.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(rb.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(rb.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			overrideExpectedEvents := []commontestutils.MockEvent{
 				{
@@ -718,7 +718,7 @@ var _ = Describe("alert tests", func() {
 			}
 
 			Expect(ee.CheckEvents(overrideExpectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric + 1))
+			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).To(BeEquivalentTo(currentMetric + 1))
 		})
 
 		It("should update the referenceOwner if missing", func() {
@@ -728,20 +728,20 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			rb := &rbacv1.RoleBinding{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(rb.OwnerReferences).Should(HaveLen(1))
-			Expect(rb.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(rb.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(rb.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(rb.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(rb.OwnerReferences).To(HaveLen(1))
+			Expect(rb.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(rb.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(rb.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(rb.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the RoleRef if modified", func() {
@@ -757,15 +757,15 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			rb := &rbacv1.RoleBinding{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).Should(Succeed())
-			Expect(rb.RoleRef.APIGroup).Should(Equal(rbacv1.GroupName))
-			Expect(rb.RoleRef.Kind).Should(Equal("Role"))
-			Expect(rb.RoleRef.Name).Should(Equal(roleName))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).To(Succeed())
+			Expect(rb.RoleRef.APIGroup).To(Equal(rbacv1.GroupName))
+			Expect(rb.RoleRef.Kind).To(Equal("Role"))
+			Expect(rb.RoleRef.Name).To(Equal(roleName))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the RoleRef if it's missing", func() {
@@ -777,15 +777,15 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			rb := &rbacv1.RoleBinding{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).Should(Succeed())
-			Expect(rb.RoleRef.APIGroup).Should(Equal(rbacv1.GroupName))
-			Expect(rb.RoleRef.Kind).Should(Equal("Role"))
-			Expect(rb.RoleRef.Name).Should(Equal(roleName))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).To(Succeed())
+			Expect(rb.RoleRef.APIGroup).To(Equal(rbacv1.GroupName))
+			Expect(rb.RoleRef.Kind).To(Equal("Role"))
+			Expect(rb.RoleRef.Name).To(Equal(roleName))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the Subjects if modified", func() {
@@ -808,16 +808,16 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			rb := &rbacv1.RoleBinding{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).Should(Succeed())
-			Expect(rb.Subjects).Should(HaveLen(1))
-			Expect(rb.Subjects[0].Kind).Should(Equal(rbacv1.ServiceAccountKind))
-			Expect(rb.Subjects[0].Name).Should(Equal("prometheus-k8s"))
-			Expect(rb.Subjects[0].Namespace).Should(Equal(getMonitoringNamespace(ci)))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).To(Succeed())
+			Expect(rb.Subjects).To(HaveLen(1))
+			Expect(rb.Subjects[0].Kind).To(Equal(rbacv1.ServiceAccountKind))
+			Expect(rb.Subjects[0].Name).To(Equal("prometheus-k8s"))
+			Expect(rb.Subjects[0].Namespace).To(Equal(getMonitoringNamespace(ci)))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the Subjects if it's missing", func() {
@@ -829,17 +829,17 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existRB})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 
 			rb := &rbacv1.RoleBinding{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).Should(Succeed())
-			Expect(rb.Subjects).Should(HaveLen(1))
-			Expect(rb.Subjects[0].Kind).Should(Equal(rbacv1.ServiceAccountKind))
-			Expect(rb.Subjects[0].Name).Should(Equal("prometheus-k8s"))
-			Expect(rb.Subjects[0].Namespace).Should(Equal(getMonitoringNamespace(ci)))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: roleName}, rb)).To(Succeed())
+			Expect(rb.Subjects).To(HaveLen(1))
+			Expect(rb.Subjects[0].Kind).To(Equal(rbacv1.ServiceAccountKind))
+			Expect(rb.Subjects[0].Name).To(Equal("prometheus-k8s"))
+			Expect(rb.Subjects[0].Namespace).To(Equal(getMonitoringNamespace(ci)))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("RoleBinding", roleName)).To(BeEquivalentTo(currentMetric))
 		})
 	})
 
@@ -868,13 +868,13 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			svc := &corev1.Service{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).To(Succeed())
 
 			Expect(svc.Labels).To(gstruct.MatchKeys(gstruct.IgnoreExtras, commontestutils.KeysFromSSMap(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring))))
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the labels if it's missing", func() {
@@ -885,13 +885,13 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			svc := &corev1.Service{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).To(Succeed())
 
-			Expect(svc.Labels).Should(Equal(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)))
+			Expect(svc.Labels).To(Equal(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)))
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the referenceOwner if modified", func() {
@@ -907,20 +907,20 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			svc := &corev1.Service{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(svc.OwnerReferences).Should(HaveLen(1))
-			Expect(svc.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(svc.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(svc.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(svc.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(svc.OwnerReferences).To(HaveLen(1))
+			Expect(svc.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(svc.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(svc.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(svc.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the referenceOwner if modified; No HCO triggered", func() {
@@ -938,17 +938,17 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			svc := &corev1.Service{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(svc.OwnerReferences).Should(HaveLen(1))
-			Expect(svc.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(svc.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(svc.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(svc.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(svc.OwnerReferences).To(HaveLen(1))
+			Expect(svc.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(svc.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(svc.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(svc.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			overrideExpectedEvents := []commontestutils.MockEvent{
 				{
@@ -959,7 +959,7 @@ var _ = Describe("alert tests", func() {
 			}
 
 			Expect(ee.CheckEvents(overrideExpectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).Should(BeEquivalentTo(currentMetric + 1))
+			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).To(BeEquivalentTo(currentMetric + 1))
 		})
 
 		It("should update the referenceOwner if missing", func() {
@@ -969,20 +969,20 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			svc := &corev1.Service{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(svc.OwnerReferences).Should(HaveLen(1))
-			Expect(svc.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(svc.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(svc.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(svc.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(svc.OwnerReferences).To(HaveLen(1))
+			Expect(svc.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(svc.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(svc.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(svc.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the Spec if modified", func() {
@@ -1010,17 +1010,17 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			svc := &corev1.Service{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).Should(Succeed())
-			Expect(svc.Spec.Ports).Should(HaveLen(1))
-			Expect(svc.Spec.Ports[0].Port).Should(Equal(hcoutil.MetricsPort))
-			Expect(svc.Spec.Ports[0].Name).Should(Equal(operatorPortName))
-			Expect(svc.Spec.Ports[0].Protocol).Should(Equal(corev1.ProtocolTCP))
-			Expect(svc.Spec.Ports[0].TargetPort).Should(Equal(intstr.IntOrString{Type: intstr.Int, IntVal: hcoutil.MetricsPort}))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).To(Succeed())
+			Expect(svc.Spec.Ports).To(HaveLen(1))
+			Expect(svc.Spec.Ports[0].Port).To(Equal(hcoutil.MetricsPort))
+			Expect(svc.Spec.Ports[0].Name).To(Equal(operatorPortName))
+			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+			Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.IntOrString{Type: intstr.Int, IntVal: hcoutil.MetricsPort}))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the Spec if it's missing", func() {
@@ -1032,17 +1032,17 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			svc := &corev1.Service{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).Should(Succeed())
-			Expect(svc.Spec.Ports).Should(HaveLen(1))
-			Expect(svc.Spec.Ports[0].Port).Should(Equal(hcoutil.MetricsPort))
-			Expect(svc.Spec.Ports[0].Name).Should(Equal(operatorPortName))
-			Expect(svc.Spec.Ports[0].Protocol).Should(Equal(corev1.ProtocolTCP))
-			Expect(svc.Spec.Ports[0].TargetPort).Should(Equal(intstr.IntOrString{Type: intstr.Int, IntVal: hcoutil.MetricsPort}))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).To(Succeed())
+			Expect(svc.Spec.Ports).To(HaveLen(1))
+			Expect(svc.Spec.Ports[0].Port).To(Equal(hcoutil.MetricsPort))
+			Expect(svc.Spec.Ports[0].Name).To(Equal(operatorPortName))
+			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+			Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.IntOrString{Type: intstr.Int, IntVal: hcoutil.MetricsPort}))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("Service", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 	})
 
@@ -1071,13 +1071,13 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			sm := &monitoringv1.ServiceMonitor{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).To(Succeed())
 
 			Expect(sm.Labels).To(gstruct.MatchKeys(gstruct.IgnoreExtras, commontestutils.KeysFromSSMap(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring))))
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the labels if it's missing", func() {
@@ -1088,13 +1088,13 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			sm := &monitoringv1.ServiceMonitor{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).To(Succeed())
 
-			Expect(sm.Labels).Should(Equal(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)))
+			Expect(sm.Labels).To(Equal(hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)))
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the referenceOwner if modified", func() {
@@ -1110,20 +1110,20 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			sm := &monitoringv1.ServiceMonitor{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(sm.OwnerReferences).Should(HaveLen(1))
-			Expect(sm.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(sm.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(sm.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(sm.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(sm.OwnerReferences).To(HaveLen(1))
+			Expect(sm.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(sm.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(sm.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(sm.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the referenceOwner if modified; no HCO triggered", func() {
@@ -1141,17 +1141,17 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			sm := &monitoringv1.ServiceMonitor{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(sm.OwnerReferences).Should(HaveLen(1))
-			Expect(sm.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(sm.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(sm.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(sm.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(sm.OwnerReferences).To(HaveLen(1))
+			Expect(sm.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(sm.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(sm.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(sm.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			overrideExpectedEvents := []commontestutils.MockEvent{
 				{
@@ -1162,7 +1162,7 @@ var _ = Describe("alert tests", func() {
 			}
 
 			Expect(ee.CheckEvents(overrideExpectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).Should(BeEquivalentTo(currentMetric + 1))
+			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).To(BeEquivalentTo(currentMetric + 1))
 		})
 
 		It("should update the referenceOwner if missing", func() {
@@ -1172,20 +1172,20 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			sm := &monitoringv1.ServiceMonitor{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).To(Succeed())
 
 			deployment := ci.GetDeployment()
 
-			Expect(sm.OwnerReferences).Should(HaveLen(1))
-			Expect(sm.OwnerReferences[0].Name).Should(Equal(deployment.Name))
-			Expect(sm.OwnerReferences[0].Kind).Should(Equal("Deployment"))
-			Expect(sm.OwnerReferences[0].APIVersion).Should(Equal(appsv1.GroupName + "/v1"))
-			Expect(sm.OwnerReferences[0].UID).Should(Equal(deployment.UID))
+			Expect(sm.OwnerReferences).To(HaveLen(1))
+			Expect(sm.OwnerReferences[0].Name).To(Equal(deployment.Name))
+			Expect(sm.OwnerReferences[0].Kind).To(Equal("Deployment"))
+			Expect(sm.OwnerReferences[0].APIVersion).To(Equal(appsv1.GroupName + "/v1"))
+			Expect(sm.OwnerReferences[0].UID).To(Equal(deployment.UID))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the Spec if modified", func() {
@@ -1205,14 +1205,14 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			sm := &monitoringv1.ServiceMonitor{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).Should(Succeed())
-			Expect(sm.Spec.Selector).Should(Equal(metav1.LabelSelector{MatchLabels: hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)}))
-			Expect(sm.Spec.Endpoints[0].Port).Should(Equal(operatorPortName))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).To(Succeed())
+			Expect(sm.Spec.Selector).To(Equal(metav1.LabelSelector{MatchLabels: hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)}))
+			Expect(sm.Spec.Endpoints[0].Port).To(Equal(operatorPortName))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 
 		It("should update the Spec if it's missing", func() {
@@ -1224,14 +1224,14 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns, existSM})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 			sm := &monitoringv1.ServiceMonitor{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).Should(Succeed())
-			Expect(sm.Spec.Selector).Should(Equal(metav1.LabelSelector{MatchLabels: hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)}))
-			Expect(sm.Spec.Endpoints[0].Port).Should(Equal(operatorPortName))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).To(Succeed())
+			Expect(sm.Spec.Selector).To(Equal(metav1.LabelSelector{MatchLabels: hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)}))
+			Expect(sm.Spec.Endpoints[0].Port).To(Equal(operatorPortName))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
-			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).Should(BeEquivalentTo(currentMetric))
+			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).To(BeEquivalentTo(currentMetric))
 		})
 	})
 
@@ -1241,11 +1241,11 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{nsGenerator()})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 
 			foundNS := &corev1.Namespace{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Name: r.namespace}, foundNS)).Should(Succeed())
-			Expect(foundNS.Annotations).ShouldNot(BeEmpty())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: r.namespace}, foundNS)).To(Succeed())
+			Expect(foundNS.Annotations).ToNot(BeEmpty())
 			annotation, ok := foundNS.Annotations[hcoutil.OpenshiftNodeSelectorAnn]
 			Expect(ok).To(BeTrue())
 			Expect(annotation).To(BeEmpty())
@@ -1283,15 +1283,15 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 
 			foundNS := &corev1.Namespace{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Name: r.namespace}, foundNS)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: r.namespace}, foundNS)).To(Succeed())
 
-			Expect(foundNS.Labels).Should(HaveLen(3))
-			Expect(foundNS.Labels).Should(HaveKeyWithValue("aaa", "AAA"))
-			Expect(foundNS.Labels).Should(HaveKeyWithValue("bbb", "BBB"))
-			Expect(foundNS.Labels).Should(HaveKeyWithValue(hcoutil.PrometheusNSLabel, "true"))
+			Expect(foundNS.Labels).To(HaveLen(3))
+			Expect(foundNS.Labels).To(HaveKeyWithValue("aaa", "AAA"))
+			Expect(foundNS.Labels).To(HaveKeyWithValue("bbb", "BBB"))
+			Expect(foundNS.Labels).To(HaveKeyWithValue(hcoutil.PrometheusNSLabel, "true"))
 		})
 
 		It("should not modify other annotations", func() {
@@ -1299,22 +1299,22 @@ var _ = Describe("alert tests", func() {
 			cl := commontestutils.InitClient([]client.Object{ns})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(Succeed())
+			Expect(r.Reconcile(req, false)).To(Succeed())
 
 			foundNS := &corev1.Namespace{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Name: r.namespace}, foundNS)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: r.namespace}, foundNS)).To(Succeed())
 
-			Expect(foundNS.Annotations).Should(HaveLen(3))
-			Expect(foundNS.Annotations).Should(HaveKeyWithValue("aaa", "AAA"))
-			Expect(foundNS.Annotations).Should(HaveKeyWithValue("bbb", "BBB"))
-			Expect(foundNS.Annotations).Should(HaveKeyWithValue(hcoutil.OpenshiftNodeSelectorAnn, ""))
+			Expect(foundNS.Annotations).To(HaveLen(3))
+			Expect(foundNS.Annotations).To(HaveKeyWithValue("aaa", "AAA"))
+			Expect(foundNS.Annotations).To(HaveKeyWithValue("bbb", "BBB"))
+			Expect(foundNS.Annotations).To(HaveKeyWithValue(hcoutil.OpenshiftNodeSelectorAnn, ""))
 		})
 
 		It("should return error if can't read the namespace", func() {
 			cl := commontestutils.InitClient([]client.Object{})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(HaveOccurred())
+			Expect(r.Reconcile(req, false)).To(HaveOccurred())
 		})
 
 		It("should return error if failed to read the namespace", func() {
@@ -1325,7 +1325,7 @@ var _ = Describe("alert tests", func() {
 			})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(MatchError(err))
+			Expect(r.Reconcile(req, false)).To(MatchError(err))
 		})
 
 		It("should return error if can't update the namespace", func() {
@@ -1336,7 +1336,7 @@ var _ = Describe("alert tests", func() {
 			})
 			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
 
-			Expect(r.Reconcile(req, false)).Should(MatchError(err))
+			Expect(r.Reconcile(req, false)).To(MatchError(err))
 		})
 	})
 })

--- a/controllers/common/hcoConditions_test.go
+++ b/controllers/common/hcoConditions_test.go
@@ -25,10 +25,10 @@ var _ = Describe("HCO Conditions Tests", func() {
 			Expect(conds).To(HaveLen(1))
 
 			Expect(conds[hcov1beta1.ConditionReconcileComplete]).ToNot(BeNil())
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Type).Should(Equal(hcov1beta1.ConditionReconcileComplete))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Status).Should(Equal(metav1.ConditionFalse))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Reason).Should(Equal("reason"))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Message).Should(Equal("a message"))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Type).To(Equal(hcov1beta1.ConditionReconcileComplete))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Status).To(Equal(metav1.ConditionFalse))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Reason).To(Equal("reason"))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Message).To(Equal("a message"))
 		})
 
 		It("Should update a condition if already exists", func() {
@@ -43,10 +43,10 @@ var _ = Describe("HCO Conditions Tests", func() {
 			Expect(conds).To(HaveLen(1))
 
 			Expect(conds[hcov1beta1.ConditionReconcileComplete]).ToNot(BeNil())
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Type).Should(Equal(hcov1beta1.ConditionReconcileComplete))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Status).Should(Equal(metav1.ConditionTrue))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Reason).Should(Equal("reason2"))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Message).Should(Equal("another message"))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Type).To(Equal(hcov1beta1.ConditionReconcileComplete))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Status).To(Equal(metav1.ConditionTrue))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Reason).To(Equal("reason2"))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Message).To(Equal("another message"))
 		})
 	})
 
@@ -67,10 +67,10 @@ var _ = Describe("HCO Conditions Tests", func() {
 			Expect(conds).To(HaveLen(1))
 
 			Expect(conds[hcov1beta1.ConditionReconcileComplete]).ToNot(BeNil())
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Type).Should(Equal(hcov1beta1.ConditionReconcileComplete))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Status).Should(Equal(metav1.ConditionFalse))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Reason).Should(Equal("reason"))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Message).Should(Equal("a message"))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Type).To(Equal(hcov1beta1.ConditionReconcileComplete))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Status).To(Equal(metav1.ConditionFalse))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Reason).To(Equal("reason"))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Message).To(Equal("a message"))
 
 			By("The condition should not be changed by this call")
 			conds.SetStatusConditionIfUnset(metav1.Condition{
@@ -85,10 +85,10 @@ var _ = Describe("HCO Conditions Tests", func() {
 
 			By("Make sure the values are the same as before and were not changed")
 			Expect(conds[hcov1beta1.ConditionReconcileComplete]).ToNot(BeNil())
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Type).Should(Equal(hcov1beta1.ConditionReconcileComplete))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Status).Should(Equal(metav1.ConditionFalse))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Reason).Should(Equal("reason"))
-			Expect(conds[hcov1beta1.ConditionReconcileComplete].Message).Should(Equal("a message"))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Type).To(Equal(hcov1beta1.ConditionReconcileComplete))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Status).To(Equal(metav1.ConditionFalse))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Reason).To(Equal("reason"))
+			Expect(conds[hcov1beta1.ConditionReconcileComplete].Message).To(Equal("a message"))
 		})
 	})
 

--- a/controllers/common/hcoRequest_test.go
+++ b/controllers/common/hcoRequest_test.go
@@ -26,9 +26,9 @@ var _ = Describe("Test HcoRequest", func() {
 			true,
 		)
 
-		Expect(req.Name).Should(Equal("name"))
-		Expect(req.Namespace).Should(Equal("namespace"))
-		Expect(req.Ctx).Should(Equal(ctx))
+		Expect(req.Name).To(Equal("name"))
+		Expect(req.Namespace).To(Equal("namespace"))
+		Expect(req.Ctx).To(Equal(ctx))
 		Expect(req.Conditions).ToNot(BeNil())
 		Expect(req.Conditions).To(BeEmpty())
 		Expect(req.UpgradeMode).To(BeFalse())

--- a/controllers/hyperconverged/dataimportschedule_test.go
+++ b/controllers/hyperconverged/dataimportschedule_test.go
@@ -23,7 +23,7 @@ var _ = Describe("test data import schedule", func() {
 
 			applyDataImportSchedule(req)
 
-			Expect(dataImportSchedule).Should(MatchRegexp(regex))
+			Expect(dataImportSchedule).To(MatchRegexp(regex))
 
 			rx := regexp.MustCompile(regex)
 			groups := rx.FindStringSubmatch(dataImportSchedule)
@@ -31,16 +31,16 @@ var _ = Describe("test data import schedule", func() {
 			minute, err := strconv.Atoi(groups[1])
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(minute).Should(BeNumerically(">=", 0), "minute should be grater than or equal to 0; cron expression is: %s", dataImportSchedule)
-			Expect(minute).Should(BeNumerically("<", 60), "minute should br less than 60; cron expression is: %s", dataImportSchedule)
+			Expect(minute).To(BeNumerically(">=", 0), "minute should be grater than or equal to 0; cron expression is: %s", dataImportSchedule)
+			Expect(minute).To(BeNumerically("<", 60), "minute should br less than 60; cron expression is: %s", dataImportSchedule)
 
 			hour, err := strconv.Atoi(groups[2])
 			Expect(err).ToNot(HaveOccurred())
-			Expect(hour).Should(BeNumerically(">=", 0), "hour should be grater than or equal to 0; cron expression is: %s", dataImportSchedule)
-			Expect(hour).Should(BeNumerically("<", 12), "hour should br less than 12; cron expression is: %s", dataImportSchedule)
+			Expect(hour).To(BeNumerically(">=", 0), "hour should be grater than or equal to 0; cron expression is: %s", dataImportSchedule)
+			Expect(hour).To(BeNumerically("<", 12), "hour should br less than 12; cron expression is: %s", dataImportSchedule)
 
-			Expect(hco.Status.DataImportSchedule).Should(Equal(dataImportSchedule))
-			Expect(req.StatusDirty).Should(BeTrue())
+			Expect(hco.Status.DataImportSchedule).To(Equal(dataImportSchedule))
+			Expect(req.StatusDirty).To(BeTrue())
 		}
 	})
 
@@ -52,9 +52,9 @@ var _ = Describe("test data import schedule", func() {
 
 		applyDataImportSchedule(req)
 
-		Expect(dataImportSchedule).Should(Equal(schedule))
-		Expect(hco.Status.DataImportSchedule).Should(Equal(schedule))
-		Expect(req.StatusDirty).Should(BeTrue())
+		Expect(dataImportSchedule).To(Equal(schedule))
+		Expect(hco.Status.DataImportSchedule).To(Equal(schedule))
+		Expect(req.StatusDirty).To(BeTrue())
 	})
 
 	It("should update the variable if it empty and the status is set", func() {
@@ -66,9 +66,9 @@ var _ = Describe("test data import schedule", func() {
 
 		applyDataImportSchedule(req)
 
-		Expect(dataImportSchedule).Should(Equal(schedule))
-		Expect(hco.Status.DataImportSchedule).Should(Equal(schedule))
-		Expect(req.StatusDirty).Should(BeFalse())
+		Expect(dataImportSchedule).To(Equal(schedule))
+		Expect(hco.Status.DataImportSchedule).To(Equal(schedule))
+		Expect(req.StatusDirty).To(BeFalse())
 	})
 
 	It("should update the variable if it different than the status", func() {
@@ -80,8 +80,8 @@ var _ = Describe("test data import schedule", func() {
 
 		applyDataImportSchedule(req)
 
-		Expect(dataImportSchedule).Should(Equal(schedule))
-		Expect(hco.Status.DataImportSchedule).Should(Equal(schedule))
-		Expect(req.StatusDirty).Should(BeFalse())
+		Expect(dataImportSchedule).To(Equal(schedule))
+		Expect(hco.Status.DataImportSchedule).To(Equal(schedule))
+		Expect(req.StatusDirty).To(BeFalse())
 	})
 })

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -89,7 +89,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 				verifyHyperConvergedCRExistsMetricFalse()
 			})
@@ -112,7 +112,7 @@ var _ = Describe("HyperconvergedController", func() {
 				}
 				res, err := r.Reconcile(context.TODO(), invalidRequest)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the HCO
 				foundResource := &hcov1beta1.HyperConverged{}
@@ -148,7 +148,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Do the reconcile
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+				Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 				verifyHyperConvergedCRExistsMetricTrue()
 
@@ -218,7 +218,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}
 				Expect(cl.List(context.TODO(), kvList)).To(Succeed())
-				Expect(kvList.Items).Should(HaveLen(1))
+				Expect(kvList.Items).To(HaveLen(1))
 				kv := kvList.Items[0]
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(expectedFeatureGates)))
@@ -233,7 +233,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{Requeue: false}))
+				Expect(res).To(Equal(reconcile.Result{Requeue: false}))
 				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 				verifyHyperConvergedCRExistsMetricTrue()
 
@@ -276,7 +276,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Do the reconcile
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+				Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 
 				// Get the HCO
@@ -322,7 +322,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{Requeue: false}))
+				Expect(res).To(Equal(reconcile.Result{Requeue: false}))
 				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 
 				// Get the HCO
@@ -386,7 +386,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Do the reconcile
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				verifyHyperConvergedCRExistsMetricTrue()
 
@@ -428,7 +428,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Do the reconcile
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the HCO
 				foundResource := &hcov1beta1.HyperConverged{}
@@ -450,11 +450,11 @@ var _ = Describe("HyperconvergedController", func() {
 					).ToNot(HaveOccurred())
 
 					foundLabels := foundRelatedObj.GetLabels()
-					Expect(foundLabels[hcoutil.AppLabel]).Should(Equal(expected.hco.Name))
-					Expect(foundLabels[hcoutil.AppLabelPartOf]).Should(Equal(hcoutil.HyperConvergedCluster))
-					Expect(foundLabels[hcoutil.AppLabelManagedBy]).Should(Equal(hcoutil.OperatorName))
-					Expect(foundLabels[hcoutil.AppLabelVersion]).Should(Equal(version.Version))
-					Expect(foundLabels[hcoutil.AppLabelComponent]).ShouldNot(BeNil())
+					Expect(foundLabels[hcoutil.AppLabel]).To(Equal(expected.hco.Name))
+					Expect(foundLabels[hcoutil.AppLabelPartOf]).To(Equal(hcoutil.HyperConvergedCluster))
+					Expect(foundLabels[hcoutil.AppLabelManagedBy]).To(Equal(hcoutil.OperatorName))
+					Expect(foundLabels[hcoutil.AppLabelVersion]).To(Equal(version.Version))
+					Expect(foundLabels[hcoutil.AppLabelComponent]).ToNot(BeNil())
 				}
 			})
 
@@ -468,7 +468,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Reconcile to get all related objects under HCO's status
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Update Kubevirt (an example of secondary CR)
 				foundKubevirt := &kubevirtcorev1.KubeVirt{}
@@ -489,7 +489,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Reconcile again to update HCO's status
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the latest objects
 				latestHCO := &hcov1beta1.HyperConverged{}
@@ -521,7 +521,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Reconcile to get all related objects under HCO's status
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the latest objects
 				HCO := &hcov1beta1.HyperConverged{}
@@ -576,7 +576,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Reconcile again to update HCO's status
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the latest objects
 				Expect(
@@ -600,7 +600,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Reconcile to get all related objects under HCO's status
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Update Kubevirt's resource version (an example of secondary CR)
 				foundKubevirt := &kubevirtcorev1.KubeVirt{}
@@ -621,7 +621,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Reconcile again to update HCO's status
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the latest objects
 				latestHCO := &hcov1beta1.HyperConverged{}
@@ -654,7 +654,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Do the reconcile
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				foundResource := &sspv1beta2.SSP{}
 				Expect(
@@ -675,7 +675,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Do the reconcile
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the HCO
 				foundResource := &hcov1beta1.HyperConverged{}
@@ -753,7 +753,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Do the reconcile
 				res, err := r.Reconcile(context.TODO(), rq)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+				Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 
 				foundResource := &kubevirtcorev1.KubeVirt{}
 				Expect(
@@ -764,13 +764,13 @@ var _ = Describe("HyperconvergedController", func() {
 
 				Expect(existingResource.Spec.Infra.NodePlacement.Tolerations).To(HaveLen(3))
 				Expect(existingResource.Spec.Workloads.NodePlacement.Tolerations).To(HaveLen(3))
-				Expect(existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("BADvalue1"))
-				Expect(existingResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("BADvalue2"))
+				Expect(existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).To(Equal("BADvalue1"))
+				Expect(existingResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).To(Equal("BADvalue2"))
 
 				Expect(foundResource.Spec.Infra.NodePlacement.Tolerations).To(HaveLen(2))
 				Expect(foundResource.Spec.Workloads.NodePlacement.Tolerations).To(HaveLen(2))
-				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("value1"))
-				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("value2"))
+				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).To(Equal("value1"))
+				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).To(Equal("value2"))
 
 				counterValueAfter, err := metrics.GetOverwrittenModificationsCount(foundResource.Kind, foundResource.Name)
 				Expect(err).ToNot(HaveOccurred())
@@ -806,7 +806,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Do the reconcile triggered by HCO
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+				Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 
 				foundResource := &kubevirtcorev1.KubeVirt{}
 				Expect(
@@ -817,13 +817,13 @@ var _ = Describe("HyperconvergedController", func() {
 
 				Expect(existingResource.Spec.Infra.NodePlacement.Tolerations).To(HaveLen(3))
 				Expect(existingResource.Spec.Workloads.NodePlacement.Tolerations).To(HaveLen(3))
-				Expect(existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("BADvalue1"))
-				Expect(existingResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("BADvalue2"))
+				Expect(existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).To(Equal("BADvalue1"))
+				Expect(existingResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).To(Equal("BADvalue2"))
 
 				Expect(foundResource.Spec.Infra.NodePlacement.Tolerations).To(HaveLen(2))
 				Expect(foundResource.Spec.Workloads.NodePlacement.Tolerations).To(HaveLen(2))
-				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("value1"))
-				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("value2"))
+				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).To(Equal("value1"))
+				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).To(Equal("value2"))
 
 				counterValueAfter, err := metrics.GetOverwrittenModificationsCount(foundResource.Kind, foundResource.Name)
 				Expect(err).ToNot(HaveOccurred())
@@ -908,7 +908,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				foundResource := &hcov1beta1.HyperConverged{}
 				Expect(
@@ -918,8 +918,8 @@ var _ = Describe("HyperconvergedController", func() {
 				).To(Succeed())
 
 				Expect(foundResource.Status.RelatedObjects).ToNot(BeNil())
-				Expect(foundResource.Status.RelatedObjects).Should(HaveLen(21))
-				Expect(foundResource.ObjectMeta.Finalizers).Should(Equal([]string{FinalizerName}))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(21))
+				Expect(foundResource.ObjectMeta.Finalizers).To(Equal([]string{FinalizerName}))
 
 				// Now, delete HCO
 				delTime := time.Now().UTC().Add(-1 * time.Minute)
@@ -930,11 +930,11 @@ var _ = Describe("HyperconvergedController", func() {
 				r = initReconciler(cl, nil)
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+				Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{Requeue: false}))
+				Expect(res).To(Equal(reconcile.Result{Requeue: false}))
 
 				foundResource = &hcov1beta1.HyperConverged{}
 				err = cl.Get(context.TODO(),
@@ -951,7 +951,7 @@ var _ = Describe("HyperconvergedController", func() {
 				r := initReconciler(cl, nil)
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				foundResource := &hcov1beta1.HyperConverged{}
 				Expect(
@@ -961,7 +961,7 @@ var _ = Describe("HyperconvergedController", func() {
 				).To(Succeed())
 
 				Expect(foundResource.Status.RelatedObjects).ToNot(BeNil())
-				Expect(foundResource.ObjectMeta.Finalizers).Should(Equal([]string{FinalizerName}))
+				Expect(foundResource.ObjectMeta.Finalizers).To(Equal([]string{FinalizerName}))
 			})
 
 			It("Should not be ready if one of the operands is returns error, on create", func() {
@@ -978,7 +978,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Do the reconcile
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+				Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 
 				// Get the HCO
 				foundResource := &hcov1beta1.HyperConverged{}
@@ -993,8 +993,8 @@ var _ = Describe("HyperconvergedController", func() {
 				for _, cond := range foundResource.Status.Conditions {
 					if cond.Type == hcov1beta1.ConditionReconcileComplete {
 						foundCond = true
-						Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
-						Expect(cond.Message).Should(ContainSubstring("fake create error"))
+						Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+						Expect(cond.Message).To(ContainSubstring("fake create error"))
 						break
 					}
 				}
@@ -1020,7 +1020,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Do the reconcile
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(res).Should(Equal(reconcile.Result{Requeue: false}))
+				Expect(res).To(Equal(reconcile.Result{Requeue: false}))
 
 				// Get the HCO
 				foundHyperConverged := &hcov1beta1.HyperConverged{}
@@ -1035,8 +1035,8 @@ var _ = Describe("HyperconvergedController", func() {
 				for _, cond := range foundHyperConverged.Status.Conditions {
 					if cond.Type == hcov1beta1.ConditionReconcileComplete {
 						foundCond = true
-						Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
-						Expect(cond.Message).Should(ContainSubstring("fake update error"))
+						Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+						Expect(cond.Message).To(ContainSubstring("fake update error"))
 						break
 					}
 				}
@@ -1049,7 +1049,7 @@ var _ = Describe("HyperconvergedController", func() {
 				cl := expected.initClient()
 				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
 
-				Expect(foundResource.Status.ObservedGeneration).Should(BeEquivalentTo(10))
+				Expect(foundResource.Status.ObservedGeneration).To(BeEquivalentTo(10))
 			})
 
 		})
@@ -1158,7 +1158,7 @@ var _ = Describe("HyperconvergedController", func() {
 				res, err := r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res.Requeue).To(BeFalse())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				foundResource := &hcov1beta1.HyperConverged{}
 				Expect(
@@ -1234,7 +1234,7 @@ var _ = Describe("HyperconvergedController", func() {
 				res, err = r.Reconcile(context.TODO(), rq)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res.Requeue).To(BeFalse())
-				Expect(res).Should(Equal(reconcile.Result{}))
+				Expect(res).To(Equal(reconcile.Result{}))
 
 				Expect(
 					cl.Get(context.TODO(),
@@ -1317,7 +1317,7 @@ var _ = Describe("HyperconvergedController", func() {
 				foundResource, _, requeue := doReconcile(cl, expected.hco, nil)
 				Expect(requeue).To(BeTrue())
 
-				Expect(foundResource.ObjectMeta.Labels[hcoutil.AppLabel]).Should(Equal(hcoutil.HyperConvergedName))
+				Expect(foundResource.ObjectMeta.Labels[hcoutil.AppLabel]).To(Equal(hcoutil.HyperConvergedName))
 			})
 
 			It("Should set required fields when missing", func() {
@@ -1327,7 +1327,7 @@ var _ = Describe("HyperconvergedController", func() {
 				foundResource, _, requeue := doReconcile(cl, expected.hco, nil)
 				Expect(requeue).To(BeFalse())
 
-				Expect(foundResource.ObjectMeta.Labels[hcoutil.AppLabel]).Should(Equal(hcoutil.HyperConvergedName))
+				Expect(foundResource.ObjectMeta.Labels[hcoutil.AppLabel]).To(Equal(hcoutil.HyperConvergedName))
 			})
 		})
 
@@ -1408,13 +1408,13 @@ var _ = Describe("HyperconvergedController", func() {
 
 				for _, cond := range foundResource.Status.Conditions {
 					if cond.Type == hcov1beta1.ConditionAvailable {
-						Expect(cond.Reason).Should(Equal("Init"))
+						Expect(cond.Reason).To(Equal("Init"))
 						break
 					}
 				}
 				ver, ok := GetVersion(&foundResource.Status, hcoVersionName)
 				Expect(ok).To(BeTrue())
-				Expect(ver).Should(Equal(newVersion))
+				Expect(ver).To(Equal(newVersion))
 
 				expected.hco.Status.Conditions = okConds
 			})
@@ -1433,7 +1433,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// check that the HCO version is not set, because upgrade is not completed
 				ver, ok := GetVersion(&foundResource.Status, hcoVersionName)
 				Expect(ok).To(BeTrue())
-				Expect(ver).Should(Equal(oldVersion))
+				Expect(ver).To(Equal(oldVersion))
 
 				// ensure we are not hot-looping setting the version
 				_, reconciler, requeue = doReconcile(cl, expected.hco, reconciler)
@@ -1450,9 +1450,9 @@ var _ = Describe("HyperconvergedController", func() {
 
 				ver, ok = GetVersion(&foundResource.Status, hcoVersionName)
 				Expect(ok).To(BeTrue())
-				Expect(ver).Should(Equal(oldVersion))
+				Expect(ver).To(Equal(oldVersion))
 				cond := apimetav1.FindStatusCondition(foundResource.Status.Conditions, hcov1beta1.ConditionProgressing)
-				Expect(cond.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 
 				// Call again, to start complete the upgrade
 				// check that the image Id is set, now, when upgrade is completed
@@ -1462,9 +1462,9 @@ var _ = Describe("HyperconvergedController", func() {
 
 				ver, ok = GetVersion(&foundResource.Status, hcoVersionName)
 				Expect(ok).To(BeTrue())
-				Expect(ver).Should(Equal(newVersion))
+				Expect(ver).To(Equal(newVersion))
 				cond = apimetav1.FindStatusCondition(foundResource.Status.Conditions, hcov1beta1.ConditionProgressing)
-				Expect(cond.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionFalse))
 				validateOperatorCondition(reconciler, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
 
 				// Call again, to start complete the upgrade
@@ -1508,7 +1508,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// check that the HCO version is not set, because upgrade is not completed
 				ver, ok := GetVersion(&foundHC.Status, hcoVersionName)
 				Expect(ok).To(BeTrue())
-				Expect(ver).Should(Equal(oldVersion))
+				Expect(ver).To(Equal(oldVersion))
 
 				counterValueAfter, err := metrics.GetOverwrittenModificationsCount(expected.cdi.Kind, expected.cdi.Name)
 				Expect(err).ToNot(HaveOccurred())
@@ -1539,7 +1539,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(res.Requeue).To(BeTrue())
 						Expect(ok).To(BeTrue())
-						Expect(ver).Should(Equal(testHcoVersion))
+						Expect(ver).To(Equal(testHcoVersion))
 						// reconcile again to complete the upgrade
 						res, err = r.Reconcile(context.TODO(), request)
 						Expect(err).ToNot(HaveOccurred())
@@ -1551,17 +1551,17 @@ var _ = Describe("HyperconvergedController", func() {
 						).To(Succeed())
 						ver, ok = GetVersion(&foundResource.Status, hcoVersionName)
 						Expect(ok).To(BeTrue())
-						Expect(ver).Should(Equal(newVersion))
+						Expect(ver).To(Equal(newVersion))
 					} else {
 						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).Should(ContainSubstring(errorMessage))
+						Expect(err.Error()).To(ContainSubstring(errorMessage))
 						Expect(res.Requeue).To(BeTrue())
 						Expect(ok).To(BeTrue())
-						Expect(ver).Should(Equal(testHcoVersion))
+						Expect(ver).To(Equal(testHcoVersion))
 						// try a second time
 						res, err = r.Reconcile(context.TODO(), request)
 						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).Should(ContainSubstring(errorMessage))
+						Expect(err.Error()).To(ContainSubstring(errorMessage))
 						Expect(res.Requeue).To(BeTrue())
 						Expect(
 							cl.Get(context.TODO(),
@@ -1570,10 +1570,10 @@ var _ = Describe("HyperconvergedController", func() {
 						).To(Succeed())
 						ver, ok = GetVersion(&foundResource.Status, hcoVersionName)
 						Expect(ok).To(BeTrue())
-						Expect(ver).Should(Equal(testHcoVersion))
+						Expect(ver).To(Equal(testHcoVersion))
 						// and a third
 						res, err = r.Reconcile(context.TODO(), request)
-						Expect(err).Should(MatchError(ContainSubstring(errorMessage)))
+						Expect(err).To(MatchError(ContainSubstring(errorMessage)))
 						Expect(res.Requeue).To(BeTrue())
 						Expect(
 							cl.Get(context.TODO(),
@@ -1582,7 +1582,7 @@ var _ = Describe("HyperconvergedController", func() {
 						).To(Succeed())
 						ver, ok = GetVersion(&foundResource.Status, hcoVersionName)
 						Expect(ok).To(BeTrue())
-						Expect(ver).Should(Equal(testHcoVersion))
+						Expect(ver).To(Equal(testHcoVersion))
 					}
 				},
 				Entry(
@@ -1691,7 +1691,7 @@ var _ = Describe("HyperconvergedController", func() {
 				ver, ok := GetVersion(&foundResource.Status, hcoVersionName)
 				_, _ = fmt.Fprintln(GinkgoWriter, "foundResource.Status.Versions", foundResource.Status.Versions)
 				Expect(ok).To(BeFalse())
-				Expect(ver).Should(BeEmpty())
+				Expect(ver).To(BeEmpty())
 
 				// now, complete the upgrade
 				expected.cdi.Status.Conditions = getGenericCompletedConditions()
@@ -1704,14 +1704,14 @@ var _ = Describe("HyperconvergedController", func() {
 				_, ok = GetVersion(&foundResource.Status, hcoVersionName)
 				Expect(ok).To(BeTrue())
 				cond := apimetav1.FindStatusCondition(foundResource.Status.Conditions, hcov1beta1.ConditionProgressing)
-				Expect(cond.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionFalse))
 
 				ver, ok = GetVersion(&foundResource.Status, hcoVersionName)
 				Expect(ok).To(BeTrue())
-				Expect(ver).Should(Equal(newVersion))
+				Expect(ver).To(Equal(newVersion))
 
 				cond = apimetav1.FindStatusCondition(foundResource.Status.Conditions, hcov1beta1.ConditionProgressing)
-				Expect(cond.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionFalse))
 			})
 
 			DescribeTable(
@@ -1738,11 +1738,11 @@ var _ = Describe("HyperconvergedController", func() {
 					// check that the image Id is not set, because upgrade is not completed
 					ver, ok := GetVersion(&foundResource.Status, hcoVersionName)
 					Expect(ok).To(BeTrue())
-					Expect(ver).Should(Equal(oldVersion))
+					Expect(ver).To(Equal(oldVersion))
 					cond := apimetav1.FindStatusCondition(foundResource.Status.Conditions, hcov1beta1.ConditionProgressing)
-					Expect(cond.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-					Expect(cond.Reason).Should(Equal("HCOUpgrading"))
-					Expect(cond.Message).Should(Equal("HCO is now upgrading to version " + newVersion))
+					Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+					Expect(cond.Reason).To(Equal("HCOUpgrading"))
+					Expect(cond.Message).To(Equal("HCO is now upgrading to version " + newVersion))
 
 					// check that the upgrade is not done if the not all the versions are match.
 					// Conditions are valid
@@ -1757,11 +1757,11 @@ var _ = Describe("HyperconvergedController", func() {
 					// check that the image Id is set, now, when upgrade is completed
 					ver, ok = GetVersion(&foundResource.Status, hcoVersionName)
 					Expect(ok).To(BeTrue())
-					Expect(ver).Should(Equal(oldVersion))
+					Expect(ver).To(Equal(oldVersion))
 					cond = apimetav1.FindStatusCondition(foundResource.Status.Conditions, hcov1beta1.ConditionProgressing)
-					Expect(cond.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-					Expect(cond.Reason).Should(Equal("HCOUpgrading"))
-					Expect(cond.Message).Should(Equal("HCO is now upgrading to version " + newVersion))
+					Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+					Expect(cond.Reason).To(Equal("HCOUpgrading"))
+					Expect(cond.Message).To(Equal("HCO is now upgrading to version " + newVersion))
 
 					// now, complete the upgrade
 					updateComponentVersion()
@@ -1775,10 +1775,10 @@ var _ = Describe("HyperconvergedController", func() {
 					// check that the image Id is set, now, when upgrade is completed
 					ver, ok = GetVersion(&foundResource.Status, hcoVersionName)
 					Expect(ok).To(BeTrue())
-					Expect(ver).Should(Equal(newVersion))
+					Expect(ver).To(Equal(newVersion))
 					cond = apimetav1.FindStatusCondition(foundResource.Status.Conditions, hcov1beta1.ConditionProgressing)
-					Expect(cond.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-					Expect(cond.Reason).Should(Equal("ReconcileCompleted"))
+					Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+					Expect(cond.Reason).To(Equal("ReconcileCompleted"))
 				},
 				Entry(
 					"don't complete upgrade if kubevirt version is not match to the kubevirt version env ver",
@@ -1844,9 +1844,9 @@ var _ = Describe("HyperconvergedController", func() {
 							client.ObjectKeyFromObject(expected.hcoCRD),
 							foundCrd),
 					).To(Succeed())
-					Expect(foundCrd.Status.StoredVersions).ShouldNot(ContainElement("v1alpha1"))
-					Expect(foundCrd.Status.StoredVersions).Should(ContainElement("v1beta1"))
-					Expect(foundCrd.Status.StoredVersions).Should(ContainElement("v1"))
+					Expect(foundCrd.Status.StoredVersions).ToNot(ContainElement("v1alpha1"))
+					Expect(foundCrd.Status.StoredVersions).To(ContainElement("v1beta1"))
+					Expect(foundCrd.Status.StoredVersions).To(ContainElement("v1"))
 
 					By("Run reconcile again")
 					foundHC, reconciler, requeue = doReconcile(cl, foundHC, reconciler)
@@ -1859,7 +1859,7 @@ var _ = Describe("HyperconvergedController", func() {
 					checkAvailability(foundHC, metav1.ConditionTrue)
 					ver, ok := GetVersion(&foundHC.Status, hcoVersionName)
 					Expect(ok).To(BeTrue())
-					Expect(ver).Should(Equal(newVersion))
+					Expect(ver).To(Equal(newVersion))
 				})
 
 				It("should not update .status.storedVersions on the HCO CRD if not in upgrade mode", func() {
@@ -1877,9 +1877,9 @@ var _ = Describe("HyperconvergedController", func() {
 							client.ObjectKeyFromObject(expected.hcoCRD),
 							foundCrd),
 					).To(Succeed())
-					Expect(foundCrd.Status.StoredVersions).Should(ContainElement("v1alpha1"))
-					Expect(foundCrd.Status.StoredVersions).Should(ContainElement("v1beta1"))
-					Expect(foundCrd.Status.StoredVersions).Should(ContainElement("v1"))
+					Expect(foundCrd.Status.StoredVersions).To(ContainElement("v1alpha1"))
+					Expect(foundCrd.Status.StoredVersions).To(ContainElement("v1beta1"))
+					Expect(foundCrd.Status.StoredVersions).To(ContainElement("v1"))
 
 				})
 
@@ -2133,7 +2133,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(requeue).To(BeTrue())
 					_, _, requeue = doReconcile(cl, expected.hco, reconciler)
 					Expect(requeue).To(BeFalse())
-					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(BeNil())
+					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).To(BeNil())
 				})
 
 				It("should preserve spec.livemigrationconfig.bandwidthpermigration if != 64Mi when upgrading from < 1.5.0", func() {
@@ -2145,7 +2145,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(requeue).To(BeTrue())
 					foundResource, _, requeue := doReconcile(cl, expected.hco, reconciler)
 					Expect(requeue).To(BeFalse())
-					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(HaveValue(Equal(customBandwidthPerMigration)))
+					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).To(HaveValue(Equal(customBandwidthPerMigration)))
 				})
 
 				It("should preserve spec.livemigrationconfig.bandwidthpermigration even if == 64Mi when upgrading from >= 1.5.1", func() {
@@ -2157,7 +2157,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(requeue).To(BeTrue())
 					foundResource, _, requeue := doReconcile(cl, expected.hco, reconciler)
 					Expect(requeue).To(BeFalse())
-					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).Should(HaveValue(Equal(badBandwidthPerMigration)))
+					Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).To(HaveValue(Equal(badBandwidthPerMigration)))
 				})
 			})
 
@@ -2675,22 +2675,22 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(commonDegradedReason))
-				Expect(cd.Message).Should(Equal("HCO is not available due to degraded components"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(commonDegradedReason))
+				Expect(cd.Message).To(Equal("HCO is not available due to degraded components"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal("CDIDegraded"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal("CDIDegraded"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(commonDegradedReason))
-				Expect(cd.Message).Should(Equal("HCO is not Upgradeable due to degraded components"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(commonDegradedReason))
+				Expect(cd.Message).To(Equal("HCO is not Upgradeable due to degraded components"))
 
 				By("operator condition should be true even the upgradeable is false")
 				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
@@ -2720,20 +2720,20 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(commonDegradedReason))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(commonDegradedReason))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal("CDIProgressing"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal("CDIDegraded"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal("CDIDegraded"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal("CDIProgressing"))
 
 				By("operator condition should be true even the upgradeable is false")
 				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
@@ -2763,20 +2763,20 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal("CDINotAvailable"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal("CDINotAvailable"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal("CDIDegraded"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal("CDIDegraded"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(commonDegradedReason))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(commonDegradedReason))
 
 				By("operator condition should be true even the upgradeable is false")
 				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
@@ -2800,20 +2800,20 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal("CDIProgressing"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal("CDIProgressing"))
 
 				By("operator condition should be true even the upgradeable is false")
 				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
@@ -2843,20 +2843,20 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal("CDINotAvailable"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal("CDINotAvailable"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal("CDIProgressing"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal("CDIProgressing"))
 
 				By("operator condition should be true even the upgradeable is false")
 				validateOperatorCondition(r, metav1.ConditionTrue, hcoutil.UpgradeableAllowReason, hcoutil.UpgradeableAllowMessage)
@@ -2880,20 +2880,20 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal("CDINotAvailable"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal("CDINotAvailable"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 			})
 
 			It("should be with all positive condition when all components working properly", func() {
@@ -2908,20 +2908,20 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 			})
 
 			It("should set the status of the last faulty component", func() {
@@ -2949,20 +2949,20 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal("NetworkAddonsConfigNotAvailable"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal("NetworkAddonsConfigNotAvailable"))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 			})
 
 			It("should not be upgradeable when a component is not upgradeable", func() {
@@ -2983,25 +2983,25 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal("CDINotUpgradeable"))
-				Expect(cd.Message).Should(Equal("CDI is not upgradeable: CDI Test Error message"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal("CDINotUpgradeable"))
+				Expect(cd.Message).To(Equal("CDI is not upgradeable: CDI Test Error message"))
 
 				By("operator condition should be false")
 				validateOperatorCondition(r, metav1.ConditionFalse, "CDINotUpgradeable", "is not upgradeable:")
@@ -3032,25 +3032,25 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal("CDIProgressing"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal("CDIProgressing"))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal("CDINotUpgradeable"))
-				Expect(cd.Message).Should(Equal("CDI is not upgradeable: CDI Upgrade Error message"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal("CDINotUpgradeable"))
+				Expect(cd.Message).To(Equal("CDI is not upgradeable: CDI Upgrade Error message"))
 
 				By("operator condition should be false")
 				validateOperatorCondition(r, metav1.ConditionFalse, "CDINotUpgradeable", "is not upgradeable:")
@@ -3081,25 +3081,25 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = wr.Encode(conditions)
 
 				cd := apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionReconcileComplete)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionAvailable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(commonDegradedReason))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(commonDegradedReason))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionProgressing)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal(reconcileCompleted))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal(reconcileCompleted))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionDegraded)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionTrue))
-				Expect(cd.Reason).Should(Equal("CDIDegraded"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionTrue))
+				Expect(cd.Reason).To(Equal("CDIDegraded"))
 
 				cd = apimetav1.FindStatusCondition(conditions, hcov1beta1.ConditionUpgradeable)
-				Expect(cd.Status).Should(BeEquivalentTo(metav1.ConditionFalse))
-				Expect(cd.Reason).Should(Equal("CDINotUpgradeable"))
-				Expect(cd.Message).Should(Equal("CDI is not upgradeable: CDI Upgrade Error message"))
+				Expect(cd.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(cd.Reason).To(Equal("CDINotUpgradeable"))
+				Expect(cd.Message).To(Equal("CDI is not upgradeable: CDI Upgrade Error message"))
 
 				By("operator condition should be false")
 				validateOperatorCondition(r, metav1.ConditionFalse, "CDINotUpgradeable", "is not upgradeable:")
@@ -3183,7 +3183,7 @@ var _ = Describe("HyperconvergedController", func() {
 					By("Reconcile", func() {
 						res, err := r.Reconcile(context.TODO(), request)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+						Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 					})
 
 					foundResource := &hcov1beta1.HyperConverged{}
@@ -3238,7 +3238,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					// Expecting "Requeue: false" since the conditions aren't empty
-					Expect(res).Should(Equal(reconcile.Result{Requeue: false}))
+					Expect(res).To(Equal(reconcile.Result{Requeue: false}))
 
 					// Get the HCO
 					foundResource := &hcov1beta1.HyperConverged{}
@@ -3338,7 +3338,7 @@ var _ = Describe("HyperconvergedController", func() {
 					By("Reconcile", func() {
 						res, err := r.Reconcile(context.TODO(), request)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+						Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 					})
 
 					foundResource := &hcov1beta1.HyperConverged{}
@@ -3369,12 +3369,12 @@ var _ = Describe("HyperconvergedController", func() {
 								cdi),
 						).To(Succeed())
 
-						Expect(cdi.Spec.Config.FeatureGates).Should(ContainElement("fg1"))
+						Expect(cdi.Spec.Config.FeatureGates).To(ContainElement("fg1"))
 						Expect(cdi.Spec.Config.FilesystemOverhead).ToNot(BeNil())
-						Expect(cdi.Spec.Config.FilesystemOverhead.Global).Should(BeEquivalentTo("50"))
+						Expect(cdi.Spec.Config.FilesystemOverhead.Global).To(BeEquivalentTo("50"))
 						Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass).ToNot(BeNil())
-						Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["AAA"]).Should(BeEquivalentTo("75"))
-						Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["BBB"]).Should(BeEquivalentTo("25"))
+						Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["AAA"]).To(BeEquivalentTo("75"))
+						Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["BBB"]).To(BeEquivalentTo("25"))
 
 					})
 				})
@@ -3489,7 +3489,7 @@ var _ = Describe("HyperconvergedController", func() {
 					By("Reconcile", func() {
 						res, err := r.Reconcile(context.TODO(), request)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+						Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 					})
 
 					foundResource := &hcov1beta1.HyperConverged{}
@@ -3521,9 +3521,9 @@ var _ = Describe("HyperconvergedController", func() {
 						).To(Succeed())
 
 						Expect(cna.Spec.KubeMacPool).ToNot(BeNil())
-						Expect(cna.Spec.KubeMacPool.RangeStart).Should(Equal("1.1.1.1.1.1"))
-						Expect(cna.Spec.KubeMacPool.RangeEnd).Should(Equal("5.5.5.5.5.5"))
-						Expect(cna.Spec.ImagePullPolicy).Should(BeEquivalentTo("Always"))
+						Expect(cna.Spec.KubeMacPool.RangeStart).To(Equal("1.1.1.1.1.1"))
+						Expect(cna.Spec.KubeMacPool.RangeEnd).To(Equal("5.5.5.5.5.5"))
+						Expect(cna.Spec.ImagePullPolicy).To(BeEquivalentTo("Always"))
 					})
 				})
 
@@ -3579,7 +3579,7 @@ var _ = Describe("HyperconvergedController", func() {
 					By("Reconcile", func() {
 						res, err := r.Reconcile(context.TODO(), request)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+						Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 					})
 
 					foundResource := &hcov1beta1.HyperConverged{}
@@ -3623,7 +3623,7 @@ var _ = Describe("HyperconvergedController", func() {
 					By("Reconcile", func() {
 						res, err := r.Reconcile(context.TODO(), request)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+						Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 					})
 
 					foundResource := &hcov1beta1.HyperConverged{}
@@ -3654,8 +3654,8 @@ var _ = Describe("HyperconvergedController", func() {
 								ssp),
 						).To(Succeed())
 
-						Expect(ssp.Spec.TemplateValidator.Replicas).Should(Not(BeNil()))
-						Expect(*ssp.Spec.TemplateValidator.Replicas).Should(Equal(int32(5)))
+						Expect(ssp.Spec.TemplateValidator.Replicas).ToNot(BeNil())
+						Expect(*ssp.Spec.TemplateValidator.Replicas).To(Equal(int32(5)))
 					})
 				})
 
@@ -3711,7 +3711,7 @@ var _ = Describe("HyperconvergedController", func() {
 					By("Reconcile", func() {
 						res, err := r.Reconcile(context.TODO(), request)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+						Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 					})
 
 					foundResource := &hcov1beta1.HyperConverged{}
@@ -3788,7 +3788,7 @@ var _ = Describe("HyperconvergedController", func() {
 					By("Reconcile", func() {
 						res, err := r.Reconcile(context.TODO(), request)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(res).Should(Equal(reconcile.Result{Requeue: true}))
+						Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 					})
 
 					foundResource := &hcov1beta1.HyperConverged{}
@@ -3834,12 +3834,12 @@ var _ = Describe("HyperconvergedController", func() {
 								cdi),
 						).To(Succeed())
 
-						Expect(cdi.Spec.Config.FeatureGates).Should(ContainElement("fg1"))
+						Expect(cdi.Spec.Config.FeatureGates).To(ContainElement("fg1"))
 						Expect(cdi.Spec.Config.FilesystemOverhead).ToNot(BeNil())
-						Expect(cdi.Spec.Config.FilesystemOverhead.Global).Should(BeEquivalentTo("50"))
+						Expect(cdi.Spec.Config.FilesystemOverhead.Global).To(BeEquivalentTo("50"))
 						Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass).ToNot(BeNil())
-						Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["AAA"]).Should(BeEquivalentTo("75"))
-						Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["BBB"]).Should(BeEquivalentTo("25"))
+						Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["AAA"]).To(BeEquivalentTo("75"))
+						Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["BBB"]).To(BeEquivalentTo("25"))
 
 					})
 					By("Verify that CNA was modified by the annotation", func() {
@@ -3851,9 +3851,9 @@ var _ = Describe("HyperconvergedController", func() {
 						).To(Succeed())
 
 						Expect(cna.Spec.KubeMacPool).ToNot(BeNil())
-						Expect(cna.Spec.KubeMacPool.RangeStart).Should(Equal("1.1.1.1.1.1"))
-						Expect(cna.Spec.KubeMacPool.RangeEnd).Should(Equal("5.5.5.5.5.5"))
-						Expect(cna.Spec.ImagePullPolicy).Should(BeEquivalentTo("Always"))
+						Expect(cna.Spec.KubeMacPool.RangeStart).To(Equal("1.1.1.1.1.1"))
+						Expect(cna.Spec.KubeMacPool.RangeEnd).To(Equal("5.5.5.5.5.5"))
+						Expect(cna.Spec.ImagePullPolicy).To(BeEquivalentTo("Always"))
 					})
 					By("Verify that SSP was modified by the annotation", func() {
 						ssp := operands.NewSSPWithNameOnly(hco)
@@ -3863,8 +3863,8 @@ var _ = Describe("HyperconvergedController", func() {
 								ssp),
 						).To(Succeed())
 
-						Expect(ssp.Spec.TemplateValidator.Replicas).Should(Not(BeNil()))
-						Expect(*ssp.Spec.TemplateValidator.Replicas).Should(Equal(int32(5)))
+						Expect(ssp.Spec.TemplateValidator.Replicas).ToNot(BeNil())
+						Expect(*ssp.Spec.TemplateValidator.Replicas).To(Equal(int32(5)))
 					})
 				})
 			})

--- a/controllers/hyperconverged/upgradePatches_test.go
+++ b/controllers/hyperconverged/upgradePatches_test.go
@@ -55,7 +55,7 @@ var _ = Describe("upgradePatches", func() {
 			Expect(copyTestFile("badJson.json")).To(Succeed())
 
 			err := validateUpgradePatches(req)
-			Expect(err).Should(MatchError(HavePrefix("invalid character")))
+			Expect(err).To(MatchError(HavePrefix("invalid character")))
 		})
 
 		Context("hcoCRPatchList", func() {
@@ -64,14 +64,14 @@ var _ = Describe("upgradePatches", func() {
 				Expect(copyTestFile("badSemverRange.json")).To(Succeed())
 
 				err := validateUpgradePatches(req)
-				Expect(err).Should(MatchError(HavePrefix("Could not get version from string:")))
+				Expect(err).To(MatchError(HavePrefix("Could not get version from string:")))
 			})
 
 			DescribeTable(
 				"should fail validating upgradePatches with bad patches",
 				func(filename, message string) {
 					Expect(copyTestFile(filename)).To(Succeed())
-					Expect(validateUpgradePatches(req)).Should(MatchError(HavePrefix(message)))
+					Expect(validateUpgradePatches(req)).To(MatchError(HavePrefix(message)))
 				},
 				Entry(
 					"bad operation kind",
@@ -97,7 +97,7 @@ var _ = Describe("upgradePatches", func() {
 
 					err := validateUpgradePatches(req)
 					if expectedErr {
-						Expect(err).Should(MatchError(HavePrefix(message)))
+						Expect(err).To(MatchError(HavePrefix(message)))
 					} else {
 						Expect(err).ToNot(HaveOccurred())
 					}
@@ -134,14 +134,14 @@ var _ = Describe("upgradePatches", func() {
 
 			It("should fail validating upgradePatches with bad semver ranges", func() {
 				Expect(copyTestFile("badSemverRangeOR.json")).To(Succeed())
-				Expect(validateUpgradePatches(req)).Should(MatchError(HavePrefix("Could not get version from string:")))
+				Expect(validateUpgradePatches(req)).To(MatchError(HavePrefix("Could not get version from string:")))
 			})
 
 			DescribeTable(
 				"should fail validating upgradePatches with bad patches",
 				func(filename, message string) {
 					Expect(copyTestFile(filename)).To(Succeed())
-					Expect(validateUpgradePatches(req)).Should(MatchError(HavePrefix(message)))
+					Expect(validateUpgradePatches(req)).To(MatchError(HavePrefix(message)))
 				},
 				Entry(
 					"empty object kind",

--- a/controllers/hyperconverged/version_test.go
+++ b/controllers/hyperconverged/version_test.go
@@ -26,15 +26,15 @@ var _ = Describe("Test utilities for HCO versions", func() {
 			UpdateVersion(hcs, testName, testVersion)
 
 			It("Versions array should be with one element", func() {
-				Expect(hcs.Versions).Should(HaveLen(1))
+				Expect(hcs.Versions).To(HaveLen(1))
 			})
 
 			It(`The version name should be "aName"`, func() {
-				Expect(hcs.Versions[0].Name).Should(Equal(testName))
+				Expect(hcs.Versions[0].Name).To(Equal(testName))
 			})
 
 			It(`The version should be "aVersion"`, func() {
-				Expect(hcs.Versions[0].Version).Should(Equal(testVersion))
+				Expect(hcs.Versions[0].Version).To(Equal(testVersion))
 			})
 		})
 
@@ -48,15 +48,15 @@ var _ = Describe("Test utilities for HCO versions", func() {
 			UpdateVersion(hcs, testName, testVersion)
 
 			It("Versions array should be with one element", func() {
-				Expect(hcs.Versions).Should(HaveLen(1))
+				Expect(hcs.Versions).To(HaveLen(1))
 			})
 
 			It(`The version name should be "aName"`, func() {
-				Expect(hcs.Versions[0].Name).Should(Equal(testName))
+				Expect(hcs.Versions[0].Name).To(Equal(testName))
 			})
 
 			It(`The version should be "aVersion"`, func() {
-				Expect(hcs.Versions[0].Version).Should(Equal(testVersion))
+				Expect(hcs.Versions[0].Version).To(Equal(testVersion))
 			})
 		})
 
@@ -74,15 +74,15 @@ var _ = Describe("Test utilities for HCO versions", func() {
 			UpdateVersion(hcs, testName, testVersion)
 
 			It("Versions array should be with four elements", func() {
-				Expect(hcs.Versions).Should(HaveLen(4))
+				Expect(hcs.Versions).To(HaveLen(4))
 			})
 
 			It(`The version name should be "aName"`, func() {
-				Expect(hcs.Versions[3].Name).Should(Equal(testName))
+				Expect(hcs.Versions[3].Name).To(Equal(testName))
 			})
 
 			It(`The version should be "aVersion"`, func() {
-				Expect(hcs.Versions[3].Version).Should(Equal(testVersion))
+				Expect(hcs.Versions[3].Version).To(Equal(testVersion))
 			})
 		})
 
@@ -100,15 +100,15 @@ var _ = Describe("Test utilities for HCO versions", func() {
 			UpdateVersion(hcs, testName, testVersion)
 
 			It("Versions array should be with three elements", func() {
-				Expect(hcs.Versions).Should(HaveLen(3))
+				Expect(hcs.Versions).To(HaveLen(3))
 			})
 
 			It(`The version name should be "aName"`, func() {
-				Expect(hcs.Versions[0].Name).Should(Equal(testName))
+				Expect(hcs.Versions[0].Name).To(Equal(testName))
 			})
 
 			It(`The version should be "aVersion"`, func() {
-				Expect(hcs.Versions[0].Version).Should(Equal(testVersion))
+				Expect(hcs.Versions[0].Version).To(Equal(testVersion))
 			})
 		})
 
@@ -126,15 +126,15 @@ var _ = Describe("Test utilities for HCO versions", func() {
 			UpdateVersion(hcs, testName, testVersion)
 
 			It("Versions array should be with three elements", func() {
-				Expect(hcs.Versions).Should(HaveLen(3))
+				Expect(hcs.Versions).To(HaveLen(3))
 			})
 
 			It(`The version name should be "aName"`, func() {
-				Expect(hcs.Versions[1].Name).Should(Equal(testName))
+				Expect(hcs.Versions[1].Name).To(Equal(testName))
 			})
 
 			It(`The version should be "aVersion"`, func() {
-				Expect(hcs.Versions[1].Version).Should(Equal(testVersion))
+				Expect(hcs.Versions[1].Version).To(Equal(testVersion))
 			})
 		})
 
@@ -152,15 +152,15 @@ var _ = Describe("Test utilities for HCO versions", func() {
 			UpdateVersion(hcs, testName, testVersion)
 
 			It("Versions array should be with three elements", func() {
-				Expect(hcs.Versions).Should(HaveLen(3))
+				Expect(hcs.Versions).To(HaveLen(3))
 			})
 
 			It(`The version name should be "aName"`, func() {
-				Expect(hcs.Versions[2].Name).Should(Equal(testName))
+				Expect(hcs.Versions[2].Name).To(Equal(testName))
 			})
 
 			It(`The version should be "aVersion"`, func() {
-				Expect(hcs.Versions[2].Version).Should(Equal(testVersion))
+				Expect(hcs.Versions[2].Version).To(Equal(testVersion))
 			})
 		})
 
@@ -241,7 +241,7 @@ var _ = Describe("Test utilities for HCO versions", func() {
 			})
 
 			It("the version should be empty", func() {
-				Expect(ver).Should(Equal(testVersion))
+				Expect(ver).To(Equal(testVersion))
 			})
 		})
 
@@ -263,7 +263,7 @@ var _ = Describe("Test utilities for HCO versions", func() {
 			})
 
 			It("the version should be empty", func() {
-				Expect(ver).Should(Equal(testVersion))
+				Expect(ver).To(Equal(testVersion))
 			})
 		})
 
@@ -285,7 +285,7 @@ var _ = Describe("Test utilities for HCO versions", func() {
 			})
 
 			It("the version should be empty", func() {
-				Expect(ver).Should(Equal(testVersion))
+				Expect(ver).To(Equal(testVersion))
 			})
 		})
 

--- a/controllers/operands/aaq_test.go
+++ b/controllers/operands/aaq_test.go
@@ -70,28 +70,28 @@ var _ = Describe("AAQ tests", func() {
 		It("should have all default fields", func() {
 			aaq := NewAAQ(hco)
 
-			Expect(aaq.Name).Should(Equal("aaq-" + hco.Name))
-			Expect(aaq.Namespace).Should(BeEmpty())
+			Expect(aaq.Name).To(Equal("aaq-" + hco.Name))
+			Expect(aaq.Namespace).To(BeEmpty())
 
-			Expect(aaq.Spec.Infra.Tolerations).Should(BeEmpty())
-			Expect(aaq.Spec.Infra.Affinity).Should(BeNil())
-			Expect(aaq.Spec.Infra.NodeSelector).Should(BeEmpty())
+			Expect(aaq.Spec.Infra.Tolerations).To(BeEmpty())
+			Expect(aaq.Spec.Infra.Affinity).To(BeNil())
+			Expect(aaq.Spec.Infra.NodeSelector).To(BeEmpty())
 
-			Expect(aaq.Spec.Workloads.Tolerations).Should(BeEmpty())
-			Expect(aaq.Spec.Workloads.Affinity).Should(BeNil())
-			Expect(aaq.Spec.Workloads.NodeSelector).Should(BeEmpty())
+			Expect(aaq.Spec.Workloads.Tolerations).To(BeEmpty())
+			Expect(aaq.Spec.Workloads.Affinity).To(BeNil())
+			Expect(aaq.Spec.Workloads.NodeSelector).To(BeEmpty())
 
 			Expect(aaq.Spec.PriorityClass).To(HaveValue(Equal(aaqv1alpha1.AAQPriorityClass(kvPriorityClass))))
 
-			Expect(aaq.Spec.CertConfig.CA).ShouldNot(BeNil())
-			Expect(aaq.Spec.CertConfig.CA.Duration).ShouldNot(BeNil())
-			Expect(aaq.Spec.CertConfig.CA.Duration.Duration.String()).Should(Equal("48h0m0s"))
-			Expect(aaq.Spec.CertConfig.CA.RenewBefore.Duration.String()).Should(Equal("24h0m0s"))
+			Expect(aaq.Spec.CertConfig.CA).ToNot(BeNil())
+			Expect(aaq.Spec.CertConfig.CA.Duration).ToNot(BeNil())
+			Expect(aaq.Spec.CertConfig.CA.Duration.Duration.String()).To(Equal("48h0m0s"))
+			Expect(aaq.Spec.CertConfig.CA.RenewBefore.Duration.String()).To(Equal("24h0m0s"))
 
-			Expect(aaq.Spec.CertConfig.Server).ShouldNot(BeNil())
-			Expect(aaq.Spec.CertConfig.Server.Duration).ShouldNot(BeNil())
-			Expect(aaq.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("24h0m0s"))
-			Expect(aaq.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("12h0m0s"))
+			Expect(aaq.Spec.CertConfig.Server).ToNot(BeNil())
+			Expect(aaq.Spec.CertConfig.Server.Duration).ToNot(BeNil())
+			Expect(aaq.Spec.CertConfig.Server.Duration.Duration.String()).To(Equal("24h0m0s"))
+			Expect(aaq.Spec.CertConfig.Server.RenewBefore.Duration.String()).To(Equal("12h0m0s"))
 
 			Expect(aaq.Spec.NamespaceSelector).To(BeNil())
 			Expect(aaq.Spec.Configuration.VmiCalculatorConfiguration.ConfigName).To(Equal(aaqv1alpha1.DedicatedVirtualResources))
@@ -136,8 +136,8 @@ var _ = Describe("AAQ tests", func() {
 
 			aaq := NewAAQ(hco)
 
-			Expect(aaq.Spec.Infra).Should(Equal(testNodePlacement))
-			Expect(aaq.Spec.Workloads).Should(Equal(testNodePlacement))
+			Expect(aaq.Spec.Infra).To(Equal(testNodePlacement))
+			Expect(aaq.Spec.Workloads).To(Equal(testNodePlacement))
 		})
 
 		It("should get certification configurations from the HyperConverged CR", func() {
@@ -155,15 +155,15 @@ var _ = Describe("AAQ tests", func() {
 
 			aaq := NewAAQ(hco)
 
-			Expect(aaq.Spec.CertConfig.CA).ShouldNot(BeNil())
-			Expect(aaq.Spec.CertConfig.CA.Duration).ShouldNot(BeNil())
-			Expect(aaq.Spec.CertConfig.CA.Duration.Duration.String()).Should(Equal("72h0m0s"))
-			Expect(aaq.Spec.CertConfig.CA.RenewBefore.Duration.String()).Should(Equal("56h0m0s"))
+			Expect(aaq.Spec.CertConfig.CA).ToNot(BeNil())
+			Expect(aaq.Spec.CertConfig.CA.Duration).ToNot(BeNil())
+			Expect(aaq.Spec.CertConfig.CA.Duration.Duration.String()).To(Equal("72h0m0s"))
+			Expect(aaq.Spec.CertConfig.CA.RenewBefore.Duration.String()).To(Equal("56h0m0s"))
 
-			Expect(aaq.Spec.CertConfig.Server).ShouldNot(BeNil())
-			Expect(aaq.Spec.CertConfig.Server.Duration).ShouldNot(BeNil())
-			Expect(aaq.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("36h0m0s"))
-			Expect(aaq.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("18h0m0s"))
+			Expect(aaq.Spec.CertConfig.Server).ToNot(BeNil())
+			Expect(aaq.Spec.CertConfig.Server.Duration).ToNot(BeNil())
+			Expect(aaq.Spec.CertConfig.Server.Duration.Duration.String()).To(Equal("36h0m0s"))
+			Expect(aaq.Spec.CertConfig.Server.RenewBefore.Duration.String()).To(Equal("18h0m0s"))
 		})
 	})
 
@@ -175,14 +175,14 @@ var _ = Describe("AAQ tests", func() {
 
 			res := handler.ensure(req)
 
-			Expect(res.Err).ShouldNot(HaveOccurred())
-			Expect(res.Created).Should(BeFalse())
-			Expect(res.Updated).Should(BeFalse())
-			Expect(res.Deleted).Should(BeFalse())
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
 
 			foundAAQs := &aaqv1alpha1.AAQList{}
-			Expect(cl.List(context.Background(), foundAAQs)).Should(Succeed())
-			Expect(foundAAQs.Items).Should(BeEmpty())
+			Expect(cl.List(context.Background(), foundAAQs)).To(Succeed())
+			Expect(foundAAQs.Items).To(BeEmpty())
 		})
 
 		It("should delete AAQ if the enableApplicationAwareQuota FG is not set", func() {
@@ -193,15 +193,15 @@ var _ = Describe("AAQ tests", func() {
 
 			res := handler.ensure(req)
 
-			Expect(res.Err).ShouldNot(HaveOccurred())
-			Expect(res.Name).Should(Equal(aaq.Name))
-			Expect(res.Created).Should(BeFalse())
-			Expect(res.Updated).Should(BeFalse())
-			Expect(res.Deleted).Should(BeTrue())
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(aaq.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
 
 			foundAAQs := &aaqv1alpha1.AAQList{}
-			Expect(cl.List(context.Background(), foundAAQs)).Should(Succeed())
-			Expect(foundAAQs.Items).Should(BeEmpty())
+			Expect(cl.List(context.Background(), foundAAQs)).To(Succeed())
+			Expect(foundAAQs.Items).To(BeEmpty())
 		})
 
 		It("should create AAQ if the enableApplicationAwareQuota FG is true", func() {
@@ -212,17 +212,17 @@ var _ = Describe("AAQ tests", func() {
 
 			res := handler.ensure(req)
 
-			Expect(res.Err).ShouldNot(HaveOccurred())
-			Expect(res.Name).Should(Equal("aaq-kubevirt-hyperconverged"))
-			Expect(res.Created).Should(BeTrue())
-			Expect(res.Updated).Should(BeFalse())
-			Expect(res.Deleted).Should(BeFalse())
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal("aaq-kubevirt-hyperconverged"))
+			Expect(res.Created).To(BeTrue())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
 
 			foundAAQ := &aaqv1alpha1.AAQ{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Name: res.Name}, foundAAQ)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: res.Name}, foundAAQ)).To(Succeed())
 
-			Expect(foundAAQ.Name).Should(Equal("aaq-" + hco.Name))
-			Expect(foundAAQ.Namespace).Should(BeEmpty())
+			Expect(foundAAQ.Name).To(Equal("aaq-" + hco.Name))
+			Expect(foundAAQ.Namespace).To(BeEmpty())
 
 			// example of field set by the handler
 			Expect(foundAAQ.Spec.PriorityClass).To(HaveValue(Equal(aaqv1alpha1.AAQPriorityClass(kvPriorityClass))))
@@ -253,31 +253,31 @@ var _ = Describe("AAQ tests", func() {
 
 			res := handler.ensure(req)
 
-			Expect(res.Err).ShouldNot(HaveOccurred())
-			Expect(res.Created).Should(BeFalse())
-			Expect(res.Deleted).Should(BeFalse())
-			Expect(res.Updated).Should(BeTrue())
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
 
 			foundAAQ := &aaqv1alpha1.AAQ{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Name: res.Name}, foundAAQ)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: res.Name}, foundAAQ)).To(Succeed())
 
-			Expect(foundAAQ.Spec.NamespaceSelector).Should(BeNil())
-			Expect(foundAAQ.Spec.Configuration.VmiCalculatorConfiguration.ConfigName).Should(Equal(aaqv1alpha1.DedicatedVirtualResources))
+			Expect(foundAAQ.Spec.NamespaceSelector).To(BeNil())
+			Expect(foundAAQ.Spec.Configuration.VmiCalculatorConfiguration.ConfigName).To(Equal(aaqv1alpha1.DedicatedVirtualResources))
 
-			Expect(foundAAQ.Spec.Infra.Affinity).Should(BeNil())
-			Expect(foundAAQ.Spec.Infra.NodeSelector).Should(BeEmpty())
-			Expect(foundAAQ.Spec.Infra.Tolerations).Should(BeEmpty())
+			Expect(foundAAQ.Spec.Infra.Affinity).To(BeNil())
+			Expect(foundAAQ.Spec.Infra.NodeSelector).To(BeEmpty())
+			Expect(foundAAQ.Spec.Infra.Tolerations).To(BeEmpty())
 
 			Expect(foundAAQ.Spec.PriorityClass).To(HaveValue(Equal(aaqv1alpha1.AAQPriorityClass(kvPriorityClass))))
-			Expect(foundAAQ.Spec.CertConfig.CA).ShouldNot(BeNil())
-			Expect(foundAAQ.Spec.CertConfig.CA.Duration).ShouldNot(BeNil())
-			Expect(foundAAQ.Spec.CertConfig.CA.Duration.Duration.String()).Should(Equal("48h0m0s"))
-			Expect(foundAAQ.Spec.CertConfig.CA.RenewBefore.Duration.String()).Should(Equal("24h0m0s"))
+			Expect(foundAAQ.Spec.CertConfig.CA).ToNot(BeNil())
+			Expect(foundAAQ.Spec.CertConfig.CA.Duration).ToNot(BeNil())
+			Expect(foundAAQ.Spec.CertConfig.CA.Duration.Duration.String()).To(Equal("48h0m0s"))
+			Expect(foundAAQ.Spec.CertConfig.CA.RenewBefore.Duration.String()).To(Equal("24h0m0s"))
 
-			Expect(foundAAQ.Spec.CertConfig.Server).ShouldNot(BeNil())
-			Expect(foundAAQ.Spec.CertConfig.Server.Duration).ShouldNot(BeNil())
-			Expect(foundAAQ.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("24h0m0s"))
-			Expect(foundAAQ.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("12h0m0s"))
+			Expect(foundAAQ.Spec.CertConfig.Server).ToNot(BeNil())
+			Expect(foundAAQ.Spec.CertConfig.Server.Duration).ToNot(BeNil())
+			Expect(foundAAQ.Spec.CertConfig.Server.Duration.Duration.String()).To(Equal("24h0m0s"))
+			Expect(foundAAQ.Spec.CertConfig.Server.RenewBefore.Duration.String()).To(Equal("12h0m0s"))
 		})
 
 		It("should reconcile managed labels to default without touching user added ones", func() {
@@ -357,31 +357,31 @@ var _ = Describe("AAQ tests", func() {
 			hco.Spec.FeatureGates.EnableApplicationAwareQuota = ptr.To(true)
 			handler := newAAQHandler(cl, commontestutils.GetScheme())
 			op, ok := handler.(*conditionalHandler)
-			Expect(ok).Should(BeTrue())
+			Expect(ok).To(BeTrue())
 
 			hooks, ok := op.operand.hooks.(*aaqHooks)
-			Expect(ok).Should(BeTrue())
+			Expect(ok).To(BeTrue())
 
-			Expect(hooks.cache).Should(BeNil())
+			Expect(hooks.cache).To(BeNil())
 
 			res := handler.ensure(req)
-			Expect(res.Err).ShouldNot(HaveOccurred())
+			Expect(res.Err).ToNot(HaveOccurred())
 
 			cache := hooks.cache
-			Expect(cache).ShouldNot(BeNil())
+			Expect(cache).ToNot(BeNil())
 
-			Expect(hooks.getFullCr(hco)).Should(BeIdenticalTo(cache))
+			Expect(hooks.getFullCr(hco)).To(BeIdenticalTo(cache))
 
 			By("recreate cache after reset")
 			handler.reset()
-			Expect(hooks.cache).Should(BeNil())
+			Expect(hooks.cache).To(BeNil())
 			res = handler.ensure(req)
-			Expect(res.Err).ShouldNot(HaveOccurred())
+			Expect(res.Err).ToNot(HaveOccurred())
 
-			Expect(hooks.cache).ShouldNot(BeIdenticalTo(cache))
+			Expect(hooks.cache).ToNot(BeIdenticalTo(cache))
 			mtq, _ := hooks.getFullCr(hco)
-			Expect(mtq).ShouldNot(BeIdenticalTo(cache))
-			Expect(mtq).Should(BeIdenticalTo(hooks.cache))
+			Expect(mtq).ToNot(BeIdenticalTo(cache))
+			Expect(mtq).To(BeIdenticalTo(hooks.cache))
 		})
 	})
 })

--- a/controllers/operands/cdi_test.go
+++ b/controllers/operands/cdi_test.go
@@ -55,7 +55,7 @@ var _ = Describe("CDI Operand", func() {
 					foundResource),
 			).To(Succeed())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			Expect(foundResource.Annotations).To(Equal(map[string]string{cdiConfigAuthorityAnnotation: ""}))
 		})
@@ -220,11 +220,11 @@ var _ = Describe("CDI Operand", func() {
 				Expect(existingResource.Spec.Workloads.NodeSelector).To(BeNil())
 
 				Expect(foundResource.Spec.Infra.Affinity).ToNot(BeNil())
-				Expect(foundResource.Spec.Infra.NodeSelector["key1"]).Should(Equal("value1"))
-				Expect(foundResource.Spec.Infra.NodeSelector["key2"]).Should(Equal("value2"))
+				Expect(foundResource.Spec.Infra.NodeSelector["key1"]).To(Equal("value1"))
+				Expect(foundResource.Spec.Infra.NodeSelector["key2"]).To(Equal("value2"))
 
 				Expect(foundResource.Spec.Workloads).ToNot(BeNil())
-				Expect(foundResource.Spec.Workloads.Tolerations).Should(Equal(hco.Spec.Workloads.NodePlacement.Tolerations))
+				Expect(foundResource.Spec.Workloads.Tolerations).To(Equal(hco.Spec.Workloads.NodePlacement.Tolerations))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -298,10 +298,10 @@ var _ = Describe("CDI Operand", func() {
 				).ToNot(HaveOccurred())
 
 				Expect(existingResource.Spec.Infra.Tolerations).To(HaveLen(2))
-				Expect(existingResource.Spec.Workloads.NodeSelector["key1"]).Should(Equal("value1"))
+				Expect(existingResource.Spec.Workloads.NodeSelector["key1"]).To(Equal("value1"))
 
 				Expect(foundResource.Spec.Infra.Tolerations).To(HaveLen(3))
-				Expect(foundResource.Spec.Workloads.NodeSelector["key1"]).Should(Equal("something else"))
+				Expect(foundResource.Spec.Workloads.NodeSelector["key1"]).To(Equal("something else"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -343,13 +343,13 @@ var _ = Describe("CDI Operand", func() {
 
 				Expect(existingResource.Spec.Infra.Tolerations).To(HaveLen(3))
 				Expect(existingResource.Spec.Workloads.Tolerations).To(HaveLen(3))
-				Expect(existingResource.Spec.Infra.NodeSelector["key1"]).Should(Equal("BADvalue1"))
-				Expect(existingResource.Spec.Workloads.NodeSelector["key2"]).Should(Equal("BADvalue2"))
+				Expect(existingResource.Spec.Infra.NodeSelector["key1"]).To(Equal("BADvalue1"))
+				Expect(existingResource.Spec.Workloads.NodeSelector["key2"]).To(Equal("BADvalue2"))
 
 				Expect(foundResource.Spec.Infra.Tolerations).To(HaveLen(2))
 				Expect(foundResource.Spec.Workloads.Tolerations).To(HaveLen(2))
-				Expect(foundResource.Spec.Infra.NodeSelector["key1"]).Should(Equal("value1"))
-				Expect(foundResource.Spec.Workloads.NodeSelector["key2"]).Should(Equal("value2"))
+				Expect(foundResource.Spec.Infra.NodeSelector["key1"]).To(Equal("value1"))
+				Expect(foundResource.Spec.Workloads.NodeSelector["key2"]).To(Equal("value2"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -390,10 +390,10 @@ var _ = Describe("CDI Operand", func() {
 
 				Expect(foundResource.Spec.Config).ToNot(BeNil())
 				Expect(foundResource.Spec.Config.PodResourceRequirements).ToNot(BeNil())
-				Expect(foundResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceCPU]).Should(Equal(resource.MustParse("500m")))
-				Expect(foundResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceMemory]).Should(Equal(resource.MustParse("2Gi")))
-				Expect(foundResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceCPU]).Should(Equal(resource.MustParse("250m")))
-				Expect(foundResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceMemory]).Should(Equal(resource.MustParse("1Gi")))
+				Expect(foundResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceCPU]).To(Equal(resource.MustParse("500m")))
+				Expect(foundResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse("2Gi")))
+				Expect(foundResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("250m")))
+				Expect(foundResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("1Gi")))
 			})
 
 			It("should remove Resource Requirements if missing in HCO CR", func() {
@@ -417,10 +417,10 @@ var _ = Describe("CDI Operand", func() {
 
 				Expect(existingResource.Spec.Config).ToNot(BeNil())
 				Expect(existingResource.Spec.Config.PodResourceRequirements).ToNot(BeNil())
-				Expect(existingResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceCPU]).Should(Equal(resource.MustParse("500m")))
-				Expect(existingResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceMemory]).Should(Equal(resource.MustParse("2Gi")))
-				Expect(existingResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceCPU]).Should(Equal(resource.MustParse("250m")))
-				Expect(existingResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceMemory]).Should(Equal(resource.MustParse("1Gi")))
+				Expect(existingResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceCPU]).To(Equal(resource.MustParse("500m")))
+				Expect(existingResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse("2Gi")))
+				Expect(existingResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("250m")))
+				Expect(existingResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("1Gi")))
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := (*genericOperand)(newCdiHandler(cl, commontestutils.GetScheme()))
@@ -478,10 +478,10 @@ var _ = Describe("CDI Operand", func() {
 				).ToNot(HaveOccurred())
 
 				Expect(foundResource.Spec.Config.PodResourceRequirements.Limits).To(HaveLen(2))
-				Expect(foundResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceCPU]).Should(Equal(resource.MustParse("1024m")))
+				Expect(foundResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceCPU]).To(Equal(resource.MustParse("1024m")))
 				Expect(foundResource.Spec.Config.PodResourceRequirements.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse("4Gi")))
 				Expect(foundResource.Spec.Config.PodResourceRequirements.Requests).To(HaveLen(2))
-				Expect(foundResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceCPU]).Should(Equal(resource.MustParse("500m")))
+				Expect(foundResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("500m")))
 				Expect(foundResource.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("2Gi")))
 			})
 		})
@@ -519,7 +519,7 @@ var _ = Describe("CDI Operand", func() {
 
 				Expect(foundCdi.Spec.Config).ToNot(BeNil())
 				Expect(foundCdi.Spec.Config.FilesystemOverhead).ToNot(BeNil())
-				Expect(*foundCdi.Spec.Config.FilesystemOverhead).Should(Equal(hcoFilesystemOverheadValue))
+				Expect(*foundCdi.Spec.Config.FilesystemOverhead).To(Equal(hcoFilesystemOverheadValue))
 			})
 
 			It("should remove FilesystemOverhead if missing in HCO CR", func() {
@@ -531,7 +531,7 @@ var _ = Describe("CDI Operand", func() {
 
 				Expect(existingCdi.Spec.Config).ToNot(BeNil())
 				Expect(existingCdi.Spec.Config.FilesystemOverhead).ToNot(BeNil())
-				Expect(*existingCdi.Spec.Config.FilesystemOverhead).Should(Equal(cdiFilesystemOverheadValue))
+				Expect(*existingCdi.Spec.Config.FilesystemOverhead).To(Equal(cdiFilesystemOverheadValue))
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingCdi})
 				handler := (*genericOperand)(newCdiHandler(cl, commontestutils.GetScheme()))
@@ -588,7 +588,7 @@ var _ = Describe("CDI Operand", func() {
 				hco.Spec.LogVerbosityConfig = &hcov1beta1.LogVerbosityConfiguration{CDI: ptr.To[int32](4)}
 				cdi, err := NewCDI(hco)
 
-				Expect(err).ShouldNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(cdi).ToNot(BeNil())
 				Expect(cdi.Spec.Config.LogVerbosity).To(HaveValue(Equal(int32(4))))
 			})
@@ -597,7 +597,7 @@ var _ = Describe("CDI Operand", func() {
 				hco.Spec.LogVerbosityConfig = logConfig
 				cdi, err := NewCDI(hco)
 
-				Expect(err).ShouldNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(cdi).ToNot(BeNil())
 				Expect(cdi.Spec.Config.LogVerbosity).To(BeNil())
 			},
@@ -634,7 +634,7 @@ var _ = Describe("CDI Operand", func() {
 				).ToNot(HaveOccurred())
 
 				Expect(foundCdi.Spec.Config).ToNot(BeNil())
-				Expect(foundCdi.Spec.Config.ScratchSpaceStorageClass).Should(HaveValue(Equal(hcoScratchSpaceStorageClassValue)))
+				Expect(foundCdi.Spec.Config.ScratchSpaceStorageClass).To(HaveValue(Equal(hcoScratchSpaceStorageClassValue)))
 			})
 
 			It("should remove ScratchSpaceStorageClass if missing in HCO CR", func() {
@@ -645,7 +645,7 @@ var _ = Describe("CDI Operand", func() {
 				existingCdi.Spec.Config.ScratchSpaceStorageClass = ptr.To(cdiScratchSpaceStorageClassValue)
 
 				Expect(existingCdi.Spec.Config).ToNot(BeNil())
-				Expect(existingCdi.Spec.Config.ScratchSpaceStorageClass).Should(HaveValue(Equal(cdiScratchSpaceStorageClassValue)))
+				Expect(existingCdi.Spec.Config.ScratchSpaceStorageClass).To(HaveValue(Equal(cdiScratchSpaceStorageClassValue)))
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingCdi})
 				handler := (*genericOperand)(newCdiHandler(cl, commontestutils.GetScheme()))
@@ -721,8 +721,8 @@ var _ = Describe("CDI Operand", func() {
 
 				Expect(foundCdi.Spec.Config).ToNot(BeNil())
 				Expect(foundCdi.Spec.Config.InsecureRegistries).ToNot(BeEmpty())
-				Expect(foundCdi.Spec.Config.InsecureRegistries).Should(HaveLen(3))
-				Expect(foundCdi.Spec.Config.InsecureRegistries).Should(ContainElements("first:5000", "second:5000", "third:5000"))
+				Expect(foundCdi.Spec.Config.InsecureRegistries).To(HaveLen(3))
+				Expect(foundCdi.Spec.Config.InsecureRegistries).To(ContainElements("first:5000", "second:5000", "third:5000"))
 			})
 
 			It("should remove InsecureRegistries if missing in HCO CR", func() {
@@ -936,10 +936,10 @@ var _ = Describe("CDI Operand", func() {
 			Expect(existingResource.Spec.CertConfig).To(BeNil())
 
 			Expect(foundResource.Spec.CertConfig).ToNot(BeNil())
-			Expect(foundResource.Spec.CertConfig.CA.Duration.Duration.String()).Should(Equal("48h0m0s"))
-			Expect(foundResource.Spec.CertConfig.CA.RenewBefore.Duration.String()).Should(Equal("24h0m0s"))
-			Expect(foundResource.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("24h0m0s"))
-			Expect(foundResource.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("12h0m0s"))
+			Expect(foundResource.Spec.CertConfig.CA.Duration.Duration.String()).To(Equal("48h0m0s"))
+			Expect(foundResource.Spec.CertConfig.CA.RenewBefore.Duration.String()).To(Equal("24h0m0s"))
+			Expect(foundResource.Spec.CertConfig.Server.Duration.Duration.String()).To(Equal("24h0m0s"))
+			Expect(foundResource.Spec.CertConfig.Server.RenewBefore.Duration.String()).To(Equal("12h0m0s"))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})
@@ -964,10 +964,10 @@ var _ = Describe("CDI Operand", func() {
 			Expect(existingResource.Spec.CertConfig).To(BeNil())
 
 			Expect(foundResource.Spec.CertConfig).ToNot(BeNil())
-			Expect(foundResource.Spec.CertConfig.CA.Duration.Duration.String()).Should(Equal("48h0m0s"))
-			Expect(foundResource.Spec.CertConfig.CA.RenewBefore.Duration.String()).Should(Equal("24h0m0s"))
-			Expect(foundResource.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("24h0m0s"))
-			Expect(foundResource.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("12h0m0s"))
+			Expect(foundResource.Spec.CertConfig.CA.Duration.Duration.String()).To(Equal("48h0m0s"))
+			Expect(foundResource.Spec.CertConfig.CA.RenewBefore.Duration.String()).To(Equal("24h0m0s"))
+			Expect(foundResource.Spec.CertConfig.Server.Duration.Duration.String()).To(Equal("24h0m0s"))
+			Expect(foundResource.Spec.CertConfig.Server.RenewBefore.Duration.String()).To(Equal("12h0m0s"))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})
@@ -1004,16 +1004,16 @@ var _ = Describe("CDI Operand", func() {
 			).ToNot(HaveOccurred())
 
 			Expect(existingResource.Spec.CertConfig).ToNot(BeNil())
-			Expect(existingResource.Spec.CertConfig.CA.Duration.Duration.String()).Should(Equal("48h0m0s"))
-			Expect(existingResource.Spec.CertConfig.CA.RenewBefore.Duration.String()).Should(Equal("24h0m0s"))
-			Expect(existingResource.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("24h0m0s"))
-			Expect(existingResource.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("12h0m0s"))
+			Expect(existingResource.Spec.CertConfig.CA.Duration.Duration.String()).To(Equal("48h0m0s"))
+			Expect(existingResource.Spec.CertConfig.CA.RenewBefore.Duration.String()).To(Equal("24h0m0s"))
+			Expect(existingResource.Spec.CertConfig.Server.Duration.Duration.String()).To(Equal("24h0m0s"))
+			Expect(existingResource.Spec.CertConfig.Server.RenewBefore.Duration.String()).To(Equal("12h0m0s"))
 
 			Expect(foundResource.Spec.CertConfig).ToNot(BeNil())
-			Expect(foundResource.Spec.CertConfig.CA.Duration.Duration.String()).Should(Equal("5h0m0s"))
-			Expect(foundResource.Spec.CertConfig.CA.RenewBefore.Duration.String()).Should(Equal("6h0m0s"))
-			Expect(foundResource.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("7h0m0s"))
-			Expect(foundResource.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("8h0m0s"))
+			Expect(foundResource.Spec.CertConfig.CA.Duration.Duration.String()).To(Equal("5h0m0s"))
+			Expect(foundResource.Spec.CertConfig.CA.RenewBefore.Duration.String()).To(Equal("6h0m0s"))
+			Expect(foundResource.Spec.CertConfig.Server.Duration.Duration.String()).To(Equal("7h0m0s"))
+			Expect(foundResource.Spec.CertConfig.Server.RenewBefore.Duration.String()).To(Equal("8h0m0s"))
 			Expect(req.Conditions).To(BeEmpty())
 
 			// ObjectReference should have been updated
@@ -1108,10 +1108,10 @@ var _ = Describe("CDI Operand", func() {
 				Expect(cdi.Spec.Config.FeatureGates).To(HaveLen(2))
 				Expect(cdi.Spec.Config.FeatureGates).To(ContainElement("fg1"))
 				Expect(cdi.Spec.Config.FilesystemOverhead).ToNot(BeNil())
-				Expect(cdi.Spec.Config.FilesystemOverhead.Global).Should(BeEquivalentTo("50"))
+				Expect(cdi.Spec.Config.FilesystemOverhead.Global).To(BeEquivalentTo("50"))
 				Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass).To(HaveLen(2))
-				Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["AAA"]).Should(BeEquivalentTo("75"))
-				Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["BBB"]).Should(BeEquivalentTo("25"))
+				Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["AAA"]).To(BeEquivalentTo("75"))
+				Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["BBB"]).To(BeEquivalentTo("25"))
 			})
 
 			It("Should fail to create CDI object with wrong jsonPatch", func() {
@@ -1158,10 +1158,10 @@ var _ = Describe("CDI Operand", func() {
 				Expect(cdi.Spec.Config.FeatureGates).To(HaveLen(2))
 				Expect(cdi.Spec.Config.FeatureGates).To(ContainElement("fg1"))
 				Expect(cdi.Spec.Config.FilesystemOverhead).ToNot(BeNil())
-				Expect(cdi.Spec.Config.FilesystemOverhead.Global).Should(BeEquivalentTo("50"))
+				Expect(cdi.Spec.Config.FilesystemOverhead.Global).To(BeEquivalentTo("50"))
 				Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass).To(HaveLen(2))
-				Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["AAA"]).Should(BeEquivalentTo("75"))
-				Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["BBB"]).Should(BeEquivalentTo("25"))
+				Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["AAA"]).To(BeEquivalentTo("75"))
+				Expect(cdi.Spec.Config.FilesystemOverhead.StorageClass["BBB"]).To(BeEquivalentTo("25"))
 			})
 
 			It("Ensure func should fail to create CDI object with wrong jsonPatch", func() {
@@ -1221,9 +1221,9 @@ var _ = Describe("CDI Operand", func() {
 						cdi),
 				).ToNot(HaveOccurred())
 
-				Expect(cdi.Spec.ImagePullPolicy).Should(BeEquivalentTo("Always"))
+				Expect(cdi.Spec.ImagePullPolicy).To(BeEquivalentTo("Always"))
 				Expect(cdi.Spec.CloneStrategyOverride).ToNot(BeNil())
-				Expect(*cdi.Spec.CloneStrategyOverride).Should(BeEquivalentTo("copy"))
+				Expect(*cdi.Spec.CloneStrategyOverride).To(BeEquivalentTo("copy"))
 			})
 
 			It("Ensure func should fail to update CDI object with wrong jsonPatch", func() {
@@ -1258,7 +1258,7 @@ var _ = Describe("CDI Operand", func() {
 						cdi),
 				).ToNot(HaveOccurred())
 
-				Expect(cdi.Spec.ImagePullPolicy).Should(BeEmpty())
+				Expect(cdi.Spec.ImagePullPolicy).To(BeEmpty())
 				Expect(cdi.Spec.CloneStrategyOverride).To(BeNil())
 
 			})
@@ -1279,12 +1279,12 @@ var _ = Describe("CDI Operand", func() {
 				Expect(handler.hooks.(*cdiHooks).cache).ToNot(BeNil())
 
 				By("compare pointers to make sure cache is working", func() {
-					Expect(handler.hooks.(*cdiHooks).cache).Should(BeIdenticalTo(cr))
+					Expect(handler.hooks.(*cdiHooks).cache).To(BeIdenticalTo(cr))
 
 					cdi1, err := handler.hooks.getFullCr(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(cdi1).ToNot(BeNil())
-					Expect(cr).Should(BeIdenticalTo(cdi1))
+					Expect(cr).To(BeIdenticalTo(cdi1))
 				})
 			})
 

--- a/controllers/operands/cliDownload_test.go
+++ b/controllers/operands/cliDownload_test.go
@@ -42,8 +42,8 @@ var _ = Describe("CLI Download", func() {
 			foundResource := &consolev1.ConsoleCLIDownload{}
 			Expect(cl.Get(context.TODO(), key, foundResource)).ToNot(HaveOccurred())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
-			Expect(foundResource.Spec.Links).Should(HaveLen(6))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Spec.Links).To(HaveLen(6))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -192,7 +192,7 @@ var _ = Describe("Downloads Service", func() {
 			foundResource := &corev1.Service{}
 			Expect(cl.Get(context.TODO(), key, foundResource)).ToNot(HaveOccurred())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -273,7 +273,7 @@ var _ = Describe("Cli Downloads Route", func() {
 			foundResource := &routev1.Route{}
 			Expect(cl.Get(context.TODO(), key, foundResource)).ToNot(HaveOccurred())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 

--- a/controllers/operands/dashboard_test.go
+++ b/controllers/operands/dashboard_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Dashboard tests", func() {
 				cli := commontestutils.InitClient([]client.Object{})
 				handlers, err := getDashboardHandlers(logger, cli, schemeForTest, hco)
 
-				Expect(err).Should(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 				Expect(handlers).To(BeEmpty())
 			})
 		})
@@ -133,7 +133,7 @@ var _ = Describe("Dashboard tests", func() {
 				cms := &corev1.ConfigMapList{}
 				Expect(cli.List(context.TODO(), cms)).To(Succeed())
 				Expect(cms.Items).To(HaveLen(1))
-				Expect(cms.Items[0].Name).Should(Equal("grafana-dashboard-kubevirt-top-consumers"))
+				Expect(cms.Items[0].Name).To(Equal("grafana-dashboard-kubevirt-top-consumers"))
 			})
 		})
 
@@ -159,11 +159,11 @@ var _ = Describe("Dashboard tests", func() {
 				cmList := &corev1.ConfigMapList{}
 				Expect(cli.List(context.TODO(), cmList)).To(Succeed())
 				Expect(cmList.Items).To(HaveLen(1))
-				Expect(cmList.Items[0].Name).Should(Equal("grafana-dashboard-kubevirt-top-consumers"))
+				Expect(cmList.Items[0].Name).To(Equal("grafana-dashboard-kubevirt-top-consumers"))
 
 				// check that data is reconciled
 				_, ok := cmList.Items[0].Data["kubevirt-top-consumers.json"]
-				Expect(ok).Should(BeTrue())
+				Expect(ok).To(BeTrue())
 			})
 		})
 
@@ -188,7 +188,7 @@ var _ = Describe("Dashboard tests", func() {
 
 				Expect(cli.List(context.TODO(), cmList)).To(Succeed())
 				Expect(cmList.Items).To(HaveLen(1))
-				Expect(cmList.Items[0].Name).Should(Equal("grafana-dashboard-kubevirt-top-consumers"))
+				Expect(cmList.Items[0].Name).To(Equal("grafana-dashboard-kubevirt-top-consumers"))
 			})
 
 			expectedLabels := make(map[string]map[string]string)
@@ -254,7 +254,7 @@ var _ = Describe("Dashboard tests", func() {
 
 				Expect(cli.List(context.TODO(), cmList)).To(Succeed())
 				Expect(cmList.Items).To(HaveLen(1))
-				Expect(cmList.Items[0].Name).Should(Equal("grafana-dashboard-kubevirt-top-consumers"))
+				Expect(cmList.Items[0].Name).To(Equal("grafana-dashboard-kubevirt-top-consumers"))
 			})
 
 			expectedLabels := make(map[string]map[string]string)

--- a/controllers/operands/deploymentHandler_test.go
+++ b/controllers/operands/deploymentHandler_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Deployment Handler", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 
-			Expect(foundResource.Spec.Selector).Should(Equal(expectedDeployment.Spec.Selector))
+			Expect(foundResource.Spec.Selector).To(Equal(expectedDeployment.Spec.Selector))
 			// let's check the object UID to ensure that the object get really deleted and recreated
 			Expect(foundResource.ObjectMeta.UID).ToNot(Equal(modifiedDeployment.ObjectMeta.UID))
 		})
@@ -99,7 +99,7 @@ var _ = Describe("Deployment Handler", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 
-			Expect(foundResource.Spec.Selector).Should(Equal(expectedDeployment.Spec.Selector))
+			Expect(foundResource.Spec.Selector).To(Equal(expectedDeployment.Spec.Selector))
 			// let's check the object UID to ensure that the object get updated and not deleted and recreated
 			Expect(foundResource.GetUID()).To(Equal(types.UID("oldObjectUID")))
 		})

--- a/controllers/operands/imageStream_test.go
+++ b/controllers/operands/imageStream_test.go
@@ -140,7 +140,7 @@ var _ = Describe("imageStream tests", func() {
 			ImageStreamObjects := &imagev1.ImageStreamList{}
 			Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 			Expect(ImageStreamObjects.Items).To(HaveLen(1))
-			Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
+			Expect(ImageStreamObjects.Items[0].Name).To(Equal("test-image-stream"))
 
 			objectRef, err := reference.GetReference(commontestutils.GetScheme(), &ImageStreamObjects.Items[0])
 			Expect(err).ToNot(HaveOccurred())
@@ -234,7 +234,7 @@ var _ = Describe("imageStream tests", func() {
 			ImageStreamObjects := &imagev1.ImageStreamList{}
 			Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 			Expect(ImageStreamObjects.Items).To(HaveLen(1))
-			Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
+			Expect(ImageStreamObjects.Items[0].Name).To(Equal("test-image-stream"))
 		})
 
 		It("should update the ImageStream resource if the docker image was changed", func() {
@@ -283,12 +283,12 @@ var _ = Describe("imageStream tests", func() {
 
 				is := imageStreamObjects.Items[0]
 
-				Expect(is.Name).Should(Equal("test-image-stream"))
+				Expect(is.Name).To(Equal("test-image-stream"))
 				// check that the existing object was reconciled
 				Expect(is.Spec.Tags).To(HaveLen(1))
 				tag := is.Spec.Tags[0]
-				Expect(tag.Name).Should(Equal("latest"))
-				Expect(tag.From.Name).Should(Equal("test-registry.io/test/test-image"))
+				Expect(tag.Name).To(Equal("latest"))
+				Expect(tag.From.Name).To(Equal("test-registry.io/test/test-image"))
 
 				// ObjectReference should have been updated
 				Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
@@ -348,12 +348,12 @@ var _ = Describe("imageStream tests", func() {
 
 				is := imageStreamObjects.Items[0]
 
-				Expect(is.Name).Should(Equal("test-image-stream"))
+				Expect(is.Name).To(Equal("test-image-stream"))
 				// check that the existing object was reconciled
 				Expect(is.Spec.Tags).To(HaveLen(1))
 				tag := is.Spec.Tags[0]
-				Expect(tag.Name).Should(Equal("latest"))
-				Expect(tag.From.Name).Should(Equal("test-registry.io/test/test-image"))
+				Expect(tag.Name).To(Equal("latest"))
+				Expect(tag.From.Name).To(Equal("test-registry.io/test/test-image"))
 
 				// ObjectReference should have been updated
 				Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
@@ -421,14 +421,14 @@ var _ = Describe("imageStream tests", func() {
 
 				is := imageStreamObjects.Items[0]
 
-				Expect(is.Name).Should(Equal("test-image-stream"))
+				Expect(is.Name).To(Equal("test-image-stream"))
 				// check that the existing object was reconciled
 				Expect(is.Spec.Tags).To(HaveLen(1))
 				tag := is.Spec.Tags[0]
-				Expect(tag.Name).Should(Equal("latest"))
-				Expect(tag.From.Name).Should(Equal("test-registry.io/test/test-image"))
+				Expect(tag.Name).To(Equal("latest"))
+				Expect(tag.From.Name).To(Equal("test-registry.io/test/test-image"))
 				// check that this tag was changed by the handler, by checking a field that is not controlled by it.
-				Expect(tag.From.UID).ShouldNot(BeEmpty())
+				Expect(tag.From.UID).ToNot(BeEmpty())
 
 				// ObjectReference should have been updated
 				Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
@@ -490,15 +490,15 @@ var _ = Describe("imageStream tests", func() {
 
 				is := imageStreamObjects.Items[0]
 
-				Expect(is.Name).Should(Equal("test-image-stream"))
+				Expect(is.Name).To(Equal("test-image-stream"))
 				// check that the existing object was reconciled
 				Expect(is.Spec.Tags).To(HaveLen(1))
 				tag := is.Spec.Tags[0]
-				Expect(tag.Name).Should(Equal("latest"))
-				Expect(tag.From.Name).Should(Equal("test-registry.io/test/test-image"))
+				Expect(tag.Name).To(Equal("latest"))
+				Expect(tag.From.Name).To(Equal("test-registry.io/test/test-image"))
 				// check that this tag was not changed by the handler, by checking a field that is not controlled by it.
-				Expect(tag.From.UID).Should(Equal(types.UID("1234567890")))
-				Expect(tag.ImportPolicy).Should(Equal(imagev1.TagImportPolicy{Insecure: false, Scheduled: true}))
+				Expect(tag.From.UID).To(Equal(types.UID("1234567890")))
+				Expect(tag.ImportPolicy).To(Equal(imagev1.TagImportPolicy{Insecure: false, Scheduled: true}))
 
 				// ObjectReference should have been updated
 				Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
@@ -559,15 +559,15 @@ var _ = Describe("imageStream tests", func() {
 
 				is := imageStreamObjects.Items[0]
 
-				Expect(is.Name).Should(Equal("test-image-stream"))
+				Expect(is.Name).To(Equal("test-image-stream"))
 				// check that the existing object was reconciled
 				Expect(is.Spec.Tags).To(HaveLen(1))
 				tag := is.Spec.Tags[0]
-				Expect(tag.Name).Should(Equal("old"))
-				Expect(tag.From.Name).Should(Equal("test-registry.io/test/old-test-image"))
+				Expect(tag.Name).To(Equal("old"))
+				Expect(tag.From.Name).To(Equal("test-registry.io/test/old-test-image"))
 				// check that this tag was not changed by the handler, by checking a field that is not controlled by it.
-				Expect(tag.From.UID).Should(Equal(types.UID("1234567890")))
-				Expect(tag.ImportPolicy).Should(Equal(imagev1.TagImportPolicy{Insecure: true, Scheduled: false}))
+				Expect(tag.From.UID).To(Equal(types.UID("1234567890")))
+				Expect(tag.ImportPolicy).To(Equal(imagev1.TagImportPolicy{Insecure: true, Scheduled: false}))
 
 				// ObjectReference should have been updated
 				Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
@@ -629,15 +629,15 @@ var _ = Describe("imageStream tests", func() {
 
 				is := imageStreamObjects.Items[0]
 
-				Expect(is.Name).Should(Equal("test-image-stream"))
+				Expect(is.Name).To(Equal("test-image-stream"))
 				// check that the existing object was reconciled
 				Expect(is.Spec.Tags).To(HaveLen(1))
 				tag := is.Spec.Tags[0]
-				Expect(tag.Name).Should(Equal("latest"))
-				Expect(tag.From.Name).Should(Equal("test-registry.io/test/test-image"))
+				Expect(tag.Name).To(Equal("latest"))
+				Expect(tag.From.Name).To(Equal("test-registry.io/test/test-image"))
 				// check that this tag was not changed by the handler, by checking a field that is not controlled by it.
-				Expect(tag.From.UID).Should(Equal(types.UID("1234567890")))
-				Expect(tag.ImportPolicy).Should(Equal(imagev1.TagImportPolicy{Insecure: false, Scheduled: true}))
+				Expect(tag.From.UID).To(Equal(types.UID("1234567890")))
+				Expect(tag.ImportPolicy).To(Equal(imagev1.TagImportPolicy{Insecure: false, Scheduled: true}))
 
 				// ObjectReference should have been updated
 				Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
@@ -711,12 +711,12 @@ var _ = Describe("imageStream tests", func() {
 
 				is := imageStreamObjects.Items[0]
 
-				Expect(is.Name).Should(Equal("test-image-stream"))
+				Expect(is.Name).To(Equal("test-image-stream"))
 				// check that the existing object was reconciled
 				Expect(is.Spec.Tags).To(HaveLen(1))
 				tag := is.Spec.Tags[0]
-				Expect(tag.Name).Should(Equal("latest"))
-				Expect(tag.From.Name).Should(Equal("test-registry.io/test/test-image"))
+				Expect(tag.Name).To(Equal("latest"))
+				Expect(tag.From.Name).To(Equal("test-registry.io/test/test-image"))
 
 				// ObjectReference should have been updated
 				Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
@@ -763,8 +763,8 @@ var _ = Describe("imageStream tests", func() {
 				ImageStreamObjects := &imagev1.ImageStreamList{}
 				Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 				Expect(ImageStreamObjects.Items).To(HaveLen(1))
-				Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
-				Expect(ImageStreamObjects.Items[0].Namespace).Should(Equal(customNS))
+				Expect(ImageStreamObjects.Items[0].Name).To(Equal("test-image-stream"))
+				Expect(ImageStreamObjects.Items[0].Namespace).To(Equal(customNS))
 			})
 
 			It("should delete an imagestream from one namespace, and create it in another one", func() {
@@ -793,8 +793,8 @@ var _ = Describe("imageStream tests", func() {
 				ImageStreamObjects := &imagev1.ImageStreamList{}
 				Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 				Expect(ImageStreamObjects.Items).To(HaveLen(1))
-				Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
-				Expect(ImageStreamObjects.Items[0].Namespace).Should(Equal("test-image-stream-ns"))
+				Expect(ImageStreamObjects.Items[0].Name).To(Equal("test-image-stream"))
+				Expect(ImageStreamObjects.Items[0].Namespace).To(Equal("test-image-stream-ns"))
 
 				By("replace the image stream with a new one in the custom namespace")
 				hco = commontestutils.NewHco()
@@ -809,8 +809,8 @@ var _ = Describe("imageStream tests", func() {
 				ImageStreamObjects = &imagev1.ImageStreamList{}
 				Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 				Expect(ImageStreamObjects.Items).To(HaveLen(1))
-				Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
-				Expect(ImageStreamObjects.Items[0].Namespace).Should(Equal(customNS))
+				Expect(ImageStreamObjects.Items[0].Name).To(Equal("test-image-stream"))
+				Expect(ImageStreamObjects.Items[0].Namespace).To(Equal(customNS))
 			})
 
 			It("should remove an imagestream from a custom namespace, and create it in the default one", func() {
@@ -841,8 +841,8 @@ var _ = Describe("imageStream tests", func() {
 				ImageStreamObjects := &imagev1.ImageStreamList{}
 				Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 				Expect(ImageStreamObjects.Items).To(HaveLen(1))
-				Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
-				Expect(ImageStreamObjects.Items[0].Namespace).Should(Equal(customNS))
+				Expect(ImageStreamObjects.Items[0].Name).To(Equal("test-image-stream"))
+				Expect(ImageStreamObjects.Items[0].Namespace).To(Equal(customNS))
 
 				By("replace the image stream with a new one in the default namespace")
 				hco = commontestutils.NewHco()
@@ -856,8 +856,8 @@ var _ = Describe("imageStream tests", func() {
 				ImageStreamObjects = &imagev1.ImageStreamList{}
 				Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 				Expect(ImageStreamObjects.Items).To(HaveLen(1))
-				Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
-				Expect(ImageStreamObjects.Items[0].Namespace).Should(Equal("test-image-stream-ns"))
+				Expect(ImageStreamObjects.Items[0].Name).To(Equal("test-image-stream"))
+				Expect(ImageStreamObjects.Items[0].Namespace).To(Equal("test-image-stream-ns"))
 			})
 
 			It("should remove an imagestream from a custom namespace, and create it in the new custom namespace", func() {
@@ -888,8 +888,8 @@ var _ = Describe("imageStream tests", func() {
 				ImageStreamObjects := &imagev1.ImageStreamList{}
 				Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 				Expect(ImageStreamObjects.Items).To(HaveLen(1))
-				Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
-				Expect(ImageStreamObjects.Items[0].Namespace).Should(Equal(customNS))
+				Expect(ImageStreamObjects.Items[0].Name).To(Equal("test-image-stream"))
+				Expect(ImageStreamObjects.Items[0].Namespace).To(Equal(customNS))
 
 				By("replace the image stream with a new one in another custom namespace")
 				hco = commontestutils.NewHco()
@@ -904,8 +904,8 @@ var _ = Describe("imageStream tests", func() {
 				ImageStreamObjects = &imagev1.ImageStreamList{}
 				Expect(cli.List(context.TODO(), ImageStreamObjects)).To(Succeed())
 				Expect(ImageStreamObjects.Items).To(HaveLen(1))
-				Expect(ImageStreamObjects.Items[0].Name).Should(Equal("test-image-stream"))
-				Expect(ImageStreamObjects.Items[0].Namespace).Should(Equal(customNS + "1"))
+				Expect(ImageStreamObjects.Items[0].Name).To(Equal("test-image-stream"))
+				Expect(ImageStreamObjects.Items[0].Namespace).To(Equal(customNS + "1"))
 			})
 		})
 	})
@@ -1120,8 +1120,8 @@ var _ = Describe("imageStream tests", func() {
 			validateImageStream(found, hook)
 
 			for _, tag := range found.Spec.Tags {
-				Expect(tag.Annotations).Should(HaveLen(1))
-				Expect(tag.Annotations).Should(HaveKeyWithValue("test-annotation", "should stay here"))
+				Expect(tag.Annotations).To(HaveLen(1))
+				Expect(tag.Annotations).To(HaveKeyWithValue("test-annotation", "should stay here"))
 			}
 
 		})

--- a/controllers/operands/kubevirtConsolePlugin_test.go
+++ b/controllers/operands/kubevirtConsolePlugin_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -290,12 +290,12 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 					foundResource),
 			).To(Succeed())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
-			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
-			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelComponent, string(appComponent)))
-			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelManagedBy, hcoutil.OperatorName))
-			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelVersion, hcoutil.GetHcoKvIoVersion()))
-			Expect(foundResource.Spec.Template.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelPartOf, hcoutil.HyperConvergedCluster))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Spec.Template.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Spec.Template.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, string(appComponent)))
+			Expect(foundResource.Spec.Template.Labels).To(HaveKeyWithValue(hcoutil.AppLabelManagedBy, hcoutil.OperatorName))
+			Expect(foundResource.Spec.Template.Labels).To(HaveKeyWithValue(hcoutil.AppLabelVersion, hcoutil.GetHcoKvIoVersion()))
+			Expect(foundResource.Spec.Template.Labels).To(HaveKeyWithValue(hcoutil.AppLabelPartOf, hcoutil.HyperConvergedCluster))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			Expect(reflect.DeepEqual(expectedResource.Spec, foundResource.Spec)).To(BeTrue())
 		},
@@ -539,11 +539,11 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 				Expect(existingResource.Spec.Template.Spec.Affinity.NodeAffinity).ToNot(BeNil())
 				Expect(existingResource.Spec.Template.Spec.Tolerations).To(HaveLen(2))
-				Expect(existingResource.Spec.Template.Spec.NodeSelector).Should(HaveKeyWithValue("key3", "value3"))
+				Expect(existingResource.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("key3", "value3"))
 
 				Expect(foundResource.Spec.Template.Spec.Affinity.NodeAffinity).ToNot(BeNil())
 				Expect(foundResource.Spec.Template.Spec.Tolerations).To(HaveLen(3))
-				Expect(foundResource.Spec.Template.Spec.NodeSelector).Should(HaveKeyWithValue("key3", "something entirely else"))
+				Expect(foundResource.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("key3", "something entirely else"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			},
@@ -585,10 +585,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				).To(Succeed())
 
 				Expect(existingResource.Spec.Template.Spec.Tolerations).To(HaveLen(3))
-				Expect(existingResource.Spec.Template.Spec.NodeSelector).Should(HaveKeyWithValue("key3", "BADvalue3"))
+				Expect(existingResource.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("key3", "BADvalue3"))
 
 				Expect(foundResource.Spec.Template.Spec.Tolerations).To(HaveLen(2))
-				Expect(foundResource.Spec.Template.Spec.NodeSelector).Should(HaveKeyWithValue("key3", "value3"))
+				Expect(foundResource.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("key3", "value3"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			},
@@ -722,7 +722,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 					foundResource),
 			).To(Succeed())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		},
 			Entry("ui plugin service", hcoutil.AppComponentUIPlugin, NewKvUIPluginSvc),

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -216,7 +216,7 @@ Version: 1.2.3`)
 					foundResource),
 			).ToNot(HaveOccurred())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 
 			Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
@@ -231,33 +231,33 @@ Version: 1.2.3`)
 				kvWithHostPassthroughCPU,
 			))
 			Expect(foundResource.Spec.Configuration.DeveloperConfiguration.DiskVerification).ToNot(BeNil())
-			Expect(*foundResource.Spec.Configuration.DeveloperConfiguration.DiskVerification.MemoryLimit).Should(Equal(kvDiskVerificationMemoryLimit))
+			Expect(*foundResource.Spec.Configuration.DeveloperConfiguration.DiskVerification.MemoryLimit).To(Equal(kvDiskVerificationMemoryLimit))
 
-			Expect(foundResource.Spec.Configuration.MachineType).Should(Equal("machine-type"))
-			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).Should(Equal("machine-type"))
+			Expect(foundResource.Spec.Configuration.MachineType).To(Equal("machine-type"))
+			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).To(Equal("machine-type"))
 
 			Expect(foundResource.Spec.Configuration.SMBIOSConfig).ToNot(BeNil())
-			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Family).Should(Equal("smbios family"))
-			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Product).Should(Equal("smbios product"))
-			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Manufacturer).Should(Equal("smbios manufacturer"))
-			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Sku).Should(Equal("1.2.3"))
-			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Version).Should(Equal("1.2.3"))
+			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Family).To(Equal("smbios family"))
+			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Product).To(Equal("smbios product"))
+			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Manufacturer).To(Equal("smbios manufacturer"))
+			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Sku).To(Equal("1.2.3"))
+			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Version).To(Equal("1.2.3"))
 
 			Expect(foundResource.Spec.Configuration.NetworkConfiguration).ToNot(BeNil())
-			Expect(foundResource.Spec.Configuration.NetworkConfiguration.NetworkInterface).Should(Equal(string(kubevirtcorev1.MasqueradeInterface)))
-			Expect(foundResource.Spec.Configuration.NetworkConfiguration.Binding).Should(Equal(bindingPlugins))
+			Expect(foundResource.Spec.Configuration.NetworkConfiguration.NetworkInterface).To(Equal(string(kubevirtcorev1.MasqueradeInterface)))
+			Expect(foundResource.Spec.Configuration.NetworkConfiguration.Binding).To(Equal(bindingPlugins))
 
 			// LiveMigration Configurations
 			mc := foundResource.Spec.Configuration.MigrationConfiguration
 			Expect(mc).ToNot(BeNil())
-			Expect(mc.BandwidthPerMigration).Should(BeNil())
-			Expect(*mc.CompletionTimeoutPerGiB).Should(Equal(int64(800)))
-			Expect(*mc.ParallelMigrationsPerCluster).Should(Equal(uint32(5)))
-			Expect(*mc.ParallelOutboundMigrationsPerNode).Should(Equal(uint32(2)))
-			Expect(*mc.ProgressTimeout).Should(Equal(int64(150)))
-			Expect(mc.Network).Should(BeNil())
-			Expect(*mc.AllowAutoConverge).Should(BeFalse())
-			Expect(*mc.AllowPostCopy).Should(BeFalse())
+			Expect(mc.BandwidthPerMigration).To(BeNil())
+			Expect(*mc.CompletionTimeoutPerGiB).To(Equal(int64(800)))
+			Expect(*mc.ParallelMigrationsPerCluster).To(Equal(uint32(5)))
+			Expect(*mc.ParallelOutboundMigrationsPerNode).To(Equal(uint32(2)))
+			Expect(*mc.ProgressTimeout).To(Equal(int64(150)))
+			Expect(mc.Network).To(BeNil())
+			Expect(*mc.AllowAutoConverge).To(BeFalse())
+			Expect(*mc.AllowPostCopy).To(BeFalse())
 		})
 
 		It("should find if present", func() {
@@ -441,32 +441,32 @@ Version: 1.2.3`)
 				kvWithHostPassthroughCPU,
 			))
 
-			Expect(foundResource.Spec.Configuration.MachineType).Should(Equal("machine-type"))
-			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).Should(Equal("machine-type"))
+			Expect(foundResource.Spec.Configuration.MachineType).To(Equal("machine-type"))
+			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).To(Equal("machine-type"))
 
 			Expect(foundResource.Spec.Configuration.SMBIOSConfig).ToNot(BeNil())
-			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Family).Should(Equal("smbios family"))
-			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Product).Should(Equal("smbios product"))
-			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Manufacturer).Should(Equal("smbios manufacturer"))
-			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Sku).Should(Equal("1.2.3"))
-			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Version).Should(Equal("1.2.3"))
+			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Family).To(Equal("smbios family"))
+			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Product).To(Equal("smbios product"))
+			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Manufacturer).To(Equal("smbios manufacturer"))
+			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Sku).To(Equal("1.2.3"))
+			Expect(foundResource.Spec.Configuration.SMBIOSConfig.Version).To(Equal("1.2.3"))
 
 			Expect(foundResource.Spec.Configuration.NetworkConfiguration).ToNot(BeNil())
-			Expect(foundResource.Spec.Configuration.NetworkConfiguration.NetworkInterface).Should(Equal(string(kubevirtcorev1.MasqueradeInterface)))
+			Expect(foundResource.Spec.Configuration.NetworkConfiguration.NetworkInterface).To(Equal(string(kubevirtcorev1.MasqueradeInterface)))
 
-			Expect(foundResource.Spec.Configuration.EmulatedMachines).Should(BeEmpty())
+			Expect(foundResource.Spec.Configuration.EmulatedMachines).To(BeEmpty())
 
 			// LiveMigration Configurations
 			mc := foundResource.Spec.Configuration.MigrationConfiguration
 			Expect(mc).ToNot(BeNil())
-			Expect(mc.BandwidthPerMigration).Should(BeNil())
-			Expect(*mc.CompletionTimeoutPerGiB).Should(Equal(int64(800)))
-			Expect(*mc.ParallelMigrationsPerCluster).Should(Equal(uint32(5)))
-			Expect(*mc.ParallelOutboundMigrationsPerNode).Should(Equal(uint32(2)))
-			Expect(*mc.ProgressTimeout).Should(Equal(int64(150)))
-			Expect(mc.Network).Should(BeNil())
-			Expect(*mc.AllowAutoConverge).Should(BeFalse())
-			Expect(*mc.AllowPostCopy).Should(BeFalse())
+			Expect(mc.BandwidthPerMigration).To(BeNil())
+			Expect(*mc.CompletionTimeoutPerGiB).To(Equal(int64(800)))
+			Expect(*mc.ParallelMigrationsPerCluster).To(Equal(uint32(5)))
+			Expect(*mc.ParallelOutboundMigrationsPerNode).To(Equal(uint32(2)))
+			Expect(*mc.ProgressTimeout).To(Equal(int64(150)))
+			Expect(mc.Network).To(BeNil())
+			Expect(*mc.AllowAutoConverge).To(BeFalse())
+			Expect(*mc.AllowPostCopy).To(BeFalse())
 		})
 
 		It("should fail if the SMBIOS is wrongly formatted mandatory configurations", func() {
@@ -1411,12 +1411,12 @@ Version: 1.2.3`)
 				Expect(foundResource.Spec.Infra).ToNot(BeNil())
 				Expect(foundResource.Spec.Infra.NodePlacement).ToNot(BeNil())
 				Expect(foundResource.Spec.Infra.NodePlacement.Affinity).ToNot(BeNil())
-				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("value1"))
-				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key2"]).Should(Equal("value2"))
+				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).To(Equal("value1"))
+				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key2"]).To(Equal("value2"))
 
 				Expect(foundResource.Spec.Workloads).ToNot(BeNil())
 				Expect(foundResource.Spec.Workloads.NodePlacement).ToNot(BeNil())
-				Expect(foundResource.Spec.Workloads.NodePlacement.Tolerations).Should(Equal(hco.Spec.Workloads.NodePlacement.Tolerations))
+				Expect(foundResource.Spec.Workloads.NodePlacement.Tolerations).To(Equal(hco.Spec.Workloads.NodePlacement.Tolerations))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -1485,7 +1485,7 @@ Version: 1.2.3`)
 				Expect(existingResource.Spec.Workloads).ToNot(BeNil())
 
 				Expect(existingResource.Spec.Workloads.NodePlacement).ToNot(BeNil())
-				Expect(existingResource.Spec.Workloads.NodePlacement.NodeSelector["key1"]).Should(Equal("value1"))
+				Expect(existingResource.Spec.Workloads.NodePlacement.NodeSelector["key1"]).To(Equal("value1"))
 
 				Expect(foundResource.Spec.Infra).ToNot(BeNil())
 				Expect(foundResource.Spec.Infra.NodePlacement).ToNot(BeNil())
@@ -1493,7 +1493,7 @@ Version: 1.2.3`)
 
 				Expect(foundResource.Spec.Workloads).ToNot(BeNil())
 				Expect(foundResource.Spec.Workloads.NodePlacement).ToNot(BeNil())
-				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key1"]).Should(Equal("something else"))
+				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key1"]).To(Equal("something else"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -1535,13 +1535,13 @@ Version: 1.2.3`)
 
 				Expect(existingResource.Spec.Infra.NodePlacement.Tolerations).To(HaveLen(3))
 				Expect(existingResource.Spec.Workloads.NodePlacement.Tolerations).To(HaveLen(3))
-				Expect(existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("BADvalue1"))
-				Expect(existingResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("BADvalue2"))
+				Expect(existingResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).To(Equal("BADvalue1"))
+				Expect(existingResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).To(Equal("BADvalue2"))
 
 				Expect(foundResource.Spec.Infra.NodePlacement.Tolerations).To(HaveLen(2))
 				Expect(foundResource.Spec.Workloads.NodePlacement.Tolerations).To(HaveLen(2))
-				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).Should(Equal("value1"))
-				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).Should(Equal("value2"))
+				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).To(Equal("value1"))
+				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector["key2"]).To(Equal("value2"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -1801,8 +1801,8 @@ Version: 1.2.3`)
 					Expect(existingResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 					fgList := getKvFeatureGateList(&hco.Spec.FeatureGates)
 					Expect(fgList).To(HaveLen(basicNumFgOnOpenshift + enabledByDefaultFeatureGates))
-					Expect(fgList).Should(ContainElements(hardCodeKvFgs))
-					Expect(fgList).Should(ContainElements(sspConditionKvFgs))
+					Expect(fgList).To(ContainElements(hardCodeKvFgs))
+					Expect(fgList).To(ContainElements(sspConditionKvFgs))
 				})
 
 				It("should add the DownwardMetrics if feature gate DownwardMetrics is true in HyperConverged CR", func() {
@@ -1919,8 +1919,8 @@ Version: 1.2.3`)
 						Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 						fgList := getKvFeatureGateList(&hco.Spec.FeatureGates)
 						Expect(fgList).To(HaveLen(basicNumFgOnOpenshift + enabledByDefaultFeatureGates))
-						Expect(fgList).Should(ContainElements(hardCodeKvFgs))
-						Expect(fgList).Should(ContainElements(sspConditionKvFgs))
+						Expect(fgList).To(ContainElements(hardCodeKvFgs))
+						Expect(fgList).To(ContainElements(sspConditionKvFgs))
 					})
 				})
 
@@ -1950,8 +1950,8 @@ Version: 1.2.3`)
 						Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 						fgList := getKvFeatureGateList(&hco.Spec.FeatureGates)
 						Expect(fgList).To(HaveLen(len(getKvFeatureGateList(&hco.Spec.FeatureGates))))
-						Expect(fgList).Should(ContainElements(hardCodeKvFgs))
-						Expect(fgList).Should(ContainElements(sspConditionKvFgs))
+						Expect(fgList).To(ContainElements(hardCodeKvFgs))
+						Expect(fgList).To(ContainElements(sspConditionKvFgs))
 					})
 				})
 
@@ -2127,7 +2127,7 @@ Version: 1.2.3`)
 						fgList := getKvFeatureGateList(fgs)
 						Expect(getKvFeatureGateList(fgs)).To(HaveLen(expectedLength))
 						for _, expected := range expectedFgs {
-							Expect(fgList).Should(ContainElements(expected))
+							Expect(fgList).To(ContainElements(expected))
 						}
 					},
 					Entry("When not using kvm-emulation and FG is empty",
@@ -2199,10 +2199,10 @@ Version: 1.2.3`)
 					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("bbb", true))
 					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("ccc", true))
 					for _, cpu := range hardcodedObsoleteCPUModels {
-						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
 					}
 
-					Expect(kv.Spec.Configuration.MinCPUModel).Should(BeEmpty())
+					Expect(kv.Spec.Configuration.MinCPUModel).To(BeEmpty())
 				})
 
 				It("should add min CPU Model if exists in HC CR", func() {
@@ -2213,23 +2213,23 @@ Version: 1.2.3`)
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(kv.Spec.Configuration.ObsoleteCPUModels).ShouldNot(BeEmpty())
+					Expect(kv.Spec.Configuration.ObsoleteCPUModels).ToNot(BeEmpty())
 					for _, cpu := range hardcodedObsoleteCPUModels {
-						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
 					}
-					Expect(kv.Spec.Configuration.MinCPUModel).Should(Equal("Penryn"))
+					Expect(kv.Spec.Configuration.MinCPUModel).To(Equal("Penryn"))
 				})
 
 				It("should not add min CPU Model and obsolete CPU Models if HC does not contain ObsoleteCPUs", func() {
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(kv.Spec.Configuration.ObsoleteCPUModels).Should(HaveLen(len(hardcodedObsoleteCPUModels)))
+					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(len(hardcodedObsoleteCPUModels)))
 					for _, cpu := range hardcodedObsoleteCPUModels {
-						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
 					}
 
-					Expect(kv.Spec.Configuration.MinCPUModel).Should(BeEmpty())
+					Expect(kv.Spec.Configuration.MinCPUModel).To(BeEmpty())
 				})
 
 				It("should not add min CPU Model and add only the hard coded obsolete CPU Models if ObsoleteCPUs is empty", func() {
@@ -2237,12 +2237,12 @@ Version: 1.2.3`)
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(kv.Spec.Configuration.ObsoleteCPUModels).Should(HaveLen(len(hardcodedObsoleteCPUModels)))
+					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(len(hardcodedObsoleteCPUModels)))
 					for _, cpu := range hardcodedObsoleteCPUModels {
-						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
 					}
 
-					Expect(kv.Spec.Configuration.MinCPUModel).Should(BeEmpty())
+					Expect(kv.Spec.Configuration.MinCPUModel).To(BeEmpty())
 				})
 			})
 
@@ -2272,15 +2272,15 @@ Version: 1.2.3`)
 					).ToNot(HaveOccurred())
 
 					By("KV CR should contain the HC obsolete CPU models and minCPUModel", func() {
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("aaa", true))
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("bbb", true))
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("ccc", true))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("aaa", true))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("bbb", true))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("ccc", true))
 						for _, cpu := range hardcodedObsoleteCPUModels {
-							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
 						}
 
-						Expect(foundKV.Spec.Configuration.MinCPUModel).Should(Equal("Penryn"))
+						Expect(foundKV.Spec.Configuration.MinCPUModel).To(Equal("Penryn"))
 					})
 
 				})
@@ -2316,17 +2316,17 @@ Version: 1.2.3`)
 					).ToNot(HaveOccurred())
 
 					By("KV CR should contain the HC obsolete CPU models and minCPUModel", func() {
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("shouldStay", true))
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("shouldBeTrue", true))
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).Should(HaveKeyWithValue("newOne", true))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("shouldStay", true))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("shouldBeTrue", true))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("newOne", true))
 						for _, cpu := range hardcodedObsoleteCPUModels {
-							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
 						}
 
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).ShouldNot(HaveKey("shouldBeRemoved"))
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).ToNot(HaveKey("shouldBeRemoved"))
 
-						Expect(foundKV.Spec.Configuration.MinCPUModel).Should(Equal("Penryn"))
+						Expect(foundKV.Spec.Configuration.MinCPUModel).To(Equal("Penryn"))
 					})
 				})
 
@@ -2356,14 +2356,14 @@ Version: 1.2.3`)
 					).ToNot(HaveOccurred())
 
 					By("KV CR ObsoleteCPUModels field should contain only the hard-coded values", func() {
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).ShouldNot(BeEmpty())
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).ToNot(BeEmpty())
 						for _, cpu := range hardcodedObsoleteCPUModels {
-							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).Should(BeTrue())
+							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
 						}
 					})
 
 					By("KV CR minCPUModel field should be empty", func() {
-						Expect(foundKV.Spec.Configuration.MinCPUModel).Should(BeEmpty())
+						Expect(foundKV.Spec.Configuration.MinCPUModel).To(BeEmpty())
 					})
 				})
 			})
@@ -2401,10 +2401,10 @@ Version: 1.2.3`)
 
 				Expect(foundResource.Spec.CertificateRotationStrategy).ToNot(BeNil())
 				certificateRotationStrategy := foundResource.Spec.CertificateRotationStrategy
-				Expect(certificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).Should(Equal("24h0m0s"))
-				Expect(certificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).Should(Equal("1h0m0s"))
-				Expect(certificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).Should(Equal("12h0m0s"))
-				Expect(certificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).Should(Equal("30m0s"))
+				Expect(certificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).To(Equal("24h0m0s"))
+				Expect(certificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).To(Equal("1h0m0s"))
+				Expect(certificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).To(Equal("12h0m0s"))
+				Expect(certificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).To(Equal("30m0s"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -2430,10 +2430,10 @@ Version: 1.2.3`)
 
 				Expect(foundResource.Spec.CertificateRotationStrategy).ToNot(BeNil())
 				certificateRotationStrategy := foundResource.Spec.CertificateRotationStrategy
-				Expect(certificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).Should(Equal("48h0m0s"))
-				Expect(certificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).Should(Equal("24h0m0s"))
-				Expect(certificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).Should(Equal("24h0m0s"))
-				Expect(certificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).Should(Equal("12h0m0s"))
+				Expect(certificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).To(Equal("48h0m0s"))
+				Expect(certificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).To(Equal("24h0m0s"))
+				Expect(certificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).To(Equal("24h0m0s"))
+				Expect(certificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).To(Equal("12h0m0s"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -2475,17 +2475,17 @@ Version: 1.2.3`)
 
 				Expect(existingResource.Spec.CertificateRotationStrategy).ToNot(BeNil())
 				existingCertificateRotationStrategy := existingResource.Spec.CertificateRotationStrategy
-				Expect(existingCertificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).Should(Equal("24h0m0s"))
-				Expect(existingCertificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).Should(Equal("1h0m0s"))
-				Expect(existingCertificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).Should(Equal("12h0m0s"))
-				Expect(existingCertificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).Should(Equal("30m0s"))
+				Expect(existingCertificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).To(Equal("24h0m0s"))
+				Expect(existingCertificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).To(Equal("1h0m0s"))
+				Expect(existingCertificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).To(Equal("12h0m0s"))
+				Expect(existingCertificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).To(Equal("30m0s"))
 
 				Expect(foundResource.Spec.CertificateRotationStrategy).ToNot(BeNil())
 				foundCertificateRotationStrategy := foundResource.Spec.CertificateRotationStrategy
-				Expect(foundCertificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).Should(Equal("48h0m0s"))
-				Expect(foundCertificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).Should(Equal("2h0m0s"))
-				Expect(foundCertificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).Should(Equal("24h0m0s"))
-				Expect(foundCertificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).Should(Equal("1h0m0s"))
+				Expect(foundCertificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).To(Equal("48h0m0s"))
+				Expect(foundCertificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).To(Equal("2h0m0s"))
+				Expect(foundCertificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).To(Equal("24h0m0s"))
+				Expect(foundCertificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).To(Equal("1h0m0s"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -2531,17 +2531,17 @@ Version: 1.2.3`)
 
 				Expect(existingResource.Spec.CertificateRotationStrategy).ToNot(BeNil())
 				existingCertificateRotationStrategy := existingResource.Spec.CertificateRotationStrategy
-				Expect(existingCertificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).Should(Equal("48h0m0s"))
-				Expect(existingCertificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).Should(Equal("2h0m0s"))
-				Expect(existingCertificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).Should(Equal("24h0m0s"))
-				Expect(existingCertificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).Should(Equal("1h0m0s"))
+				Expect(existingCertificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).To(Equal("48h0m0s"))
+				Expect(existingCertificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).To(Equal("2h0m0s"))
+				Expect(existingCertificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).To(Equal("24h0m0s"))
+				Expect(existingCertificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).To(Equal("1h0m0s"))
 
 				Expect(foundResource.Spec.CertificateRotationStrategy).ToNot(BeNil())
 				foundCertificateRotationStrategy := foundResource.Spec.CertificateRotationStrategy
-				Expect(foundCertificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).Should(Equal("24h0m0s"))
-				Expect(foundCertificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).Should(Equal("1h0m0s"))
-				Expect(foundCertificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).Should(Equal("12h0m0s"))
-				Expect(foundCertificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).Should(Equal("30m0s"))
+				Expect(foundCertificateRotationStrategy.SelfSigned.CA.Duration.Duration.String()).To(Equal("24h0m0s"))
+				Expect(foundCertificateRotationStrategy.SelfSigned.CA.RenewBefore.Duration.String()).To(Equal("1h0m0s"))
+				Expect(foundCertificateRotationStrategy.SelfSigned.Server.Duration.Duration.String()).To(Equal("12h0m0s"))
+				Expect(foundCertificateRotationStrategy.SelfSigned.Server.RenewBefore.Duration.String()).To(Equal("30m0s"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -2588,10 +2588,10 @@ Version: 1.2.3`)
 
 				Expect(foundResource.Spec.WorkloadUpdateStrategy).ToNot(BeNil())
 				kvUpdateStrategy := foundResource.Spec.WorkloadUpdateStrategy
-				Expect(kvUpdateStrategy.BatchEvictionInterval.Duration.String()).Should(Equal("1m0s"))
-				Expect(kvUpdateStrategy.BatchEvictionSize).Should(HaveValue(Equal(defaultBatchEvictionSize)))
-				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(HaveLen(2))
-				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(ContainElements(kubevirtcorev1.WorkloadUpdateMethod("aaa"), kubevirtcorev1.WorkloadUpdateMethod("bbb")))
+				Expect(kvUpdateStrategy.BatchEvictionInterval.Duration.String()).To(Equal("1m0s"))
+				Expect(kvUpdateStrategy.BatchEvictionSize).To(HaveValue(Equal(defaultBatchEvictionSize)))
+				Expect(kvUpdateStrategy.WorkloadUpdateMethods).To(HaveLen(2))
+				Expect(kvUpdateStrategy.WorkloadUpdateMethods).To(ContainElements(kubevirtcorev1.WorkloadUpdateMethod("aaa"), kubevirtcorev1.WorkloadUpdateMethod("bbb")))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -2615,10 +2615,10 @@ Version: 1.2.3`)
 
 				Expect(foundResource.Spec.WorkloadUpdateStrategy).ToNot(BeNil())
 				kvUpdateStrategy := foundResource.Spec.WorkloadUpdateStrategy
-				Expect(kvUpdateStrategy.BatchEvictionInterval.Duration.String()).Should(Equal("1m0s"))
-				Expect(kvUpdateStrategy.BatchEvictionSize).Should(HaveValue(Equal(defaultBatchEvictionSize)))
-				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(HaveLen(1))
-				Expect(kvUpdateStrategy.WorkloadUpdateMethods).Should(
+				Expect(kvUpdateStrategy.BatchEvictionInterval.Duration.String()).To(Equal("1m0s"))
+				Expect(kvUpdateStrategy.BatchEvictionSize).To(HaveValue(Equal(defaultBatchEvictionSize)))
+				Expect(kvUpdateStrategy.WorkloadUpdateMethods).To(HaveLen(1))
+				Expect(kvUpdateStrategy.WorkloadUpdateMethods).To(
 					ContainElements(
 						kubevirtcorev1.WorkloadUpdateMethodLiveMigrate,
 					),
@@ -2651,8 +2651,8 @@ Version: 1.2.3`)
 						foundKv),
 				).ToNot(HaveOccurred())
 
-				Expect(foundKv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods).Should(HaveLen(3))
-				Expect(foundKv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods).Should(
+				Expect(foundKv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods).To(HaveLen(3))
+				Expect(foundKv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods).To(
 					ContainElements(
 						kubevirtcorev1.WorkloadUpdateMethod("aaa"),
 						kubevirtcorev1.WorkloadUpdateMethod("bbb"),
@@ -2660,8 +2660,8 @@ Version: 1.2.3`)
 					),
 				)
 
-				Expect(foundKv.Spec.WorkloadUpdateStrategy.BatchEvictionInterval).Should(HaveValue(Equal(metav1.Duration{Duration: time.Minute * 3})))
-				Expect(foundKv.Spec.WorkloadUpdateStrategy.BatchEvictionSize).Should(HaveValue(Equal(modifiedBatchEvictionSize)))
+				Expect(foundKv.Spec.WorkloadUpdateStrategy.BatchEvictionInterval).To(HaveValue(Equal(metav1.Duration{Duration: time.Minute * 3})))
+				Expect(foundKv.Spec.WorkloadUpdateStrategy.BatchEvictionSize).To(HaveValue(Equal(modifiedBatchEvictionSize)))
 			})
 
 			It("should overwrite Workload Update Strategy if directly set on KV CR", func() {
@@ -2703,21 +2703,21 @@ Version: 1.2.3`)
 
 				Expect(existingKV.Spec.CertificateRotationStrategy).ToNot(BeNil())
 				existingUpdateStrategy := existingKV.Spec.WorkloadUpdateStrategy
-				Expect(existingUpdateStrategy.WorkloadUpdateMethods).Should(HaveLen(1))
-				Expect(existingUpdateStrategy.WorkloadUpdateMethods).Should(ContainElements(
+				Expect(existingUpdateStrategy.WorkloadUpdateMethods).To(HaveLen(1))
+				Expect(existingUpdateStrategy.WorkloadUpdateMethods).To(ContainElements(
 					kubevirtcorev1.WorkloadUpdateMethodEvict,
 				))
-				Expect(*existingUpdateStrategy.BatchEvictionSize).Should(Equal(kvModifiedBatchEvictionSize))
-				Expect(existingUpdateStrategy.BatchEvictionInterval.Duration.String()).Should(Equal("3m0s"))
+				Expect(*existingUpdateStrategy.BatchEvictionSize).To(Equal(kvModifiedBatchEvictionSize))
+				Expect(existingUpdateStrategy.BatchEvictionInterval.Duration.String()).To(Equal("3m0s"))
 
 				Expect(foundKV.Spec.CertificateRotationStrategy).ToNot(BeNil())
 				foundUpdateStrategy := foundKV.Spec.WorkloadUpdateStrategy
-				Expect(foundUpdateStrategy.WorkloadUpdateMethods).Should(HaveLen(1))
-				Expect(foundUpdateStrategy.WorkloadUpdateMethods).Should(ContainElements(
+				Expect(foundUpdateStrategy.WorkloadUpdateMethods).To(HaveLen(1))
+				Expect(foundUpdateStrategy.WorkloadUpdateMethods).To(ContainElements(
 					kubevirtcorev1.WorkloadUpdateMethodLiveMigrate,
 				))
-				Expect(foundUpdateStrategy.BatchEvictionSize).Should(HaveValue(Equal(hcoModifiedBatchEvictionSize)))
-				Expect(foundUpdateStrategy.BatchEvictionInterval.Duration.String()).Should(Equal("5m0s"))
+				Expect(foundUpdateStrategy.BatchEvictionSize).To(HaveValue(Equal(hcoModifiedBatchEvictionSize)))
+				Expect(foundUpdateStrategy.BatchEvictionInterval.Duration.String()).To(Equal("5m0s"))
 			})
 
 		})
@@ -3390,7 +3390,7 @@ Version: 1.2.3`)
 					hco.Spec.TuningPolicy = hcov1beta1.HyperConvergedAnnotationTuningPolicy
 
 					kv, err := NewKubeVirt(hco)
-					Expect(err).Should(MatchError("tuning policy set but annotation not present or wrong"))
+					Expect(err).To(MatchError("tuning policy set but annotation not present or wrong"))
 
 					Expect(kv).To(BeNil())
 
@@ -3403,7 +3403,7 @@ Version: 1.2.3`)
 					hco.Annotations["hco.kubevirt.io/tuningPolicy"] = `{"qps": 100}`
 
 					kv, err := NewKubeVirt(hco)
-					Expect(err).Should(MatchError("burst parameter not found in annotation"))
+					Expect(err).To(MatchError("burst parameter not found in annotation"))
 					Expect(kv).To(BeNil())
 
 				})
@@ -3523,7 +3523,7 @@ Version: 1.2.3`)
 				quantity, err := resource.ParseQuantity("12m")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(kv.Spec.Configuration.CPURequest).ToNot(BeNil())
-				Expect(*kv.Spec.Configuration.CPURequest).Should(Equal(quantity))
+				Expect(*kv.Spec.Configuration.CPURequest).To(Equal(quantity))
 			})
 
 			It("Should fail to create KV object with wrong jsonPatch", func() {
@@ -3583,7 +3583,7 @@ Version: 1.2.3`)
 				quantity, err := resource.ParseQuantity("12m")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(kv.Spec.Configuration.CPURequest).ToNot(BeNil())
-				Expect(*kv.Spec.Configuration.CPURequest).Should(Equal(quantity))
+				Expect(*kv.Spec.Configuration.CPURequest).To(Equal(quantity))
 			})
 
 			It("Ensure func should fail to create KV object with wrong jsonPatch", func() {
@@ -3657,7 +3657,7 @@ Version: 1.2.3`)
 				quantity, err := resource.ParseQuantity("12m")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(kv.Spec.Configuration.CPURequest).ToNot(BeNil())
-				Expect(*kv.Spec.Configuration.CPURequest).Should(Equal(quantity))
+				Expect(*kv.Spec.Configuration.CPURequest).To(Equal(quantity))
 			})
 
 			It("Ensure func should fail to update KV object with wrong jsonPatch", func() {
@@ -3711,12 +3711,12 @@ Version: 1.2.3`)
 				Expect(handler.hooks.(*kubevirtHooks).cache).ToNot(BeNil())
 
 				By("compare pointers to make sure cache is working", func() {
-					Expect(handler.hooks.(*kubevirtHooks).cache).Should(BeIdenticalTo(cr))
+					Expect(handler.hooks.(*kubevirtHooks).cache).To(BeIdenticalTo(cr))
 
 					crII, err := handler.hooks.getFullCr(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(crII).ToNot(BeNil())
-					Expect(cr).Should(BeIdenticalTo(crII))
+					Expect(cr).To(BeIdenticalTo(crII))
 				})
 			})
 
@@ -3918,14 +3918,14 @@ Version: 1.2.3`)
 			mc, err := hcLiveMigrationToKv(lmc)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(mc.BandwidthPerMigration).Should(HaveValue(Equal(resource.MustParse(bandwidthPerMigration))))
-			Expect(mc.CompletionTimeoutPerGiB).Should(HaveValue(Equal(completionTimeoutPerGiB)))
-			Expect(mc.ParallelMigrationsPerCluster).Should(HaveValue(Equal(parallelMigrationsPerCluster)))
-			Expect(mc.ParallelOutboundMigrationsPerNode).Should(HaveValue(Equal(parallelOutboundMigrationsPerNode)))
-			Expect(mc.ProgressTimeout).Should(HaveValue(Equal(progressTimeout)))
-			Expect(mc.Network).Should(HaveValue(Equal(network)))
-			Expect(mc.AllowAutoConverge).Should(HaveValue(BeTrue()))
-			Expect(mc.AllowPostCopy).Should(HaveValue(BeTrue()))
+			Expect(mc.BandwidthPerMigration).To(HaveValue(Equal(resource.MustParse(bandwidthPerMigration))))
+			Expect(mc.CompletionTimeoutPerGiB).To(HaveValue(Equal(completionTimeoutPerGiB)))
+			Expect(mc.ParallelMigrationsPerCluster).To(HaveValue(Equal(parallelMigrationsPerCluster)))
+			Expect(mc.ParallelOutboundMigrationsPerNode).To(HaveValue(Equal(parallelOutboundMigrationsPerNode)))
+			Expect(mc.ProgressTimeout).To(HaveValue(Equal(progressTimeout)))
+			Expect(mc.Network).To(HaveValue(Equal(network)))
+			Expect(mc.AllowAutoConverge).To(HaveValue(BeTrue()))
+			Expect(mc.AllowPostCopy).To(HaveValue(BeTrue()))
 		})
 
 		It("should create valid empty KV LM config from a valid empty HC LM config", func() {
@@ -3933,14 +3933,14 @@ Version: 1.2.3`)
 			mc, err := hcLiveMigrationToKv(lmc)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(mc.BandwidthPerMigration).Should(BeNil())
-			Expect(mc.CompletionTimeoutPerGiB).Should(BeNil())
-			Expect(mc.ParallelMigrationsPerCluster).Should(BeNil())
-			Expect(mc.ParallelOutboundMigrationsPerNode).Should(BeNil())
-			Expect(mc.ProgressTimeout).Should(BeNil())
-			Expect(mc.Network).Should(BeNil())
-			Expect(mc.AllowAutoConverge).Should(BeNil())
-			Expect(mc.AllowPostCopy).Should(BeNil())
+			Expect(mc.BandwidthPerMigration).To(BeNil())
+			Expect(mc.CompletionTimeoutPerGiB).To(BeNil())
+			Expect(mc.ParallelMigrationsPerCluster).To(BeNil())
+			Expect(mc.ParallelOutboundMigrationsPerNode).To(BeNil())
+			Expect(mc.ProgressTimeout).To(BeNil())
+			Expect(mc.Network).To(BeNil())
+			Expect(mc.AllowAutoConverge).To(BeNil())
+			Expect(mc.AllowPostCopy).To(BeNil())
 		})
 
 		It("should return error if the value of the BandwidthPerMigration field is not valid", func() {

--- a/controllers/operands/mtq_test.go
+++ b/controllers/operands/mtq_test.go
@@ -71,28 +71,28 @@ var _ = Describe("MTQ tests", func() {
 		It("should have all default fields", func() {
 			mtq := NewMTQ(hco)
 
-			Expect(mtq.Name).Should(Equal("mtq-" + hco.Name))
-			Expect(mtq.Namespace).Should(BeEmpty())
+			Expect(mtq.Name).To(Equal("mtq-" + hco.Name))
+			Expect(mtq.Namespace).To(BeEmpty())
 
-			Expect(mtq.Spec.Infra.Tolerations).Should(BeEmpty())
-			Expect(mtq.Spec.Infra.Affinity).Should(BeNil())
-			Expect(mtq.Spec.Infra.NodeSelector).Should(BeEmpty())
+			Expect(mtq.Spec.Infra.Tolerations).To(BeEmpty())
+			Expect(mtq.Spec.Infra.Affinity).To(BeNil())
+			Expect(mtq.Spec.Infra.NodeSelector).To(BeEmpty())
 
-			Expect(mtq.Spec.Workloads.Tolerations).Should(BeEmpty())
-			Expect(mtq.Spec.Workloads.Affinity).Should(BeNil())
-			Expect(mtq.Spec.Workloads.NodeSelector).Should(BeEmpty())
+			Expect(mtq.Spec.Workloads.Tolerations).To(BeEmpty())
+			Expect(mtq.Spec.Workloads.Affinity).To(BeNil())
+			Expect(mtq.Spec.Workloads.NodeSelector).To(BeEmpty())
 
 			Expect(mtq.Spec.PriorityClass).To(HaveValue(Equal(mtqv1alpha1.MTQPriorityClass(kvPriorityClass))))
 
-			Expect(mtq.Spec.CertConfig.CA).ShouldNot(BeNil())
-			Expect(mtq.Spec.CertConfig.CA.Duration).ShouldNot(BeNil())
-			Expect(mtq.Spec.CertConfig.CA.Duration.Duration.String()).Should(Equal("48h0m0s"))
-			Expect(mtq.Spec.CertConfig.CA.RenewBefore.Duration.String()).Should(Equal("24h0m0s"))
+			Expect(mtq.Spec.CertConfig.CA).ToNot(BeNil())
+			Expect(mtq.Spec.CertConfig.CA.Duration).ToNot(BeNil())
+			Expect(mtq.Spec.CertConfig.CA.Duration.Duration.String()).To(Equal("48h0m0s"))
+			Expect(mtq.Spec.CertConfig.CA.RenewBefore.Duration.String()).To(Equal("24h0m0s"))
 
-			Expect(mtq.Spec.CertConfig.Server).ShouldNot(BeNil())
-			Expect(mtq.Spec.CertConfig.Server.Duration).ShouldNot(BeNil())
-			Expect(mtq.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("24h0m0s"))
-			Expect(mtq.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("12h0m0s"))
+			Expect(mtq.Spec.CertConfig.Server).ToNot(BeNil())
+			Expect(mtq.Spec.CertConfig.Server.Duration).ToNot(BeNil())
+			Expect(mtq.Spec.CertConfig.Server.Duration.Duration.String()).To(Equal("24h0m0s"))
+			Expect(mtq.Spec.CertConfig.Server.RenewBefore.Duration.String()).To(Equal("12h0m0s"))
 		})
 
 		It("should get node placement node placement configurations from the HyperConverged CR", func() {
@@ -101,8 +101,8 @@ var _ = Describe("MTQ tests", func() {
 
 			mtq := NewMTQ(hco)
 
-			Expect(mtq.Spec.Infra).Should(Equal(testNodePlacement))
-			Expect(mtq.Spec.Workloads).Should(Equal(testNodePlacement))
+			Expect(mtq.Spec.Infra).To(Equal(testNodePlacement))
+			Expect(mtq.Spec.Workloads).To(Equal(testNodePlacement))
 		})
 
 		It("should get node placement certification configurations from the HyperConverged CR", func() {
@@ -120,15 +120,15 @@ var _ = Describe("MTQ tests", func() {
 
 			mtq := NewMTQ(hco)
 
-			Expect(mtq.Spec.CertConfig.CA).ShouldNot(BeNil())
-			Expect(mtq.Spec.CertConfig.CA.Duration).ShouldNot(BeNil())
-			Expect(mtq.Spec.CertConfig.CA.Duration.Duration.String()).Should(Equal("72h0m0s"))
-			Expect(mtq.Spec.CertConfig.CA.RenewBefore.Duration.String()).Should(Equal("56h0m0s"))
+			Expect(mtq.Spec.CertConfig.CA).ToNot(BeNil())
+			Expect(mtq.Spec.CertConfig.CA.Duration).ToNot(BeNil())
+			Expect(mtq.Spec.CertConfig.CA.Duration.Duration.String()).To(Equal("72h0m0s"))
+			Expect(mtq.Spec.CertConfig.CA.RenewBefore.Duration.String()).To(Equal("56h0m0s"))
 
-			Expect(mtq.Spec.CertConfig.Server).ShouldNot(BeNil())
-			Expect(mtq.Spec.CertConfig.Server.Duration).ShouldNot(BeNil())
-			Expect(mtq.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("36h0m0s"))
-			Expect(mtq.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("18h0m0s"))
+			Expect(mtq.Spec.CertConfig.Server).ToNot(BeNil())
+			Expect(mtq.Spec.CertConfig.Server.Duration).ToNot(BeNil())
+			Expect(mtq.Spec.CertConfig.Server.Duration.Duration.String()).To(Equal("36h0m0s"))
+			Expect(mtq.Spec.CertConfig.Server.RenewBefore.Duration.String()).To(Equal("18h0m0s"))
 		})
 	})
 
@@ -140,14 +140,14 @@ var _ = Describe("MTQ tests", func() {
 
 			res := handler.ensure(req)
 
-			Expect(res.Err).ShouldNot(HaveOccurred())
-			Expect(res.Created).Should(BeFalse())
-			Expect(res.Updated).Should(BeFalse())
-			Expect(res.Deleted).Should(BeFalse())
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
 
 			foundMTQs := &mtqv1alpha1.MTQList{}
-			Expect(cl.List(context.Background(), foundMTQs)).Should(Succeed())
-			Expect(foundMTQs.Items).Should(BeEmpty())
+			Expect(cl.List(context.Background(), foundMTQs)).To(Succeed())
+			Expect(foundMTQs.Items).To(BeEmpty())
 		})
 
 		It("should delete MTQ if the FG is not set", func() {
@@ -158,15 +158,15 @@ var _ = Describe("MTQ tests", func() {
 
 			res := handler.ensure(req)
 
-			Expect(res.Err).ShouldNot(HaveOccurred())
-			Expect(res.Name).Should(Equal(mtq.Name))
-			Expect(res.Created).Should(BeFalse())
-			Expect(res.Updated).Should(BeFalse())
-			Expect(res.Deleted).Should(BeTrue())
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(mtq.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
 
 			foundMTQs := &mtqv1alpha1.MTQList{}
-			Expect(cl.List(context.Background(), foundMTQs)).Should(Succeed())
-			Expect(foundMTQs.Items).Should(BeEmpty())
+			Expect(cl.List(context.Background(), foundMTQs)).To(Succeed())
+			Expect(foundMTQs.Items).To(BeEmpty())
 		})
 
 		It("should create MTQ if the FG is set", func() {
@@ -177,17 +177,17 @@ var _ = Describe("MTQ tests", func() {
 
 			res := handler.ensure(req)
 
-			Expect(res.Err).ShouldNot(HaveOccurred())
-			Expect(res.Name).Should(Equal("mtq-kubevirt-hyperconverged"))
-			Expect(res.Created).Should(BeTrue())
-			Expect(res.Updated).Should(BeFalse())
-			Expect(res.Deleted).Should(BeFalse())
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal("mtq-kubevirt-hyperconverged"))
+			Expect(res.Created).To(BeTrue())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
 
 			foundMTQ := &mtqv1alpha1.MTQ{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Name: res.Name}, foundMTQ)).Should(Succeed())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: res.Name}, foundMTQ)).To(Succeed())
 
-			Expect(foundMTQ.Name).Should(Equal("mtq-" + hco.Name))
-			Expect(foundMTQ.Namespace).Should(BeEmpty())
+			Expect(foundMTQ.Name).To(Equal("mtq-" + hco.Name))
+			Expect(foundMTQ.Namespace).To(BeEmpty())
 
 			// example of field set by the handler
 			Expect(foundMTQ.Spec.PriorityClass).To(HaveValue(Equal(mtqv1alpha1.MTQPriorityClass(kvPriorityClass))))
@@ -205,11 +205,11 @@ var _ = Describe("MTQ tests", func() {
 
 			res := handler.ensure(req)
 
-			Expect(res.Err).ShouldNot(HaveOccurred())
-			Expect(res.Name).Should(Equal("mtq-kubevirt-hyperconverged"))
-			Expect(res.Created).Should(BeFalse())
-			Expect(res.Updated).Should(BeFalse())
-			Expect(res.Deleted).Should(BeFalse())
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal("mtq-kubevirt-hyperconverged"))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
 
 			foundMTQ := &mtqv1alpha1.MTQ{}
 			err := cl.Get(context.Background(), client.ObjectKey{Name: res.Name}, foundMTQ)
@@ -236,27 +236,27 @@ var _ = Describe("MTQ tests", func() {
 
 			res := handler.ensure(req)
 
-			Expect(res.Err).ShouldNot(HaveOccurred())
-			Expect(res.Created).Should(BeFalse())
-			Expect(res.Deleted).Should(BeFalse())
-			Expect(res.Updated).Should(BeTrue())
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
 
 			foundMTQ := &mtqv1alpha1.MTQ{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Name: res.Name}, foundMTQ)).Should(Succeed())
-			Expect(foundMTQ.Spec.Infra.Affinity).Should(BeNil())
-			Expect(foundMTQ.Spec.Infra.NodeSelector).Should(BeEmpty())
-			Expect(foundMTQ.Spec.Infra.Tolerations).Should(BeEmpty())
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: res.Name}, foundMTQ)).To(Succeed())
+			Expect(foundMTQ.Spec.Infra.Affinity).To(BeNil())
+			Expect(foundMTQ.Spec.Infra.NodeSelector).To(BeEmpty())
+			Expect(foundMTQ.Spec.Infra.Tolerations).To(BeEmpty())
 
 			Expect(foundMTQ.Spec.PriorityClass).To(HaveValue(Equal(mtqv1alpha1.MTQPriorityClass(kvPriorityClass))))
-			Expect(foundMTQ.Spec.CertConfig.CA).ShouldNot(BeNil())
-			Expect(foundMTQ.Spec.CertConfig.CA.Duration).ShouldNot(BeNil())
-			Expect(foundMTQ.Spec.CertConfig.CA.Duration.Duration.String()).Should(Equal("48h0m0s"))
-			Expect(foundMTQ.Spec.CertConfig.CA.RenewBefore.Duration.String()).Should(Equal("24h0m0s"))
+			Expect(foundMTQ.Spec.CertConfig.CA).ToNot(BeNil())
+			Expect(foundMTQ.Spec.CertConfig.CA.Duration).ToNot(BeNil())
+			Expect(foundMTQ.Spec.CertConfig.CA.Duration.Duration.String()).To(Equal("48h0m0s"))
+			Expect(foundMTQ.Spec.CertConfig.CA.RenewBefore.Duration.String()).To(Equal("24h0m0s"))
 
-			Expect(foundMTQ.Spec.CertConfig.Server).ShouldNot(BeNil())
-			Expect(foundMTQ.Spec.CertConfig.Server.Duration).ShouldNot(BeNil())
-			Expect(foundMTQ.Spec.CertConfig.Server.Duration.Duration.String()).Should(Equal("24h0m0s"))
-			Expect(foundMTQ.Spec.CertConfig.Server.RenewBefore.Duration.String()).Should(Equal("12h0m0s"))
+			Expect(foundMTQ.Spec.CertConfig.Server).ToNot(BeNil())
+			Expect(foundMTQ.Spec.CertConfig.Server.Duration).ToNot(BeNil())
+			Expect(foundMTQ.Spec.CertConfig.Server.Duration.Duration.String()).To(Equal("24h0m0s"))
+			Expect(foundMTQ.Spec.CertConfig.Server.RenewBefore.Duration.String()).To(Equal("12h0m0s"))
 		})
 
 		It("should reconcile managed labels to default without touching user added ones", func() {
@@ -334,31 +334,31 @@ var _ = Describe("MTQ tests", func() {
 			hco.Spec.FeatureGates.EnableManagedTenantQuota = ptr.To(true)
 			handler := newMtqHandler(cl, commontestutils.GetScheme())
 			op, ok := handler.(*conditionalHandler)
-			Expect(ok).Should(BeTrue())
+			Expect(ok).To(BeTrue())
 
 			hooks, ok := op.operand.hooks.(*mtqHooks)
-			Expect(ok).Should(BeTrue())
+			Expect(ok).To(BeTrue())
 
-			Expect(hooks.cache).Should(BeNil())
+			Expect(hooks.cache).To(BeNil())
 
 			res := handler.ensure(req)
-			Expect(res.Err).ShouldNot(HaveOccurred())
+			Expect(res.Err).ToNot(HaveOccurred())
 
 			cache := hooks.cache
-			Expect(cache).ShouldNot(BeNil())
+			Expect(cache).ToNot(BeNil())
 
-			Expect(hooks.getFullCr(hco)).Should(BeIdenticalTo(cache))
+			Expect(hooks.getFullCr(hco)).To(BeIdenticalTo(cache))
 
 			By("recreate cache after reset")
 			handler.reset()
-			Expect(hooks.cache).Should(BeNil())
+			Expect(hooks.cache).To(BeNil())
 			res = handler.ensure(req)
-			Expect(res.Err).ShouldNot(HaveOccurred())
+			Expect(res.Err).ToNot(HaveOccurred())
 
-			Expect(hooks.cache).ShouldNot(BeIdenticalTo(cache))
+			Expect(hooks.cache).ToNot(BeIdenticalTo(cache))
 			mtq, _ := hooks.getFullCr(hco)
-			Expect(mtq).ShouldNot(BeIdenticalTo(cache))
-			Expect(mtq).Should(BeIdenticalTo(hooks.cache))
+			Expect(mtq).ToNot(BeIdenticalTo(cache))
+			Expect(mtq).To(BeIdenticalTo(hooks.cache))
 		})
 	})
 })

--- a/controllers/operands/networkAddons_test.go
+++ b/controllers/operands/networkAddons_test.go
@@ -52,7 +52,7 @@ var _ = Describe("CNA Operand", func() {
 					foundResource),
 			).To(Succeed())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 			Expect(foundResource.Spec.Multus).To(Equal(&networkaddonsshared.Multus{}))
 			Expect(foundResource.Spec.LinuxBridge).To(Equal(&networkaddonsshared.LinuxBridge{}))
@@ -221,11 +221,11 @@ var _ = Describe("CNA Operand", func() {
 			Expect(foundResource.Spec.PlacementConfiguration).ToNot(BeNil())
 			placementConfig := foundResource.Spec.PlacementConfiguration
 			Expect(placementConfig.Infra).ToNot(BeNil())
-			Expect(placementConfig.Infra.NodeSelector["key1"]).Should(Equal("value1"))
-			Expect(placementConfig.Infra.NodeSelector["key2"]).Should(Equal("value2"))
+			Expect(placementConfig.Infra.NodeSelector["key1"]).To(Equal("value1"))
+			Expect(placementConfig.Infra.NodeSelector["key2"]).To(Equal("value2"))
 
 			Expect(placementConfig.Workloads).ToNot(BeNil())
-			Expect(placementConfig.Workloads.Tolerations).Should(Equal(hco.Spec.Workloads.NodePlacement.Tolerations))
+			Expect(placementConfig.Workloads.Tolerations).To(Equal(hco.Spec.Workloads.NodePlacement.Tolerations))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})
@@ -288,11 +288,11 @@ var _ = Describe("CNA Operand", func() {
 
 			Expect(existingResource.Spec.PlacementConfiguration).ToNot(BeNil())
 			Expect(existingResource.Spec.PlacementConfiguration.Infra.Tolerations).To(HaveLen(2))
-			Expect(existingResource.Spec.PlacementConfiguration.Workloads.NodeSelector["key1"]).Should(Equal("value1"))
+			Expect(existingResource.Spec.PlacementConfiguration.Workloads.NodeSelector["key1"]).To(Equal("value1"))
 
 			Expect(foundResource.Spec.PlacementConfiguration).ToNot(BeNil())
 			Expect(foundResource.Spec.PlacementConfiguration.Infra.Tolerations).To(HaveLen(3))
-			Expect(foundResource.Spec.PlacementConfiguration.Workloads.NodeSelector["key1"]).Should(Equal("something else"))
+			Expect(foundResource.Spec.PlacementConfiguration.Workloads.NodeSelector["key1"]).To(Equal("something else"))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})
@@ -334,13 +334,13 @@ var _ = Describe("CNA Operand", func() {
 
 			Expect(existingResource.Spec.PlacementConfiguration.Infra.Tolerations).To(HaveLen(3))
 			Expect(existingResource.Spec.PlacementConfiguration.Workloads.Tolerations).To(HaveLen(3))
-			Expect(existingResource.Spec.PlacementConfiguration.Infra.NodeSelector["key1"]).Should(Equal("BADvalue1"))
-			Expect(existingResource.Spec.PlacementConfiguration.Workloads.NodeSelector["key2"]).Should(Equal("BADvalue2"))
+			Expect(existingResource.Spec.PlacementConfiguration.Infra.NodeSelector["key1"]).To(Equal("BADvalue1"))
+			Expect(existingResource.Spec.PlacementConfiguration.Workloads.NodeSelector["key2"]).To(Equal("BADvalue2"))
 
 			Expect(foundResource.Spec.PlacementConfiguration.Infra.Tolerations).To(HaveLen(2))
 			Expect(foundResource.Spec.PlacementConfiguration.Workloads.Tolerations).To(HaveLen(2))
-			Expect(foundResource.Spec.PlacementConfiguration.Infra.NodeSelector["key1"]).Should(Equal("value1"))
-			Expect(foundResource.Spec.PlacementConfiguration.Workloads.NodeSelector["key2"]).Should(Equal("value2"))
+			Expect(foundResource.Spec.PlacementConfiguration.Infra.NodeSelector["key1"]).To(Equal("value1"))
+			Expect(foundResource.Spec.PlacementConfiguration.Workloads.NodeSelector["key2"]).To(Equal("value2"))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})
@@ -376,10 +376,10 @@ var _ = Describe("CNA Operand", func() {
 
 			Expect(foundResource.Spec.SelfSignConfiguration).ToNot(BeNil())
 			selfSignedConfig := foundResource.Spec.SelfSignConfiguration
-			Expect(selfSignedConfig.CARotateInterval).Should(Equal("24h0m0s"))
-			Expect(selfSignedConfig.CAOverlapInterval).Should(Equal("1h0m0s"))
-			Expect(selfSignedConfig.CertRotateInterval).Should(Equal("12h0m0s"))
-			Expect(selfSignedConfig.CertOverlapInterval).Should(Equal("30m0s"))
+			Expect(selfSignedConfig.CARotateInterval).To(Equal("24h0m0s"))
+			Expect(selfSignedConfig.CAOverlapInterval).To(Equal("1h0m0s"))
+			Expect(selfSignedConfig.CertRotateInterval).To(Equal("12h0m0s"))
+			Expect(selfSignedConfig.CertOverlapInterval).To(Equal("30m0s"))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})
@@ -405,10 +405,10 @@ var _ = Describe("CNA Operand", func() {
 
 			Expect(foundResource.Spec.SelfSignConfiguration.CARotateInterval).ToNot(BeNil())
 			selfSignedConfig := foundResource.Spec.SelfSignConfiguration
-			Expect(selfSignedConfig.CARotateInterval).Should(Equal("48h0m0s"))
-			Expect(selfSignedConfig.CAOverlapInterval).Should(Equal("24h0m0s"))
-			Expect(selfSignedConfig.CertRotateInterval).Should(Equal("24h0m0s"))
-			Expect(selfSignedConfig.CertOverlapInterval).Should(Equal("12h0m0s"))
+			Expect(selfSignedConfig.CARotateInterval).To(Equal("48h0m0s"))
+			Expect(selfSignedConfig.CAOverlapInterval).To(Equal("24h0m0s"))
+			Expect(selfSignedConfig.CertRotateInterval).To(Equal("24h0m0s"))
+			Expect(selfSignedConfig.CertOverlapInterval).To(Equal("12h0m0s"))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})
@@ -450,17 +450,17 @@ var _ = Describe("CNA Operand", func() {
 
 			Expect(existingResource.Spec.SelfSignConfiguration).ToNot(BeNil())
 			existingSelfSignedConfig := existingResource.Spec.SelfSignConfiguration
-			Expect(existingSelfSignedConfig.CARotateInterval).Should(Equal("24h0m0s"))
-			Expect(existingSelfSignedConfig.CAOverlapInterval).Should(Equal("1h0m0s"))
-			Expect(existingSelfSignedConfig.CertRotateInterval).Should(Equal("12h0m0s"))
-			Expect(existingSelfSignedConfig.CertOverlapInterval).Should(Equal("30m0s"))
+			Expect(existingSelfSignedConfig.CARotateInterval).To(Equal("24h0m0s"))
+			Expect(existingSelfSignedConfig.CAOverlapInterval).To(Equal("1h0m0s"))
+			Expect(existingSelfSignedConfig.CertRotateInterval).To(Equal("12h0m0s"))
+			Expect(existingSelfSignedConfig.CertOverlapInterval).To(Equal("30m0s"))
 
 			Expect(foundResource.Spec.SelfSignConfiguration).ToNot(BeNil())
 			foundSelfSignedConfig := foundResource.Spec.SelfSignConfiguration
-			Expect(foundSelfSignedConfig.CARotateInterval).Should(Equal("48h0m0s"))
-			Expect(foundSelfSignedConfig.CAOverlapInterval).Should(Equal("2h0m0s"))
-			Expect(foundSelfSignedConfig.CertRotateInterval).Should(Equal("24h0m0s"))
-			Expect(foundSelfSignedConfig.CertOverlapInterval).Should(Equal("1h0m0s"))
+			Expect(foundSelfSignedConfig.CARotateInterval).To(Equal("48h0m0s"))
+			Expect(foundSelfSignedConfig.CAOverlapInterval).To(Equal("2h0m0s"))
+			Expect(foundSelfSignedConfig.CertRotateInterval).To(Equal("24h0m0s"))
+			Expect(foundSelfSignedConfig.CertOverlapInterval).To(Equal("1h0m0s"))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})
@@ -506,17 +506,17 @@ var _ = Describe("CNA Operand", func() {
 
 			Expect(existingResource.Spec.SelfSignConfiguration).ToNot(BeNil())
 			existingSelfSignedConfig := existingResource.Spec.SelfSignConfiguration
-			Expect(existingSelfSignedConfig.CARotateInterval).Should(Equal("48h0m0s"))
-			Expect(existingSelfSignedConfig.CAOverlapInterval).Should(Equal("2h0m0s"))
-			Expect(existingSelfSignedConfig.CertRotateInterval).Should(Equal("24h0m0s"))
-			Expect(existingSelfSignedConfig.CertOverlapInterval).Should(Equal("1h0m0s"))
+			Expect(existingSelfSignedConfig.CARotateInterval).To(Equal("48h0m0s"))
+			Expect(existingSelfSignedConfig.CAOverlapInterval).To(Equal("2h0m0s"))
+			Expect(existingSelfSignedConfig.CertRotateInterval).To(Equal("24h0m0s"))
+			Expect(existingSelfSignedConfig.CertOverlapInterval).To(Equal("1h0m0s"))
 
 			Expect(foundResource.Spec.SelfSignConfiguration).ToNot(BeNil())
 			foundSelfSignedConfig := foundResource.Spec.SelfSignConfiguration
-			Expect(foundSelfSignedConfig.CARotateInterval).Should(Equal("24h0m0s"))
-			Expect(foundSelfSignedConfig.CAOverlapInterval).Should(Equal("1h0m0s"))
-			Expect(foundSelfSignedConfig.CertRotateInterval).Should(Equal("12h0m0s"))
-			Expect(foundSelfSignedConfig.CertOverlapInterval).Should(Equal("30m0s"))
+			Expect(foundSelfSignedConfig.CARotateInterval).To(Equal("24h0m0s"))
+			Expect(foundSelfSignedConfig.CAOverlapInterval).To(Equal("1h0m0s"))
+			Expect(foundSelfSignedConfig.CertRotateInterval).To(Equal("12h0m0s"))
+			Expect(foundSelfSignedConfig.CertOverlapInterval).To(Equal("30m0s"))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})
@@ -861,8 +861,8 @@ var _ = Describe("CNA Operand", func() {
 				cna, err := NewNetworkAddons(hco)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cna).ToNot(BeNil())
-				Expect(cna.Spec.KubeMacPool.RangeStart).Should(Equal("1.1.1.1.1.1"))
-				Expect(cna.Spec.KubeMacPool.RangeEnd).Should(Equal("5.5.5.5.5.5"))
+				Expect(cna.Spec.KubeMacPool.RangeStart).To(Equal("1.1.1.1.1.1"))
+				Expect(cna.Spec.KubeMacPool.RangeEnd).To(Equal("5.5.5.5.5.5"))
 				Expect(cna.Spec.ImagePullPolicy).To(BeEquivalentTo("Always"))
 			})
 
@@ -908,8 +908,8 @@ var _ = Describe("CNA Operand", func() {
 				).To(Succeed())
 
 				Expect(cna).ToNot(BeNil())
-				Expect(cna.Spec.KubeMacPool.RangeStart).Should(Equal("1.1.1.1.1.1"))
-				Expect(cna.Spec.KubeMacPool.RangeEnd).Should(Equal("5.5.5.5.5.5"))
+				Expect(cna.Spec.KubeMacPool.RangeStart).To(Equal("1.1.1.1.1.1"))
+				Expect(cna.Spec.KubeMacPool.RangeEnd).To(Equal("5.5.5.5.5.5"))
 				Expect(cna.Spec.ImagePullPolicy).To(BeEquivalentTo("Always"))
 			})
 
@@ -970,8 +970,8 @@ var _ = Describe("CNA Operand", func() {
 						cna),
 				).To(Succeed())
 
-				Expect(cna.Spec.KubeMacPool.RangeStart).Should(Equal("1.1.1.1.1.1"))
-				Expect(cna.Spec.KubeMacPool.RangeEnd).Should(Equal("5.5.5.5.5.5"))
+				Expect(cna.Spec.KubeMacPool.RangeStart).To(Equal("1.1.1.1.1.1"))
+				Expect(cna.Spec.KubeMacPool.RangeEnd).To(Equal("5.5.5.5.5.5"))
 				Expect(cna.Spec.ImagePullPolicy).To(BeEquivalentTo("Always"))
 			})
 
@@ -1023,12 +1023,12 @@ var _ = Describe("CNA Operand", func() {
 				Expect(handler.hooks.(*cnaHooks).cache).ToNot(BeNil())
 
 				By("compare pointers to make sure cache is working", func() {
-					Expect(handler.hooks.(*cnaHooks).cache).Should(BeIdenticalTo(cr))
+					Expect(handler.hooks.(*cnaHooks).cache).To(BeIdenticalTo(cr))
 
 					crII, err := handler.hooks.getFullCr(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(crII).ToNot(BeNil())
-					Expect(cr).Should(BeIdenticalTo(crII))
+					Expect(cr).To(BeIdenticalTo(crII))
 				})
 			})
 
@@ -1167,8 +1167,8 @@ var _ = Describe("CNA Operand", func() {
 			Expect(cnaoPlacement.Affinity.PodAffinity).To(BeNil())
 			Expect(cnaoPlacement.Affinity.PodAntiAffinity).To(BeNil())
 
-			Expect(cnaoPlacement.NodeSelector["key1"]).Should(Equal("value1"))
-			Expect(cnaoPlacement.NodeSelector["key2"]).Should(Equal("value2"))
+			Expect(cnaoPlacement.NodeSelector["key1"]).To(Equal("value1"))
+			Expect(cnaoPlacement.NodeSelector["key2"]).To(Equal("value2"))
 		})
 
 		It("Should return only Tolerations", func() {
@@ -1184,8 +1184,8 @@ var _ = Describe("CNA Operand", func() {
 			Expect(cnaoPlacement.Affinity.PodAffinity).To(BeNil())
 			Expect(cnaoPlacement.Affinity.PodAntiAffinity).To(BeNil())
 
-			Expect(cnaoPlacement.Tolerations[0]).Should(Equal(tolr1))
-			Expect(cnaoPlacement.Tolerations[1]).Should(Equal(tolr2))
+			Expect(cnaoPlacement.Tolerations[0]).To(Equal(tolr1))
+			Expect(cnaoPlacement.Tolerations[1]).To(Equal(tolr2))
 		})
 
 		It("Should return only Affinity", func() {
@@ -1219,7 +1219,7 @@ var _ = Describe("CNA Operand", func() {
 			Expect(cnaoPlacement.Affinity.PodAffinity).To(BeNil())
 			Expect(cnaoPlacement.Affinity.PodAntiAffinity).To(BeNil())
 
-			Expect(cnaoPlacement.Affinity.NodeAffinity).Should(Equal(affinity.NodeAffinity))
+			Expect(cnaoPlacement.Affinity.NodeAffinity).To(Equal(affinity.NodeAffinity))
 		})
 
 		It("Should return the whole object", func() {
@@ -1257,13 +1257,13 @@ var _ = Describe("CNA Operand", func() {
 			Expect(cnaoPlacement.Tolerations).ToNot(BeNil())
 			Expect(cnaoPlacement.Affinity.NodeAffinity).ToNot(BeNil())
 
-			Expect(cnaoPlacement.NodeSelector["key1"]).Should(Equal("value1"))
-			Expect(cnaoPlacement.NodeSelector["key2"]).Should(Equal("value2"))
+			Expect(cnaoPlacement.NodeSelector["key1"]).To(Equal("value1"))
+			Expect(cnaoPlacement.NodeSelector["key2"]).To(Equal("value2"))
 
-			Expect(cnaoPlacement.Tolerations[0]).Should(Equal(tolr1))
-			Expect(cnaoPlacement.Tolerations[1]).Should(Equal(tolr2))
+			Expect(cnaoPlacement.Tolerations[0]).To(Equal(tolr1))
+			Expect(cnaoPlacement.Tolerations[1]).To(Equal(tolr2))
 
-			Expect(cnaoPlacement.Affinity.NodeAffinity).Should(Equal(hcoConf.Affinity.NodeAffinity))
+			Expect(cnaoPlacement.Affinity.NodeAffinity).To(Equal(hcoConf.Affinity.NodeAffinity))
 		})
 	})
 })

--- a/controllers/operands/operandHandler_test.go
+++ b/controllers/operands/operandHandler_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Test operandHandler", func() {
 				Expect(cli.List(req.Ctx, &kvList)).To(Succeed())
 				Expect(kvList).ToNot(BeNil())
 				Expect(kvList.Items).To(HaveLen(1))
-				Expect(kvList.Items[0].Name).Should(Equal("kubevirt-kubevirt-hyperconverged"))
+				Expect(kvList.Items[0].Name).To(Equal("kubevirt-kubevirt-hyperconverged"))
 			})
 
 			By("make sure the CNA object created", func() {
@@ -103,7 +103,7 @@ var _ = Describe("Test operandHandler", func() {
 				Expect(cli.List(req.Ctx, &cnaList)).To(Succeed())
 				Expect(cnaList).ToNot(BeNil())
 				Expect(cnaList.Items).To(HaveLen(1))
-				Expect(cnaList.Items[0].Name).Should(Equal("cluster"))
+				Expect(cnaList.Items[0].Name).To(Equal("cluster"))
 			})
 
 			By("make sure the CDI object created", func() {
@@ -112,7 +112,7 @@ var _ = Describe("Test operandHandler", func() {
 				Expect(cli.List(req.Ctx, &cdiList)).To(Succeed())
 				Expect(cdiList).ToNot(BeNil())
 				Expect(cdiList.Items).To(HaveLen(1))
-				Expect(cdiList.Items[0].Name).Should(Equal("cdi-kubevirt-hyperconverged"))
+				Expect(cdiList.Items[0].Name).To(Equal("cdi-kubevirt-hyperconverged"))
 			})
 
 			By("make sure the ConsoleQuickStart object created", func() {
@@ -121,7 +121,7 @@ var _ = Describe("Test operandHandler", func() {
 				Expect(cli.List(req.Ctx, &qsList)).To(Succeed())
 				Expect(qsList).ToNot(BeNil())
 				Expect(qsList.Items).To(HaveLen(1))
-				Expect(qsList.Items[0].Name).Should(Equal("test-quick-start"))
+				Expect(qsList.Items[0].Name).To(Equal("test-quick-start"))
 			})
 
 			By("make sure the Dashboard confimap created", func() {
@@ -129,7 +129,7 @@ var _ = Describe("Test operandHandler", func() {
 				Expect(cli.List(req.Ctx, &cmList, &client.ListOptions{Namespace: "openshift-config-managed"})).To(Succeed())
 				Expect(cmList).ToNot(BeNil())
 				Expect(cmList.Items).To(HaveLen(1))
-				Expect(cmList.Items[0].Name).Should(Equal("grafana-dashboard-kubevirt-top-consumers"))
+				Expect(cmList.Items[0].Name).To(Equal("grafana-dashboard-kubevirt-top-consumers"))
 			})
 		})
 
@@ -155,14 +155,14 @@ var _ = Describe("Test operandHandler", func() {
 				return nil
 			})
 
-			Expect(handler.Ensure(req)).Should(Equal(fakeError))
+			Expect(handler.Ensure(req)).To(Equal(fakeError))
 
 			Expect(req.ComponentUpgradeInProgress).To(BeFalse())
 			cond := req.Conditions[hcov1beta1.ConditionReconcileComplete]
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
-			Expect(cond.Reason).Should(Equal(reconcileFailed))
-			Expect(cond.Message).Should(Equal(fmt.Sprintf("Error while reconciling: %v", fakeError)))
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(reconcileFailed))
+			Expect(cond.Message).To(Equal(fmt.Sprintf("Error while reconciling: %v", fakeError)))
 
 			By("make sure the CDI object not created", func() {
 				// Read back CDI
@@ -294,7 +294,7 @@ var _ = Describe("Test operandHandler", func() {
 			}
 			eventEmitter.Reset()
 			err := handler.EnsureDeleted(req)
-			Expect(err).Should(Equal(fakeError))
+			Expect(err).To(Equal(fakeError))
 
 			By("Check that event was emitted", func() {
 				Expect(eventEmitter.CheckEvents(expectedEvents)).To(BeTrue())
@@ -306,7 +306,7 @@ var _ = Describe("Test operandHandler", func() {
 				Expect(cli.List(req.Ctx, &kvList)).To(Succeed())
 				Expect(kvList).ToNot(BeNil())
 				Expect(kvList.Items).To(HaveLen(1))
-				Expect(kvList.Items[0].Name).Should(Equal("kubevirt-kubevirt-hyperconverged"))
+				Expect(kvList.Items[0].Name).To(Equal("kubevirt-kubevirt-hyperconverged"))
 			})
 		})
 
@@ -344,7 +344,7 @@ var _ = Describe("Test operandHandler", func() {
 
 			eventEmitter.Reset()
 			err := handler.EnsureDeleted(req)
-			Expect(err).Should(Equal(fakeError))
+			Expect(err).To(Equal(fakeError))
 
 			By("Check that event was emitted", func() {
 				Expect(eventEmitter.CheckEvents(expectedEvents)).To(BeTrue())
@@ -356,7 +356,7 @@ var _ = Describe("Test operandHandler", func() {
 				Expect(cli.List(req.Ctx, &cdiList)).To(Succeed())
 				Expect(cdiList).ToNot(BeNil())
 				Expect(cdiList.Items).To(HaveLen(1))
-				Expect(cdiList.Items[0].Name).Should(Equal("cdi-kubevirt-hyperconverged"))
+				Expect(cdiList.Items[0].Name).To(Equal("cdi-kubevirt-hyperconverged"))
 			})
 		})
 
@@ -394,7 +394,7 @@ var _ = Describe("Test operandHandler", func() {
 
 			eventEmitter.Reset()
 			err := handler.EnsureDeleted(req)
-			Expect(err).Should(Equal(fakeError))
+			Expect(err).To(Equal(fakeError))
 
 			By("Check that event was emitted", func() {
 				Expect(eventEmitter.CheckEvents(expectedEvents)).To(BeTrue())
@@ -406,7 +406,7 @@ var _ = Describe("Test operandHandler", func() {
 				Expect(cli.List(req.Ctx, &cnaList)).To(Succeed())
 				Expect(cnaList).ToNot(BeNil())
 				Expect(cnaList.Items).To(HaveLen(1))
-				Expect(cnaList.Items[0].Name).Should(Equal("cluster"))
+				Expect(cnaList.Items[0].Name).To(Equal("cluster"))
 			})
 		})
 
@@ -438,7 +438,7 @@ var _ = Describe("Test operandHandler", func() {
 			defer cancelFunc()
 			req.Ctx = ctx
 			err := handler.EnsureDeleted(req)
-			Expect(err).Should(MatchError("context deadline exceeded"))
+			Expect(err).To(MatchError("context deadline exceeded"))
 
 			expectedEvents := []commontestutils.MockEvent{
 				{

--- a/controllers/operands/operand_test.go
+++ b/controllers/operands/operand_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Test operator.go", func() {
 
 			Expect(obj.Spec.Config).NotTo(BeNil())
 			Expect(obj.Spec.Config.FilesystemOverhead).NotTo(BeNil())
-			Expect(obj.Spec.Config.FilesystemOverhead.Global).Should(BeEquivalentTo("55"))
+			Expect(obj.Spec.Config.FilesystemOverhead.Global).To(BeEquivalentTo("55"))
 		})
 	})
 

--- a/controllers/operands/quickStart_test.go
+++ b/controllers/operands/quickStart_test.go
@@ -37,7 +37,7 @@ var _ = Describe("QuickStart tests", func() {
 			cli := commontestutils.InitClient([]client.Object{})
 
 			err := checkCrdExists(context.TODO(), cli, logger)
-			Expect(err).Should(HaveOccurred())
+			Expect(err).To(HaveOccurred())
 			Expect(errors.Unwrap(err)).ToNot(HaveOccurred())
 		})
 
@@ -124,7 +124,7 @@ var _ = Describe("QuickStart tests", func() {
 				cli := commontestutils.InitClient([]client.Object{qsCrd})
 				handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 
-				Expect(err).Should(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 				Expect(handlers).To(BeEmpty())
 			})
 		})
@@ -160,7 +160,7 @@ var _ = Describe("QuickStart tests", func() {
 				quickstartObjects := &consolev1.ConsoleQuickStartList{}
 				Expect(cli.List(context.TODO(), quickstartObjects)).To(Succeed())
 				Expect(quickstartObjects.Items).To(HaveLen(1))
-				Expect(quickstartObjects.Items[0].Name).Should(Equal("test-quick-start"))
+				Expect(quickstartObjects.Items[0].Name).To(Equal("test-quick-start"))
 			})
 		})
 
@@ -187,9 +187,9 @@ var _ = Describe("QuickStart tests", func() {
 				quickstartObjects := &consolev1.ConsoleQuickStartList{}
 				Expect(cli.List(context.TODO(), quickstartObjects)).To(Succeed())
 				Expect(quickstartObjects.Items).To(HaveLen(1))
-				Expect(quickstartObjects.Items[0].Name).Should(Equal("test-quick-start"))
+				Expect(quickstartObjects.Items[0].Name).To(Equal("test-quick-start"))
 				// check that the existing object was reconciled
-				Expect(quickstartObjects.Items[0].Spec.DurationMinutes).Should(Equal(20))
+				Expect(quickstartObjects.Items[0].Spec.DurationMinutes).To(Equal(20))
 
 				// ObjectReference should have been updated
 				Expect(hco.Status.RelatedObjects).To(Not(BeNil()))
@@ -224,7 +224,7 @@ var _ = Describe("QuickStart tests", func() {
 
 				Expect(cli.List(context.TODO(), quickstartObjects)).To(Succeed())
 				Expect(quickstartObjects.Items).To(HaveLen(1))
-				Expect(quickstartObjects.Items[0].Name).Should(Equal("test-quick-start"))
+				Expect(quickstartObjects.Items[0].Name).To(Equal("test-quick-start"))
 			})
 
 			expectedLabels := make(map[string]map[string]string)
@@ -291,7 +291,7 @@ var _ = Describe("QuickStart tests", func() {
 
 				Expect(cli.List(context.TODO(), quickstartObjects)).To(Succeed())
 				Expect(quickstartObjects.Items).To(HaveLen(1))
-				Expect(quickstartObjects.Items[0].Name).Should(Equal("test-quick-start"))
+				Expect(quickstartObjects.Items[0].Name).To(Equal("test-quick-start"))
 			})
 
 			expectedLabels := make(map[string]map[string]string)

--- a/controllers/operands/ssp_test.go
+++ b/controllers/operands/ssp_test.go
@@ -63,7 +63,7 @@ var _ = Describe("SSP Operands", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -309,11 +309,11 @@ var _ = Describe("SSP Operands", func() {
 
 				Expect(existingResource.Spec.TemplateValidator.Placement.Affinity.NodeAffinity).ToNot(BeNil())
 				Expect(existingResource.Spec.TemplateValidator.Placement.Tolerations).To(HaveLen(2))
-				Expect(existingResource.Spec.TemplateValidator.Placement.NodeSelector).Should(HaveKeyWithValue("key3", "value3"))
+				Expect(existingResource.Spec.TemplateValidator.Placement.NodeSelector).To(HaveKeyWithValue("key3", "value3"))
 
 				Expect(foundResource.Spec.TemplateValidator.Placement.Affinity.NodeAffinity).ToNot(BeNil())
 				Expect(foundResource.Spec.TemplateValidator.Placement.Tolerations).To(HaveLen(3))
-				Expect(foundResource.Spec.TemplateValidator.Placement.NodeSelector).Should(HaveKeyWithValue("key3", "something entirely else"))
+				Expect(foundResource.Spec.TemplateValidator.Placement.NodeSelector).To(HaveKeyWithValue("key3", "something entirely else"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -349,10 +349,10 @@ var _ = Describe("SSP Operands", func() {
 				).ToNot(HaveOccurred())
 
 				Expect(existingResource.Spec.TemplateValidator.Placement.Tolerations).To(HaveLen(3))
-				Expect(existingResource.Spec.TemplateValidator.Placement.NodeSelector).Should(HaveKeyWithValue("key3", "BADvalue3"))
+				Expect(existingResource.Spec.TemplateValidator.Placement.NodeSelector).To(HaveKeyWithValue("key3", "BADvalue3"))
 
 				Expect(foundResource.Spec.TemplateValidator.Placement.Tolerations).To(HaveLen(2))
-				Expect(foundResource.Spec.TemplateValidator.Placement.NodeSelector).Should(HaveKeyWithValue("key3", "value3"))
+				Expect(foundResource.Spec.TemplateValidator.Placement.NodeSelector).To(HaveKeyWithValue("key3", "value3"))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -371,8 +371,8 @@ var _ = Describe("SSP Operands", func() {
 				ssp, _, err := NewSSP(hco)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ssp).ToNot(BeNil())
-				Expect(ssp.Spec.TemplateValidator.Replicas).Should(Not(BeNil()))
-				Expect(*ssp.Spec.TemplateValidator.Replicas).Should(Equal(int32(5)))
+				Expect(ssp.Spec.TemplateValidator.Replicas).ToNot(BeNil())
+				Expect(*ssp.Spec.TemplateValidator.Replicas).To(Equal(int32(5)))
 			})
 
 			It("Should fail to create SSP object with wrong jsonPatch", func() {
@@ -412,8 +412,8 @@ var _ = Describe("SSP Operands", func() {
 				).To(Succeed())
 
 				Expect(ssp).ToNot(BeNil())
-				Expect(ssp.Spec.TemplateValidator.Replicas).Should(Not(BeNil()))
-				Expect(*ssp.Spec.TemplateValidator.Replicas).Should(Equal(int32(5)))
+				Expect(ssp.Spec.TemplateValidator.Replicas).ToNot(BeNil())
+				Expect(*ssp.Spec.TemplateValidator.Replicas).To(Equal(int32(5)))
 			})
 
 			It("Ensure func should fail to create SSP object with wrong jsonPatch", func() {
@@ -468,8 +468,8 @@ var _ = Describe("SSP Operands", func() {
 						ssp),
 				).To(Succeed())
 
-				Expect(ssp.Spec.TemplateValidator.Replicas).Should(Not(BeNil()))
-				Expect(*ssp.Spec.TemplateValidator.Replicas).Should(Equal(int32(5)))
+				Expect(ssp.Spec.TemplateValidator.Replicas).ToNot(BeNil())
+				Expect(*ssp.Spec.TemplateValidator.Replicas).To(Equal(int32(5)))
 			})
 
 			It("Ensure func should fail to update SSP object with wrong jsonPatch", func() {
@@ -499,8 +499,8 @@ var _ = Describe("SSP Operands", func() {
 						ssp),
 				).To(Succeed())
 
-				Expect(ssp.Spec.TemplateValidator.Replicas).Should(Not(BeNil()))
-				Expect(*ssp.Spec.TemplateValidator.Replicas).Should(Equal(int32(defaultTemplateValidatorReplicas)))
+				Expect(ssp.Spec.TemplateValidator.Replicas).ToNot(BeNil())
+				Expect(*ssp.Spec.TemplateValidator.Replicas).To(Equal(int32(defaultTemplateValidatorReplicas)))
 			})
 		})
 
@@ -519,12 +519,12 @@ var _ = Describe("SSP Operands", func() {
 				Expect(handler.hooks.(*sspHooks).cache).ToNot(BeNil())
 
 				By("compare pointers to make sure cache is working", func() {
-					Expect(handler.hooks.(*sspHooks).cache).Should(BeIdenticalTo(cr))
+					Expect(handler.hooks.(*sspHooks).cache).To(BeIdenticalTo(cr))
 
 					cdi1, err := handler.hooks.getFullCr(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(cdi1).ToNot(BeNil())
-					Expect(cr).Should(BeIdenticalTo(cdi1))
+					Expect(cr).To(BeIdenticalTo(cdi1))
 				})
 			})
 
@@ -882,12 +882,12 @@ var _ = Describe("SSP Operands", func() {
 
 					for _, dict := range goldenImageList {
 						if dict.Name == "image1" {
-							Expect(dict.Spec).Should(Equal(modifiedImage1.Spec))
-							Expect(dict.Status.Modified).Should(BeTrue())
-							Expect(dict.Status.CommonTemplate).Should(BeTrue())
+							Expect(dict.Spec).To(Equal(modifiedImage1.Spec))
+							Expect(dict.Status.Modified).To(BeTrue())
+							Expect(dict.Status.CommonTemplate).To(BeTrue())
 						} else if dict.Name == "image2" {
-							Expect(dict.Status.Modified).Should(BeFalse())
-							Expect(dict.Status.CommonTemplate).Should(BeTrue())
+							Expect(dict.Status.Modified).To(BeFalse())
+							Expect(dict.Status.CommonTemplate).To(BeTrue())
 						}
 					}
 				})
@@ -932,12 +932,12 @@ var _ = Describe("SSP Operands", func() {
 
 					for _, dict := range goldenImageList {
 						if dict.Name == "image1" {
-							Expect(dict.Spec.Template.Spec.Storage).Should(BeEquivalentTo(storageFromCr))
-							Expect(dict.Status.Modified).Should(BeTrue())
-							Expect(dict.Status.CommonTemplate).Should(BeTrue())
+							Expect(dict.Spec.Template.Spec.Storage).To(BeEquivalentTo(storageFromCr))
+							Expect(dict.Status.Modified).To(BeTrue())
+							Expect(dict.Status.CommonTemplate).To(BeTrue())
 						} else if dict.Name == "image2" {
-							Expect(dict.Status.Modified).Should(BeFalse())
-							Expect(dict.Status.CommonTemplate).Should(BeTrue())
+							Expect(dict.Status.Modified).To(BeFalse())
+							Expect(dict.Status.CommonTemplate).To(BeTrue())
 						}
 					}
 				})
@@ -951,7 +951,7 @@ var _ = Describe("SSP Operands", func() {
 					ssp, _, err := NewSSP(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(BeNil())
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(BeNil())
 				})
 
 				It("should return an the hard coded list if there is a file, but no list in the HyperConverged CR", func() {
@@ -968,8 +968,8 @@ var _ = Describe("SSP Operands", func() {
 					ssp, _, err := NewSSP(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ShouldNot(BeNil())
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(2))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ToNot(BeNil())
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
 				})
 
 				It("should return a combined list if there is a file and a list in the HyperConverged CR", func() {
@@ -989,8 +989,8 @@ var _ = Describe("SSP Operands", func() {
 					ssp, _, err := NewSSP(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ShouldNot(BeNil())
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(4))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ToNot(BeNil())
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(4))
 
 					var commonImages []hcov1beta1.DataImportCronTemplate
 					for _, dict := range dataImportCronTemplateHardCodedMap {
@@ -999,7 +999,7 @@ var _ = Describe("SSP Operands", func() {
 					commonImages = append(commonImages, image3)
 					commonImages = append(commonImages, image4)
 
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(ContainElements(hcoDictSliceToSSP(commonImages)))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(ContainElements(hcoDictSliceToSSP(commonImages)))
 				})
 
 				It("Should not add a common DIC template if it marked as disabled", func() {
@@ -1026,10 +1026,10 @@ var _ = Describe("SSP Operands", func() {
 					hco.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{*fedoraDic, image3, image4}
 					ssp, _, err := NewSSP(hco)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(3))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(3))
 					expected := hcoDictSliceToSSP([]hcov1beta1.DataImportCronTemplate{commonCentos8, image3, image4})
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(ContainElements(expected))
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ShouldNot(ContainElement(commonFedora))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(ContainElements(expected))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ToNot(ContainElement(commonFedora))
 				})
 
 				It("Should reject if the CR list contain DIC template with the same name, and there are also common DIC templates", func() {
@@ -1074,7 +1074,7 @@ var _ = Describe("SSP Operands", func() {
 
 				It("should return a only the list from the HyperConverged CR, if the file is missing", func() {
 					Expect(readDataImportCronTemplatesFromFile()).To(Succeed())
-					Expect(dataImportCronTemplateHardCodedMap).Should(BeEmpty())
+					Expect(dataImportCronTemplateHardCodedMap).To(BeEmpty())
 
 					hco := commontestutils.NewHco()
 					hco.Spec.FeatureGates.EnableCommonBootImageImport = ptr.To(true)
@@ -1082,10 +1082,10 @@ var _ = Describe("SSP Operands", func() {
 					ssp, _, err := NewSSP(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ShouldNot(BeNil())
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(2))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ToNot(BeNil())
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
 					expected := hcoDictSliceToSSP([]hcov1beta1.DataImportCronTemplate{image3, image4})
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(ContainElements(expected))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(ContainElements(expected))
 				})
 
 				It("should not return the common templates, if feature gate is false", func() {
@@ -1105,9 +1105,9 @@ var _ = Describe("SSP Operands", func() {
 					ssp, _, err := NewSSP(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(2))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
 					expected := hcoDictSliceToSSP([]hcov1beta1.DataImportCronTemplate{image3, image4})
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(ContainElements(expected))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(ContainElements(expected))
 				})
 
 				It("should modify a common dic if it exist in the HyperConverged CR", func() {
@@ -1141,9 +1141,9 @@ var _ = Describe("SSP Operands", func() {
 					hco.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{*fedoraDic, image3, image4}
 					ssp, _, err := NewSSP(hco)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(4))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(4))
 					expected := hcoDictSliceToSSP([]hcov1beta1.DataImportCronTemplate{*fedoraDic, commonCentos8, image3, image4})
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(ContainElements(expected))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(ContainElements(expected))
 				})
 
 				It("should add the cdi.kubevirt.io/storage.bind.immediate.requested annotation if missing", func() {
@@ -1172,22 +1172,22 @@ var _ = Describe("SSP Operands", func() {
 					hco.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{customDicAnnotationFalse, image4}
 					ssp, _, err := NewSSP(hco)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(4))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(4))
 
 					annotationTrue := 0
 					annotationFalse := 0
 					for _, dict := range ssp.Spec.CommonTemplates.DataImportCronTemplates {
 						Expect(dict.Annotations).ToNot(BeEmpty())
 						if strings.HasSuffix(dict.Name, "-annotation-false") {
-							Expect(dict.Annotations[CDIImmediateBindAnnotation]).Should(Equal("false"))
+							Expect(dict.Annotations[CDIImmediateBindAnnotation]).To(Equal("false"))
 							annotationFalse++
 						} else {
-							Expect(dict.Annotations[CDIImmediateBindAnnotation]).Should(Equal("true"))
+							Expect(dict.Annotations[CDIImmediateBindAnnotation]).To(Equal("true"))
 							annotationTrue++
 						}
 					}
-					Expect(annotationTrue).Should(Equal(2))
-					Expect(annotationFalse).Should(Equal(2))
+					Expect(annotationTrue).To(Equal(2))
+					Expect(annotationFalse).To(Equal(2))
 				})
 
 				It("should use custom namespace for common dicts, if defined in the hyperConverged CR", func() {
@@ -1205,11 +1205,11 @@ var _ = Describe("SSP Operands", func() {
 					ssp, _, err := NewSSP(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ShouldNot(BeNil())
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(2))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ToNot(BeNil())
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
 
 					for _, dict := range ssp.Spec.CommonTemplates.DataImportCronTemplates {
-						Expect(dict.Namespace).Should(Equal(customNS))
+						Expect(dict.Namespace).To(Equal(customNS))
 					}
 				})
 
@@ -1231,8 +1231,8 @@ var _ = Describe("SSP Operands", func() {
 					ssp, _, err := NewSSP(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ShouldNot(BeNil())
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(4))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).ToNot(BeNil())
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(4))
 
 					var commonImages []hcov1beta1.DataImportCronTemplate
 					for _, d := range dataImportCronTemplateHardCodedMap {
@@ -1244,7 +1244,7 @@ var _ = Describe("SSP Operands", func() {
 					commonImages = append(commonImages, image3)
 					commonImages = append(commonImages, image4)
 
-					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(ContainElements(hcoDictSliceToSSP(commonImages)))
+					Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(ContainElements(hcoDictSliceToSSP(commonImages)))
 				})
 			})
 
@@ -1258,8 +1258,8 @@ var _ = Describe("SSP Operands", func() {
 
 					applyDataImportSchedule(hco)
 
-					Expect(dataImportCronTemplateHardCodedMap[image1.Name].Spec.Schedule).Should(Equal("1 */12 * * *"))
-					Expect(dataImportCronTemplateHardCodedMap[image2.Name].Spec.Schedule).Should(Equal("2 */12 * * *"))
+					Expect(dataImportCronTemplateHardCodedMap[image1.Name].Spec.Schedule).To(Equal("1 */12 * * *"))
+					Expect(dataImportCronTemplateHardCodedMap[image2.Name].Spec.Schedule).To(Equal("2 */12 * * *"))
 				})
 
 				It("should set the variable and the images, if the schedule is in the status field", func() {
@@ -1274,7 +1274,7 @@ var _ = Describe("SSP Operands", func() {
 
 					applyDataImportSchedule(hco)
 					for _, image := range dataImportCronTemplateHardCodedMap {
-						Expect(image.Spec.Schedule).Should(Equal(schedule))
+						Expect(image.Spec.Schedule).To(Equal(schedule))
 					}
 				})
 			})
@@ -1316,7 +1316,7 @@ var _ = Describe("SSP Operands", func() {
 								foundResource),
 						).ToNot(HaveOccurred())
 						Expect(foundResource.Name).To(Equal(expectedResource.Name))
-						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(2))
+						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
 						Expect(hco.Status.DataImportCronTemplates).To(HaveLen(2))
 						for _, dict := range hco.Status.DataImportCronTemplates {
 							Expect(dict.Status.CommonTemplate).To(BeTrue())
@@ -1345,7 +1345,7 @@ var _ = Describe("SSP Operands", func() {
 								foundResource),
 						).ToNot(HaveOccurred())
 						Expect(foundResource.Name).To(Equal(expectedResource.Name))
-						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(2))
+						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
 						Expect(hco.Status.DataImportCronTemplates).To(HaveLen(2))
 						for _, dict := range hco.Status.DataImportCronTemplates {
 							Expect(dict.Status.CommonTemplate).To(BeFalse())
@@ -1374,7 +1374,7 @@ var _ = Describe("SSP Operands", func() {
 								foundResource),
 						).ToNot(HaveOccurred())
 						Expect(foundResource.Name).To(Equal(expectedResource.Name))
-						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(4))
+						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(4))
 						Expect(hco.Status.DataImportCronTemplates).To(HaveLen(4))
 						for _, dict := range hco.Status.DataImportCronTemplates {
 							if dict.Name == image3.Name || dict.Name == image4.Name {
@@ -1412,10 +1412,10 @@ var _ = Describe("SSP Operands", func() {
 								foundResource),
 						).ToNot(HaveOccurred())
 						Expect(foundResource.Name).To(Equal(expectedResource.Name))
-						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(3))
+						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(3))
 						Expect(hco.Status.DataImportCronTemplates).To(HaveLen(3))
 						for _, dict := range hco.Status.DataImportCronTemplates {
-							Expect(dict.Name).ShouldNot(Equal("centos8-image-cron"))
+							Expect(dict.Name).ToNot(Equal("centos8-image-cron"))
 							if dict.Name == image3.Name || dict.Name == image4.Name {
 								Expect(dict.Status.CommonTemplate).To(BeFalse())
 							} else {
@@ -1456,10 +1456,10 @@ var _ = Describe("SSP Operands", func() {
 								foundResource),
 						).ToNot(HaveOccurred())
 						Expect(foundResource.Name).To(Equal(expectedResource.Name))
-						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(4))
+						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(4))
 						for _, dict := range foundResource.Spec.CommonTemplates.DataImportCronTemplates {
 							if dict.Name == "centos8-image-cron" {
-								Expect(dict.Spec.Template.Spec.Storage).Should(Equal(modifiedStorage))
+								Expect(dict.Spec.Template.Spec.Storage).To(Equal(modifiedStorage))
 							}
 						}
 
@@ -1500,7 +1500,7 @@ var _ = Describe("SSP Operands", func() {
 								foundResource),
 						).ToNot(HaveOccurred())
 						Expect(foundResource.Name).To(Equal(expectedResource.Name))
-						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(2))
+						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
 						Expect(hco.Status.DataImportCronTemplates).To(HaveLen(2))
 						for _, dict := range hco.Status.DataImportCronTemplates {
 							Expect(dict.Status.CommonTemplate).To(BeTrue())
@@ -1543,16 +1543,16 @@ var _ = Describe("SSP Operands", func() {
 								foundResource),
 						).ToNot(HaveOccurred())
 						Expect(foundResource.Name).To(Equal(expectedResource.Name))
-						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(4))
+						Expect(foundResource.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(4))
 						for _, dict := range foundResource.Spec.CommonTemplates.DataImportCronTemplates {
 							if dict.Name == "centos8-image-cron" {
-								Expect(dict.Spec.Template.Spec.Storage).Should(Equal(modifiedStorage))
+								Expect(dict.Spec.Template.Spec.Storage).To(Equal(modifiedStorage))
 							}
 
 							if dict.Name == "fedora-image-cron" {
-								Expect(dict.Namespace).Should(Equal(customNS))
+								Expect(dict.Namespace).To(Equal(customNS))
 							} else {
-								Expect(dict.Namespace).Should(Equal(""))
+								Expect(dict.Namespace).To(Equal(""))
 							}
 						}
 
@@ -1594,7 +1594,7 @@ var _ = Describe("SSP Operands", func() {
 								foundSSP),
 						).ToNot(HaveOccurred())
 						Expect(foundSSP.Name).To(Equal(origSSP.Name))
-						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(2))
+						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
 						Expect(hco.Status.DataImportCronTemplates).To(HaveLen(2))
 						for _, dict := range hco.Status.DataImportCronTemplates {
 							Expect(dict.Status.CommonTemplate).To(BeTrue())
@@ -1626,7 +1626,7 @@ var _ = Describe("SSP Operands", func() {
 								foundSSP),
 						).ToNot(HaveOccurred())
 						Expect(foundSSP.Name).To(Equal(origSSP.Name))
-						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(2))
+						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
 						Expect(hco.Status.DataImportCronTemplates).To(HaveLen(2))
 						for _, dict := range hco.Status.DataImportCronTemplates {
 							Expect(dict.Status.CommonTemplate).To(BeFalse())
@@ -1658,7 +1658,7 @@ var _ = Describe("SSP Operands", func() {
 								foundSSP),
 						).ToNot(HaveOccurred())
 						Expect(foundSSP.Name).To(Equal(origSSP.Name))
-						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(4))
+						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(4))
 						Expect(hco.Status.DataImportCronTemplates).To(HaveLen(4))
 						for _, dict := range hco.Status.DataImportCronTemplates {
 							if dict.Name == image3.Name || dict.Name == image4.Name {
@@ -1698,10 +1698,10 @@ var _ = Describe("SSP Operands", func() {
 								foundSSP),
 						).ToNot(HaveOccurred())
 						Expect(foundSSP.Name).To(Equal(origSSP.Name))
-						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(3))
+						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(3))
 						Expect(hco.Status.DataImportCronTemplates).To(HaveLen(3))
 						for _, dict := range hco.Status.DataImportCronTemplates {
-							Expect(dict.Name).ShouldNot(Equal("centos8-image-cron"))
+							Expect(dict.Name).ToNot(Equal("centos8-image-cron"))
 							if dict.Name == image3.Name || dict.Name == image4.Name {
 								Expect(dict.Status.CommonTemplate).To(BeFalse())
 							} else {
@@ -1740,10 +1740,10 @@ var _ = Describe("SSP Operands", func() {
 								foundSSP),
 						).ToNot(HaveOccurred())
 						Expect(foundSSP.Name).To(Equal(origSSP.Name))
-						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(4))
+						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(4))
 						for _, dict := range foundSSP.Spec.CommonTemplates.DataImportCronTemplates {
 							if dict.Name == "centos8-image-cron" {
-								Expect(dict.Spec.Template.Spec.Storage.StorageClassName).Should(HaveValue(Equal(scName)))
+								Expect(dict.Spec.Template.Spec.Storage.StorageClassName).To(HaveValue(Equal(scName)))
 							}
 						}
 
@@ -1785,7 +1785,7 @@ var _ = Describe("SSP Operands", func() {
 								foundSSP),
 						).ToNot(HaveOccurred())
 						Expect(foundSSP.Name).To(Equal(origSSP.Name))
-						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(2))
+						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
 						Expect(hco.Status.DataImportCronTemplates).To(HaveLen(2))
 						for _, dict := range hco.Status.DataImportCronTemplates {
 							Expect(dict.Status.CommonTemplate).To(BeTrue())
@@ -1825,10 +1825,10 @@ var _ = Describe("SSP Operands", func() {
 								foundSSP),
 						).ToNot(HaveOccurred())
 						Expect(foundSSP.Name).To(Equal(origSSP.Name))
-						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(4))
+						Expect(foundSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(4))
 						for _, dict := range foundSSP.Spec.CommonTemplates.DataImportCronTemplates {
 							if dict.Name == "centos8-image-cron" {
-								Expect(dict.Spec.Template.Spec.Storage.StorageClassName).Should(HaveValue(Equal(scName)))
+								Expect(dict.Spec.Template.Spec.Storage.StorageClassName).To(HaveValue(Equal(scName)))
 							}
 
 							if dict.Name == "fedora-image-cron" {

--- a/controllers/operands/virtio_win_ConfigMap_test.go
+++ b/controllers/operands/virtio_win_ConfigMap_test.go
@@ -60,7 +60,7 @@ var _ = Describe("VirtioWin", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).Should(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 
@@ -222,8 +222,8 @@ var _ = Describe("VirtioWin", func() {
 					foundRole),
 			).ToNot(HaveOccurred())
 
-			Expect(expectedRole.ObjectMeta).Should(Equal(foundRole.ObjectMeta))
-			Expect(expectedRole.Rules).Should(Equal(foundRole.Rules))
+			Expect(expectedRole.ObjectMeta).To(Equal(foundRole.ObjectMeta))
+			Expect(expectedRole.Rules).To(Equal(foundRole.Rules))
 		})
 
 		It("should update if labels are missing", func() {

--- a/pkg/util/event_emitter_test.go
+++ b/pkg/util/event_emitter_test.go
@@ -54,7 +54,7 @@ var _ = Describe("", func() {
 				Expect(mock.events).To(HaveLen(1))
 				rsEvent, found := mock.events["ConfigMap"]
 				Expect(found).To(BeTrue())
-				Expect(rsEvent).Should(Equal(expectedEvent))
+				Expect(rsEvent).To(Equal(expectedEvent))
 
 				_, found = mock.events["Pod"]
 				Expect(found).To(BeFalse())
@@ -135,15 +135,15 @@ var _ = Describe("", func() {
 
 				rsEvent, found := mock.events["ReplicaSet"]
 				Expect(found).To(BeTrue())
-				Expect(rsEvent).Should(Equal(expectedEvent))
+				Expect(rsEvent).To(Equal(expectedEvent))
 
 				rsEvent, found = mock.events["Pod"]
 				Expect(found).To(BeTrue())
-				Expect(rsEvent).Should(Equal(expectedEvent))
+				Expect(rsEvent).To(Equal(expectedEvent))
 
 				rsEvent, found = mock.events["ClusterServiceVersion"]
 				Expect(found).To(BeTrue())
-				Expect(rsEvent).Should(Equal(expectedEvent))
+				Expect(rsEvent).To(Equal(expectedEvent))
 			})
 
 		})

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -34,7 +34,7 @@ fieldObj:
 			var obj testType
 			Expect(UnmarshalYamlFileToObject(reader, &obj)).To(Succeed())
 
-			Expect(obj).Should(Equal(testType{FieldStr: "abcd", FieldInt: 123, FieldObj: &nestedObj{NestedStr: "nested", NestedInt: 456}}))
+			Expect(obj).To(Equal(testType{FieldStr: "abcd", FieldInt: 123, FieldObj: &nestedObj{NestedStr: "nested", NestedInt: 456}}))
 		})
 
 		It("should unmarshal invalid input", func() {
@@ -96,14 +96,14 @@ fieldObj:
 	Context("test GetManifestDirPath", func() {
 		It("should return default if the environment variable is not set", func() {
 			result := GetManifestDirPath("TEST_VAR_NAME", "defaultValue")
-			Expect(result).Should(Equal("defaultValue"))
+			Expect(result).To(Equal("defaultValue"))
 		})
 
 		It("should return value of the environment variable is it set", func() {
 			os.Setenv("TEST_VAR_NAME", "non-default-value")
 			defer os.Unsetenv("TEST_VAR_NAME")
 			result := GetManifestDirPath("TEST_VAR_NAME", "defaultValue")
-			Expect(result).Should(Equal("non-default-value"))
+			Expect(result).To(Equal("non-default-value"))
 		})
 	})
 })

--- a/pkg/util/operatorcondition_test.go
+++ b/pkg/util/operatorcondition_test.go
@@ -42,7 +42,7 @@ var _ = Describe("OperatorCondition", func() {
 
 	It("valid condition", func() {
 		testScheme := scheme.Scheme
-		Expect(operatorsapiv2.AddToScheme(testScheme)).Should(Succeed())
+		Expect(operatorsapiv2.AddToScheme(testScheme)).To(Succeed())
 
 		cl := fake.NewClientBuilder().
 			WithScheme(testScheme).
@@ -61,22 +61,22 @@ var _ = Describe("OperatorCondition", func() {
 			managedByOLM:   true,
 			runningLocally: false,
 		}, cl, "testCondition")
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		cond, err := oc.cond.Get(context.TODO())
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cond.Type).Should(Equal("testCondition"))
+		Expect(cond.Type).To(Equal("testCondition"))
 
 		Expect(
 			oc.Set(context.TODO(), metav1.ConditionTrue, "myReason", "my message"),
-		).Should(Succeed())
+		).To(Succeed())
 
 		cond, err = oc.cond.Get(context.TODO())
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(cond.Type).Should(Equal("testCondition"))
-		Expect(cond.Reason).Should(Equal("myReason"))
-		Expect(cond.Message).Should(Equal("my message"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cond.Type).To(Equal("testCondition"))
+		Expect(cond.Reason).To(Equal("myReason"))
+		Expect(cond.Message).To(Equal("my message"))
 	})
 })
 

--- a/pkg/util/own_resources_test.go
+++ b/pkg/util/own_resources_test.go
@@ -130,9 +130,9 @@ var _ = Describe("Test OwnResources", func() {
 			Build()
 
 		or := findOwnResources(context.Background(), cl, logger)
-		Expect(*or.GetPod()).Should(Equal(*pod))
-		Expect(*or.GetDeployment()).Should(Equal(*dep))
-		Expect(*or.GetCSV()).Should(Equal(*csv))
+		Expect(*or.GetPod()).To(Equal(*pod))
+		Expect(*or.GetDeployment()).To(Equal(*dep))
+		Expect(*or.GetCSV()).To(Equal(*csv))
 	})
 
 })

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -37,15 +37,15 @@ var _ = Describe("Test general utilities", func() {
 			_ = os.Setenv(OperatorNamespaceEnv, expectedNs)
 
 			ns, err := GetOperatorNamespaceFromEnv()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(ns).Should(Equal(expectedNs))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ns).To(Equal(expectedNs))
 		})
 
 		It("should return an error if the OPERATOR_NAMESPACE env var is not set", func() {
 			_ = os.Unsetenv(OperatorNamespaceEnv)
 
 			_, err := GetOperatorNamespaceFromEnv()
-			Expect(err).Should(HaveOccurred())
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
@@ -76,11 +76,11 @@ var _ = Describe("Test general utilities", func() {
 				Build()
 
 			deleted, err := EnsureDeleted(ctx, cl, pod, appName, logger, false, true, true)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(deleted).To(BeTrue())
 
 			podToSearch := &corev1.Pod{}
-			Expect(cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)).ShouldNot(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)).ToNot(Succeed())
 		})
 
 		It("should not return error if the resource does not exist", func() {
@@ -89,29 +89,29 @@ var _ = Describe("Test general utilities", func() {
 				Build()
 
 			deleted, err := EnsureDeleted(ctx, cl, pod, appName, logger, false, true, true)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(deleted).To(BeFalse())
 
 			podToSearch := &corev1.Pod{}
-			Expect(cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)).ShouldNot(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)).ToNot(Succeed())
 		})
 	})
 
 	Context("test ContainsString", func() {
 		It("should return false if the list is empty", func() {
-			Expect(ContainsString([]string{}, "a word")).Should(BeFalse())
+			Expect(ContainsString([]string{}, "a word")).To(BeFalse())
 		})
 
 		It("should return false if the list is nil", func() {
-			Expect(ContainsString(nil, "a word")).Should(BeFalse())
+			Expect(ContainsString(nil, "a word")).To(BeFalse())
 		})
 
 		It("should return false if the list does not contain the string", func() {
-			Expect(ContainsString([]string{"aaa", "bbb", "ccc", "ddd"}, "eee")).Should(BeFalse())
+			Expect(ContainsString([]string{"aaa", "bbb", "ccc", "ddd"}, "eee")).To(BeFalse())
 		})
 
 		It("should return true if the list contains the string", func() {
-			Expect(ContainsString([]string{"aaa", "bbb", "ccc", "ddd"}, "bbb")).Should(BeTrue())
+			Expect(ContainsString([]string{"aaa", "bbb", "ccc", "ddd"}, "bbb")).To(BeTrue())
 		})
 	})
 })

--- a/pkg/webhooks/setup_test.go
+++ b/pkg/webhooks/setup_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Hyperconverged API: Webhook", func() {
 		})
 
 		It("should return default value, if the env var is not set", func() {
-			Expect(GetWebhookCertDir()).Should(Equal(hcoutil.DefaultWebhookCertDir))
+			Expect(GetWebhookCertDir()).To(Equal(hcoutil.DefaultWebhookCertDir))
 		})
 
 		It("should return the value of the env var, if set", func() {
@@ -54,7 +54,7 @@ var _ = Describe("Hyperconverged API: Webhook", func() {
 
 			const somethingElse = "/something/else"
 			os.Setenv(webHookCertDirEnv, somethingElse)
-			Expect(GetWebhookCertDir()).Should(Equal(somethingElse))
+			Expect(GetWebhookCertDir()).To(Equal(somethingElse))
 		})
 
 		It("should setup the webhooks with the manager", func() {

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -447,7 +447,7 @@ var _ = Describe("webhooks validator", func() {
 			It("should fail if does not have any of the HTTP/2-required ciphers", func() {
 				err := updateTLSSecurityProfile(openshiftconfigv1.VersionTLS12, []string{"DHE-RSA-AES256-GCM-SHA384", "DHE-RSA-CHACHA20-POLY1305"})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).Should(ContainSubstring("http2: TLSConfig.CipherSuites is missing an HTTP/2-required AES_128_GCM_SHA256 cipher (need at least one of ECDHE-RSA-AES128-GCM-SHA256 or ECDHE-ECDSA-AES128-GCM-SHA256)"))
+				Expect(err.Error()).To(ContainSubstring("http2: TLSConfig.CipherSuites is missing an HTTP/2-required AES_128_GCM_SHA256 cipher (need at least one of ECDHE-RSA-AES128-GCM-SHA256 or ECDHE-ECDSA-AES128-GCM-SHA256)"))
 			})
 
 			It("should succeed if does not have any of the HTTP/2-required ciphers but TLS version >= 1.3", func() {
@@ -459,13 +459,13 @@ var _ = Describe("webhooks validator", func() {
 			It("should fail if does have custom ciphers with TLS version >= 1.3", func() {
 				err := updateTLSSecurityProfile(openshiftconfigv1.VersionTLS13, []string{"TLS_AES_128_GCM_SHA256", "TLS_CHACHA20_POLY1305_SHA256"})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).Should(ContainSubstring("custom ciphers cannot be selected when minTLSVersion is VersionTLS13"))
+				Expect(err.Error()).To(ContainSubstring("custom ciphers cannot be selected when minTLSVersion is VersionTLS13"))
 			})
 
 			It("should fail when minTLSVersion is invalid", func() {
 				err := updateTLSSecurityProfile("invalidProtocolVersion", []string{"TLS_AES_128_GCM_SHA256", "TLS_CHACHA20_POLY1305_SHA256"})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).Should(ContainSubstring("invalid value for spec.tlsSecurityProfile.custom.minTLSVersion"))
+				Expect(err.Error()).To(ContainSubstring("invalid value for spec.tlsSecurityProfile.custom.minTLSVersion"))
 			})
 		})
 
@@ -572,7 +572,7 @@ var _ = Describe("webhooks validator", func() {
 			newHco.Spec.Workloads.NodePlacement.NodeSelector["a change"] = "Something else"
 
 			err := wh.ValidateUpdate(ctx, dryRun, newHco, hco)
-			Expect(err).Should(MatchError(ErrFakeKvError))
+			Expect(err).To(MatchError(ErrFakeKvError))
 		})
 
 		It("should return error if CDI CR is missing", func() {
@@ -605,7 +605,7 @@ var _ = Describe("webhooks validator", func() {
 			newHco.Spec.Workloads.NodePlacement.NodeSelector["a change"] = "Something else"
 
 			err := wh.ValidateUpdate(ctx, dryRun, newHco, hco)
-			Expect(err).Should(MatchError(ErrFakeCdiError))
+			Expect(err).To(MatchError(ErrFakeCdiError))
 		})
 
 		It("should not return error if dry-run update of ALL CR passes", func() {
@@ -652,7 +652,7 @@ var _ = Describe("webhooks validator", func() {
 			newHco.Spec.Workloads.NodePlacement.NodeSelector["a change"] = "Something else"
 
 			err := wh.ValidateUpdate(ctx, dryRun, newHco, hco)
-			Expect(err).Should(MatchError(ErrFakeNetworkError))
+			Expect(err).To(MatchError(ErrFakeNetworkError))
 		})
 
 		It("should return error if SSP CR is missing", func() {
@@ -683,7 +683,7 @@ var _ = Describe("webhooks validator", func() {
 			newHco.Spec.Workloads.NodePlacement.NodeSelector["a change"] = "Something else"
 
 			err := wh.ValidateUpdate(ctx, dryRun, newHco, hco)
-			Expect(err).Should(MatchError(ErrFakeSspError))
+			Expect(err).To(MatchError(ErrFakeSspError))
 
 		})
 
@@ -699,7 +699,7 @@ var _ = Describe("webhooks validator", func() {
 			newHco.Spec.Workloads.NodePlacement.NodeSelector["a change"] = "Something else"
 
 			err := wh.ValidateUpdate(ctx, dryRun, newHco, hco)
-			Expect(err).Should(MatchError(context.DeadlineExceeded))
+			Expect(err).To(MatchError(context.DeadlineExceeded))
 		})
 
 		It("should not return error if nothing was changed", func() {
@@ -895,7 +895,7 @@ var _ = Describe("webhooks validator", func() {
 					wh := NewWebhookHandler(logger, cli, decoder, HcoValidNamespace, true, nil)
 
 					err := wh.ValidateUpdate(ctx, dryRun, &newHco, hco)
-					Expect(err).Should(MatchError(ContainSubstring(errorMsg)))
+					Expect(err).To(MatchError(ContainSubstring(errorMsg)))
 				},
 				Entry("certConfig.ca.duration is too short",
 					v1beta1.HyperConverged{
@@ -1081,7 +1081,7 @@ var _ = Describe("webhooks validator", func() {
 			It("should fail if does not have any of the HTTP/2-required ciphers", func() {
 				err := updateTLSSecurityProfile(openshiftconfigv1.VersionTLS12, []string{"DHE-RSA-AES256-GCM-SHA384", "DHE-RSA-CHACHA20-POLY1305"})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).Should(ContainSubstring("http2: TLSConfig.CipherSuites is missing an HTTP/2-required AES_128_GCM_SHA256 cipher (need at least one of ECDHE-RSA-AES128-GCM-SHA256 or ECDHE-ECDSA-AES128-GCM-SHA256)"))
+				Expect(err.Error()).To(ContainSubstring("http2: TLSConfig.CipherSuites is missing an HTTP/2-required AES_128_GCM_SHA256 cipher (need at least one of ECDHE-RSA-AES128-GCM-SHA256 or ECDHE-ECDSA-AES128-GCM-SHA256)"))
 			})
 
 			It("should succeed if does not have any of the HTTP/2-required ciphers but TLS version >= 1.3", func() {
@@ -1093,13 +1093,13 @@ var _ = Describe("webhooks validator", func() {
 			It("should fail if does have custom ciphers with TLS version >= 1.3", func() {
 				err := updateTLSSecurityProfile(openshiftconfigv1.VersionTLS13, []string{"TLS_AES_128_GCM_SHA256", "TLS_CHACHA20_POLY1305_SHA256"})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).Should(ContainSubstring("custom ciphers cannot be selected when minTLSVersion is VersionTLS13"))
+				Expect(err.Error()).To(ContainSubstring("custom ciphers cannot be selected when minTLSVersion is VersionTLS13"))
 			})
 
 			It("should fail when minTLSVersion is invalid", func() {
 				err := updateTLSSecurityProfile("invalidProtocolVersion", []string{"TLS_AES_128_GCM_SHA256", "TLS_CHACHA20_POLY1305_SHA256"})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).Should(ContainSubstring("invalid value for spec.tlsSecurityProfile.custom.minTLSVersion"))
+				Expect(err.Error()).To(ContainSubstring("invalid value for spec.tlsSecurityProfile.custom.minTLSVersion"))
 			})
 		})
 
@@ -1548,7 +1548,7 @@ var _ = Describe("webhooks validator", func() {
 					Expect(ci.IsOpenshift()).To(BeTrue())
 
 					_, minTypedTLSVersion := SelectCipherSuitesAndMinTLSVersion()
-					Expect(minTypedTLSVersion).Should(Equal(initExpected))
+					Expect(minTypedTLSVersion).To(Equal(initExpected))
 
 					apiServer.Spec.TLSSecurityProfile = midApiTlsSecurityProfile
 					Expect(cl.Update(context.TODO(), apiServer)).To(Succeed())
@@ -1556,7 +1556,7 @@ var _ = Describe("webhooks validator", func() {
 					Expect(util.GetClusterInfo().RefreshAPIServerCR(context.TODO(), cl)).To(Succeed())
 
 					_, minTypedTLSVersion = SelectCipherSuitesAndMinTLSVersion()
-					Expect(minTypedTLSVersion).Should(Equal(midExpected))
+					Expect(minTypedTLSVersion).To(Equal(midExpected))
 
 					apiServer.Spec.TLSSecurityProfile = finApiTlsSecurityProfile
 					Expect(cl.Update(context.TODO(), apiServer)).To(Succeed())
@@ -1564,7 +1564,7 @@ var _ = Describe("webhooks validator", func() {
 
 					Expect(util.GetClusterInfo().RefreshAPIServerCR(context.TODO(), cl)).To(Succeed())
 					_, minTypedTLSVersion = SelectCipherSuitesAndMinTLSVersion()
-					Expect(minTypedTLSVersion).Should(Equal(finExpected))
+					Expect(minTypedTLSVersion).To(Equal(finExpected))
 				},
 				Entry("nil on APIServer, nil on HCO -> old on API server -> nil on API server",
 					nil,

--- a/tests/func-tests/aaq_test.go
+++ b/tests/func-tests/aaq_test.go
@@ -57,25 +57,25 @@ var _ = Describe("Test AAQ", Label("AAQ"), Serial, Ordered, func() {
 			By("check the AAQ CR")
 			Eventually(func(g Gomega) bool {
 				aaq := getAAQ(ctx, cli, g)
-				g.Expect(aaq.Status.Conditions).ShouldNot(BeEmpty())
+				g.Expect(aaq.Status.Conditions).ToNot(BeEmpty())
 				return conditionsv1.IsStatusConditionTrue(aaq.Status.Conditions, conditionsv1.ConditionAvailable)
 			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).ShouldNot(BeTrue())
 
 			By("check AAQ pods")
 			Eventually(func(g Gomega) {
 				deps, err := cli.AppsV1().Deployments(flags.KubeVirtInstallNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=aaq-operator"})
-				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(deps.Items).To(HaveLen(2))
 
 				expectedPods := int32(0)
 				for _, dep := range deps.Items {
-					g.Expect(dep.Status.ReadyReplicas).Should(Equal(dep.Status.Replicas))
+					g.Expect(dep.Status.ReadyReplicas).To(Equal(dep.Status.Replicas))
 					expectedPods += dep.Status.Replicas
 				}
 
 				pods, err := cli.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=aaq-operator"})
-				g.Expect(err).ShouldNot(HaveOccurred())
-				g.Expect(pods.Items).Should(HaveLen(int(expectedPods)))
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(pods.Items).To(HaveLen(int(expectedPods)))
 			}).WithTimeout(5 * time.Minute).
 				WithPolling(time.Second).
 				Should(Succeed())

--- a/tests/func-tests/console_plugin_test.go
+++ b/tests/func-tests/console_plugin_test.go
@@ -61,7 +61,7 @@ var _ = Describe("kubevirt console plugin", func() {
 
 	It("console should reach kubevirt-plugin manifests", func() {
 		unstructured, err := cli.DynamicClient().Resource(consoleGVR).Get(ctx, expectedKubevirtConsolePluginName, metav1.GetOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		kubevirtPlugin := &consolev1.ConsolePlugin{}
 		Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, kubevirtPlugin)).To(Succeed())
@@ -74,21 +74,21 @@ var _ = Describe("kubevirt console plugin", func() {
 		consolePods, err := cli.CoreV1().Pods(openshiftConsoleNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: consolePodsLabelSelector,
 		})
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(consolePods.Items).ShouldNot(BeEmpty())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(consolePods.Items).ToNot(BeEmpty())
 
 		testConsolePod := consolePods.Items[0]
 		command := fmt.Sprintf(`curl -ks https://%s.%s.svc:%d/plugin-manifest.json`,
 			pluginServiceName, flags.KubeVirtInstallNamespace, pluginServicePort)
 
 		stdout, stderr, err := executeCommandOnPod(ctx, cli, &testConsolePod, command)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(stdout).ShouldNot(BeEmpty())
-		Expect(stderr).Should(BeEmpty())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stdout).ToNot(BeEmpty())
+		Expect(stderr).To(BeEmpty())
 
 		var pluginManifests map[string]interface{}
 		err = json.Unmarshal([]byte(stdout), &pluginManifests)
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		pluginName := pluginManifests["name"]
 		Expect(pluginName).To(Equal(expectedKubevirtConsolePluginName))
@@ -100,7 +100,7 @@ var _ = Describe("kubevirt console plugin", func() {
 			"foo": "bar",
 		}
 		expectedNodeSelectorBytes, err := json.Marshal(expectedNodeSelector)
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		expectedNodeSelectorStr := string(expectedNodeSelectorBytes)
 		addNodeSelectorPatch := []byte(fmt.Sprintf(`[{"op": "add", "path": "/spec/infra", "value": {"nodePlacement": {"nodeSelector": %s}}}]`, expectedNodeSelectorStr))
 
@@ -113,7 +113,7 @@ var _ = Describe("kubevirt console plugin", func() {
 
 		Eventually(func(g Gomega) {
 			consoleUIDeployment, err := cli.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(ctx, string(hcoutil.AppComponentUIPlugin), metav1.GetOptions{})
-			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(consoleUIDeployment.Spec.Template.Spec.NodeSelector).To(Equal(expectedNodeSelector))
 		}).WithTimeout(1 * time.Minute).
 			WithPolling(100 * time.Millisecond).
@@ -121,7 +121,7 @@ var _ = Describe("kubevirt console plugin", func() {
 
 		Eventually(func(g Gomega) {
 			proxyUIDeployment, err := cli.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(ctx, string(hcoutil.AppComponentUIProxy), metav1.GetOptions{})
-			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(proxyUIDeployment.Spec.Template.Spec.NodeSelector).To(Equal(expectedNodeSelector))
 		}).WithTimeout(1 * time.Minute).
 			WithPolling(100 * time.Millisecond).
@@ -138,7 +138,7 @@ var _ = Describe("kubevirt console plugin", func() {
 
 		Eventually(func(g Gomega) {
 			consoleUIDeployment, err := cli.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(ctx, string(hcoutil.AppComponentUIPlugin), metav1.GetOptions{})
-			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(consoleUIDeployment.Spec.Template.Spec.NodeSelector).To(BeEmpty())
 		}).WithTimeout(1 * time.Minute).
 			WithPolling(100 * time.Millisecond).
@@ -146,7 +146,7 @@ var _ = Describe("kubevirt console plugin", func() {
 
 		Eventually(func(g Gomega) {
 			proxyUIDeployment, err := cli.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(ctx, string(hcoutil.AppComponentUIProxy), metav1.GetOptions{})
-			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(proxyUIDeployment.Spec.Template.Spec.NodeSelector).To(BeEmpty())
 		}).WithTimeout(1 * time.Minute).
 			WithPolling(100 * time.Millisecond).

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 			Eventually(func(g Gomega) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.CertConfig, defaultCertConfig)).Should(BeTrue(), "certConfig should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.CertConfig, defaultCertConfig)).To(BeTrue(), "certConfig should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 		},
 			Entry("when removing /spec/certConfig/ca/duration", "/spec/certConfig/ca/duration"),
@@ -97,7 +97,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 			Eventually(func(g Gomega) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.FeatureGates, defaultFeatureGates)).Should(BeTrue(), "featureGates should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.FeatureGates, defaultFeatureGates)).To(BeTrue(), "featureGates should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 		},
 			Entry("when removing /spec/featureGates/deployKubeSecondaryDNS", "/spec/featureGates/deployKubeSecondaryDNS"),
@@ -134,7 +134,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 			Eventually(func(g Gomega) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.LiveMigrationConfig, defaultLiveMigrationConfig)).Should(BeTrue(), "liveMigrationConfig should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.LiveMigrationConfig, defaultLiveMigrationConfig)).To(BeTrue(), "liveMigrationConfig should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 		},
 			Entry("when removing /spec/liveMigrationConfig/allowAutoConverge", "/spec/liveMigrationConfig/allowAutoConverge"),
@@ -161,7 +161,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 			Eventually(func(g Gomega) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.ResourceRequirements, &defaultResourceRequirements)).Should(BeTrue(), "resourceRequirements should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.ResourceRequirements, &defaultResourceRequirements)).To(BeTrue(), "resourceRequirements should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 		},
 			Entry("when removing /spec/resourceRequirements/vmiCPUAllocationRatio", "/spec/resourceRequirements/vmiCPUAllocationRatio"),
@@ -185,7 +185,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 			Eventually(func(g Gomega) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.WorkloadUpdateStrategy, defaultWorkloadUpdateStrategy)).Should(BeTrue(), "workloadUpdateStrategy should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.WorkloadUpdateStrategy, defaultWorkloadUpdateStrategy)).To(BeTrue(), "workloadUpdateStrategy should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 		},
 			Entry("when removing /spec/workloadUpdateStrategy/batchEvictionInterval", "/spec/workloadUpdateStrategy/batchEvictionInterval"),
@@ -207,7 +207,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 			Eventually(func(g Gomega) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(hc.Spec.UninstallStrategy).Should(Equal(v1beta1.HyperConvergedUninstallStrategy(defaultUninstallStrategy)), "uninstallStrategy should be equal to default")
+				g.Expect(hc.Spec.UninstallStrategy).To(Equal(v1beta1.HyperConvergedUninstallStrategy(defaultUninstallStrategy)), "uninstallStrategy should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 		},
 			Entry("when removing /spec/uninstallStrategy", "/spec/uninstallStrategy"),
@@ -229,7 +229,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 			Eventually(func(g Gomega) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.VirtualMachineOptions, defaultVirtualMachineOptions)).Should(BeTrue(), "virtualMachineOptions should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.VirtualMachineOptions, defaultVirtualMachineOptions)).To(BeTrue(), "virtualMachineOptions should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 		},
 			Entry("when removing /spec/virtualMachineOptions/disableFreePageReporting", "/spec/virtualMachineOptions/disableFreePageReporting"),
@@ -252,7 +252,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 			Eventually(func(g Gomega) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.HigherWorkloadDensity, defaultHigherWorkloadDensity)).Should(BeTrue(), "HigherWorkloadDensity should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.HigherWorkloadDensity, defaultHigherWorkloadDensity)).To(BeTrue(), "HigherWorkloadDensity should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 		},
 			Entry("when removing /spec/higherWorkloadDensity/memoryOvercommitPercentage", "/spec/higherWorkloadDensity/memoryOvercommitPercentage"),

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -107,14 +107,14 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 		DescribeTable("check that imagestream created", func(expectedIS tests.ImageStreamConfig) {
 			unstructured, err := cli.DynamicClient().Resource(isGVR).Namespace(imageNamespace).Get(ctx, expectedIS.Name, metav1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			is := &v1.ImageStream{}
 			Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, is)).To(Succeed())
 
-			Expect(is.Spec.Tags[0].From).ShouldNot(BeNil())
-			Expect(is.Spec.Tags[0].From.Kind).Should(Equal("DockerImage"))
-			Expect(is.Spec.Tags[0].From.Name).Should(Equal(expectedIS.RegistryName))
+			Expect(is.Spec.Tags[0].From).ToNot(BeNil())
+			Expect(is.Spec.Tags[0].From.Kind).To(Equal("DockerImage"))
+			Expect(is.Spec.Tags[0].From.Name).To(Equal(expectedIS.RegistryName))
 		},
 			isEntries,
 		)
@@ -137,7 +137,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			is = &v1.ImageStream{}
 			Eventually(func(g Gomega) string {
 				unstructured, err := cli.DynamicClient().Resource(isGVR).Namespace(imageNamespace).Get(ctx, expectedIS.Name, metav1.GetOptions{})
-				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, is)).To(Succeed())
 
 				return is.GetLabels()["app.kubernetes.io/part-of"]
@@ -156,12 +156,12 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		It("should propagate the DICT to SSP", func() {
 			Eventually(func(g Gomega) []string {
 				unstructured, err := cli.DynamicClient().Resource(sspGVR).Namespace(flags.KubeVirtInstallNamespace).Get(ctx, "ssp-kubevirt-hyperconverged", metav1.GetOptions{})
-				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				ssp := &v1beta2.SSP{}
 				g.Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, ssp)).To(Succeed())
 
-				g.Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).Should(HaveLen(len(expectedImages)))
+				g.Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(len(expectedImages)))
 
 				imageNames := make([]string, len(expectedImages))
 				for i, image := range ssp.Spec.CommonTemplates.DataImportCronTemplates {
@@ -176,7 +176,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			Eventually(func(g Gomega) []string {
 				hco := tests.GetHCO(ctx, cli)
 
-				g.Expect(hco.Status.DataImportCronTemplates).Should(HaveLen(len(expectedImages)))
+				g.Expect(hco.Status.DataImportCronTemplates).To(HaveLen(len(expectedImages)))
 
 				imageNames := make([]string, len(expectedImages))
 				for i, image := range hco.Status.DataImportCronTemplates {
@@ -191,7 +191,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		It("should have all the DataImportCron resources", func() {
 			Eventually(func(g Gomega) []string {
 				unstructured, err := cli.DynamicClient().Resource(dicGVR).Namespace(imageNamespace).List(ctx, metav1.ListOptions{})
-				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				items := make([]cdiv1beta1.DataImportCron, len(unstructured.Items))
 				for i, item := range unstructured.Items {
@@ -199,7 +199,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 					g.Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, &dic)).To(Succeed())
 					items[i] = dic
 				}
-				g.Expect(items).Should(HaveLen(len(expectedImages)))
+				g.Expect(items).To(HaveLen(len(expectedImages)))
 
 				imageNames := make([]string, len(expectedImages))
 				for i, image := range items {
@@ -223,13 +223,13 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		DescribeTable("check the images that use image streams", func(imageName, streamName string) {
 			dic := &cdiv1beta1.DataImportCron{}
 			unstructured, err := cli.DynamicClient().Resource(dicGVR).Namespace(imageNamespace).Get(ctx, imageName, metav1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, dic)).To(Succeed())
 
-			Expect(dic.Spec.Template.Spec.Source).ShouldNot(BeNil())
-			Expect(dic.Spec.Template.Spec.Source.Registry).ShouldNot(BeNil())
-			Expect(dic.Spec.Template.Spec.Source.Registry.ImageStream).Should(HaveValue(Equal(streamName)))
-			Expect(dic.Spec.Template.Spec.Source.Registry.PullMethod).Should(HaveValue(Equal(cdiv1beta1.RegistryPullNode)))
+			Expect(dic.Spec.Template.Spec.Source).ToNot(BeNil())
+			Expect(dic.Spec.Template.Spec.Source.Registry).ToNot(BeNil())
+			Expect(dic.Spec.Template.Spec.Source.Registry.ImageStream).To(HaveValue(Equal(streamName)))
+			Expect(dic.Spec.Template.Spec.Source.Registry.PullMethod).To(HaveValue(Equal(cdiv1beta1.RegistryPullNode)))
 		}, isUsageEntries)
 	})
 
@@ -256,7 +256,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		It("should empty the DICT in SSP", func() {
 			Eventually(func(g Gomega) []v1beta2.DataImportCronTemplate {
 				unstructured, err := cli.DynamicClient().Resource(sspGVR).Namespace(flags.KubeVirtInstallNamespace).Get(ctx, "ssp-kubevirt-hyperconverged", metav1.GetOptions{})
-				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				ssp := &v1beta2.SSP{}
 				g.Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, ssp)).To(Succeed())
 				return ssp.Spec.CommonTemplates.DataImportCronTemplates
@@ -274,7 +274,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 			Eventually(func(g Gomega) []unstructured.Unstructured {
 				list, err := cli.DynamicClient().Resource(dicGVR).Namespace(imageNamespace).List(ctx, metav1.ListOptions{})
-				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				return list.Items
 			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).Should(BeEmpty())
@@ -304,7 +304,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		It("should propagate the DICT in SSP", func() {
 			Eventually(func(g Gomega) []v1beta2.DataImportCronTemplate {
 				unstructured, err := cli.DynamicClient().Resource(sspGVR).Namespace(flags.KubeVirtInstallNamespace).Get(ctx, "ssp-kubevirt-hyperconverged", metav1.GetOptions{})
-				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				ssp := &v1beta2.SSP{}
 				g.Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, ssp)).To(Succeed())
 				return ssp.Spec.CommonTemplates.DataImportCronTemplates
@@ -321,7 +321,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		It("should restore all the DataImportCron resources", func() {
 			Eventually(func(g Gomega) []unstructured.Unstructured {
 				list, err := cli.DynamicClient().Resource(dicGVR).Namespace(imageNamespace).List(ctx, metav1.ListOptions{})
-				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				return list.Items
 			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(HaveLen(len(expectedImages)))

--- a/tests/func-tests/labels_test.go
+++ b/tests/func-tests/labels_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Check that all the sub-resources have the required labels", La
 
 		By("removing one of the managed labels and wait for it to be added back")
 		kv, err := cli.KubeVirt(hc.Namespace).Get(kv_name, &metav1.GetOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		expectedVersion := kv.Labels[hcoutil.AppLabelVersion]
 
 		patch := []byte(`[{"op": "remove", "path": "/metadata/labels/app.kubernetes.io~1version"}]`)
@@ -54,8 +54,8 @@ var _ = Describe("Check that all the sub-resources have the required labels", La
 
 		Eventually(func(g Gomega) {
 			kv, err := cli.KubeVirt(hc.Namespace).Get(kv_name, &metav1.GetOptions{})
-			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(kv.Labels).Should(HaveKeyWithValue(hcoutil.AppLabelVersion, expectedVersion))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(kv.Labels).To(HaveKeyWithValue(hcoutil.AppLabelVersion, expectedVersion))
 		}).WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 		By("checking all the labels")
@@ -66,12 +66,12 @@ var _ = Describe("Check that all the sub-resources have the required labels", La
 				switch resource.Kind {
 				case "ConfigMap":
 					cm, err := cli.CoreV1().ConfigMaps(resource.Namespace).Get(ctx, resource.Name, metav1.GetOptions{})
-					Expect(err).ShouldNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 					checkLabels(cm.GetLabels())
 
 				case "Service":
 					svc, err := cli.CoreV1().Services(resource.Namespace).Get(ctx, resource.Name, metav1.GetOptions{})
-					Expect(err).ShouldNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 					checkLabels(svc.GetLabels())
 				default:
 					GinkgoWriter.Printf("Missed corev1 resource to check the labels for; %s/%s\n", resource.Kind, resource.Name)
@@ -85,11 +85,11 @@ var _ = Describe("Check that all the sub-resources have the required labels", La
 				}
 				if len(resource.Namespace) == 0 {
 					rc, err := cli.DynamicClient().Resource(gvr).Get(ctx, resource.Name, metav1.GetOptions{})
-					Expect(err).ShouldNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 					checkLabels(rc.GetLabels())
 				} else {
 					rc, err := cli.DynamicClient().Resource(gvr).Namespace(resource.Namespace).Get(ctx, resource.Name, metav1.GetOptions{})
-					Expect(err).ShouldNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 					checkLabels(rc.GetLabels())
 				}
 			}

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -50,7 +50,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 
 	BeforeEach(func() {
 		virtCli, err = kubecli.GetKubevirtClient()
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		tests.SkipIfNotOpenShift(virtCli, "Prometheus")
 		promClient = initializePromClient(getPrometheusURL(virtCli), getAuthorizationTokenForPrometheus(virtCli))
@@ -97,7 +97,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 		Eventually(func(g Gomega) map[string]string {
 			patch := []byte(`[{"op": "add", "path": "/metadata/labels/test-label", "value": "test-label-value"}]`)
 			kv, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Patch("kubevirt-kubevirt-hyperconverged", types.JSONPatchType, patch, &metav1.PatchOptions{})
-			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(err).ToNot(HaveOccurred())
 			return kv.GetLabels()
 		}).WithTimeout(10 * time.Second).
 			WithPolling(100 * time.Millisecond).
@@ -105,7 +105,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 
 		Eventually(func() *promApiv1.Alert {
 			alerts, err := promClient.Alerts(context.TODO())
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			alert := getAlertByName(alerts, "KubeVirtCRModified")
 			return alert
 		}).WithTimeout(60 * time.Second).WithPolling(time.Second).ShouldNot(BeNil())
@@ -124,7 +124,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 
 		Eventually(func() *promApiv1.Alert {
 			alerts, err := promClient.Alerts(context.TODO())
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			alert := getAlertByName(alerts, "UnsupportedHCOModification")
 			return alert
 		}, 60*time.Second, time.Second).ShouldNot(BeNil())
@@ -215,7 +215,7 @@ func initializePromClient(prometheusURL string, token string) promApiv1.API {
 		RoundTripper: promConfig.NewAuthorizationCredentialsRoundTripper("Bearer", promConfig.Secret(token), defaultRoundTripper),
 	})
 
-	Expect(err).ShouldNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	promClient := promApiv1.NewAPI(c)
 	return promClient

--- a/tests/func-tests/mtq_test.go
+++ b/tests/func-tests/mtq_test.go
@@ -65,25 +65,25 @@ var _ = Describe("Test MTQ", Label("MTQ"), Serial, Ordered, func() {
 			By("check the MTQ CR")
 			Eventually(func(g Gomega) bool {
 				mtq := getMTQ(ctx, cli, g)
-				g.Expect(mtq.Status.Conditions).ShouldNot(BeEmpty())
+				g.Expect(mtq.Status.Conditions).ToNot(BeEmpty())
 				return conditionsv1.IsStatusConditionTrue(mtq.Status.Conditions, conditionsv1.ConditionAvailable)
 			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).ShouldNot(BeTrue())
 
 			By("check MTQ pods")
 			Eventually(func(g Gomega) {
 				deps, err := cli.AppsV1().Deployments(flags.KubeVirtInstallNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=multi-tenant"})
-				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(deps.Items).To(HaveLen(3))
 
 				expectedPods := int32(0)
 				for _, dep := range deps.Items {
-					g.Expect(dep.Status.ReadyReplicas).Should(Equal(dep.Status.Replicas))
+					g.Expect(dep.Status.ReadyReplicas).To(Equal(dep.Status.Replicas))
 					expectedPods += dep.Status.Replicas
 				}
 
 				pods, err := cli.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=multi-tenant"})
-				g.Expect(err).ShouldNot(HaveOccurred())
-				g.Expect(pods.Items).Should(HaveLen(int(expectedPods)))
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(pods.Items).To(HaveLen(int(expectedPods)))
 			}).WithTimeout(5 * time.Minute).
 				WithPolling(time.Second).
 				Should(Succeed())

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -40,7 +40,7 @@ var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 	BeforeAll(func() {
 		var err error
 		cli, err = kubecli.GetKubevirtClient()
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		nodes := listNodesByLabels(cli, "node-role.kubernetes.io/control-plane!=")
 		if len(nodes.Items) < 2 {

--- a/tests/func-tests/tuningpolicy_test.go
+++ b/tests/func-tests/tuningpolicy_test.go
@@ -82,9 +82,9 @@ var _ = Describe("Check that the TuningPolicy annotation is configuring the KV o
 func checkTuningPolicy(cli kubecli.KubevirtClient, expected kvv1.TokenBucketRateLimiter) {
 	Eventually(func(g Gomega) {
 		kv, err := cli.KubeVirt(flags.KubeVirtInstallNamespace).Get("kubevirt-kubevirt-hyperconverged", &metav1.GetOptions{})
-		g.Expect(err).ShouldNot(HaveOccurred())
-		g.Expect(kv).ShouldNot(BeNil())
-		g.Expect(kv.Spec.Configuration).ShouldNot(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(kv).ToNot(BeNil())
+		g.Expect(kv.Spec.Configuration).ToNot(BeNil())
 
 		checkReloadableComponentConfiguration(g, kv.Spec.Configuration.APIConfiguration, expected)
 		checkReloadableComponentConfiguration(g, kv.Spec.Configuration.ControllerConfiguration, expected)

--- a/tests/func-tests/update_priority_class_test.go
+++ b/tests/func-tests/update_priority_class_test.go
@@ -45,13 +45,13 @@ var _ = Describe("check update priorityClass", Ordered, Serial, func() {
 		pc, err := cli.SchedulingV1().PriorityClasses().Get(ctx, priorityClassName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(pc.UID).ShouldNot(BeEmpty())
+		Expect(pc.UID).ToNot(BeEmpty())
 		oldPriorityClassUID = pc.UID
 	})
 
 	It("should have the right reference for the priorityClass in the HyperConverged CR", func() {
 		uid := getPriorityClassHCORef()
-		Expect(uid).Should(Equal(oldPriorityClassUID))
+		Expect(uid).To(Equal(oldPriorityClassUID))
 	})
 
 	It("should recreate the priorityClass on update", func() {
@@ -71,8 +71,8 @@ var _ = Describe("check update priorityClass", Ordered, Serial, func() {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			newUID = pc.UID
-			g.Expect(newUID).ShouldNot(Or(Equal(types.UID("")), Equal(oldPriorityClassUID)))
-			g.Expect(pc.GetLabels()).ShouldNot(HaveKey("test"))
+			g.Expect(newUID).ToNot(Or(Equal(types.UID("")), Equal(oldPriorityClassUID)))
+			g.Expect(pc.GetLabels()).ToNot(HaveKey("test"))
 		}).WithTimeout(30 * time.Second).
 			WithPolling(100 * time.Millisecond).
 			Should(Succeed())

--- a/tests/func-tests/utils.go
+++ b/tests/func-tests/utils.go
@@ -49,7 +49,7 @@ func FlagParse() {
 
 func BeforeEach() {
 	virtClient, err := kubecli.GetKubevirtClient()
-	Expect(err).ShouldNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	deleteAllResources(virtClient.RestClient(), "virtualmachines")
 	deleteAllResources(virtClient.RestClient(), "virtualmachineinstances")
@@ -71,7 +71,7 @@ func SkipIfNotOpenShift(cli kubecli.KubevirtClient, testName string) {
 
 func SkipIfNotSingleStackIPv6OpenShift(cli kubecli.KubevirtClient, testName string) {
 	isSingleStackIPv6, err := IsOpenShiftSingleStackIPv6(cli)
-	Expect(err).ShouldNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	if !isSingleStackIPv6 {
 		ginkgo.Skip(fmt.Sprintf("Skipping %s tests since the OpenShift cluster is not single stack IPv6", testName))

--- a/tests/func-tests/virtual_machines_test.go
+++ b/tests/func-tests/virtual_machines_test.go
@@ -64,7 +64,7 @@ func verifyVMIRunning(client kubecli.KubevirtClient, vmiName string) *kubevirtco
 		var err error
 		vmi, err = client.VirtualMachineInstance(kvtutil.NamespaceTestDefault).Get(context.Background(), vmiName, &k8smetav1.GetOptions{})
 		g.Expect(err).ToNot(HaveOccurred())
-		Expect(vmi.Status.Phase).ShouldNot(Equal(kubevirtcorev1.Failed), "vmi scheduling failed: %s\n", vmi2JSON(vmi))
+		Expect(vmi.Status.Phase).ToNot(Equal(kubevirtcorev1.Failed), "vmi scheduling failed: %s\n", vmi2JSON(vmi))
 		return vmi.Status.Phase == kubevirtcorev1.Running
 	}, timeout, pollingInterval).Should(BeTrue(), "failed to get the vmi Running")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to be prepared for the next release of golangci-lint with the new ginkgo linter, used ginkgolinter auto fix to change all `Expect().Should/Not()` to `Expect().To/Not()`

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
