### PR TITLE
pkg/monitoring/metrics: add new alert for vms using outdated machine type

### DIFF
--- a/pkg/monitoring/rules/alerts/operator_alerts.go
+++ b/pkg/monitoring/rules/alerts/operator_alerts.go
@@ -1,23 +1,31 @@
 package alerts
 
 import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
-	outOfBandUpdateAlert          = "KubeVirtCRModified"
-	unsafeModificationAlert       = "UnsupportedHCOModification"
-	installationNotCompletedAlert = "HCOInstallationIncomplete"
-	singleStackIPv6Alert          = "SingleStackIPv6Unsupported"
-	MisconfiguredDeschedulerAlert = "HCOMisconfiguredDescheduler"
-	severityAlertLabelKey         = "severity"
-	healthImpactAlertLabelKey     = "operator_health_impact"
+	outOfBandUpdateAlert              = "KubeVirtCRModified"
+	unsafeModificationAlert           = "UnsupportedHCOModification"
+	installationNotCompletedAlert     = "HCOInstallationIncomplete"
+	singleStackIPv6Alert              = "SingleStackIPv6Unsupported"
+	MisconfiguredDeschedulerAlert     = "HCOMisconfiguredDescheduler"
+	VMOutdatedMachineTypeAlert        = "VMHasOutdatedMachineType"
+	minSupportedVirtLauncherOSVersion = 8
+	severityAlertLabelKey             = "severity"
+	healthImpactAlertLabelKey         = "operator_health_impact"
 )
 
 func operatorAlerts() []promv1.Rule {
-	return []promv1.Rule{
+	rules := []promv1.Rule{
 		{
 			Alert: outOfBandUpdateAlert,
 			Expr:  intstr.FromString("sum by(component_name) ((round(increase(kubevirt_hco_out_of_band_modifications_total[10m]))>0 and kubevirt_hco_out_of_band_modifications_total offset 10m) or (kubevirt_hco_out_of_band_modifications_total != 0 unless kubevirt_hco_out_of_band_modifications_total offset 10m))"),
@@ -80,4 +88,51 @@ func operatorAlerts() []promv1.Rule {
 			},
 		},
 	}
+
+	if rule, created := createVMOutdatedMachineTypeRule(); created {
+		rules = append(rules, rule)
+	}
+
+	return rules
+}
+
+func createVMOutdatedMachineTypeRule() (promv1.Rule, bool) {
+	logger := logf.Log.WithName("operator-alerts")
+	rhelVersion, exists := os.LookupEnv("VIRT_LAUNCHER_OS_VERSION")
+	if !exists {
+		return promv1.Rule{}, false
+	}
+
+	virtLauncherOSVersion, err := strconv.Atoi(rhelVersion)
+	if err != nil {
+		logger.Error(err, "Error parsing VIRT_LAUNCHER_OS_VERSION")
+		return promv1.Rule{}, false
+	}
+
+	if virtLauncherOSVersion > minSupportedVirtLauncherOSVersion {
+		rule := promv1.Rule{
+			Alert: VMOutdatedMachineTypeAlert,
+			Expr:  intstr.FromString(getMachineTypeVersionExpr(minSupportedVirtLauncherOSVersion, virtLauncherOSVersion)),
+			Annotations: map[string]string{
+				"description": "There are virtual machines using an outdated machine type that need to be patched.",
+				"summary":     "{{ $value }} virtual machines are using an outdated machine type.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "none",
+			},
+		}
+		return rule, true
+	}
+
+	return promv1.Rule{}, false
+}
+
+func getMachineTypeVersionExpr(mn, mx int) string {
+	var versions []string
+	for v := mn; v < mx; v++ {
+		versions = append(versions, fmt.Sprintf(".*rhel%d.*", v))
+	}
+	vers := strings.Join(versions, "|")
+	return fmt.Sprintf(`count(kubevirt_vmi_info{guest_os_machine=~%q} and on(name, namespace) kubevirt_vm_info{status=~"Running|Stopped"}) > 0`, vers)
 }

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -20,13 +20,16 @@ import (
 	promConfig "github.com/prometheus/common/config"
 	promModel "github.com/prometheus/common/model"
 	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
@@ -190,6 +193,60 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			return alert
 		}).WithTimeout(60 * time.Second).WithPolling(time.Second).WithContext(ctx).ShouldNot(BeNil())
 		verifyOperatorHealthMetricValue(ctx, promClient, hcoClient, initialOperatorHealthMetricValue, warningImpact)
