### PR TITLE
Update the default hardcodedObsoleteCPUModels

### DIFF
--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -194,6 +194,8 @@ var (
 		"qemu32",
 		"kvm64",
 		"kvm32",
+		"Opteron_G1",
+		"Opteron_G2",
 	}
 )
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The default ObsoleteCPUModels has changed in kv:
https://github.com/kubevirt/kubevirt/pull/11671/commits/0f4f837deb6fde6ca258da642ec3495acdc5fcb7

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding Opteron_G1 AND Opteron_G2 to the default ObsoleteCPUModels
```
