### PR TITLE
Drop skips from func tests

### DIFF
--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -11,8 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	consolev1 "github.com/openshift/api/console/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"kubevirt.io/client-go/kubecli"
@@ -20,67 +18,51 @@ import (
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
-var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:system]HyperConverged Cluster Operator should create ConsoleCliDownload objects", Label(openshiftLabel), func() {
+var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:system]HyperConverged Cluster Operator should create ConsoleCliDownload objects", Label(tests.OpenshiftLabel), func() {
 	flag.Parse()
 
+	var cli kubecli.KubevirtClient
 	BeforeEach(func() {
 		tests.BeforeEach()
-	})
-
-	It("[test_id:6956]should create ConsoleCliDownload objects with expected spec", Label("test_id:6956"), func() {
 		virtCli, err := kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 
-		client, err := kubecli.GetKubevirtClientFromRESTConfig(virtCli.Config())
+		cli, err = kubecli.GetKubevirtClientFromRESTConfig(virtCli.Config())
 		Expect(err).ToNot(HaveOccurred())
-
-		skipIfConsoleCliDownloadsCrdDoesNotExist(virtCli)
-
-		checkConsoleCliDownloadSpec(client)
+		tests.FailIfNotOpenShift(cli, "ConsoleCliDownload")
 	})
 
-})
+	It("[test_id:6956]should create ConsoleCliDownload objects with expected spec", Label("test_id:6956"), func() {
+		By("Checking existence of ConsoleCliDownload")
+		s := scheme.Scheme
+		_ = consolev1.Install(s)
+		s.AddKnownTypes(consolev1.GroupVersion)
 
-func skipIfConsoleCliDownloadsCrdDoesNotExist(cli kubecli.KubevirtClient) {
-	By("Checking ConsoleCLIDownload CRD exists or not")
+		var ccd consolev1.ConsoleCLIDownload
+		ExpectWithOffset(1, cli.RestClient().Get().
+			Resource("consoleclidownloads").
+			Name("virtctl-clidownloads-kubevirt-hyperconverged").
+			AbsPath("/apis", consolev1.GroupVersion.Group, consolev1.GroupVersion.Version).
+			Timeout(10*time.Second).
+			Do(context.TODO()).Into(&ccd)).To(Succeed())
 
-	_, err := cli.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), "consoleclidownloads.console.openshift.io", metav1.GetOptions{})
-	if err != nil && apierrors.IsNotFound(err) {
-		Skip("ConsoleCLIDownload CRD does not exist")
-	}
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-}
+		ExpectWithOffset(1, ccd.Spec.Links).Should(HaveLen(6))
 
-func checkConsoleCliDownloadSpec(client kubecli.KubevirtClient) {
-	By("Checking existence of ConsoleCliDownload")
-	s := scheme.Scheme
-	_ = consolev1.Install(s)
-	s.AddKnownTypes(consolev1.GroupVersion)
+		for _, link := range ccd.Spec.Links {
+			// virtctl for Windows for ARM 64 is still not shipped, avoid checking it
+			// TODO: remove this once ready
+			if !(strings.Contains(link.Href, "windows") && strings.Contains(link.Href, "arm64")) {
+				By("Checking links. Link:" + link.Href)
+				client := &http.Client{Transport: &http.Transport{
+					// ssl of the route is irrelevant
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				}}
+				resp, err := client.Get(link.Href)
+				_ = resp.Body.Close()
 
-	var ccd consolev1.ConsoleCLIDownload
-	ExpectWithOffset(1, client.RestClient().Get().
-		Resource("consoleclidownloads").
-		Name("virtctl-clidownloads-kubevirt-hyperconverged").
-		AbsPath("/apis", consolev1.GroupVersion.Group, consolev1.GroupVersion.Version).
-		Timeout(10*time.Second).
-		Do(context.TODO()).Into(&ccd)).To(Succeed())
-
-	ExpectWithOffset(1, ccd.Spec.Links).Should(HaveLen(6))
-
-	for _, link := range ccd.Spec.Links {
-		// virtctl for Windows for ARM 64 is still not shipped, avoid checking it
-		// TODO: remove this once ready
-		if !(strings.Contains(link.Href, "windows") && strings.Contains(link.Href, "arm64")) {
-			By("Checking links. Link:" + link.Href)
-			client := &http.Client{Transport: &http.Transport{
-				// ssl of the route is irrelevant
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}}
-			resp, err := client.Get(link.Href)
-			_ = resp.Body.Close()
-
-			ExpectWithOffset(1, err).ToNot(HaveOccurred())
-			ExpectWithOffset(1, resp).Should(HaveHTTPStatus(http.StatusOK))
+				ExpectWithOffset(1, err).ToNot(HaveOccurred())
+				ExpectWithOffset(1, resp).Should(HaveHTTPStatus(http.StatusOK))
+			}
 		}
-	}
-}
+	})
+})