+	})
+
+	Context("VMHasOutdatedMachineType alert", func() {
+		const (
+			query  = `kubevirt_vmi_info{guest_os_machine=pc-q35-rhel8.4.0"}`
+			vmName = "test-vm-outdated-machine-type"
+		)
+
+		It("should fire the VMHasOutdatedMachineType alert when a VM is using an outdated machine type", func(ctx context.Context) {
+
+			ruleExists, err := checkVMOutdatedMachineTypeRuleExists(ctx, promClient)
+			Expect(err).ToNot(HaveOccurred())
+			if !ruleExists {
+				Skip("Skipping test because the VMHasOutdatedMachineType rule is not registered")
+			}
+
+			By("Ensuring the VMHasOutdatedMachineType alert doesnt exist before creating the VM")
+			Consistently(func(ctx context.Context) *promApiv1.Alert {
+				alerts, err := promClient.Alerts(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				alert := getAlertByName(alerts, hcoalerts.VMOutdatedMachineTypeAlert)
+				return alert
+			}).WithPolling(time.Second).WithTimeout(15 * time.Second).WithContext(ctx).Should(BeNil())
+
+			By("Creating a VM with an outdated machine type")
+			vm := &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmName,
+					Namespace: tests.TestNamespace,
+				},
+			}
+			vm.Spec.Template.Spec.Domain.Resources.Requests = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")}
+			vm.Spec.RunStrategy = ptr.To(kubevirtcorev1.RunStrategyOnce)
+			vm.Spec.Template.Spec.Domain.Machine = &kubevirtcorev1.Machine{Type: "pc-q35-rhel8.4.0"}
+			Expect(cli.Create(ctx, vm)).To(Succeed())
+
+			By("Checking that the metric for outdated machine types is set to 1.0")
+			Eventually(func(g Gomega, ctx context.Context) float64 {
+				valueAfter, err := hcoClient.GetHCOMetric(ctx, query)
+				g.Expect(err).NotTo(HaveOccurred())
+				return valueAfter
+			}).WithTimeout(60*time.Second).WithPolling(time.Second).WithContext(ctx).Should(
+				Equal(float64(1)),
+				"expected outdated machine type metric to be 1.0",
+			)
+
+			By("Checking the VMHasOutdatedMachineType alert")
+			Eventually(func(ctx context.Context) *promApiv1.Alert {
+				alerts, err := promClient.Alerts(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				alert := getAlertByName(alerts, hcoalerts.VMOutdatedMachineTypeAlert)
+				return alert
+			}).WithTimeout(60 * time.Second).WithPolling(time.Second).WithContext(ctx).ShouldNot(BeNil())
+		})
 	})
 
 	Describe("KubeDescheduler", Serial, Ordered, Label(tests.OpenshiftLabel, "monitoring"), func() {
@@ -498,4 +555,22 @@ func getPrometheusURL(ctx context.Context, cli rest.Interface) string {
 		Should(Succeed())
 
 	return fmt.Sprintf("https://%s", route.Spec.Host)
+}
+
+func checkVMOutdatedMachineTypeRuleExists(ctx context.Context, promClient promApiv1.API) (bool, error) {
+	rulesResult, err := promClient.Rules(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	for _, group := range rulesResult.Groups {
+		for _, rule := range group.Rules {
+			if alertingRule, ok := rule.(promApiv1.AlertingRule); ok {
+				if alertingRule.Name == hcoalerts.VMOutdatedMachineTypeAlert {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a new Prometheus alert for virtual machines (VMs) in the cluster that require a machine type update. For instance, VMs configured with the machine type set to RHEL 8 would be flagged as outdated. This is because the base image of the virt-launcher will transition to RHEL 10, which introduces breaking changes incompatible with older machine types.

Depends-On #3132, https://github.com/kubevirt/kubevirt/pull/13010

**Reviewer Checklist**

- [x] PR Message
- [x] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [x] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Release note**:
```release-note
None
```
