### PR TITLE
Use standard lib  instead of self baked functions.

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 
 	"github.com/blang/semver/v4"
 	jsonpatch "github.com/evanphx/json-patch/v5"
@@ -715,7 +716,7 @@ func (r *ReconcileHyperConverged) ensureHcoDeleted(req *common.HcoRequest) (reco
 
 	// Remove the finalizers
 	finDropped := false
-	if hcoutil.ContainsString(req.Instance.ObjectMeta.Finalizers, FinalizerName) {
+	if slices.Contains(req.Instance.ObjectMeta.Finalizers, FinalizerName) {
 		req.Instance.ObjectMeta.Finalizers, finDropped = drop(req.Instance.ObjectMeta.Finalizers, FinalizerName)
 		req.Dirty = true
 		requeue = requeue || finDropped
@@ -1341,7 +1342,7 @@ func removeOldQuickStartGuides(req *common.HcoRequest, cl client.Client, require
 		}
 
 		for name, existQs := range existingQSNames {
-			if !hcoutil.ContainsString(requiredQSList, name) {
+			if !slices.Contains(requiredQSList, name) {
 				req.Logger.Info("deleting ConsoleQuickStart", "name", name)
 				if _, err = hcoutil.EnsureDeleted(req.Ctx, cl, &existQs, req.Instance.Name, req.Logger, false, false, true); err != nil {
 					req.Logger.Error(err, "failed to delete ConsoleQuickStart", "name", name)
@@ -1361,7 +1362,7 @@ func removeRelatedQSObjects(req *common.HcoRequest, requiredNames []string) {
 	foundOldQs := false
 
 	for _, obj := range req.Instance.Status.RelatedObjects {
-		if obj.Kind == "ConsoleQuickStart" && !hcoutil.ContainsString(requiredNames, obj.Name) {
+		if obj.Kind == "ConsoleQuickStart" && !slices.Contains(requiredNames, obj.Name) {
 			foundOldQs = true
 			continue
 		}
@@ -1472,7 +1473,7 @@ func init() {
 func checkFinalizers(req *common.HcoRequest) bool {
 	if req.Instance.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Add the finalizer if it's not there
-		if !hcoutil.ContainsString(req.Instance.ObjectMeta.Finalizers, FinalizerName) {
+		if !slices.Contains(req.Instance.ObjectMeta.Finalizers, FinalizerName) {
 			req.Logger.Info("setting a finalizer (with fully qualified name)")
 			req.Instance.ObjectMeta.Finalizers = append(req.Instance.ObjectMeta.Finalizers, FinalizerName)
 			req.Dirty = true

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"slices"
 
 	"github.com/go-logr/logr"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
@@ -364,21 +365,7 @@ func (c *ClusterInfoImp) validateAPIServerTLSSecurityProfile(apiServerTLSSecurit
 }
 
 func isValidCipherName(str string) bool {
-	for _, v := range openshiftconfigv1.TLSProfiles[openshiftconfigv1.TLSProfileOldType].Ciphers {
-		if v == str {
-			return true
-		}
-	}
-	for _, v := range openshiftconfigv1.TLSProfiles[openshiftconfigv1.TLSProfileIntermediateType].Ciphers {
-		if v == str {
-			return true
-		}
-	}
-	for _, v := range openshiftconfigv1.TLSProfiles[openshiftconfigv1.TLSProfileModernType].Ciphers {
-		if v == str {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(openshiftconfigv1.TLSProfiles[openshiftconfigv1.TLSProfileOldType].Ciphers, str) ||
+		slices.Contains(openshiftconfigv1.TLSProfiles[openshiftconfigv1.TLSProfileIntermediateType].Ciphers, str) ||
+		slices.Contains(openshiftconfigv1.TLSProfiles[openshiftconfigv1.TLSProfileModernType].Ciphers, str)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -226,15 +226,6 @@ func EnsureDeleted(ctx context.Context, c client.Client, obj client.Object, hcoN
 	return ComponentResourceRemoval(ctx, c, obj, hcoName, logger, dryRun, wait, protectNonHCOObjects)
 }
 
-func ContainsString(s []string, word string) bool {
-	for _, w := range s {
-		if w == word {
-			return true
-		}
-	}
-	return false
-}
-
 var hcoKvIoVersion string
 
 func GetHcoKvIoVersion() string {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -96,22 +96,4 @@ var _ = Describe("Test general utilities", func() {
 			Expect(cl.Get(ctx, client.ObjectKeyFromObject(pod), podToSearch)).ToNot(Succeed())
 		})
 	})
-
-	Context("test ContainsString", func() {
-		It("should return false if the list is empty", func() {
-			Expect(ContainsString([]string{}, "a word")).To(BeFalse())
-		})
-
-		It("should return false if the list is nil", func() {
-			Expect(ContainsString(nil, "a word")).To(BeFalse())
-		})
-
-		It("should return false if the list does not contain the string", func() {
-			Expect(ContainsString([]string{"aaa", "bbb", "ccc", "ddd"}, "eee")).To(BeFalse())
-		})
-
-		It("should return true if the list contains the string", func() {
-			Expect(ContainsString([]string{"aaa", "bbb", "ccc", "ddd"}, "bbb")).To(BeTrue())
-		})
-	})
 })

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -147,15 +148,6 @@ func IOReadDir(root string) ([]string, error) {
 	return files, nil
 }
 
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}
-
 func validateNoAPIOverlap(crdDir string) error {
 	crdFiles, err := IOReadDir(crdDir)
 	if err != nil {
@@ -207,7 +199,7 @@ func compareMapWithEntry(crdMap map[string][]string, operator string, apigroup s
 			continue
 		}
 
-		if stringInSlice(apigroup, crdMap[comparedOperator]) {
+		if slices.Contains(crdMap[comparedOperator], apigroup) {
 			overlapsMap[apigroup].Insert(operator)
 			overlapsMap[apigroup].Insert(comparedOperator)
 		}
@@ -235,7 +227,7 @@ func getCrdMap(crdFiles []string) map[string][]string {
 		err = yaml.Unmarshal(content, &crd)
 		panicOnError(err)
 
-		if !stringInSlice(crd.Spec.Group, crdMap[operator]) {
+		if !slices.Contains(crdMap[operator], crd.Spec.Group) {
 			crdMap[operator] = append(crdMap[operator], crd.Spec.Group)
 		}
 	}
@@ -347,7 +339,7 @@ func getHiddenCrds(csvBase csvv1alpha1.ClusterServiceVersion) (string, error) {
 	hiddenCrds := make([]string, 0)
 	visibleCrds := strings.Split(*visibleCRDList, ",")
 	for _, owned := range csvBase.Spec.CustomResourceDefinitions.Owned {
-		if !stringInSlice(owned.Name, visibleCrds) {
+		if !slices.Contains(visibleCrds, owned.Name) {
 			hiddenCrds = append(
 				hiddenCrds,
 				owned.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:

There are currently two different implementations for searching string in a slice. golang now have the `slices.Contains` standard library function to do the same thing.

This PR removes the private implementation, replacing them with calls to the standard library.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
