### PR TITLE
Publish stable releases to the stable OLM channel

### DIFF
--- a/automation/publisher/publisher.sh
+++ b/automation/publisher/publisher.sh
@@ -22,6 +22,9 @@ function main() {
 
   PR_BODY=$(get_pr_body "${TAGGED_VERSION}")
 
+  echo "Switch to stable channel"
+  sed -r -i "s/(.*channel.*: ).+/\1\stable/g" hco_bundle/metadata/annotations.yaml
+
   echo "Add annotation for community-operators index image"
   IFS='.' read -r -a SPLITTED_BASE_VERSION <<< "${TAGGED_VERSION%.*}"
   SPLITTED_BASE_VERSION[0]=$((SPLITTED_BASE_VERSION[0]+3))


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the release automation to always publish
stable releases to the stable OLM channel.

Fixes: https://github.com/kubevirt/hyperconverged-cluster-operator/issues/2954

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Publish stable releases to stable OLM channel again
```
