### PR TITLE
fix: Allow disabling of common data import crons

### DIFF
--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -284,6 +284,10 @@ func isDataImportCronTemplateEnabled(dict hcov1beta1.DataImportCronTemplate) boo
 
 func getCustomDicts(list []hcov1beta1.DataImportCronTemplateStatus, crDicts map[string]hcov1beta1.DataImportCronTemplate) []hcov1beta1.DataImportCronTemplateStatus {
 	for dictName, crDict := range crDicts {
+		if !isDataImportCronTemplateEnabled(crDict) {
+			continue
+		}
+
 		if _, isCommon := dataImportCronTemplateHardCodedMap[dictName]; !isCommon {
 			list = append(list, hcov1beta1.DataImportCronTemplateStatus{
 				DataImportCronTemplate: *crDict.DeepCopy(),

--- a/controllers/operands/ssp_test.go
+++ b/controllers/operands/ssp_test.go
@@ -764,6 +764,29 @@ var _ = Describe("SSP Operands", func() {
 					Expect(goldenImageList).To(ContainElements(*statusImage2Enabled, statusImage3, statusImage4))
 				})
 
+				It("should not add user DIC template if it is disabled", func() {
+					dataImportCronTemplateHardCodedMap = nil
+					hco := commontestutils.NewHco()
+					hco.Spec.FeatureGates.EnableCommonBootImageImport = ptr.To(true)
+
+					disabledUserImage := image1.DeepCopy()
+					disableDict(disabledUserImage)
+					enabledUserImage := image2.DeepCopy()
+					enableDict(enabledUserImage)
+
+					hco.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{*disabledUserImage, *enabledUserImage}
+					goldenImageList, err := getDataImportCronTemplates(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(goldenImageList).To(HaveLen(1))
+
+					statusImageEnabled := hcov1beta1.DataImportCronTemplateStatus{
+						DataImportCronTemplate: *enabledUserImage,
+						Status:                 hcov1beta1.DataImportCronStatus{},
+					}
+
+					Expect(goldenImageList).To(ContainElements(statusImageEnabled))
+				})
+
 				It("Should reject if the CR list contain DIC templates with the same name, when there are also common DIC templates", func() {
 					dataImportCronTemplateHardCodedMap = map[string]hcov1beta1.DataImportCronTemplate{
 						image1.Name: image1,


### PR DESCRIPTION
**What this PR does / why we need it**:
Some of the common data import crons can be disabled. Before this commit, the disabled data import crons were still added to SSP.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-49037
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
