### PR TITLE
[release-1.9] dataImportCronTemplates: Remove CentOS 7 & stream 8

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -1,26 +1,6 @@
 - metadata:
     annotations:
       cdi.kubevirt.io/storage.bind.immediate.requested: "true"
-    name: centos-stream8-image-cron
-    labels:
-      instancetype.kubevirt.io/default-preference: centos.8.stream
-      instancetype.kubevirt.io/default-instancetype: server.medium
-  spec:
-    schedule: "0 */12 * * *"
-    template:
-      spec:
-        source:
-          registry:
-            url: docker://quay.io/containerdisks/centos-stream:8
-        storage:
-          resources:
-            requests:
-              storage: 10Gi
-    garbageCollect: Outdated
-    managedDataSource: centos-stream8
-- metadata:
-    annotations:
-      cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: centos-stream9-image-cron
     labels:
       instancetype.kubevirt.io/default-preference: centos.9.stream
@@ -58,23 +38,3 @@
               storage: 5Gi
     garbageCollect: Outdated
     managedDataSource: fedora
-- metadata:
-    annotations:
-      cdi.kubevirt.io/storage.bind.immediate.requested: "true"
-    name: centos-7-image-cron
-    labels:
-      instancetype.kubevirt.io/default-preference: centos.7
-      instancetype.kubevirt.io/default-instancetype: server.medium
-  spec:
-    schedule: "0 */12 * * *"
-    template:
-      spec:
-        source:
-          registry:
-            url: docker://quay.io/containerdisks/centos:7-2009
-        storage:
-          resources:
-            requests:
-              storage: 10Gi
-    garbageCollect: Outdated
-    managedDataSource: centos7

--- a/build/Dockerfile.okd
+++ b/build/Dockerfile.okd
@@ -7,6 +7,6 @@ COPY hack/testFiles/test_quickstart.yaml quickStart/
 COPY hack/testFiles/test_dashboard_cm.yaml dashboard/
 COPY assets/ .
 COPY ci-test-files/dataImportCronTemplatesWithImageStream.yaml dataImportCronTemplates/
-COPY ci-test-files/centos8-imagestream.yaml imageStreams/
+COPY ci-test-files/centos9-stream-imagestream.yaml imageStreams/
 
 ENTRYPOINT /usr/bin/hyperconverged-cluster-operator

--- a/ci-test-files/centos9-stream-imagestream.yaml
+++ b/ci-test-files/centos9-stream-imagestream.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: centos8
+  name: centos-stream9
   namespace: kubevirt-os-images
 spec:
   lookupPolicy:
@@ -10,7 +10,7 @@ spec:
   - annotations: null
     from:
       kind: DockerImage
-      name: quay.io/kubevirt/centos8-container-disk-images
+      name: quay.io/containerdisks/centos-stream:9
     importPolicy:
       scheduled: true
       importMode: Legacy

--- a/ci-test-files/dataImportCronTemplatesWithImageStream.yaml
+++ b/ci-test-files/dataImportCronTemplatesWithImageStream.yaml
@@ -1,16 +1,16 @@
 - metadata:
-    name: centos8-image-cron-is
+    name: centos-stream9-image-cron-is
   spec:
     schedule: "0 */12 * * *"
     template:
       spec:
         source:
           registry:
-            imageStream: "centos8"
+            imageStream: "centos-stream9"
             pullMethod: node
         storage:
           resources:
             requests:
               storage: 10Gi
     garbageCollect: Outdated
-    managedDataSource: centos8-is
+    managedDataSource: centos-stream9-is

--- a/hack/check_golden_images.sh
+++ b/hack/check_golden_images.sh
@@ -23,19 +23,15 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
   ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o yaml"
 
   ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.featureGates.enableCommonBootImageImport}'
-  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-stream8-image-cron")'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-stream9-image-cron")'
-  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-7-image-cron")'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="fedora-image-cron")'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron-is")'
 
-  ./hack/retry.sh 10 30 "[[ \$(count_data_import_crons) -eq 5 ]]" "${KUBECTL_BINARY} get DataImportCron -A"
+  ./hack/retry.sh 10 30 "[[ \$(count_data_import_crons) -eq 3 ]]" "${KUBECTL_BINARY} get DataImportCron -A"
 
   ${KUBECTL_BINARY} get DataImportCron -n ${IMAGES_NS}
 
-  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-stream8-image-cron
   ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-stream9-image-cron
-  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-7-image-cron
   ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} fedora-image-cron
   ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos8-image-cron-is || true
 
