### PR TITLE
[release-1.11] Destroy tektontasks CRD when upgrading from <=1.10.0

### DIFF
--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -140,7 +140,7 @@
       }
     },
     {
-      "semverRange": "<=1.11.0",
+      "semverRange": "<=1.10.0",
       "groupVersionKind": {
         "group": "apiextensions.k8s.io",
         "version": "v1",


### PR DESCRIPTION
**What this PR does / why we need it**:
Destroy tektontasks CRD when upgrading from <=1.10.0

Partially revert a wrong update introduced with
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2453/files#diff-97c5af6084c1f6351eccef14764fe3d846a7d660cd634beddcb6f3768d5cf965

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-41129
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
