### PR TITLE
Fix the monitoring e2e test

### DIFF
--- a/tests/func-tests/wasp_test.go
+++ b/tests/func-tests/wasp_test.go
@@ -10,16 +10,17 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests/flags"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
 const (
 	setWaspFGPatchTemplate = `[{"op": "replace", "path": "/spec/featureGates/enableHigherDensityWithSwap", "value": %t}]`
 )
 
-var _ = Describe("wasp-agent", Label("wasp", "Openshift"), Serial, Ordered, func() {
+var _ = Describe("wasp-agent", Label("wasp", openshiftLabel), Serial, Ordered, func() {
 	tests.FlagParse()
 	var (
 		cli kubecli.KubevirtClient


### PR DESCRIPTION
## What this PR does / why we need it
The "KubeVirtCRModified alert should fired when there is a modification on a CR" e2e test fails frequently, because the test logic is trying to trigger the `KubeVirtCRModified` alert, by adding a new label to KubeVirt CR, while we now allowing adding custom lables.

This PR adds a fake feature gate to the KubeVirt CR in order to trigger the same alert. HCO fully reconciles the KV feature gates, so it should trigger the alert in this case.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
