### PR TITLE
kubvirt: Fix aarch64 machine type and OVMF path

### DIFF
--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -30,9 +30,11 @@ import (
 
 // env vars
 const (
-	kvmEmulationEnvName = "KVM_EMULATION"
-	smbiosEnvName       = "SMBIOS"
-	machineTypeEnvName  = "MACHINETYPE"
+	kvmEmulationEnvName     = "KVM_EMULATION"
+	smbiosEnvName           = "SMBIOS"
+	machineTypeEnvName      = "MACHINETYPE"
+	amd64MachineTypeEnvName = "AMD64_MACHINETYPE"
+	arm64MachineTypeEnvName = "ARM64_MACHINETYPE"
 )
 
 const (
@@ -459,21 +461,34 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		}
 	}
 
-	if val, ok := os.LookupEnv(machineTypeEnvName); ok {
-		if val = strings.TrimSpace(val); val != "" {
-			config.MachineType = val
+	var amd64MachineType string
+	// Remain backwards compatibility with the original env variable for a release before removing
+	if machineTypeEnvValue, ok := os.LookupEnv(machineTypeEnvName); ok {
+		amd64MachineType = machineTypeEnvValue
+	} else if machineTypeEnvValue, ok := os.LookupEnv(amd64MachineTypeEnvName); ok {
+		amd64MachineType = machineTypeEnvValue
+	}
 
-			config.ArchitectureConfiguration = &kubevirtcorev1.ArchConfiguration{
-				Amd64: &kubevirtcorev1.ArchSpecificConfiguration{
-					MachineType:      val,
-					OVMFPath:         DefaultAMD64OVMFPath,
-					EmulatedMachines: strings.Split(DefaultAMD64EmulatedMachines, ","),
-				},
-				Arm64: &kubevirtcorev1.ArchSpecificConfiguration{
-					MachineType:      val,
-					OVMFPath:         DefaultARM64OVMFPath,
-					EmulatedMachines: strings.Split(DefaultARM64EmulatedMachines, ","),
-				},
+	if amd64MachineType = strings.TrimSpace(amd64MachineType); amd64MachineType != "" {
+		if config.ArchitectureConfiguration == nil {
+			config.ArchitectureConfiguration = &kubevirtcorev1.ArchConfiguration{}
+		}
+		config.ArchitectureConfiguration.Amd64 = &kubevirtcorev1.ArchSpecificConfiguration{
+			MachineType:      amd64MachineType,
+			OVMFPath:         DefaultAMD64OVMFPath,
+			EmulatedMachines: strings.Split(DefaultAMD64EmulatedMachines, ","),
+		}
+	}
+
+	if armMachineType, ok := os.LookupEnv(arm64MachineTypeEnvName); ok {
+		if armMachineType = strings.TrimSpace(armMachineType); armMachineType != "" {
+			if config.ArchitectureConfiguration == nil {
+				config.ArchitectureConfiguration = &kubevirtcorev1.ArchConfiguration{}
+			}
+			config.ArchitectureConfiguration.Arm64 = &kubevirtcorev1.ArchSpecificConfiguration{
+				MachineType:      armMachineType,
+				OVMFPath:         DefaultARM64OVMFPath,
+				EmulatedMachines: strings.Split(DefaultARM64EmulatedMachines, ","),
 			}
 		}
 	}

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -172,10 +172,6 @@ var _ = Describe("KubeVirt Operand", func() {
 		var hco *hcov1beta1.HyperConverged
 		var req *common.HcoRequest
 
-		defer os.Unsetenv(smbiosEnvName)
-		defer os.Unsetenv(machineTypeEnvName)
-		defer os.Unsetenv(kvmEmulationEnvName)
-
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
@@ -186,8 +182,17 @@ Manufacturer: smbios manufacturer
 Sku: 1.2.3
 Version: 1.2.3`)
 
-			os.Setenv(machineTypeEnvName, "machine-type")
+			os.Setenv(amd64MachineTypeEnvName, "q35")
+			os.Setenv(arm64MachineTypeEnvName, "virt")
 			os.Setenv(kvmEmulationEnvName, "false")
+
+			DeferCleanup(func() {
+				os.Unsetenv(smbiosEnvName)
+				os.Unsetenv(machineTypeEnvName)
+				os.Unsetenv(amd64MachineTypeEnvName)
+				os.Unsetenv(arm64MachineTypeEnvName)
+				os.Unsetenv(kvmEmulationEnvName)
+			})
 		})
 
 		It("should create if not present", func() {
@@ -232,10 +237,10 @@ Version: 1.2.3`)
 			Expect(foundResource.Spec.Configuration.DeveloperConfiguration.DiskVerification).ToNot(BeNil())
 			Expect(*foundResource.Spec.Configuration.DeveloperConfiguration.DiskVerification.MemoryLimit).To(Equal(kvDiskVerificationMemoryLimit))
 
-			Expect(foundResource.Spec.Configuration.MachineType).To(Equal("machine-type"))
-			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).To(Equal("machine-type"))
+			Expect(foundResource.Spec.Configuration.MachineType).To(BeEmpty())
+			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).To(Equal("q35"))
 			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.OVMFPath).To(Equal(DefaultAMD64OVMFPath))
-			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Arm64.MachineType).To(Equal("machine-type"))
+			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Arm64.MachineType).To(Equal("virt"))
 			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Arm64.OVMFPath).To(Equal(DefaultARM64OVMFPath))
 
 			Expect(foundResource.Spec.Configuration.SMBIOSConfig).ToNot(BeNil())
