### PR TITLE
Support labels in e2e tests

### DIFF
--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+export GINKGO_LABELS="${GINKGO_LABELS:-}"
 set -exuo pipefail
 
 INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE:-"kubevirt-hyperconverged"}
@@ -62,12 +63,15 @@ metadata:
 spec:
   containers:
   - name: functest
+    imagePullPolicy: Always
     args:
     - --config-file
     - hack/testFiles/test_config.yaml
     env:
     - name: INSTALLED_NAMESPACE
       value: $INSTALLED_NAMESPACE
+    - name: GINKGO_LABELS
+      value: "${GINKGO_LABELS}"
     image: $FUNC_TEST_IMAGE
     volumeMounts:
       - mountPath: /test/output
@@ -77,6 +81,7 @@ spec:
       capabilities:
         add: ["NET_RAW"]
   - name: copy
+    imagePullPolicy: Always
     image: $FUNC_TEST_IMAGE
     command: ["/bin/sh"]
     args: [ "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -28,7 +28,9 @@ fi
 source ./hack/check_operator_condition.sh
 printOperatorCondition
 
-${TEST_OUT_PATH}/func-tests.test -ginkgo.v -ginkgo.junit-report="${TEST_OUT_PATH}/output/junit.xml" -installed-namespace="${INSTALLED_NAMESPACE}" -cdi-namespace="${INSTALLED_NAMESPACE}" "$@" "${KUBECONFIG_FLAG}"
+GINKGO_LABELS="${GINKGO_LABELS:-}"
+echo "GINKGO_LABELS=${GINKGO_LABELS}"
+${TEST_OUT_PATH}/func-tests.test -ginkgo.v -ginkgo.junit-report="${TEST_OUT_PATH}/output/junit.xml" -installed-namespace="${INSTALLED_NAMESPACE}" -cdi-namespace="${INSTALLED_NAMESPACE}" --ginkgo.label-filter="${GINKGO_LABELS}" "$@" "${KUBECONFIG_FLAG}"
 
 # wait a minute to allow all VMs to be deleted before attempting to change node placement configuration
 sleep 60

--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -15,11 +15,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 	"kubevirt.io/client-go/kubecli"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
-var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:system]HyperConverged Cluster Operator should create ConsoleCliDownload objects", func() {
+var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:system]HyperConverged Cluster Operator should create ConsoleCliDownload objects", Label("OpenShift"), func() {
 	flag.Parse()
 
 	BeforeEach(func() {

--- a/tests/func-tests/cluster_eviction_strategy_test.go
+++ b/tests/func-tests/cluster_eviction_strategy_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Cluster level evictionStrategy default value", Serial, Ordered
 		_ = tests.UpdateHCORetry(ctx, cli, hc)
 	})
 