--- a/tests/func-tests/cluster_eviction_strategy_test.go
+++ b/tests/func-tests/cluster_eviction_strategy_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Cluster level evictionStrategy default value", Serial, Ordered
 
 	var (
 		initialEvictionStrategy *v1.EvictionStrategy
-		singleworkerCluster     bool
+		singleWorkerCluster     bool
 	)
 
 	BeforeEach(func() {
@@ -29,7 +29,7 @@ var _ = Describe("Cluster level evictionStrategy default value", Serial, Ordered
 		Expect(cli).ToNot(BeNil())
 		Expect(err).ToNot(HaveOccurred())
 
-		singleworkerCluster, err = isSingleWorkerCluster(cli)
+		singleWorkerCluster, err = isSingleWorkerCluster(cli)
 		Expect(err).ToNot(HaveOccurred())
 
 		tests.BeforeEach()
@@ -43,10 +43,9 @@ var _ = Describe("Cluster level evictionStrategy default value", Serial, Ordered
 		_ = tests.UpdateHCORetry(ctx, cli, hc)
 	})
 
-	It("Should set spec.evictionStrategy = None by default on single worker clusters", Label(singleNodeLabel), func() {
-		if !singleworkerCluster {
-			Skip("Skipping single worker cluster test having more than one worker node")
-		}
+	It("Should set spec.evictionStrategy = None by default on single worker clusters", Label(tests.SingleNodeLabel), func() {
+		Expect(singleWorkerCluster).To(BeTrue(), "this test requires single worker cluster; use the %q label to skip this test", tests.SingleNodeLabel)
+
 		hco := tests.GetHCO(ctx, cli)
 		hco.Spec.EvictionStrategy = nil
 		hco = tests.UpdateHCORetry(ctx, cli, hco)
@@ -55,10 +54,8 @@ var _ = Describe("Cluster level evictionStrategy default value", Serial, Ordered
 		Expect(hco.Spec.EvictionStrategy).To(Equal(&noneEvictionStrategy))
 	})
 
-	It("Should set spec.evictionStrategy = LiveMigrate by default with multiple worker node", Label(highlyAvailableClusterLabel), func() {
-		if singleworkerCluster {
-			Skip("Skipping not single worker cluster test having a single worker node")
-		}
+	It("Should set spec.evictionStrategy = LiveMigrate by default with multiple worker node", Label(tests.HighlyAvailableClusterLabel), func() {
+		tests.FailIfSingleNode(singleWorkerCluster)
 		hco := tests.GetHCO(ctx, cli)
 		hco.Spec.EvictionStrategy = nil
 		hco = tests.UpdateHCORetry(ctx, cli, hco)

--- a/tests/func-tests/console_plugin_test.go
+++ b/tests/func-tests/console_plugin_test.go
@@ -29,7 +29,7 @@ const (
 	openshiftConsoleNamespace = "openshift-console"
 )
 
-var _ = Describe("kubevirt console plugin", Label(openshiftLabel), func() {
+var _ = Describe("kubevirt console plugin", Label(tests.OpenshiftLabel), func() {
 	var (
 		cli                               kubecli.KubevirtClient
 		ctx                               context.Context
@@ -48,7 +48,7 @@ var _ = Describe("kubevirt console plugin", Label(openshiftLabel), func() {
 		cli, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 
-		tests.SkipIfNotOpenShift(cli, "kubevirt console plugin")
+		tests.FailIfNotOpenShift(cli, "kubevirt console plugin")
 		ctx = context.Background()
 
 		hco := tests.GetHCO(ctx, cli)

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -65,7 +65,7 @@ var (
 	}
 )
 
-var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered, Label(openshiftLabel), func() {
+var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered, Label(tests.OpenshiftLabel), func() {
 	var (
 		cli kubecli.KubevirtClient
 		ctx context.Context
@@ -95,7 +95,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		cli, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 
-		tests.SkipIfNotOpenShift(cli, "golden image test")
+		tests.FailIfNotOpenShift(cli, "golden image test")
 
 		ctx = context.Background()
 	})

--- a/tests/func-tests/main_test.go
+++ b/tests/func-tests/main_test.go
@@ -16,13 +16,6 @@ import (
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
-// labels
-const (
-	singleNodeLabel             = "SINGLE_NODE_ONLY"
-	highlyAvailableClusterLabel = "HIGHLY_AVAILABLE_CLUSTER"
-	openshiftLabel              = "OpenShift"
-)
-
 func TestTests(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "HyperConverged cluster E2E Test suite")

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -37,7 +37,7 @@ const (
 	criticalImpact
 )
 
-var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring", Serial, Ordered, Label(openshiftLabel), func() {
+var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring", Serial, Ordered, Label(tests.OpenshiftLabel), func() {
 	flag.Parse()
 
 	var err error
@@ -53,7 +53,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 		virtCli, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 
-		tests.SkipIfNotOpenShift(virtCli, "Prometheus")
+		tests.FailIfNotOpenShift(virtCli, "Prometheus")
 		promClient = initializePromClient(getPrometheusURL(virtCli), getAuthorizationTokenForPrometheus(virtCli))
 		prometheusRule = getPrometheusRule(virtCli)
 

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -145,18 +145,6 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 		}, 60*time.Second, time.Second).ShouldNot(BeNil())
 		verifyOperatorHealthMetricValue(promClient, initialOperatorHealthMetricValue, warningImpact)
 	})
-
-	It("[test_id:10760] KubevirtHyperconvergedClusterOperatorSingleStackIPv6 alert should be fired for single stack ipv6 cluster", Label("test_id:10760"), func() {
-		tests.SkipIfNotSingleStackIPv6OpenShift(virtCli, "KubevirtHyperconvergedClusterOperatorSingleStackIPv6")
-
-		Eventually(func() *promApiv1.Alert {
-			alerts, err := promClient.Alerts(context.TODO())
-			Expect(err).ToNot(HaveOccurred())
-			return getAlertByName(alerts, "KubevirtHyperconvergedClusterOperatorSingleStackIPv6")
-		}, 60*time.Second, time.Second).ShouldNot(BeNil())
-
-		Expect(getMetricValue(promClient, "kubevirt_hco_single_stack_ipv6")).To(Equal(criticalImpact))
-	})
 })
 
 func getAlertByName(alerts promApiv1.AlertsResult, alertName string) *promApiv1.Alert {

--- a/tests/func-tests/mtq_test.go
+++ b/tests/func-tests/mtq_test.go
@@ -55,11 +55,9 @@ var _ = Describe("Test MTQ", Label("MTQ"), Serial, Ordered, func() {
 	})
 
 	When("set the EnableManagedTenantQuota FG", func() {
-		It("should create the MTQ CR and all the pods", Label(highlyAvailableClusterLabel), func() {
+		It("should create the MTQ CR and all the pods", Label(tests.HighlyAvailableClusterLabel), func() {
 
-			if singleWorkerCluster {
-				Skip("Don't test MTQ on single node")
-			}
+			tests.FailIfSingleNode(singleWorkerCluster)
 
 			enableMTQFeatureGate(ctx, cli)
 
@@ -90,10 +88,8 @@ var _ = Describe("Test MTQ", Label("MTQ"), Serial, Ordered, func() {
 				Should(Succeed())
 		})
 
-		It("should reject setting of the FG in SNO", Label(singleNodeLabel), func() {
-			if !singleWorkerCluster {
-				Skip("this test is not relevant for highly available clusters")
-			}
+		It("should reject setting of the FG in SNO", Label(tests.SingleNodeLabel), func() {
+			tests.FailIfHighAvailableCluster(singleWorkerCluster)
 
 			patch := []byte(fmt.Sprintf(setMTQFGPatchTemplate, true))
 			err := tests.PatchHCO(ctx, cli, patch)

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -27,7 +27,7 @@ const (
 	workloads = "workloads"
 )
 
-var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:system]Node Placement", Ordered, Serial, Label(highlyAvailableClusterLabel), func() {
+var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:system]Node Placement", Ordered, Serial, Label(tests.HighlyAvailableClusterLabel), func() {
 	ctx := context.TODO()
 	tests.FlagParse()
 	hco := &hcov1beta1.HyperConverged{}
@@ -44,9 +44,7 @@ var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 		Expect(err).ToNot(HaveOccurred())
 
 		nodes := listNodesByLabels(cli, "node-role.kubernetes.io/control-plane!=")
-		if len(nodes.Items) < 2 {
-			Skip("Skipping Node Placement tests due to insufficient cluster nodes")
-		}
+		tests.FailIfSingleNode(len(nodes.Items) < 2)
 
 		// Label all but first node with "node.kubernetes.io/hco-test-node-type=infra"
 		// We are doing this to remove dependency of this Describe block on a shell script that

--- a/tests/func-tests/quickstart_test.go
+++ b/tests/func-tests/quickstart_test.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	consolev1 "github.com/openshift/api/console/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"kubevirt.io/client-go/kubecli"
@@ -17,60 +15,45 @@ import (
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
-var _ = Describe("[rfe_id:5882][crit:high][vendor:cnv-qe@redhat.com][level:system]ConsoleQuickStart objects", Label(openshiftLabel), func() {
+var _ = Describe("[rfe_id:5882][crit:high][vendor:cnv-qe@redhat.com][level:system]ConsoleQuickStart objects", Label(tests.OpenshiftLabel), func() {
 	flag.Parse()
 
+	var cli kubecli.KubevirtClient
 	BeforeEach(func() {
 		tests.BeforeEach()
-	})
-
-	It("[test_id:5883]should create ConsoleQuickStart objects", Label("test_id:5883"), func() {
 		virtCli, err := kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 
-		client, err := kubecli.GetKubevirtClientFromRESTConfig(virtCli.Config())
+		tests.FailIfNotOpenShift(virtCli, "quickstart")
+
+		cli, err = kubecli.GetKubevirtClientFromRESTConfig(virtCli.Config())
 		Expect(err).ToNot(HaveOccurred())
+	})
 
-		skipIfQuickStartCrdDoesNotExist(virtCli)
+	It("[test_id:5883]should create ConsoleQuickStart objects", Label("test_id:5883"), func() {
+		By("Checking expected quickstart objects")
+		s := scheme.Scheme
+		_ = consolev1.Install(s)
+		s.AddKnownTypes(consolev1.GroupVersion)
 
-		checkExpectedQuickStarts(client)
+		items := tests.GetConfig().QuickStart.TestItems
+
+		if len(items) == 0 {
+			GinkgoLogr.Info("There is no quickstart test item for quickstart tests.")
+		}
+
+		for _, qs := range items {
+			// use a fresh object for each loop. get requests only override non-empty fields
+			var cqs consolev1.ConsoleQuickStart
+			ExpectWithOffset(1, cli.RestClient().Get().
+				Resource("consolequickstarts").
+				Name(qs.Name).
+				AbsPath("/apis", consolev1.GroupVersion.Group, consolev1.GroupVersion.Version).
+				Timeout(10*time.Second).
+				Do(context.TODO()).Into(&cqs)).To(Succeed())
+
+			ExpectWithOffset(1, cqs.Spec.DisplayName).Should(Equal(qs.DisplayName))
+		}
 	})
 
 })
-
-func skipIfQuickStartCrdDoesNotExist(cli kubecli.KubevirtClient) {
-	By("Checking ConsoleQuickStarts CRD exists or not")
-
-	_, err := cli.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), "consolequickstarts.console.openshift.io", metav1.GetOptions{})
-	if err != nil && apierrors.IsNotFound(err) {
-		Skip("ConsoleQuickStarts CRD does not exist")
-	}
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-}
-
-func checkExpectedQuickStarts(client kubecli.KubevirtClient) {
-	By("Checking expected quickstart objects")
-	s := scheme.Scheme
-	_ = consolev1.Install(s)
-	s.AddKnownTypes(consolev1.GroupVersion)
-
-	items := tests.GetConfig().QuickStart.TestItems
-
-	if len(items) == 0 {
-		Skip("There is no quickstart test item for dashboard tests.")
-	}
-
-	for _, qs := range items {
-		// use a fresh object for each loop. get requests only override non-empty fields
-		var cqs consolev1.ConsoleQuickStart
-		ExpectWithOffset(1, client.RestClient().Get().
-			Resource("consolequickstarts").
-			Name(qs.Name).
-			AbsPath("/apis", consolev1.GroupVersion.Group, consolev1.GroupVersion.Version).
-			Timeout(10*time.Second).
-			Do(context.TODO()).Into(&cqs)).To(Succeed())
-
-		ExpectWithOffset(1, cqs.Spec.DisplayName).Should(Equal(qs.DisplayName))
-	}
-
-}

--- a/tests/func-tests/wasp_test.go
+++ b/tests/func-tests/wasp_test.go
@@ -20,7 +20,7 @@ const (
 	setWaspFGPatchTemplate = `[{"op": "replace", "path": "/spec/featureGates/enableHigherDensityWithSwap", "value": %t}]`
 )
 
-var _ = Describe("wasp-agent", Label("wasp", openshiftLabel), Serial, Ordered, func() {
+var _ = Describe("wasp-agent", Label("wasp", tests.OpenshiftLabel), Serial, Ordered, func() {
 	tests.FlagParse()
 	var (
 		cli kubecli.KubevirtClient
@@ -33,7 +33,7 @@ var _ = Describe("wasp-agent", Label("wasp", openshiftLabel), Serial, Ordered, f
 		cli, err = kubecli.GetKubevirtClient()
 		Expect(cli).ToNot(BeNil())
 		Expect(err).ToNot(HaveOccurred())
-		tests.SkipIfNotOpenShift(cli, "wasp-agent")
+		tests.FailIfNotOpenShift(cli, "wasp-agent")
 
 		ctx = context.Background()
 		hc := tests.GetHCO(ctx, cli)


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace all the call for `Skip()` with asserting the skip condition, to
force running with the right ginkgo label filters.

Also, remove test `[test_id:10760]`, as it's never run

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
