### PR TITLE
dataImportCronTemplates: Remove instancetype.kubevirt.io labels

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -2,9 +2,6 @@
     annotations:
       cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: centos-stream8-image-cron
-    labels:
-      instancetype.kubevirt.io/default-preference: centos.stream8
-      instancetype.kubevirt.io/default-instancetype: u1.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -22,9 +19,6 @@
     annotations:
       cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: centos-stream9-image-cron
-    labels:
-      instancetype.kubevirt.io/default-preference: centos.stream9
-      instancetype.kubevirt.io/default-instancetype: u1.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -42,9 +36,6 @@
     annotations:
       cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: fedora-image-cron
-    labels:
-      instancetype.kubevirt.io/default-preference: fedora
-      instancetype.kubevirt.io/default-instancetype: u1.medium
   spec:
     schedule: "0 */12 * * *"
     template:
@@ -62,9 +53,6 @@
     annotations:
       cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: centos-7-image-cron
-    labels:
-      instancetype.kubevirt.io/default-preference: centos.7
-      instancetype.kubevirt.io/default-instancetype: u1.medium
   spec:
     schedule: "0 */12 * * *"
     template:


### PR DESCRIPTION
**What this PR does / why we need it**:

This metadata is now provided by the containerdisks project for these imports and used by CDI to later populate the required labels on the resulting PVCs:

```
$ podman image inspect quay.io/containerdisks/centos-stream:8 | jq '.[] | .Config.Env'
[
  "INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE=u1.medium",
  "INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE=centos.stream8"
]
```

```
$ ./cluster-up/kubectl.sh apply -f -<<EOF
apiVersion: cdi.kubevirt.io/v1beta1
kind: DataImportCron
metadata:
  annotations:
    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
  name: centos-stream8-image-cron
spec:
  schedule: "0 */12 * * *"
  template:
    spec:
      source:
        registry:
          url: docker://quay.io/containerdisks/centos-stream:8
      storage:
        resources:
          requests:
            storage: 10Gi
  garbageCollect: Outdated
  managedDataSource: centos-stream8
EOF
[..]
./cluster-up/kubectl.sh get dv
selecting podman as container runtime
NAME                          PHASE       PROGRESS   RESTARTS   AGE
centos-stream8-d06927f5ae68   Succeeded   100.0%                61s
[..]
./cluster-up/kubectl.sh get pvc/centos-stream8-d06927f5ae68 -o json | jq .metadata.labels 
selecting podman as container runtime
{
  "alerts.k8s.io/KubePersistentVolumeFillingUp": "disabled",
  "app": "containerized-data-importer",
  "app.kubernetes.io/component": "storage",
  "app.kubernetes.io/managed-by": "cdi-controller",
  "cdi.kubevirt.io/dataImportCron": "centos-stream8-image-cron",
  "instancetype.kubevirt.io/default-instancetype": "u1.medium",
  "instancetype.kubevirt.io/default-preference": "centos.stream8"
}

$ ./cluster-up/kubectl.sh apply -k https://github.com/kubevirt/common-instancetypes.git
[..]
./cluster-up/virtctl.sh create vm --volume-import type:pvc,size:10Gi,src:default/centos-stream8-d06927f5ae68  --infer-instancetype --infer-preference --cloud-init-user-data $USER_DATA --name centos | ./cluster-up/kubectl.sh apply -f -
[..]
./cluster-up/kubectl.sh get vm/centos -o json | jq '.spec |.instancetype,.preference'
selecting podman as container runtime
{
  "kind": "virtualmachineclusterinstancetype",
  "name": "u1.medium",
  "revisionName": "centos-u1.medium-9af4814d-f78a-458c-b3d1-2b60d64bfcf6-1"
}
{
  "kind": "virtualmachineclusterpreference",
  "name": "centos.stream8",
  "revisionName": "centos-centos.stream8-7a5e492e-bac0-4e73-878a-aa88564d0803-1"
}

./cluster-up/kubectl.sh delete vms/centos

./cluster-up/virtctl.sh create vm --volume-datasource src:centos-stream8,name:centos,size:10Gi  --infer-instancetype --infer-preference --cloud-init-user-data $USER_DATA --name centos | ./cluster-up/kubectl.sh apply -f -
[..]
./cluster-up/kubectl.sh get vm/centos -o json | jq '.spec |.instancetype,.preference'
selecting podman as container runtime
{
  "kind": "virtualmachineclusterinstancetype",
  "name": "u1.medium",
  "revisionName": "centos-u1.medium-9af4814d-f78a-458c-b3d1-2b60d64bfcf6-1"
}
{
  "kind": "virtualmachineclusterpreference",
  "name": "centos.stream8",
  "revisionName": "centos-centos.stream8-7a5e492e-bac0-4e73-878a-aa88564d0803-1"
}
```

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-41767
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
