### PR TITLE
Enable DataVolumeClaimAdoption feature gate for CDI

### DIFF
--- a/controllers/operands/cdi.go
+++ b/controllers/operands/cdi.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	HonorWaitForFirstConsumerGate = "HonorWaitForFirstConsumer"
+	honorWaitForFirstConsumerGate = "HonorWaitForFirstConsumer"
+	dataVolumeClaimAdoptionGate   = "DataVolumeClaimAdoption"
 	cdiConfigAuthorityAnnotation  = "cdi.kubevirt.io/configAuthority"
 )
 
@@ -89,7 +90,7 @@ func (*cdiHooks) updateCr(req *common.HcoRequest, Client client.Client, exists r
 func (*cdiHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func getDefaultFeatureGates() []string {
-	return []string{HonorWaitForFirstConsumerGate}
+	return []string{honorWaitForFirstConsumerGate, dataVolumeClaimAdoptionGate}
 }
 
 func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, error) {

--- a/controllers/operands/cdi_test.go
+++ b/controllers/operands/cdi_test.go
@@ -878,12 +878,12 @@ var _ = Describe("CDI Operand", func() {
 			Expect(foundResource.Spec.Config.ScratchSpaceStorageClass).To(BeNil())
 			Expect(foundResource.Spec.Config.PodResourceRequirements).To(BeNil())
 			Expect(foundResource.Spec.Config.FilesystemOverhead).To(BeNil())
-			Expect(foundResource.Spec.Config.FeatureGates).To(HaveLen(1))
-			Expect(foundResource.Spec.Config.FeatureGates).To(ContainElement("HonorWaitForFirstConsumer"))
+			Expect(foundResource.Spec.Config.FeatureGates).To(HaveLen(2))
+			Expect(foundResource.Spec.Config.FeatureGates).To(ContainElements(honorWaitForFirstConsumerGate, dataVolumeClaimAdoptionGate))
 			Expect(*foundResource.Spec.UninstallStrategy).To(Equal(cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist))
 		})
 
-		It("should add HonorWaitForFirstConsumer feature gate if Spec.Config if empty", func() {
+		It("should add HonorWaitForFirstConsumer and DataVolumeClaimAdoption feature gates if Spec.Config if empty", func() {
 			expectedResource, err := NewCDI(hco)
 			Expect(err).ToNot(HaveOccurred())
 			expectedResource.Spec.Config = nil
@@ -906,7 +906,8 @@ var _ = Describe("CDI Operand", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 			Expect(foundResource.Spec.Config).ToNot(BeNil())
-			Expect(foundResource.Spec.Config.FeatureGates).To(ContainElement("HonorWaitForFirstConsumer"))
+			Expect(foundResource.Spec.Config.FeatureGates).To(HaveLen(2))
+			Expect(foundResource.Spec.Config.FeatureGates).To(ContainElements(honorWaitForFirstConsumerGate, dataVolumeClaimAdoptionGate))
 			Expect(*foundResource.Spec.UninstallStrategy).To(Equal(cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist))
 		})
 
@@ -1100,7 +1101,7 @@ var _ = Describe("CDI Operand", func() {
 
 				cdi, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cdi.Spec.Config.FeatureGates).To(HaveLen(2))
+				Expect(cdi.Spec.Config.FeatureGates).To(HaveLen(3))
 				Expect(cdi.Spec.Config.FeatureGates).To(ContainElement("fg1"))
 				Expect(cdi.Spec.Config.FilesystemOverhead).ToNot(BeNil())
 				Expect(cdi.Spec.Config.FilesystemOverhead.Global).To(BeEquivalentTo("50"))
@@ -1150,7 +1151,7 @@ var _ = Describe("CDI Operand", func() {
 						cdi),
 				).ToNot(HaveOccurred())
 
-				Expect(cdi.Spec.Config.FeatureGates).To(HaveLen(2))
+				Expect(cdi.Spec.Config.FeatureGates).To(HaveLen(3))
 				Expect(cdi.Spec.Config.FeatureGates).To(ContainElement("fg1"))
 				Expect(cdi.Spec.Config.FilesystemOverhead).ToNot(BeNil())
 				Expect(cdi.Spec.Config.FilesystemOverhead.Global).To(BeEquivalentTo("50"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Let's make this feature gate a default in order to better support third party backup/DR apps

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-38591
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable DataVolumeClaimAdoption feature gate for CDI
```
