### PR TITLE
[release-1.11] dataImportCronTemplates: Remove CentOS 7 & stream 8

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -1,26 +1,6 @@
 - metadata:
     annotations:
       cdi.kubevirt.io/storage.bind.immediate.requested: "true"
-    name: centos-stream8-image-cron
-    labels:
-      instancetype.kubevirt.io/default-preference: centos.stream8
-      instancetype.kubevirt.io/default-instancetype: u1.medium
-  spec:
-    schedule: "0 */12 * * *"
-    template:
-      spec:
-        source:
-          registry:
-            url: docker://quay.io/containerdisks/centos-stream:8
-        storage:
-          resources:
-            requests:
-              storage: 10Gi
-    garbageCollect: Outdated
-    managedDataSource: centos-stream8
-- metadata:
-    annotations:
-      cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: centos-stream9-image-cron
     labels:
       instancetype.kubevirt.io/default-preference: centos.stream9
@@ -58,23 +38,3 @@
               storage: 5Gi
     garbageCollect: Outdated
     managedDataSource: fedora
-- metadata:
-    annotations:
-      cdi.kubevirt.io/storage.bind.immediate.requested: "true"
-    name: centos-7-image-cron
-    labels:
-      instancetype.kubevirt.io/default-preference: centos.7
-      instancetype.kubevirt.io/default-instancetype: u1.medium
-  spec:
-    schedule: "0 */12 * * *"
-    template:
-      spec:
-        source:
-          registry:
-            url: docker://quay.io/containerdisks/centos:7-2009
-        storage:
-          resources:
-            requests:
-              storage: 10Gi
-    garbageCollect: Outdated
-    managedDataSource: centos7

--- a/build/Dockerfile.okd
+++ b/build/Dockerfile.okd
@@ -7,6 +7,6 @@ COPY hack/testFiles/test_quickstart.yaml quickStart/
 COPY hack/testFiles/test_dashboard_cm.yaml dashboard/
 COPY assets/ .
 COPY ci-test-files/dataImportCronTemplatesWithImageStream.yaml dataImportCronTemplates/
-COPY ci-test-files/centos8-imagestream.yaml imageStreams/
+COPY ci-test-files/centos9-stream-imagestream.yaml imageStreams/
 
 ENTRYPOINT /usr/bin/hyperconverged-cluster-operator

--- a/ci-test-files/centos9-stream-imagestream.yaml
+++ b/ci-test-files/centos9-stream-imagestream.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: centos8
+  name: centos-stream9
   namespace: kubevirt-os-images
 spec:
   lookupPolicy:
@@ -10,7 +10,7 @@ spec:
   - annotations: null
     from:
       kind: DockerImage
-      name: quay.io/kubevirt/centos8-container-disk-images
+      name: quay.io/containerdisks/centos-stream:9
     importPolicy:
       scheduled: true
       importMode: Legacy

--- a/ci-test-files/dataImportCronTemplatesWithImageStream.yaml
+++ b/ci-test-files/dataImportCronTemplatesWithImageStream.yaml
@@ -1,16 +1,16 @@
 - metadata:
-    name: centos8-image-cron-is
+    name: centos-stream9-image-cron-is
   spec:
     schedule: "0 */12 * * *"
     template:
       spec:
         source:
           registry:
-            imageStream: "centos8"
+            imageStream: "centos-stream9"
             pullMethod: node
         storage:
           resources:
             requests:
               storage: 10Gi
     garbageCollect: Outdated
-    managedDataSource: centos8-is
+    managedDataSource: centos-stream9-is

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -53,13 +53,13 @@ var (
 		Resource: "ssps",
 	}
 
-	expectedImages       = []string{"centos-stream9-image-cron", "centos8-image-cron-is", "fedora-image-cron"}
+	expectedImages       = []string{"centos-stream9-image-cron", "centos-stream9-image-cron-is", "fedora-image-cron"}
 	imageNamespace       = defaultImageNamespace
 	expectedImageStreams = []tests.ImageStreamConfig{
 		{
-			Name:         "centos8",
-			RegistryName: "quay.io/kubevirt/centos8-container-disk-images",
-			UsageImages:  []string{"centos8-image-cron-is"},
+			Name:         "centos-stream9",
+			RegistryName: "quay.io/containerdisks/centos-stream:9",
+			UsageImages:  []string{"centos-stream9-image-cron-is"},
 		},
 	}
 )

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -53,7 +53,7 @@ var (
 		Resource: "ssps",
 	}
 
-	expectedImages       = []string{"centos-7-image-cron", "centos-stream8-image-cron", "centos-stream9-image-cron", "centos8-image-cron-is", "fedora-image-cron"}
+	expectedImages       = []string{"centos-stream9-image-cron", "centos8-image-cron-is", "fedora-image-cron"}
 	imageNamespace       = defaultImageNamespace
 	expectedImageStreams = []tests.ImageStreamConfig{
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual backport of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3048.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-45848
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CentOS 7 & CentOS stream 8 are now EOL so the associated `DataImportCronTemplates` have been removed
```
