### PR TITLE
[Release 1.12] set kubevirtci tag to `2408151028-a0ad3359`

### DIFF
--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.28'}
-export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+export KUBEVIRTCI_TAG="2408151028-a0ad3359"
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 


### PR DESCRIPTION
Kubevirtci was modified and no longer works from older version of HCO. This PR set the kubevirtci tag to a working version.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
