### PR TITLE
Use ginkgo's context in e2e

### DIFF
--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -23,11 +23,10 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 
 	var (
 		cli client.Client
-		ctx context.Context
 	)
 
-	BeforeEach(func() {
-		tests.BeforeEach()
+	BeforeEach(func(ctx context.Context) {
+		tests.BeforeEach(ctx)
 		cfg, err := config.GetConfig()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -36,11 +35,10 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 		cli, err = client.New(cfg, client.Options{Scheme: s})
 		Expect(err).ToNot(HaveOccurred())
 
-		ctx = context.Background()
 		tests.FailIfNotOpenShift(ctx, cli, "ConsoleCliDownload")
 	})
 
-	It("[test_id:6956]should create ConsoleCliDownload objects with expected spec", Label("test_id:6956"), func() {
+	It("[test_id:6956]should create ConsoleCliDownload objects with expected spec", Label("test_id:6956"), func(ctx context.Context) {
 		By("Checking existence of ConsoleCliDownload")
 
 		ccd := &consolev1.ConsoleCLIDownload{

--- a/tests/func-tests/cluster_eviction_strategy_test.go
+++ b/tests/func-tests/cluster_eviction_strategy_test.go
@@ -17,33 +17,30 @@ var _ = Describe("Cluster level evictionStrategy default value", Serial, Ordered
 	tests.FlagParse()
 	var (
 		cli client.Client
-		ctx context.Context
 
 		initialEvictionStrategy *v1.EvictionStrategy
 		singleWorkerCluster     bool
 	)
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx context.Context) {
 		cli = tests.GetControllerRuntimeClient()
-
-		ctx = context.Background()
 
 		var err error
 		singleWorkerCluster, err = isSingleWorkerCluster(ctx, cli)
 		Expect(err).ToNot(HaveOccurred())
 
-		tests.BeforeEach()
+		tests.BeforeEach(ctx)
 		hc := tests.GetHCO(ctx, cli)
 		initialEvictionStrategy = hc.Spec.EvictionStrategy
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx context.Context) {
 		hc := tests.GetHCO(ctx, cli)
 		hc.Spec.EvictionStrategy = initialEvictionStrategy
 		tests.UpdateHCORetry(ctx, cli, hc)
 	})
 
-	It("Should set spec.evictionStrategy = None by default on single worker clusters", Label(tests.SingleNodeLabel), func() {
+	It("Should set spec.evictionStrategy = None by default on single worker clusters", Label(tests.SingleNodeLabel), func(ctx context.Context) {
 		Expect(singleWorkerCluster).To(BeTrue(), "this test requires single worker cluster; use the %q label to skip this test", tests.SingleNodeLabel)
 
 		hco := tests.GetHCO(ctx, cli)
@@ -54,7 +51,7 @@ var _ = Describe("Cluster level evictionStrategy default value", Serial, Ordered
 		Expect(hco.Spec.EvictionStrategy).To(Equal(&noneEvictionStrategy))
 	})
 
-	It("Should set spec.evictionStrategy = LiveMigrate by default with multiple worker node", Label(tests.HighlyAvailableClusterLabel), func() {
+	It("Should set spec.evictionStrategy = LiveMigrate by default with multiple worker node", Label(tests.HighlyAvailableClusterLabel), func(ctx context.Context) {
 		tests.FailIfSingleNode(singleWorkerCluster)
 		hco := tests.GetHCO(ctx, cli)
 		hco.Spec.EvictionStrategy = nil

--- a/tests/func-tests/dashboard_test.go
+++ b/tests/func-tests/dashboard_test.go
@@ -15,23 +15,19 @@ import (
 var _ = Describe("[rfe_id:5108][crit:medium][vendor:cnv-qe@redhat.com][level:system]Dashboard configmaps", Label(tests.OpenshiftLabel), func() {
 	flag.Parse()
 
-	var (
-		cli *kubernetes.Clientset
-		ctx context.Context
-	)
+	var cli *kubernetes.Clientset
 
-	BeforeEach(func() {
-		tests.BeforeEach()
+	BeforeEach(func(ctx context.Context) {
+		tests.BeforeEach(ctx)
 
 		k8sCli := tests.GetControllerRuntimeClient()
-		ctx = context.Background()
 
 		tests.FailIfNotOpenShift(ctx, k8sCli, "Dashboard configmaps")
 
 		cli = tests.GetK8sClientSet()
 	})
 
-	It("[test_id:5919]should create configmaps for OCP Dashboard", Label("test_id:5919"), func() {
+	It("[test_id:5919]should create configmaps for OCP Dashboard", Label("test_id:5919"), func(ctx context.Context) {
 		By("Checking expected configmaps")
 		items := tests.GetConfig().Dashboard.TestItems
 

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -22,15 +22,10 @@ const (
 )
 
 var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
-	var (
-		cli client.Client
-		ctx context.Context
-	)
+	var cli client.Client
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx context.Context) {
 		cli = tests.GetControllerRuntimeClient()
-
-		ctx = context.Background()
 
 		tests.RestoreDefaults(ctx, cli)
 	})
@@ -47,16 +42,16 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			},
 		}
 
-		DescribeTable("Check that certConfig defaults are behaving as expected", func(path string) {
+		DescribeTable("Check that certConfig defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
 				g.Expect(reflect.DeepEqual(hc.Spec.CertConfig, defaultCertConfig)).To(BeTrue(), "certConfig should be equal to default")
-			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
 			Entry("when removing /spec/certConfig/ca/duration", "/spec/certConfig/ca/duration"),
 			Entry("when removing /spec/certConfig/ca/renewBefore", "/spec/certConfig/ca/renewBefore"),
@@ -86,16 +81,16 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			EnableApplicationAwareQuota: ptr.To(false),
 		}
 
-		DescribeTable("Check that featureGates defaults are behaving as expected", func(path string) {
+		DescribeTable("Check that featureGates defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
 				g.Expect(reflect.DeepEqual(hc.Spec.FeatureGates, defaultFeatureGates)).To(BeTrue(), "featureGates should be equal to default")
-			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
 			Entry("when removing /spec/featureGates/downwardMetrics", "/spec/featureGates/downwardMetrics"),
 			Entry("when removing /spec/featureGates/deployKubeSecondaryDNS", "/spec/featureGates/deployKubeSecondaryDNS"),
@@ -124,16 +119,16 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			ProgressTimeout:                   ptr.To(int64(150)),
 		}
 
-		DescribeTable("Check that liveMigrationConfig defaults are behaving as expected", func(path string) {
+		DescribeTable("Check that liveMigrationConfig defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
 				g.Expect(reflect.DeepEqual(hc.Spec.LiveMigrationConfig, defaultLiveMigrationConfig)).To(BeTrue(), "liveMigrationConfig should be equal to default")
-			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
 			Entry("when removing /spec/liveMigrationConfig/allowAutoConverge", "/spec/liveMigrationConfig/allowAutoConverge"),
 			Entry("when removing /spec/liveMigrationConfig/allowPostCopy", "/spec/liveMigrationConfig/allowPostCopy"),
@@ -151,16 +146,16 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			VmiCPUAllocationRatio: ptr.To(10),
 		}
 
-		DescribeTable("Check that resourceRequirements defaults are behaving as expected", func(path string) {
+		DescribeTable("Check that resourceRequirements defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
 				g.Expect(reflect.DeepEqual(hc.Spec.ResourceRequirements, &defaultResourceRequirements)).To(BeTrue(), "resourceRequirements should be equal to default")
-			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
 			Entry("when removing /spec/resourceRequirements/vmiCPUAllocationRatio", "/spec/resourceRequirements/vmiCPUAllocationRatio"),
 			Entry("when removing /spec/resourceRequirements", "/spec/resourceRequirements"),
@@ -175,16 +170,16 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			WorkloadUpdateMethods: []string{"LiveMigrate"},
 		}
 
-		DescribeTable("Check that workloadUpdateStrategy defaults are behaving as expected", func(path string) {
+		DescribeTable("Check that workloadUpdateStrategy defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
 				g.Expect(reflect.DeepEqual(hc.Spec.WorkloadUpdateStrategy, defaultWorkloadUpdateStrategy)).To(BeTrue(), "workloadUpdateStrategy should be equal to default")
-			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
 			Entry("when removing /spec/workloadUpdateStrategy/batchEvictionInterval", "/spec/workloadUpdateStrategy/batchEvictionInterval"),
 			Entry("when removing /spec/workloadUpdateStrategy/batchEvictionSize", "/spec/workloadUpdateStrategy/batchEvictionSize"),
@@ -197,16 +192,16 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 	Context("uninstallStrategy defaults", func() {
 		const defaultUninstallStrategy = `BlockUninstallIfWorkloadsExist`
 
-		DescribeTable("Check that uninstallStrategy default is behaving as expected", func(path string) {
+		DescribeTable("Check that uninstallStrategy default is behaving as expected", func(ctx context.Context, path string) {
 			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
 				g.Expect(hc.Spec.UninstallStrategy).To(Equal(v1beta1.HyperConvergedUninstallStrategy(defaultUninstallStrategy)), "uninstallStrategy should be equal to default")
-			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
 			Entry("when removing /spec/uninstallStrategy", "/spec/uninstallStrategy"),
 			Entry("when removing /spec", "/spec"),
@@ -219,16 +214,16 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			DisableSerialConsoleLog:  ptr.To(true),
 		}
 
-		DescribeTable("Check that featureGates defaults are behaving as expected", func(path string) {
+		DescribeTable("Check that featureGates defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
 				g.Expect(reflect.DeepEqual(hc.Spec.VirtualMachineOptions, defaultVirtualMachineOptions)).To(BeTrue(), "virtualMachineOptions should be equal to default")
-			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
 			Entry("when removing /spec/virtualMachineOptions/disableFreePageReporting", "/spec/virtualMachineOptions/disableFreePageReporting"),
 			Entry("when removing /spec/virtualMachineOptions/disableSerialConsoleLog", "/spec/virtualMachineOptions/disableSerialConsoleLog"),
@@ -242,16 +237,16 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			MemoryOvercommitPercentage: 100,
 		}
 
-		DescribeTable("Check that HigherWorkloadDensity defaults are behaving as expected", func(path string) {
+		DescribeTable("Check that HigherWorkloadDensity defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
 				g.Expect(reflect.DeepEqual(hc.Spec.HigherWorkloadDensity, defaultHigherWorkloadDensity)).To(BeTrue(), "HigherWorkloadDensity should be equal to default")
-			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
 			Entry("when removing /spec/higherWorkloadDensity/memoryOvercommitPercentage", "/spec/higherWorkloadDensity/memoryOvercommitPercentage"),
 			Entry("when removing /spec/higherWorkloadDensity", "/spec/higherWorkloadDensity"),

--- a/tests/func-tests/dependency_objects_test.go
+++ b/tests/func-tests/dependency_objects_test.go
@@ -16,8 +16,8 @@ var _ = Describe("[rfe_id:5672][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 
 	var stopChan chan struct{}
 
-	BeforeEach(func() {
-		tests.BeforeEach()
+	BeforeEach(func(ctx context.Context) {
+		tests.BeforeEach(ctx)
 		stopChan = make(chan struct{})
 	})
 
@@ -25,9 +25,9 @@ var _ = Describe("[rfe_id:5672][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 		close(stopChan)
 	})
 
-	It("[test_id:5674]should get the created priority class for critical workloads", Label("test_id:5674"), func() {
+	It("[test_id:5674]should get the created priority class for critical workloads", Label("test_id:5674"), func(ctx context.Context) {
 		cli := tests.GetK8sClientSet()
-		_, err := cli.SchedulingV1().PriorityClasses().Get(context.TODO(), priorityClassName, v1.GetOptions{})
+		_, err := cli.SchedulingV1().PriorityClasses().Get(ctx, priorityClassName, v1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/func-tests/main_test.go
+++ b/tests/func-tests/main_test.go
@@ -18,7 +18,7 @@ func TestTests(t *testing.T) {
 	RunSpecs(t, "HyperConverged cluster E2E Test suite")
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx context.Context) {
 	cli := tests.GetK8sClientSet()
 
 	ns := &v1.Namespace{
@@ -28,19 +28,19 @@ var _ = BeforeSuite(func() {
 	}
 
 	opt := metav1.CreateOptions{}
-	_, err := cli.CoreV1().Namespaces().Create(context.Background(), ns, opt)
+	_, err := cli.CoreV1().Namespaces().Create(ctx, ns, opt)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			panic(err)
 		}
 	}
 
-	tests.BeforeEach()
+	tests.BeforeEach(ctx)
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx context.Context) {
 	cli := tests.GetK8sClientSet()
-	err := cli.CoreV1().Namespaces().Delete(context.Background(), tests.TestNamespace, metav1.DeleteOptions{})
+	err := cli.CoreV1().Namespaces().Delete(ctx, tests.TestNamespace, metav1.DeleteOptions{})
 	if err != nil {
 		panic(err)
 	}

--- a/tests/func-tests/quickstart_test.go
+++ b/tests/func-tests/quickstart_test.go
@@ -19,17 +19,15 @@ var _ = Describe("[rfe_id:5882][crit:high][vendor:cnv-qe@redhat.com][level:syste
 
 	var (
 		cli client.Client
-		ctx context.Context
 	)
-	BeforeEach(func() {
-		tests.BeforeEach()
+	BeforeEach(func(ctx context.Context) {
+		tests.BeforeEach(ctx)
 		cli = tests.GetControllerRuntimeClient()
-		ctx = context.Background()
 
 		tests.FailIfNotOpenShift(ctx, cli, "quickstart")
 	})
 
-	It("[test_id:5883]should create ConsoleQuickStart objects", Label("test_id:5883"), func() {
+	It("[test_id:5883]should create ConsoleQuickStart objects", Label("test_id:5883"), func(ctx context.Context) {
 		By("Checking expected quickstart objects")
 		s := scheme.Scheme
 		_ = consolev1.Install(s)

--- a/tests/func-tests/tuningpolicy_test.go
+++ b/tests/func-tests/tuningpolicy_test.go
@@ -21,15 +21,13 @@ var _ = Describe("Check that the TuningPolicy annotation is configuring the KV o
 	tests.FlagParse()
 	var (
 		cli client.Client
-		ctx context.Context
 	)
 
 	BeforeEach(func() {
 		cli = tests.GetControllerRuntimeClient()
-		ctx = context.Background()
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx context.Context) {
 		hc := tests.GetHCO(ctx, cli)
 
 		delete(hc.Annotations, common.TuningPolicyAnnotationName)
@@ -38,7 +36,7 @@ var _ = Describe("Check that the TuningPolicy annotation is configuring the KV o
 		tests.UpdateHCORetry(ctx, cli, hc)
 	})
 
-	It("should update KV with the tuningPolicy annotation", func() {
+	It("should update KV with the tuningPolicy annotation", func(ctx context.Context) {
 		hc := tests.GetHCO(ctx, cli)
 
 		if hc.Annotations == nil {
@@ -57,7 +55,7 @@ var _ = Describe("Check that the TuningPolicy annotation is configuring the KV o
 		checkTuningPolicy(ctx, cli, expected)
 	})
 
-	It("should update KV with the highBurst tuningPolicy", func() {
+	It("should update KV with the highBurst tuningPolicy", func(ctx context.Context) {
 		hc := tests.GetHCO(ctx, cli)
 
 		delete(hc.Annotations, common.TuningPolicyAnnotationName)
@@ -75,7 +73,7 @@ var _ = Describe("Check that the TuningPolicy annotation is configuring the KV o
 })
 
 func checkTuningPolicy(ctx context.Context, cli client.Client, expected kvv1.TokenBucketRateLimiter) {
-	Eventually(func(g Gomega) {
+	Eventually(func(g Gomega, ctx context.Context) {
 		kv := &kvv1.KubeVirt{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kubevirt-kubevirt-hyperconverged",
@@ -90,7 +88,7 @@ func checkTuningPolicy(ctx context.Context, cli client.Client, expected kvv1.Tok
 		checkReloadableComponentConfiguration(g, kv.Spec.Configuration.ControllerConfiguration, expected)
 		checkReloadableComponentConfiguration(g, kv.Spec.Configuration.HandlerConfiguration, expected)
 		checkReloadableComponentConfiguration(g, kv.Spec.Configuration.WebhookConfiguration, expected)
-	}).WithTimeout(time.Minute * 2).WithPolling(time.Second).Should(Succeed())
+	}).WithTimeout(time.Minute * 2).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
 
 }
 

--- a/tests/func-tests/validation_test.go
+++ b/tests/func-tests/validation_test.go
@@ -19,32 +19,29 @@ import (
 var _ = Describe("Check CR validation", Label("validation"), Serial, func() {
 	var (
 		cli client.Client
-		ctx context.Context
 	)
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx context.Context) {
 		cli = tests.GetControllerRuntimeClient()
-
-		ctx = context.Background()
 
 		tests.RestoreDefaults(ctx, cli)
 	})
 
 	Context("for AutoCPULimitNamespaceLabelSelector", func() {
-		DescribeTable("should", func(allocationRatio *int, outcome gomegatypes.GomegaMatcher) {
+		DescribeTable("should", func(ctx context.Context, allocationRatio *int, outcome gomegatypes.GomegaMatcher) {
 			requirements := &v1beta1.OperandResourceRequirements{
 				VmiCPUAllocationRatio: allocationRatio,
 				AutoCPULimitNamespaceLabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"someLabel": "true"},
 				},
 			}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				var err error
 				hc := tests.GetHCO(ctx, cli)
 				hc.Spec.ResourceRequirements = requirements
 				_, err = tests.UpdateHCO(ctx, cli, hc)
 				return err
-			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(outcome)
+			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(outcome)
 		},
 			Entry("succeed when VMI CPU allocation is nil", nil, Succeed()),
 			Entry("fail when VMI CPU allocation is 1", ptr.To(1), MatchError(ContainSubstring("Automatic CPU limits are incompatible with a VMI CPU allocation ratio of 1"))),


### PR DESCRIPTION
## What this PR does / why we need it
Use ginkgo contexts instead and let ginkgo handle them, instead of creating our on contexts.

This is prove of concept, so it's done for several tests, but not for all of them.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
