### PR TITLE
Fix wrong labels in cluster_eviction_strategy_test

### DIFF
--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -20,7 +20,7 @@ import (
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
-var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:system]HyperConverged Cluster Operator should create ConsoleCliDownload objects", Label("OpenShift"), func() {
+var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:system]HyperConverged Cluster Operator should create ConsoleCliDownload objects", Label(openshiftLabel), func() {
 	flag.Parse()
 
 	BeforeEach(func() {

--- a/tests/func-tests/cluster_eviction_strategy_test.go
+++ b/tests/func-tests/cluster_eviction_strategy_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Cluster level evictionStrategy default value", Serial, Ordered
 		_ = tests.UpdateHCORetry(ctx, cli, hc)
 	})
 
-	It("Should set spec.evictionStrategy = None by default on single worker clusters", Label("MULTI_NODE_ONLY"), func() {
+	It("Should set spec.evictionStrategy = None by default on single worker clusters", Label(singleNodeLabel), func() {
 		if !singleworkerCluster {
 			Skip("Skipping single worker cluster test having more than one worker node")
 		}
@@ -55,7 +55,7 @@ var _ = Describe("Cluster level evictionStrategy default value", Serial, Ordered
 		Expect(hco.Spec.EvictionStrategy).To(Equal(&noneEvictionStrategy))
 	})
 
-	It("Should set spec.evictionStrategy = LiveMigrate by default with multiple worker node", Label("SINGLE_NODE_ONLY"), func() {
+	It("Should set spec.evictionStrategy = LiveMigrate by default with multiple worker node", Label(highlyAvailableClusterLabel), func() {
 		if singleworkerCluster {
 			Skip("Skipping not single worker cluster test having a single worker node")
 		}

--- a/tests/func-tests/console_plugin_test.go
+++ b/tests/func-tests/console_plugin_test.go
@@ -29,7 +29,7 @@ const (
 	openshiftConsoleNamespace = "openshift-console"
 )
 
-var _ = Describe("kubevirt console plugin", Label("OpenShift"), func() {
+var _ = Describe("kubevirt console plugin", Label(openshiftLabel), func() {
 	var (
 		cli                               kubecli.KubevirtClient
 		ctx                               context.Context

--- a/tests/func-tests/dashboard_test.go
+++ b/tests/func-tests/dashboard_test.go
@@ -15,7 +15,7 @@ import (
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
-var _ = Describe("[rfe_id:5108][crit:medium][vendor:cnv-qe@redhat.com][level:system]Dashboard configmaps", Label("OpenShift"), func() {
+var _ = Describe("[rfe_id:5108][crit:medium][vendor:cnv-qe@redhat.com][level:system]Dashboard configmaps", Label(openshiftLabel), func() {
 	flag.Parse()
 
 	BeforeEach(func() {

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -65,7 +65,7 @@ var (
 	}
 )
 
-var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered, Label("OpenShift"), func() {
+var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered, Label(openshiftLabel), func() {
 	var (
 		cli kubecli.KubevirtClient
 		ctx context.Context

--- a/tests/func-tests/main_test.go
+++ b/tests/func-tests/main_test.go
@@ -10,9 +10,17 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 	"kubevirt.io/client-go/kubecli"
 	kvtutil "kubevirt.io/kubevirt/tests/util"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
+)
+
+// labels
+const (
+	singleNodeLabel             = "SINGLE_NODE_ONLY"
+	highlyAvailableClusterLabel = "HIGHLY_AVAILABLE_CLUSTER"
+	openshiftLabel              = "OpenShift"
 )
 
 func TestTests(t *testing.T) {

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -37,7 +37,7 @@ const (
 	criticalImpact
 )
 
-var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring", Serial, Ordered, Label("OpenShift"), func() {
+var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring", Serial, Ordered, Label(openshiftLabel), func() {
 	flag.Parse()
 
 	var err error

--- a/tests/func-tests/mtq_test.go
+++ b/tests/func-tests/mtq_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Test MTQ", Label("MTQ"), Serial, Ordered, func() {
 	})
 
 	When("set the EnableManagedTenantQuota FG", func() {
-		It("should create the MTQ CR and all the pods", Label("MULTI_NODE_ONLY"), func() {
+		It("should create the MTQ CR and all the pods", Label(highlyAvailableClusterLabel), func() {
 
 			if singleWorkerCluster {
 				Skip("Don't test MTQ on single node")
@@ -90,7 +90,7 @@ var _ = Describe("Test MTQ", Label("MTQ"), Serial, Ordered, func() {
 				Should(Succeed())
 		})
 
-		It("should reject setting of the FG in SNO", Label("SINGLE_NODE_ONLY"), func() {
+		It("should reject setting of the FG in SNO", Label(singleNodeLabel), func() {
 			if !singleWorkerCluster {
 				Skip("this test is not relevant for highly available clusters")
 			}

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -27,7 +27,7 @@ const (
 	workloads = "workloads"
 )
 
-var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:system]Node Placement", Ordered, Serial, Label("MULTI_NODE_ONLY"), func() {
+var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:system]Node Placement", Ordered, Serial, Label(highlyAvailableClusterLabel), func() {
 	ctx := context.TODO()
 	tests.FlagParse()
 	hco := &hcov1beta1.HyperConverged{}

--- a/tests/func-tests/quickstart_test.go
+++ b/tests/func-tests/quickstart_test.go
@@ -17,7 +17,7 @@ import (
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
-var _ = Describe("[rfe_id:5882][crit:high][vendor:cnv-qe@redhat.com][level:system]ConsoleQuickStart objects", Label("OpenShift"), func() {
+var _ = Describe("[rfe_id:5882][crit:high][vendor:cnv-qe@redhat.com][level:system]ConsoleQuickStart objects", Label(openshiftLabel), func() {
 	flag.Parse()
 
 	BeforeEach(func() {


### PR DESCRIPTION
## What this PR does / why we need it
SNO and highly available labels were switched.

Also, rename the highly available label for better readability.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
