### PR TITLE
[release-1.12] Ignore legacy MACHINETYPE when empty

### DIFF
--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -465,7 +465,7 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 
 	var amd64MachineType string
 	// Remain backwards compatibility with the original env variable for a release before removing
-	if machineTypeEnvValue, ok := os.LookupEnv(machineTypeEnvName); ok {
+	if machineTypeEnvValue, _ := os.LookupEnv(machineTypeEnvName); machineTypeEnvValue != "" {
 		amd64MachineType = machineTypeEnvValue
 	} else if machineTypeEnvValue, ok := os.LookupEnv(amd64MachineTypeEnvName); ok {
 		amd64MachineType = machineTypeEnvValue

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -490,6 +490,20 @@ Version: 1.2.3`)
 			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Arm64).To(BeNil())
 		})
 
+		It("should not use legacy MACHINETYPE env if empty", func() {
+			os.Setenv(machineTypeEnvName, "")
+			os.Setenv(amd64MachineTypeEnvName, "q35")
+			os.Unsetenv(arm64MachineTypeEnvName)
+
+			kv, err := NewKubeVirt(hco, commontestutils.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(kv.Spec.Configuration.MachineType).To(BeEmpty())
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).To(Equal("q35"))
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Amd64.OVMFPath).To(Equal(DefaultAMD64OVMFPath))
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Arm64).To(BeNil())
+		})
+
 		It("should fail if the SMBIOS is wrongly formatted mandatory configurations", func() {
 			hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
 				WithHostPassthroughCPU: ptr.To(true),

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.12.0/manifests/kubevirt-hyperconverged-operator.v1.12.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.12.0/manifests/kubevirt-hyperconverged-operator.v1.12.0.clusterserviceversion.yaml
@@ -3307,7 +3307,9 @@ spec:
                     Product: None
                 - name: MACHINETYPE
                 - name: AMD64_MACHINETYPE
+                  value: q35
                 - name: ARM64_MACHINETYPE
+                  value: virt
                 - name: HCO_KV_IO_VERSION
                   value: 1.12.0
                 - name: KUBEVIRT_VERSION

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.12.0/manifests/kubevirt-hyperconverged-operator.v1.12.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.12.0/manifests/kubevirt-hyperconverged-operator.v1.12.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.12.0-unstable
-    createdAt: "2024-04-26 05:04:44"
+    createdAt: "2024-05-07 15:39:39"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -3307,7 +3307,9 @@ spec:
                     Product: None
                 - name: MACHINETYPE
                 - name: AMD64_MACHINETYPE
+                  value: q35
                 - name: ARM64_MACHINETYPE
+                  value: virt
                 - name: HCO_KV_IO_VERSION
                   value: 1.12.0
                 - name: KUBEVIRT_VERSION

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -51,7 +51,9 @@ spec:
             Product: None
         - name: MACHINETYPE
         - name: AMD64_MACHINETYPE
+          value: q35
         - name: ARM64_MACHINETYPE
+          value: virt
         - name: HCO_KV_IO_VERSION
           value: 1.12.0
         - name: KUBEVIRT_VERSION

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -65,6 +65,9 @@ CSV_EXT="clusterserviceversion.yaml"
 CSV_CRD_EXT="csv_crds.yaml"
 CRD_EXT="crd.yaml"
 
+readonly amd64_machinetype=q35
+readonly arm64_machinetype=virt
+
 function gen_csv() {
   # Handle arguments
   local csvGeneratorPath="$1" && shift
@@ -310,6 +313,8 @@ ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
   --kv-virtiowin-image-name="${KUBEVIRT_VIRTIO_IMAGE}" \
   --operator-namespace="${OPERATOR_NAMESPACE}" \
   --smbios="${SMBIOS}" \
+  --amd64-machinetype="${amd64_machinetype}" \
+  --arm64-machinetype="${arm64_machinetype}" \
   --hco-kv-io-version="${CSV_VERSION}" \
   --kubevirt-version="${KUBEVIRT_VERSION}" \
   --cdi-version="${CDI_VERSION}" \
@@ -351,6 +356,8 @@ ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
   --metadata-description="A unified operator deploying and controlling KubeVirt and its supporting operators with opinionated defaults" \
   --crd-display="HyperConverged Cluster Operator" \
   --smbios="${SMBIOS}" \
+  --amd64-machinetype="${amd64_machinetype}" \
+  --arm64-machinetype="${arm64_machinetype}" \
   --csv-overrides="$(<${csvOverrides})" \
   --enable-unique-version=${ENABLE_UNIQUE} \
   --kubevirt-version="${KUBEVIRT_VERSION}" \


### PR DESCRIPTION
**What this PR does / why we need it**:
Ignore legacy MACHINETYPE env variable
when the variable is defined but empty.
Correctly set defaults during manifests
generation.

This is a manual cherry-pick of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2946

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [X] PR Message
- [X] Commit Messages
- [ ] How to test
- [X] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [X] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-37722
```

**Release note**:
```release-note
NONE
```
