### PR TITLE
Fix the manual run of the bump bot, for specific branch

### DIFF
--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -25,7 +25,11 @@ jobs:
 
       - id: set_branches
         run: |
-          matrix=$(git for-each-ref --format='%(refname:short)' refs/remotes/origin | grep -e "origin/main" -e "origin/release-1.[0-9]\+$" | grep -v "release-1\.[0,1,2,3]$" | sed -r 's/origin\/(.*)/{"branch": "\1"}/g' | jq -s)
+          if [[ ${{ github.event_name }} == "workflow_dispatch" && ${{ github.ref }} != "refs/heads/main" ]]; then
+            matrix="[{\"branch\": \"${GITHUB_REF#refs/heads/}\"}]"
+          else
+            matrix=$(git for-each-ref --format='%(refname:short)' refs/remotes/origin | grep -e "origin/main" -e "origin/release-1.[0-9]\+$" | grep -v "release-1\.[0,1,2,3]$" | sed -r 's/origin\/(.*)/{"branch": "\1"}/g' | jq -s)
+          fi
           echo "matrix={\"branches\":$(echo $matrix)}" >> $GITHUB_OUTPUT
 
   bump_components_version:


### PR DESCRIPTION
If running the bump bot on a specific branch, the bot will still run for all the release branches.

After this fix, only if running on main, it will run for all branches.

This change should be back ported to all the release branches in order to take affect.

```release-note
None
```
