### PR TITLE
Fix bug with ImageStreams in relatedObjects

### DIFF
--- a/controllers/operands/imageStream.go
+++ b/controllers/operands/imageStream.go
@@ -98,6 +98,17 @@ func (iso imageStreamOperand) deleteImageStream(req *common.HcoRequest) *EnsureR
 	if err != nil {
 		return NewEnsureResult(h.required).Error(fmt.Errorf("failed to delete imagestream %s/%s; %w", h.required.Namespace, h.required.Name, err))
 	}
+
+	objectRef, err := reference.GetReference(iso.operand.Scheme, h.required)
+	if err != nil {
+		return NewEnsureResult(req.Instance).Error(err)
+	}
+
+	if err = objectreferencesv1.RemoveObjectReference(&req.Instance.Status.RelatedObjects, *objectRef); err != nil {
+		return NewEnsureResult(req.Instance).Error(err)
+	}
+	req.StatusDirty = true
+
 	return nil
 }
 


### PR DESCRIPTION
When an ImageStream is deleted for any reason, it stays in the relatedObjects list in the HypeConverged Status.

This PR fixes this issue, and remove the deleted imageStreams from the relatedObject list.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug with ImageStreams in relatedObjects
```
