### PR TITLE
unit-tests: Invoke unit tests using go test directly instead of ginkgo cli

### DIFF
--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -8,14 +8,13 @@ JOB_TYPE="${JOB_TYPE:-}"
 if [ "${JOB_TYPE}" == "travis" ]; then
     go get -v -t ./...
     go install github.com/mattn/goveralls@latest
-    go install github.com/onsi/ginkgo/v2/ginkgo@$(grep github.com/onsi/ginkgo go.mod | cut -d " " -f2)
     go mod vendor
     PKG_PACKAGE_PATH="./pkg/"
     CONTROLLERS_PACKAGE_PATH="./controllers/"
     mkdir -p coverprofiles
     # Workaround - run tests on webhooks first to prevent failure when running all the test in the following line.
-    ginkgo -r ${PKG_PACKAGE_PATH}webhooks
-    ginkgo -cover -output-dir=./coverprofiles -coverprofile=cover.coverprofile -r ${PKG_PACKAGE_PATH} -r ${CONTROLLERS_PACKAGE_PATH}
+    go test ${PKG_PACKAGE_PATH}webhooks/...
+    go test -v -outputdir=./coverprofiles -coverprofile=cover.coverprofile ${PKG_PACKAGE_PATH}... ${CONTROLLERS_PACKAGE_PATH}...
 else
     test_path="./tests/func-tests"
     GOFLAGS='' go install github.com/onsi/ginkgo/v2/ginkgo@$(grep github.com/onsi/ginkgo go.mod | cut -d " " -f2)


### PR DESCRIPTION
Saves having to install the gingko cli for unit tests. Additionally, this brings HCO more in line with how the kubevirt/cdi invokes unit-tests with go.
Lastly invoking the tests with ginkgo on s390x causes it to randomly hang forever.

Please note if you compare the output of the coverprofiles, that golang since 1.23 also adds uncovered packages to the output.
This means that with this change, packages without tests will now be reported as 0%.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Switches out the ginkgo cli command for invoking unit-tests with the equivalent go command.
This fixes the test hanging on s390x on random points when invoking it via ginkgo.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [x] PR Message
- [x] Commit Messages
- [x] How to test
- [x] Unit Tests
- [x] Functional Tests
- [x] User Documentation
- [x] Developer Documentation
- [x] Upgrade Scenario
- [x] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
