### PR TITLE
Enable VM live update rollout strategy always

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -212,6 +212,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"VMPersistentState",
 					"NetworkBindingPlugins",
 					"CommonInstancetypesDeploymentGate",
+					"VMLiveUpdateFeatures",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -104,6 +104,9 @@ const (
 
 	// Deploy common-instancetypes using virt-operator
 	kvDeployCommonInstancetypes = "CommonInstancetypesDeploymentGate"
+
+	// Enable VM live update, to allow live propagation of VM changes to their VMI
+	kvVMLiveUpdateFeatures = "VMLiveUpdateFeatures"
 )
 
 const (
@@ -127,6 +130,7 @@ var (
 		kvVMPersistentState,
 		kvHNetworkBindingPluginsGate,
 		kvDeployCommonInstancetypes,
+		kvVMLiveUpdateFeatures,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of
@@ -436,6 +440,7 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		SeccompConfiguration:         seccompConfig,
 		EvictionStrategy:             hc.Spec.EvictionStrategy,
 		KSMConfiguration:             hc.Spec.KSMConfiguration,
+		VMRolloutStrategy:            ptr.To(kubevirtcorev1.VMRolloutStrategyLiveUpdate),
 	}
 
 	if smbiosConfig, ok := os.LookupEnv(smbiosEnvName); ok {

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -3339,6 +3339,15 @@ Version: 1.2.3`)
 			})
 		})
 
+		Context("Rollout Strategy", func() {
+			It("should be set to live update", func() {
+				kv, err := NewKubeVirt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(kv.Spec.Configuration.VMRolloutStrategy).To(HaveValue(Equal(kubevirtcorev1.VMRolloutStrategyLiveUpdate)))
+			})
+		})
+
 		It("should handle conditions", func() {
 			expectedResource, err := NewKubeVirt(hco, commontestutils.Namespace)
 			Expect(err).ToNot(HaveOccurred())

--- a/hack/kv-smoke-tests.sh
+++ b/hack/kv-smoke-tests.sh
@@ -229,6 +229,10 @@ echo "waiting for testing infrastructure to be ready"
 ${CMD} wait deployment cdi-http-import-server -n "${INSTALLED_NAMESPACE}" --for condition=Available --timeout=10m
 ${CMD} wait pods -l "kubevirt.io=disks-images-provider" -n "${INSTALLED_NAMESPACE}" --for condition=Ready --timeout=10m
 
+# TODO: remove once https://github.com/kubevirt/kubevirt/pull/12073 will be merged
+# and we will be able to consume a new release with a fix
+KVPR12073='(test_id:6867)'
+
 echo "starting tests"
 ${TESTS_BINARY} \
     -cdi-namespace="$INSTALLED_NAMESPACE" \
@@ -239,7 +243,7 @@ ${TESTS_BINARY} \
     -ginkgo.focus='(rfe_id:1177)|(rfe_id:273)|(rfe_id:151)' \
     -ginkgo.no-color \
     -ginkgo.seed=0 \
-    -ginkgo.skip='(Slirp Networking)|(with CPU spec)|(with TX offload disabled)|(with cni flannel and ptp plugin interface)|(with ovs-cni plugin)|(test_id:1752)|(SRIOV)|(with EFI)|(Operator)|(GPU)|(DataVolume Integration)|(when virt-handler is not responsive)|(with default cpu model)|(should set the default MachineType when created without explicit value)|(should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself)|(test_id:3468)|(test_id:3466)|(test_id:1015)|(rfe_id:393)|(test_id:4646)|(test_id:4647)|(test_id:4648)|(test_id:4649)|(test_id:4650)|(test_id:4651)|(test_id:4652)|(test_id:4654)|(test_id:4655)|(test_id:4656)|(test_id:4657)|(test_id:4658)|(test_id:4659)|(should obey the disk verification limits in the KubeVirt CR)' \
+    -ginkgo.skip="(Slirp Networking)|(with CPU spec)|(with TX offload disabled)|(with cni flannel and ptp plugin interface)|(with ovs-cni plugin)|(test_id:1752)|(SRIOV)|(with EFI)|(Operator)|(GPU)|(DataVolume Integration)|(when virt-handler is not responsive)|(with default cpu model)|(should set the default MachineType when created without explicit value)|(should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself)|(test_id:3468)|(test_id:3466)|(test_id:1015)|(rfe_id:393)|(test_id:4646)|(test_id:4647)|(test_id:4648)|(test_id:4649)|(test_id:4650)|(test_id:4651)|(test_id:4652)|(test_id:4654)|(test_id:4655)|(test_id:4656)|(test_id:4657)|(test_id:4658)|(test_id:4659)|(should obey the disk verification limits in the KubeVirt CR)|${KVPR12073}" \
     -ginkgo.slow-spec-threshold=60s \
     -ginkgo.succinct \
     -ginkgo.flake-attempts=3 \


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the KubeVirt VM rollout strategy LiveUpdate, allowing changes to VM specs to dynamically propagate to their VMI.
Rollout strategy LiveUpdate is enabled using `VMLiveUpdateFeatures` Feature Gate and not a configuration knob. 
This because, from Kubevirt side, the feature is still protected by a FG, therefore it is still considered not stable in all the contexts and can potentially 1) be dropped, 2) changed in a breaking manner.
So the FeatureGate is still there and no configuration knob is exposed.
Nevertheless, according to the results of our tests, we can consider it as suitable for this use case and so we can handle it as part of the HCO opinionated deployment.
Eventual breaking changes will be evaluated and handled on the HCO side when consuming a future version of Kubevirt.

Kubevirt test_id:6867 is currently broken,
it will be fixed with https://github.com/kubevirt/kubevirt/pull/12073
It's not a blocker/critical issue so we can temporarely tolerate it.
The test will be enabled back when we will be able to consume a
newer and fixed Kubevirt release.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-36370
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt VM rollout strategy LiveUpdate is now always enabled
```
