### PR TITLE
cluster-configuration.md: improved allowPostCopy

### DIFF
--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -328,7 +328,7 @@ When enabled, KubeVirt attempts to use post-copy live-migration in case it
 reaches its completion timeout while attempting pre-copy live-migration.
 Post-copy migrations allow even the busiest VMs to successfully live-migrate.
 However, events like a network failure or a failure in any of the source or
-destination nodes can cause the migrated VM to crash or reach inconsistency.
+destination nodes can cause the migrated VM to crash.
 Enable this option when evicting nodes is more important than keeping VMs
 alive.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

With https://github.com/kubevirt/kubevirt/pull/11479 we can now drop the warning about VMs reaching an inconsistent state.

/cc @vladikr 

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [x] PR Message
- [x] Commit Messages
- [x] User Documentation

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
