### PR TITLE
kubevirtci lanes: run in a pod

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -14,11 +14,5 @@ make cluster-up
 trap '{ make cluster-down; }' EXIT SIGINT SIGTERM SIGSTOP
 
 make cluster-sync
-make ci-functest
-
-# Upgrade test requires OLM which is currently
-# only available with okd providers
-if [[ $TARGET =~ okd-.* || $TARGET =~ ocp-.* ]]; then
-  make upgrade-test
-  make ci-functest
-fi
+export KUBECONFIG=$(_kubevirtci/cluster-up/kubeconfig.sh)
+JOB_TYPE="stdci" GINKGO_LABELS=${GINKGO_LABELS} make functest

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -28,4 +28,5 @@ ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git
 ARG git_sha=NONE
 
 LABEL multi.GIT_URL=${git_url} \
-      multi.GIT_SHA=${git_sha}
+      multi.GIT_SHA=${git_sha} \
+      app=hyperconverged-cluster-operator

--- a/build/Dockerfile.artifacts
+++ b/build/Dockerfile.artifacts
@@ -46,7 +46,8 @@ ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git
 ARG git_sha=NONE
 
 LABEL multi.GIT_URL=${git_url} \
-      multi.GIT_SHA=${git_sha}
+      multi.GIT_SHA=${git_sha} \
+      app=virt-artifacts-server
 
 CMD if [[ -d "/proc/sys/net/ipv4" && -d "/proc/sys/net/ipv6" ]]; \
     then \

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -29,4 +29,5 @@ ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git
 ARG git_sha=NONE
 
 LABEL multi.GIT_URL=${git_url} \
-      multi.GIT_SHA=${git_sha}
+      multi.GIT_SHA=${git_sha} \
+      app=hyperconverged-cluster-functest

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -26,4 +26,5 @@ ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git
 ARG git_sha=NONE
 
 LABEL multi.GIT_URL=${git_url} \
-      multi.GIT_SHA=${git_sha}
+      multi.GIT_SHA=${git_sha} \
+      app=hyperconverged-cluster-webhook

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.30'}
-export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+export LATEST_KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-${LATEST_KUBEVIRTCI_TAG}}
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 

--- a/deploy/webhooks.yaml
+++ b/deploy/webhooks.yaml
@@ -56,6 +56,59 @@ webhooks:
     scope: '*'
   sideEffects: None
   timeoutSeconds: 30
+- admissionReviewVersions:
+    - v1beta1
+    - v1
+  clientConfig:
+    # caBundle: WILL BE INJECTED BY CERT-MANAGER BECAUSE OF THE ANNOTATION
+    service:
+      name: hyperconverged-cluster-webhook-service
+      namespace: kubevirt-hyperconverged
+      path: /mutate-ns-hco-kubevirt-io
+      port: 4343
+  failurePolicy: Fail
+  name: mutate-ns-hco.kubevirt.io
+  objectSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: kubevirt-hyperconverged
+  rules:
+    - apiGroups:
+        - ""
+      apiVersions:
+        - v1
+      operations:
+        - DELETE
+      resources:
+        - namespaces
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
+  #type: MutatingAdmissionWebhook
+- admissionReviewVersions:
+    - v1beta1
+    - v1
+  clientConfig:
+    # caBundle: WILL BE INJECTED BY CERT-MANAGER BECAUSE OF THE ANNOTATION
+    service:
+      name: hyperconverged-cluster-webhook-service
+      namespace: kubevirt-hyperconverged
+      path: /mutate-hco-kubevirt-io-v1beta1-hyperconverged
+      port: 4343
+  failurePolicy: Fail
+  name: mutate-hyperconverged-hco.kubevirt.io
+  rules:
+    - apiGroups:
+        - hco.kubevirt.io
+      apiVersions:
+        - v1alpha1
+        - v1beta1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - hyperconvergeds
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
+  #type: MutatingAdmissionWebhook
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -31,7 +31,7 @@ CNA_URL_PREFIX="https://github.com/kubevirt/cluster-network-addons-operator/rele
 
 mem_size=${KUBEVIRT_MEMORY_SIZE:-5120M}
 num_nodes=${KUBEVIRT_NUM_NODES:-1}
-KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.17}
+KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.30}
 BASE_PATH=${KUBEVIRTCI_CONFIG_PATH:-$PWD}
 KUBEVIRTCI_PATH=$(kubevirtci::path)
 CMD=${CMD:-}

--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -5,6 +5,7 @@ set -exuo pipefail
 
 INSTALLED_NAMESPACE=${INSTALLED_NAMESPACE:-"kubevirt-hyperconverged"}
 OUTPUT_DIR=${ARTIFACT_DIR:-"$(pwd)/_out"}
+FUNCTEST_IMAGE=${FUNCTEST_IMAGE:-}
 
 source hack/common.sh
 source cluster/kubevirtci.sh
@@ -17,7 +18,7 @@ if [ "${JOB_TYPE}" == "stdci" ]; then
     KUBECTL_BINARY="cluster/kubectl.sh"
 fi
 
-if [[ ${JOB_TYPE} = "prow" ]]; then
+if [[ ${JOB_TYPE} = "prow" && -n ${FUNCTEST_IMAGE} ]]; then
     KUBECTL_BINARY="oc"
     computed_test_image=${FUNCTEST_IMAGE}
 else
@@ -126,4 +127,4 @@ echo "Exiting... Exit code: $exitCode"
 
 # Brutally delete HCO removing the namespace where it's running"
 source hack/test_delete_ns.sh
-test_delete_ns
+CMD=${KUBECTL_BINARY} test_delete_ns


### PR DESCRIPTION
Run the functional test from a pod, as done in openshift-ci lanes, to get the same tests.

Enable the namespace webhook in K8s, and enable the delete namespace functional test.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