@@ -58,5 +54,5 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
   [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
 
   # make sure all the DataImportCrons are back
-  ./hack/retry.sh 10 30 "[[ \$(count_data_import_crons) -eq 5 ]]" "${KUBECTL_BINARY} get DataImportCron -A"
+  ./hack/retry.sh 10 30 "[[ \$(count_data_import_crons) -eq 3 ]]" "${KUBECTL_BINARY} get DataImportCron -A"
 fi

--- a/hack/check_golden_images.sh
+++ b/hack/check_golden_images.sh
@@ -13,19 +13,19 @@ export -f count_data_import_crons
 if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
 
   # test image streams
-  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
-  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
+  [[ $(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
+  [[ "$(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/containerdisks/centos-stream:9"}' ]]
 
   # check that HCO reconciles the image stream
-  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch imageStream -n ${IMAGES_NS} centos8 --type=json -p '[{\"op\": \"add\", \"path\": \"/metadata/labels/test-label\", \"value\": \"test\"}]'"
+  ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch imageStream -n ${IMAGES_NS} centos-stream9 --type=json -p '[{\"op\": \"add\", \"path\": \"/metadata/labels/test-label\", \"value\": \"test\"}]'"
   sleep 10
   # HCO expect to remove the test-label label from the image stream
-  ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos8 -o yaml"
+  ./hack/retry.sh 10 3 "[[ -z '$(${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos-stream9 -o jsonpath='{.metadata.labels.test-label}')' ]]" "${KUBECTL_BINARY} get imageStream -n ${IMAGES_NS} centos-stream9 -o yaml"
 
   ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o jsonpath='{.spec.featureGates.enableCommonBootImageImport}'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-stream9-image-cron")'
   ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="fedora-image-cron")'
-  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos8-image-cron-is")'
+  ${KUBECTL_BINARY} get ssp -n "${INSTALLED_NAMESPACE}" ssp-kubevirt-hyperconverged -o jsonpath='{.spec.commonTemplates.dataImportCronTemplates}' | jq -e '.[] |select(.metadata.name=="centos-stream9-image-cron-is")'
 
   ./hack/retry.sh 10 30 "[[ \$(count_data_import_crons) -eq 3 ]]" "${KUBECTL_BINARY} get DataImportCron -A"
 
@@ -33,16 +33,16 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
 
   ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-stream9-image-cron
   ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} fedora-image-cron
-  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos8-image-cron-is || true
+  ${KUBECTL_BINARY} get DataImportCron -o yaml -n ${IMAGES_NS} centos-stream9-image-cron-is || true
 
-  [[ $(${KUBECTL_BINARY} get DataImportCron -o json -n ${IMAGES_NS} centos8-image-cron-is | jq -cM '.spec.template.spec.source.registry') == '{"imageStream":"centos8","pullMethod":"node"}' ]]
+  [[ $(${KUBECTL_BINARY} get DataImportCron -o json -n ${IMAGES_NS} centos-stream9-image-cron-is | jq -cM '.spec.template.spec.source.registry') == '{"imageStream":"centos-stream9","pullMethod":"node"}' ]]
 
   # disable the feature
   ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n \"${INSTALLED_NAMESPACE}\" --type=json kubevirt-hyperconverged -p '[{ \"op\": \"replace\", \"path\": \"/spec/featureGates/enableCommonBootImageImport\", \"value\": false }]'"
   sleep 10
 
   # check that the image streams and the DataImportCron were removed
-  ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 0 ]]"
+  ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} --no-headers | wc -l) -eq 0 ]]"
   ./hack/retry.sh 10 3 "[[ $(${KUBECTL_BINARY} get DataImportCron -A --no-headers | wc -l) -eq 0 ]]"
 
   # enable it back
@@ -50,8 +50,8 @@ if [[ $(${KUBECTL_BINARY} get ssp -n ${INSTALLED_NAMESPACE}) ]]; then
   sleep 10
 
   # test image streams
-  [[ $(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
-  [[ "$(${KUBECTL_BINARY} get imageStream centos8  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/kubevirt/centos8-container-disk-images"}' ]]
+  [[ $(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} --no-headers | wc -l) -eq 1 ]]
+  [[ "$(${KUBECTL_BINARY} get imageStream centos-stream9  -n ${IMAGES_NS} -o json | jq -cM '.spec.tags[0].from')" == '{"kind":"DockerImage","name":"quay.io/containerdisks/centos-stream:9"}' ]]
 
   # make sure all the DataImportCrons are back
   ./hack/retry.sh 10 30 "[[ \$(count_data_import_crons) -eq 3 ]]" "${KUBECTL_BINARY} get DataImportCron -A"

--- a/tests/func-tests/dict_test.go
+++ b/tests/func-tests/dict_test.go
@@ -171,14 +171,14 @@ func getDICT() hcov1beta1.DataImportCronTemplate {
 		},
 		Spec: &cdiv1beta1.DataImportCronSpec{
 			GarbageCollect:    &gcType,
-			ManagedDataSource: "centos7",
+			ManagedDataSource: "centos-stream9",
 			Schedule:          "18 1/12 * * *",
 			Template: cdiv1beta1.DataVolume{
 				Spec: cdiv1beta1.DataVolumeSpec{
 					Source: &cdiv1beta1.DataVolumeSource{
 						Registry: &cdiv1beta1.DataVolumeSourceRegistry{
 							PullMethod: &pullMethod,
-							URL:        pointer.String("docker://quay.io/containerdisks/centos:7-2009"),
+							URL:        pointer.String("docker://quay.io/containerdisks/centos-stream:9"),
 						},
 					},
 					Storage: &cdiv1beta1.StorageSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual backport of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3048.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-45851
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CentOS 7 & CentOS stream 8 are now EOL so the associated `DataImportCronTemplates` have been removed
```
