### PR TITLE
Revert "[release-1.10] Update the default hardcodedObsoleteCPUModels"

### DIFF
--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -181,8 +181,6 @@ var (
 		"qemu32",
 		"kvm64",
 		"kvm32",
-		"Opteron_G1",
-		"Opteron_G2",
 	}
 )
 


### PR DESCRIPTION
Reverts kubevirt/hyperconverged-cluster-operator#2935

The hardcodedObsoleteCPUModels wasn't change in kubevirt v.1.0 so it shouldn't be modifed in HCO as well.

```release-note
Removing Opteron_G1 AND Opteron_G2 from the default ObsoleteCPUModels
```