### PR TITLE
remove redundant loops

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
@@ -266,14 +267,10 @@ func getCacheOption(operatorNamespace string, isMonitoringAvailable, isOpenshift
 	}
 
 	if isMonitoringAvailable {
-		for k, v := range cacheOptionsByOjectForMonitoring {
-			cacheOptions.ByObject[k] = v
-		}
+		maps.Copy(cacheOptions.ByObject, cacheOptionsByOjectForMonitoring)
 	}
 	if isOpenshift {
-		for k, v := range cacheOptionsByOjectForOpenshift {
-			cacheOptions.ByObject[k] = v
-		}
+		maps.Copy(cacheOptions.ByObject, cacheOptionsByOjectForOpenshift)
 	}
 
 	return cacheOptions

--- a/controllers/operands/aaq_test.go
+++ b/controllers/operands/aaq_test.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"context"
+	"maps"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -286,10 +287,7 @@ var _ = Describe("AAQ tests", func() {
 			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
 			hco.Spec.FeatureGates.EnableApplicationAwareQuota = ptr.To(true)
 			outdatedResource := NewAAQWithNameOnly(hco)
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
 			}
@@ -322,10 +320,7 @@ var _ = Describe("AAQ tests", func() {
 			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
 			hco.Spec.FeatureGates.EnableApplicationAwareQuota = ptr.To(true)
 			outdatedResource := NewAAQWithNameOnly(hco)
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
 

--- a/controllers/operands/cdi_test.go
+++ b/controllers/operands/cdi_test.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"context"
+	"maps"
 	"time"
 
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
@@ -101,10 +102,7 @@ var _ = Describe("CDI Operand", func() {
 			const userLabelValue = "userLabelValue"
 			outdatedResource, err := NewCDI(hco)
 			Expect(err).ToNot(HaveOccurred())
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
 			}
@@ -136,10 +134,7 @@ var _ = Describe("CDI Operand", func() {
 			const userLabelValue = "userLabelValue"
 			outdatedResource, err := NewCDI(hco)
 			Expect(err).ToNot(HaveOccurred())
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
 

--- a/controllers/operands/cliDownload_test.go
+++ b/controllers/operands/cliDownload_test.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"context"
+	"maps"
 	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -105,10 +106,7 @@ var _ = Describe("CLI Download", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 			outdatedResource := NewConsoleCLIDownload(hco)
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
 			}
@@ -139,10 +137,7 @@ var _ = Describe("CLI Download", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 			outdatedResource := NewConsoleCLIDownload(hco)
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
 

--- a/controllers/operands/cmHandler.go
+++ b/controllers/operands/cmHandler.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"errors"
+	"maps"
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
@@ -56,10 +57,7 @@ func (h cmHooks) updateCr(req *common.HcoRequest, Client client.Client, exists r
 			req.Logger.Info("Reconciling an externally updated Configmap to its opinionated values", "name", h.required.Name)
 		}
 		util.MergeLabels(&h.required.ObjectMeta, &found.ObjectMeta)
-		found.Data = make(map[string]string, len(h.required.Data))
-		for k, v := range h.required.Data {
-			found.Data[k] = v
-		}
+		found.Data = maps.Clone(h.required.Data)
 		err := Client.Update(req.Ctx, found)
 		if err != nil {
 			return false, false, err

--- a/controllers/operands/dashboard.go
+++ b/controllers/operands/dashboard.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"errors"
+	"maps"
 	"os"
 	filepath "path/filepath"
 	"strings"
@@ -68,9 +69,7 @@ func processDashboardConfigMapFile(path string, info os.FileInfo, logger log.Log
 		if err != nil {
 			logger.Error(err, "Can't generate a Configmap object from yaml file", "file name", path)
 		} else {
-			for k, v := range getLabels(hc, util.AppComponentCompute) {
-				cm.Labels[k] = v
-			}
+			maps.Copy(cm.Labels, getLabels(hc, util.AppComponentCompute))
 			return newCmHandler(Client, Scheme, cm), nil
 		}
 	}

--- a/controllers/operands/dashboard_test.go
+++ b/controllers/operands/dashboard_test.go
@@ -3,6 +3,7 @@ package operands
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"strings"
@@ -195,10 +196,7 @@ var _ = Describe("Dashboard tests", func() {
 
 			By("getting opinionated labels", func() {
 				for _, cm := range cmList.Items {
-					expectedLabels[cm.Name] = make(map[string]string)
-					for k, v := range cm.Labels {
-						expectedLabels[cm.Name][k] = v
-					}
+					expectedLabels[cm.Name] = maps.Clone(cm.Labels)
 				}
 			})
 
@@ -261,10 +259,7 @@ var _ = Describe("Dashboard tests", func() {
 
 			By("getting opinionated labels", func() {
 				for _, cm := range cmList.Items {
-					expectedLabels[cm.Name] = make(map[string]string)
-					for k, v := range cm.Labels {
-						expectedLabels[cm.Name][k] = v
-					}
+					expectedLabels[cm.Name] = maps.Clone(cm.Labels)
 				}
 			})
 

--- a/controllers/operands/deploymentHandler_test.go
+++ b/controllers/operands/deploymentHandler_test.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"context"
+	"maps"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -108,10 +109,7 @@ var _ = Describe("Deployment Handler", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 			outdatedResource := NewExpectedDeployment(hco)
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
@@ -143,10 +141,7 @@ var _ = Describe("Deployment Handler", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 			outdatedResource := NewExpectedDeployment(hco)
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 
 			removed := false
 			for k := range outdatedResource.Labels {

--- a/controllers/operands/imageStream_test.go
+++ b/controllers/operands/imageStream_test.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"context"
+	"maps"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -678,10 +679,7 @@ var _ = Describe("imageStream tests", func() {
 				},
 			}
 			exists.Labels = getLabels(hco, util.AppComponentCompute)
-			expectedLabels := make(map[string]string, len(exists.Labels))
-			for k, v := range exists.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(exists.Labels)
 			exists.Labels[userLabelKey] = userLabelValue
 			for k, v := range expectedLabels {
 				exists.Labels[k] = "wrong_" + v

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 	"strconv"
@@ -740,10 +741,7 @@ func hcoConfig2KvConfig(hcoConfig hcov1beta1.HyperConvergedConfig, infrastructur
 		}
 
 		if hcoConfig.NodePlacement.NodeSelector != nil {
-			kvConfig.NodePlacement.NodeSelector = make(map[string]string)
-			for k, v := range hcoConfig.NodePlacement.NodeSelector {
-				kvConfig.NodePlacement.NodeSelector[k] = v
-			}
+			kvConfig.NodePlacement.NodeSelector = maps.Clone(hcoConfig.NodePlacement.NodeSelector)
 		}
 
 		for _, hcoTolr := range hcoConfig.NodePlacement.Tolerations {

--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -3,6 +3,7 @@ package operands
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 
@@ -172,10 +173,7 @@ func getKvUIDeployment(hc *hcov1beta1.HyperConverged, deploymentName string, ima
 
 	if hc.Spec.Infra.NodePlacement != nil {
 		if hc.Spec.Infra.NodePlacement.NodeSelector != nil {
-			deployment.Spec.Template.Spec.NodeSelector = make(map[string]string)
-			for key, value := range hc.Spec.Infra.NodePlacement.NodeSelector {
-				deployment.Spec.Template.Spec.NodeSelector[key] = value
-			}
+			deployment.Spec.Template.Spec.NodeSelector = maps.Clone(hc.Spec.Infra.NodePlacement.NodeSelector)
 		} else {
 			deployment.Spec.Template.Spec.NodeSelector = nil
 		}

--- a/controllers/operands/kubevirtConsolePlugin_test.go
+++ b/controllers/operands/kubevirtConsolePlugin_test.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"context"
+	"maps"
 	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -193,10 +194,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 			outdatedResource := NewKVConsolePlugin(hco)
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
 			}
@@ -227,10 +225,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 			outdatedResource := NewExpectedDeployment(hco)
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			removed := false
 			for k := range outdatedResource.Labels {
 				if !removed {

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -3,6 +3,7 @@ package operands
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"time"
 
@@ -301,10 +302,7 @@ Version: 1.2.3`)
 			const userLabelValue = "userLabelValue"
 			outdatedResource, err := NewKubeVirt(hco)
 			Expect(err).ToNot(HaveOccurred())
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
 			}
@@ -337,10 +335,7 @@ Version: 1.2.3`)
 			const userLabelValue = "userLabelValue"
 			outdatedResource, err := NewKubeVirt(hco)
 			Expect(err).ToNot(HaveOccurred())
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
 

--- a/controllers/operands/mtq_test.go
+++ b/controllers/operands/mtq_test.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"context"
+	"maps"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -264,10 +265,7 @@ var _ = Describe("MTQ tests", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 			outdatedResource := NewMTQ(hco)
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
 			}
@@ -300,10 +298,7 @@ var _ = Describe("MTQ tests", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 			outdatedResource := NewMTQ(hco)
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
 

--- a/controllers/operands/networkAddons.go
+++ b/controllers/operands/networkAddons.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"errors"
+	"maps"
 	"reflect"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
@@ -222,10 +223,7 @@ func hcoConfig2CnaoPlacement(hcoConf *sdkapi.NodePlacement) *networkaddonsshared
 
 	if len(hcoConf.NodeSelector) > 0 {
 		empty = false
-		cnaoPlacement.NodeSelector = make(map[string]string)
-		for k, v := range hcoConf.NodeSelector {
-			cnaoPlacement.NodeSelector[k] = v
-		}
+		cnaoPlacement.NodeSelector = maps.Clone(hcoConf.NodeSelector)
 	}
 
 	if empty {

--- a/controllers/operands/networkAddons_test.go
+++ b/controllers/operands/networkAddons_test.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"context"
+	"maps"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -18,11 +19,12 @@ import (
 
 	networkaddonsshared "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
+	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
+
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 )
 
 var _ = Describe("CNA Operand", func() {
@@ -133,10 +135,7 @@ var _ = Describe("CNA Operand", func() {
 			const userLabelValue = "userLabelValue"
 			outdatedResource, err := NewNetworkAddons(hco)
 			Expect(err).ToNot(HaveOccurred())
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
 			}
@@ -168,10 +167,7 @@ var _ = Describe("CNA Operand", func() {
 			const userLabelValue = "userLabelValue"
 			outdatedResource, err := NewNetworkAddons(hco)
 			Expect(err).ToNot(HaveOccurred())
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
 

--- a/controllers/operands/quickStart_test.go
+++ b/controllers/operands/quickStart_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"strings"
@@ -231,10 +232,7 @@ var _ = Describe("QuickStart tests", func() {
 
 			By("getting opinionated labels", func() {
 				for _, quickstart := range quickstartObjects.Items {
-					expectedLabels[quickstart.Name] = make(map[string]string)
-					for k, v := range quickstart.Labels {
-						expectedLabels[quickstart.Name][k] = v
-					}
+					expectedLabels[quickstart.Name] = maps.Clone(quickstart.Labels)
 				}
 			})
 
@@ -298,10 +296,7 @@ var _ = Describe("QuickStart tests", func() {
 
 			By("getting opinionated labels", func() {
 				for _, quickstart := range quickstartObjects.Items {
-					expectedLabels[quickstart.Name] = make(map[string]string)
-					for k, v := range quickstart.Labels {
-						expectedLabels[quickstart.Name][k] = v
-					}
+					expectedLabels[quickstart.Name] = maps.Clone(quickstart.Labels)
 				}
 			})
 

--- a/controllers/operands/ssp_test.go
+++ b/controllers/operands/ssp_test.go
@@ -3,6 +3,7 @@ package operands
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"strings"
@@ -131,10 +132,7 @@ var _ = Describe("SSP Operands", func() {
 			const userLabelValue = "userLabelValue"
 			outdatedResource, _, err := NewSSP(hco)
 			Expect(err).ToNot(HaveOccurred())
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
 			}
@@ -166,10 +164,7 @@ var _ = Describe("SSP Operands", func() {
 			const userLabelValue = "userLabelValue"
 			outdatedResource, _, err := NewSSP(hco)
 			Expect(err).ToNot(HaveOccurred())
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
 

--- a/controllers/operands/virtio_win_ConfigMap_test.go
+++ b/controllers/operands/virtio_win_ConfigMap_test.go
@@ -2,6 +2,8 @@ package operands
 
 import (
 	"context"
+	"maps"
+	"os"
 	"reflect"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -14,8 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-
-	"os"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
@@ -135,10 +135,7 @@ var _ = Describe("VirtioWin", func() {
 			const userLabelValue = "userLabelValue"
 			outdatedResource, err := NewVirtioWinCm(hco)
 			Expect(err).ToNot(HaveOccurred())
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
 			}
@@ -169,10 +166,7 @@ var _ = Describe("VirtioWin", func() {
 			const userLabelValue = "userLabelValue"
 			outdatedResource, err := NewVirtioWinCm(hco)
 			Expect(err).ToNot(HaveOccurred())
-			expectedLabels := make(map[string]string, len(outdatedResource.Labels))
-			for k, v := range outdatedResource.Labels {
-				expectedLabels[k] = v
-			}
+			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
 

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"maps"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -13,9 +15,8 @@ func MergeLabels(src, tgt *metav1.ObjectMeta) {
 	if tgt.Labels == nil {
 		tgt.Labels = make(map[string]string, len(src.Labels))
 	}
-	for key, val := range src.Labels {
-		tgt.Labels[key] = val
-	}
+
+	maps.Copy(tgt.Labels, src.Labels)
 }
 
 // CompareLabels reports whether src labels are contained into tgt ones; extra labels on tgt are ignored.

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/labels.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/labels.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"maps"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -13,9 +15,8 @@ func MergeLabels(src, tgt *metav1.ObjectMeta) {
 	if tgt.Labels == nil {
 		tgt.Labels = make(map[string]string, len(src.Labels))
 	}
-	for key, val := range src.Labels {
-		tgt.Labels[key] = val
-	}
+
+	maps.Copy(tgt.Labels, src.Labels)
 }
 
 // CompareLabels reports whether src labels are contained into tgt ones; extra labels on tgt are ignored.


### PR DESCRIPTION
Use maps.Clone() from the standard library, instead of manually loop over map to clone them.

```release-note
None
```
