### PR TITLE
Fix the monitoring flaky functest

### DIFF
--- a/tests/func-tests/main_test.go
+++ b/tests/func-tests/main_test.go
@@ -41,7 +41,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 var _ = AfterSuite(func(ctx context.Context) {
 	cli := tests.GetK8sClientSet()
 	err := cli.CoreV1().Namespaces().Delete(ctx, tests.TestNamespace, metav1.DeleteOptions{})
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		panic(err)
 	}
 })

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -39,7 +39,7 @@ const (
 	criticalImpact
 )
 
-var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring", Serial, Ordered, Label(tests.OpenshiftLabel), func() {
+var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring", Serial, Ordered, Label(tests.OpenshiftLabel, "monitoring"), func() {
 	flag.Parse()
 
 	var (
@@ -121,17 +121,15 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 
 		Expect(cli.Patch(ctx, kv, patch)).To(Succeed())
 
-		var metricValue float64
 		Eventually(func(g Gomega, ctx context.Context) float64 {
-			metricValue = getMetricValue(ctx, promClient, query)
-			return metricValue
+			return getMetricValue(ctx, promClient, query)
 		}).
 			WithTimeout(60*time.Second).
 			WithPolling(time.Second).
 			WithContext(ctx).
 			Should(
 				Equal(valueBefore+float64(1)),
-				"expected different counter value; value before: %0.2f; value after: %0.2f; expected value: %0.2f", valueBefore, metricValue, valueBefore+float64(1),
+				"expected different counter value; value before: %0.2f; expected value: %0.2f", valueBefore, valueBefore+float64(1),
 			)
 
 		Eventually(func(ctx context.Context) *promApiv1.Alert {


### PR DESCRIPTION
The test modifies the KubeVirt CR and expects that the kubevirt_hco_out_of_band_modifications_total metric will increased by 1.
However, this test is sometimes fails, when the actual result is greater by 1 than the expected metric value.

The reason for that is that another test - labels test, also modifies the KubeVirt CR. In cases where the labels test runs first, sometimes prometheus takes some time to update the metric, and then, in the monitoring test, when reading the value before test, we're getting the value before it was modified by the labels test, and when reading the value after the KubeVirt modification, we get the metric values for both modifications.

This PR fixes the issue by using the CDI CR instead of the KubeVirt CR in the labels test, so there is only one modification for the KubeVirt CR during the functional test suite, and the test should always pass.

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-46588
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
