### PR TITLE
Fix bug in community CSV

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.13.0/manifests/kubevirt-hyperconverged-operator.v1.13.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.13.0/manifests/kubevirt-hyperconverged-operator.v1.13.0.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
   name: kubevirt-hyperconverged-operator.v1.13.0
-  namespace: placeholder
+  namespace: kubevirt-hyperconverged
 spec:
   apiservicedefinitions: {}
   cleanup:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.13.0/manifests/kubevirt-hyperconverged-operator.v1.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.13.0/manifests/kubevirt-hyperconverged-operator.v1.13.0.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
   name: kubevirt-hyperconverged-operator.v1.13.0
-  namespace: placeholder
+  namespace: kubevirt-hyperconverged
 spec:
   apiservicedefinitions: {}
   cleanup:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -860,7 +860,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%v.v%v", params.Name, params.Version.String()),
-			Namespace: "placeholder",
+			Namespace: params.Namespace,
 			Annotations: map[string]string{
 				"alm-examples":                   string(almExamples),
 				"capabilities":                   "Deep Insights",


### PR DESCRIPTION
The CSV namespace is "placeholder" by default, but must be "kubevirt-hyperconverged".

This PR fixes this issue.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix community CSV installation at the wrong namespace
```
