### PR TITLE
Enable VolumesUpdateStrategy and VolumeMigration FGs on Kubevirt

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -213,6 +213,8 @@ var _ = Describe("HyperconvergedController", func() {
 					"NetworkBindingPlugins",
 					"CommonInstancetypesDeploymentGate",
 					"VMLiveUpdateFeatures",
+					"VolumesUpdateStrategy",
+					"VolumeMigration",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -115,6 +115,12 @@ const (
 
 	// Enable VM live update, to allow live propagation of VM changes to their VMI
 	kvVMLiveUpdateFeatures = "VMLiveUpdateFeatures"
+
+	// kvVolumesUpdateStrategy enables to specify the strategy on the volume updates.
+	kvVolumesUpdateStrategy = "VolumesUpdateStrategy"
+
+	// kvVolumeMigration enables to migrate the storage. It depends on the kvVolumesUpdateStrategy feature.
+	kvVolumeMigration = "VolumeMigration"
 )
 
 const (
@@ -139,6 +145,8 @@ var (
 		kvHNetworkBindingPluginsGate,
 		kvDeployCommonInstancetypes,
 		kvVMLiveUpdateFeatures,
+		kvVolumesUpdateStrategy,
+		kvVolumeMigration,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of


### PR DESCRIPTION
Enable VolumesUpdateStrategy and VolumeMigration
feature gates on KubeVirt opinionated deployment.


**What this PR does / why we need it**:
Enable VolumesUpdateStrategy and VolumeMigration
feature gates on KubeVirt opinionated deployment.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable VolumesUpdateStrategy and VolumeMigration feature gates on KubeVirt opinionated deployment.
```
