### PR TITLE
fix the publish-community-operators gh action

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -53,6 +53,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ env.CSV_VERSION }}
         run: |
+          make quay-login
           IMAGE_TAG=${IMAGE_TAG} make container-push
       - name: Build Digester
         run: |
@@ -74,7 +75,6 @@ jobs:
           chmod +x _out/opm
       - name: Build and Push the Index Image
         run: |
-          make quay-login
           export OPM=$(pwd)/_out/opm
           ./hack/build-index-image.sh ${{ env.CSV_VERSION }}
       - name: Run Publisher script


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