-	It("Should set spec.evictionStrategy = None by default on single worker clusters", func() {
+	It("Should set spec.evictionStrategy = None by default on single worker clusters", Label("MULTI_NODE_ONLY"), func() {
 		if !singleworkerCluster {
 			Skip("Skipping single worker cluster test having more than one worker node")
 		}
@@ -55,7 +55,7 @@ var _ = Describe("Cluster level evictionStrategy default value", Serial, Ordered
 		Expect(hco.Spec.EvictionStrategy).To(Equal(&noneEvictionStrategy))
 	})
 
-	It("Should set spec.evictionStrategy = LiveMigrate by default with multiple worker node", func() {
+	It("Should set spec.evictionStrategy = LiveMigrate by default with multiple worker node", Label("SINGLE_NODE_ONLY"), func() {
 		if singleworkerCluster {
 			Skip("Skipping not single worker cluster test having a single worker node")
 		}

--- a/tests/func-tests/console_plugin_test.go
+++ b/tests/func-tests/console_plugin_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -22,6 +21,7 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
@@ -29,7 +29,7 @@ const (
 	openshiftConsoleNamespace = "openshift-console"
 )
 
-var _ = Describe("kubevirt console plugin", func() {
+var _ = Describe("kubevirt console plugin", Label("OpenShift"), func() {
 	var (
 		cli                               kubecli.KubevirtClient
 		ctx                               context.Context

--- a/tests/func-tests/dashboard_test.go
+++ b/tests/func-tests/dashboard_test.go
@@ -10,11 +10,12 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 	"kubevirt.io/client-go/kubecli"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
-var _ = Describe("[rfe_id:5108][crit:medium][vendor:cnv-qe@redhat.com][level:system]Dashboard configmaps", func() {
+var _ = Describe("[rfe_id:5108][crit:medium][vendor:cnv-qe@redhat.com][level:system]Dashboard configmaps", Label("OpenShift"), func() {
 	flag.Parse()
 
 	BeforeEach(func() {

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -26,6 +26,7 @@ import (
 	"kubevirt.io/ssp-operator/api/v1beta2"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
@@ -64,7 +65,7 @@ var (
 	}
 )
 
-var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered, func() {
+var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered, Label("OpenShift"), func() {
 	var (
 		cli kubecli.KubevirtClient
 		ctx context.Context

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -23,9 +23,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests/flags"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
 var runbookClient = http.DefaultClient
@@ -36,7 +37,7 @@ const (
 	criticalImpact
 )
 
-var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring", Serial, Ordered, func() {
+var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring", Serial, Ordered, Label("OpenShift"), func() {
 	flag.Parse()
 
 	var err error

--- a/tests/func-tests/mtq_test.go
+++ b/tests/func-tests/mtq_test.go
@@ -19,6 +19,7 @@ import (
 	mtqv1alpha1 "kubevirt.io/managed-tenant-quota/staging/src/kubevirt.io/managed-tenant-quota-api/pkg/apis/core/v1alpha1"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
@@ -54,7 +55,7 @@ var _ = Describe("Test MTQ", Label("MTQ"), Serial, Ordered, func() {
 	})
 
 	When("set the EnableManagedTenantQuota FG", func() {
-		It("should create the MTQ CR and all the pods", func() {
+		It("should create the MTQ CR and all the pods", Label("MULTI_NODE_ONLY"), func() {
 
 			if singleWorkerCluster {
 				Skip("Don't test MTQ on single node")
@@ -89,7 +90,7 @@ var _ = Describe("Test MTQ", Label("MTQ"), Serial, Ordered, func() {
 				Should(Succeed())
 		})
 
-		It("should reject setting of the FG in SNO", func() {
+		It("should reject setting of the FG in SNO", Label("SINGLE_NODE_ONLY"), func() {
 			if !singleWorkerCluster {
 				Skip("this test is not relevant for highly available clusters")
 			}

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -14,10 +14,11 @@ import (
 
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
-	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 	"kubevirt.io/client-go/kubecli"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 	"kubevirt.io/kubevirt/tests/flags"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 	workloads = "workloads"
 )
 
-var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:system]Node Placement", Ordered, Serial, func() {
+var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:system]Node Placement", Ordered, Serial, Label("MULTI_NODE_ONLY"), func() {
 	ctx := context.TODO()
 	tests.FlagParse()
 	hco := &hcov1beta1.HyperConverged{}

--- a/tests/func-tests/quickstart_test.go
+++ b/tests/func-tests/quickstart_test.go
@@ -12,11 +12,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 	"kubevirt.io/client-go/kubecli"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
-var _ = Describe("[rfe_id:5882][crit:high][vendor:cnv-qe@redhat.com][level:system]ConsoleQuickStart objects", func() {
+var _ = Describe("[rfe_id:5882][crit:high][vendor:cnv-qe@redhat.com][level:system]ConsoleQuickStart objects", Label("OpenShift"), func() {
 	flag.Parse()
 
 	BeforeEach(func() {


### PR DESCRIPTION
## What this PR does / why we need it
This PR add the GINKGO_LABELS environment variable so we could use labels in order filter functional tests, instead of using `Skip()` within the test logic.

**Jira Ticket**:
```jira-ticket
None
```

**Release note**:
```release-note
None
```