@@ -373,17 +378,20 @@ Product: smbios product
 Manufacturer: smbios manufacturer
 Sku: 1.2.3
 Version: 1.2.3`)
-			os.Setenv(machineTypeEnvName, "machine-type")
+			os.Setenv(amd64MachineTypeEnvName, "q35")
+			os.Setenv(arm64MachineTypeEnvName, "virt")
 
 			existKv, err := NewKubeVirt(hco, commontestutils.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 			existKv.Spec.Configuration.DeveloperConfiguration = &kubevirtcorev1.DeveloperConfiguration{
 				FeatureGates: []string{"wrongFG1", "wrongFG2", "wrongFG3"},
 			}
-			existKv.Spec.Configuration.MachineType = "wrong machine type"
 			existKv.Spec.Configuration.ArchitectureConfiguration = &kubevirtcorev1.ArchConfiguration{
 				Amd64: &kubevirtcorev1.ArchSpecificConfiguration{
-					MachineType: "wrong machine type",
+					MachineType: "wrong amd64 machine type",
+				},
+				Arm64: &kubevirtcorev1.ArchSpecificConfiguration{
+					MachineType: "wrong arm64 machine type",
 				},
 			}
 			existKv.Spec.Configuration.SMBIOSConfig = &kubevirtcorev1.SMBiosConfiguration{
@@ -437,10 +445,10 @@ Version: 1.2.3`)
 				kvWithHostPassthroughCPU,
 			))
 
-			Expect(foundResource.Spec.Configuration.MachineType).To(Equal("machine-type"))
-			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).To(Equal("machine-type"))
+			Expect(foundResource.Spec.Configuration.MachineType).To(BeEmpty())
+			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).To(Equal("q35"))
 			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Amd64.OVMFPath).To(Equal(DefaultAMD64OVMFPath))
-			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Arm64.MachineType).To(Equal("machine-type"))
+			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Arm64.MachineType).To(Equal("virt"))
 			Expect(foundResource.Spec.Configuration.ArchitectureConfiguration.Arm64.OVMFPath).To(Equal(DefaultARM64OVMFPath))
 
 			Expect(foundResource.Spec.Configuration.SMBIOSConfig).ToNot(BeNil())
