### PR TITLE
Remove some hard coded KV FGs

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -194,10 +194,7 @@ var _ = Describe("HyperconvergedController", func() {
 				verifySystemHealthStatusError(foundResource)
 
 				expectedFeatureGates := []string{
-					"DataVolumes",
-					"SRIOV",
 					"CPUManager",
-					"CPUNodeDiscovery",
 					"Snapshot",
 					"HotplugVolumes",
 					"GPU",

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -61,22 +61,9 @@ func init() {
 // KubeVirt hard coded FeatureGates
 // These feature gates are set by HCO in the KubeVirt CR and can't be modified by the end user.
 const (
-	// indicates that we support turning on DataVolume workflows. This means using DataVolumes in the VM and VMI
-	// definitions. There was a period of time where this was in alpha and needed to be explicility enabled.
-	// It also means that someone is using KubeVirt with CDI. So by not enabling this feature gate, someone can safely
-	// use kubevirt without CDI and know that users of kubevirt will not be able to post VM/VMIs that use CDI workflows
-	// that aren't available to them
-	kvDataVolumesGate = "DataVolumes"
-
-	// Enable Single-root input/output virtualization
-	kvSRIOVGate = "SRIOV"
-
 	// Enables the CPUManager feature gate to label the nodes which have the Kubernetes CPUManager running. VMIs that
 	// require dedicated CPU resources will automatically be scheduled on the labeled nodes
 	kvCPUManagerGate = "CPUManager"
-
-	// Enables schedule VMIs according to their CPU model
-	kvCPUNodeDiscoveryGate = "CPUNodeDiscovery"
 
 	// Enables the alpha offline snapshot functionality
 	kvSnapshotGate = "Snapshot"
@@ -125,10 +112,7 @@ const (
 
 var (
 	hardCodeKvFgs = []string{
-		kvDataVolumesGate,
-		kvSRIOVGate,
 		kvCPUManagerGate,
-		kvCPUNodeDiscoveryGate,
 		kvSnapshotGate,
 		kvHotplugVolumesGate,
 		kvExpandDisksGate,

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -3711,7 +3711,6 @@ Version: 1.2.3`)
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(getKvFeatureGateList(&hco.Spec.FeatureGates))))
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(hardCodeKvFgs))
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvSRIOVGate))
 				Expect(kv.Spec.Configuration.CPURequest).To(BeNil())
 
 			})


### PR DESCRIPTION
## What this PR does / why we need it
HCO will no longer set the following FGs in KubeVirt CR:
* The `DataVolumes` and `SRIOV` feature gates are no longer supported in KV.
* The `CPUNodeDiscovery` feature gate is already GA.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
HCO will no longer set the following FGs in KubeVirt CR: `DataVolumes`, `SRIOV` and `CPUNodeDiscovery`
```
