### PR TITLE
Bump OPM to v1.47.0

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -20,7 +20,7 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       REGISTRY_NAMESPACE: kubevirt
-      OPM_VERSION: v1.35.0
+      OPM_VERSION: v1.47.0
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v4

--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -73,7 +73,7 @@ function create_file_based_catalog() {
 
   rm -rf fbc-catalog
   mkdir fbc-catalog
-  ${OPM} alpha render-template semver index-template.yaml > fbc-catalog/catalog.json
+  ${OPM} alpha render-template semver --migrate-level=bundle-object-to-csv-metadata index-template.yaml > fbc-catalog/catalog.json
   ${OPM} validate fbc-catalog
   rm -f fbc-catalog.Dockerfile
   ${OPM} generate dockerfile fbc-catalog


### PR DESCRIPTION
From OCP 4.17, the index image should contain `olm.csv.metadata` instead of `olm.bundle.object`, as was in previous versions.

the few latest OPM didn't support this, but from OPM 1.47, we can use the `--migrate-level=bundle-object-to-csv-metadata` flag to create the desired FBC index image.

This PR bumps OPM to the latest version and add the `--migrate-level=bundle-object-to-csv-metadata` flag, when running it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-46910
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump OPM to v1.47.0
```