@@ -466,6 +474,20 @@ Version: 1.2.3`)
 			Expect(mc.Network).To(BeNil())
 			Expect(*mc.AllowAutoConverge).To(BeFalse())
 			Expect(*mc.AllowPostCopy).To(BeFalse())
+		})
+
+		It("should use legacy MACHINETYPE env if provided", func() {
+			os.Setenv(machineTypeEnvName, "legacy")
+			os.Setenv(amd64MachineTypeEnvName, "q35")
+			os.Unsetenv(arm64MachineTypeEnvName)
+
+			kv, err := NewKubeVirt(hco, commontestutils.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(kv.Spec.Configuration.MachineType).To(BeEmpty())
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).To(Equal("legacy"))
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Amd64.OVMFPath).To(Equal(DefaultAMD64OVMFPath))
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Arm64).To(BeNil())
 		})
 
 		It("should fail if the SMBIOS is wrongly formatted mandatory configurations", func() {

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.12.0/manifests/kubevirt-hyperconverged-operator.v1.12.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.12.0/manifests/kubevirt-hyperconverged-operator.v1.12.0.clusterserviceversion.yaml
@@ -3330,6 +3330,8 @@ spec:
                     Manufacturer: KubeVirt
                     Product: None
                 - name: MACHINETYPE
+                - name: AMD64_MACHINETYPE
+                - name: ARM64_MACHINETYPE
                 - name: HCO_KV_IO_VERSION
                   value: 1.12.0
                 - name: KUBEVIRT_VERSION

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.12.0/manifests/kubevirt-hyperconverged-operator.v1.12.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.12.0/manifests/kubevirt-hyperconverged-operator.v1.12.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.12.0-unstable
-    createdAt: "2024-04-07 10:10:54"
+    createdAt: "2024-04-08 12:10:05"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -3330,6 +3330,8 @@ spec:
                     Manufacturer: KubeVirt
                     Product: None
                 - name: MACHINETYPE
+                - name: AMD64_MACHINETYPE
+                - name: ARM64_MACHINETYPE
                 - name: HCO_KV_IO_VERSION
                   value: 1.12.0
                 - name: KUBEVIRT_VERSION

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -50,6 +50,8 @@ spec:
             Manufacturer: KubeVirt
             Product: None
         - name: MACHINETYPE
+        - name: AMD64_MACHINETYPE
+        - name: ARM64_MACHINETYPE
         - name: HCO_KV_IO_VERSION
           value: 1.12.0
         - name: KUBEVIRT_VERSION

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -76,6 +76,8 @@ type DeploymentOperatorParams struct {
 	VirtIOWinContainer  string
 	Smbios              string
 	Machinetype         string
+	Amd64MachineType    string
+	Arm64MachineType    string
 	HcoKvIoVersion      string
 	KubevirtVersion     string
 	CdiVersion          string
@@ -227,6 +229,14 @@ func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.Deployme
 							{
 								Name:  "MACHINETYPE",
 								Value: params.Machinetype,
+							},
+							{
+								Name:  "AMD64_MACHINETYPE",
+								Value: params.Amd64MachineType,
+							},
+							{
+								Name:  "ARM64_MACHINETYPE",
+								Value: params.Arm64MachineType,
 							},
 							{
 								Name:  util.HcoKvIoVersionName,

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -65,7 +65,9 @@ var (
 	cliDownloadsImage = flag.String("cli-downloads-image", "", "Downloads Server image")
 	kvVirtIOWinImage  = flag.String("kv-virtiowin-image-name", "", "KubeVirt VirtIO Win image")
 	smbios            = flag.String("smbios", "", "Custom SMBIOS string for KubeVirt ConfigMap")
-	machinetype       = flag.String("machinetype", "", "Custom MACHINETYPE string for KubeVirt ConfigMap")
+	machinetype       = flag.String("machinetype", "", "Custom MACHINETYPE string for KubeVirt ConfigMap (Deprecated, use amd64-machinetype)")
+	amd64MachineType  = flag.String("amd64-machinetype", "", "Custom AMD64_MACHINETYPE string for KubeVirt ConfigMap")
+	arm64MachineType  = flag.String("arm64-machinetype", "", "Custom ARM64_MACHINETYPE string for KubeVirt ConfigMap")
 	hcoKvIoVersion    = flag.String("hco-kv-io-version", "", "KubeVirt version")
 	kubevirtVersion   = flag.String("kubevirt-version", "", "Kubevirt operator version")
 	cdiVersion        = flag.String("cdi-version", "", "CDI operator version")
@@ -425,6 +427,8 @@ func getOperatorParameters() *components.DeploymentOperatorParams {
 		VirtIOWinContainer: *kvVirtIOWinImage,
 		Smbios:             *smbios,
 		Machinetype:        *machinetype,
+		Amd64MachineType:   *amd64MachineType,
+		Arm64MachineType:   *arm64MachineType,
 		HcoKvIoVersion:     *hcoKvIoVersion,
 		KubevirtVersion:    *kubevirtVersion,
 		CdiVersion:         *cdiVersion,


### PR DESCRIPTION
**What this PR does / why we need it**:

As documented [1] downstream aarch64 guests require a different UEFI firmware to x86_64. This is provided by the edk2-aarch64 package with the resulting firmware placed under /usr/share/AAVMF.

This change updates the OVMFPath configured for use with such guests on aarch64 and also updates some tests to assert this is set.

This change also introduces arch specific versions of the machine type env variable. This avoids the same machine type being set for both x86_64 and aarch64. The original `MACHINETYPE` env variable is supported for a release to ensure any downstream consumers continue to work.

Finally we also stop setting the deprecated top level machineType [2] configurable in favour of these arch specific versions.

[1] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/configuring_and_managing_virtualization/index#how-virtualization-on-arm-64-differs-from-amd64-and-intel64_feature-support-and-limitations-in-rhel-9-virtualization
[2] https://kubevirt.io/api-reference/main/definitions.html#_v1_kubevirtconfiguration

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
