### PR TITLE
console plugin/proxy: Change AntiAffinity rule to `Preferred` instead of `Required`

### DIFF
--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -214,18 +214,21 @@ func getPodAntiAffinity(componentLabel string, infrastructureHighlyAvailable boo
 	if infrastructureHighlyAvailable {
 		return &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 					{
-						LabelSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{
-									Key:      hcoutil.AppLabelComponent,
-									Operator: metav1.LabelSelectorOpIn,
-									Values:   []string{componentLabel},
+						Weight: 90,
+						PodAffinityTerm: corev1.PodAffinityTerm{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      hcoutil.AppLabelComponent,
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{componentLabel},
+									},
 								},
 							},
+							TopologyKey: corev1.LabelHostname,
 						},
-						TopologyKey: corev1.LabelHostname,
 					},
 				},
 			},

--- a/controllers/operands/kubevirtConsolePlugin_test.go
+++ b/controllers/operands/kubevirtConsolePlugin_test.go
@@ -889,18 +889,21 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 func expectedPodAntiAffinity(appComponent hcoutil.AppComponent) *v1.Affinity {
 	return &v1.Affinity{
 		PodAntiAffinity: &v1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
 				{
-					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      hcoutil.AppLabelComponent,
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{string(appComponent)},
+					Weight: 90,
+					PodAffinityTerm: v1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      hcoutil.AppLabelComponent,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{string(appComponent)},
+								},
 							},
 						},
+						TopologyKey: v1.LabelHostname,
 					},
-					TopologyKey: v1.LabelHostname,
 				},
 			},
 		},


### PR DESCRIPTION
Due to the (default setting of) rollingUpdate of the `kubevirt-console-plugin` and `kubevirt-apiserver-proxy` Deployments, when there is a change, a 3rd pod is being scheduled as a replacement. If there is a nodeSelector placement config alongside the anti-affinity rules, the replacement pod won`t get scheduled if there are less than 3 nodes labeled with the node selector label. We`ll use `PreferredDuringSchedulingIgnoredDuringExecution` instead of `RequiredDuringSchedulingIgnoredDuringExecution` to soften the affinity rule so no pod will get stuck at Pending.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-45427
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
soften console plugin and proxy anti affinity rules to avoid pending pods with rolling update
```
