### PR TITLE
[CNV-39949] enable nosniff for kubevirt-console-plugin nginx config

### DIFF
--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -261,6 +261,7 @@ http {
 	include            /etc/nginx/mime.types;
 	default_type       application/octet-stream;
 	keepalive_timeout  65;
+	add_header X-Content-Type-Options nosniff;
 		server {
 			listen              %d ssl;
 			ssl_certificate     /var/serving-cert/tls.crt;


### PR DESCRIPTION
**What this PR does / why we need it**:
To increase security measures, it is advise to add the 'nosniff' Anti-MIME-Sniffing header X-Content-Type-Options in the kubevirt-console-plugin NGINX configuration. The advantages of setting it are:

- **Improved Security**: Prevents MIME type sniffing and reduces the risk of executing unintended scripts.
- **XSS Mitigation**: Decreases the chances of cross-site scripting attacks.
- **Effective CSP**: Ensures that Content Security Policies are enforced correctly.
- **Adherence to Best Practices**: Aligns with recommended security practices.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-39949
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable 'nosniff' for kubevirt-console-plugin nginx webserver
```
