### PR TITLE
API: Use new token generation SSP API and remove feature gate

### DIFF
--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -158,7 +158,9 @@ func NewSSP(hc *hcov1beta1.HyperConverged, opts ...string) (*sspv1beta2.SSP, []h
 	}
 
 	if hc.Spec.FeatureGates.DeployVMConsoleProxy != nil {
-		spec.FeatureGates.DeployVmConsoleProxy = *hc.Spec.FeatureGates.DeployVMConsoleProxy
+		spec.TokenGenerationService = &sspv1beta2.TokenGenerationService{
+			Enabled: *hc.Spec.FeatureGates.DeployVMConsoleProxy,
+		}
 	}
 
 	// Disable common-instancetypes deployment by SSP from 4.16, now handled by virt-operator

--- a/controllers/operands/ssp_test.go
+++ b/controllers/operands/ssp_test.go
@@ -196,7 +196,8 @@ var _ = Describe("SSP Operands", func() {
 			expectedResource, _, err := NewSSP(hco)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(expectedResource.Spec.FeatureGates.DeployVmConsoleProxy).To(BeTrue())
+			Expect(expectedResource.Spec.TokenGenerationService).ToNot(BeNil())
+			Expect(expectedResource.Spec.TokenGenerationService.Enabled).To(BeTrue())
 		})
 
 		It("should create with deployCommonInstancetypes feature gate disabled", func() {

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -166,9 +166,6 @@ the [dataImportCronTemplates field](#configure-custom-golden-images), even if th
 Set the `deployVmConsoleProxy` feature gate to true to allow SSP operator to deploy its resources. SSP operator will 
 deploy a proxy that provides an access to the VNC console of a KubeVirt Virtual Machine (VM).
 
-**Note**: Once `deployVmConsoleProxy` is set to true, SSP operator will not delete deployed resources if `deployVmConsoleProxy` is 
-reverted back to false.
-
 **Default**: `false`
 
 ### deployKubeSecondaryDNS Feature Gate


### PR DESCRIPTION

**What this PR does / why we need it**:
The token generation API was stabilized in the SSP, and feature gate was removed:
https://github.com/kubevirt/ssp-operator/pull/1018

This PR removes the same feature gate from HCO, and adds a new field in the .spec to enable this feature.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-45065
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- The feature gate "deployVmConsoleProxy" was deprecated and is now ignored.
- Added a new field ".spec.enableTokenGenerationApi" to enable the token generation API.
```
