### PR TITLE
[Release 1.10] Allow disabling of custom DICTs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ sanity: generate generate-doc validate-no-offensive-lang goimport lint-metrics
 	git difftool -y --trust-exit-code --extcmd=./hack/diff-csv.sh
 
 goimport:
-	go install golang.org/x/tools/cmd/goimports@latest
+	go install golang.org/x/tools/cmd/goimports@v0.24.0
 	goimports -w -local="kubevirt.io,github.com/kubevirt,github.com/kubevirt/hyperconverged-cluster-operator"  $(shell find . -type f -name '*.go' ! -path "*/vendor/*" ! -path "./_kubevirtci/*" ! -path "*zz_generated*" )
 
 

--- a/controllers/operands/ssp.go
+++ b/controllers/operands/ssp.go
@@ -300,6 +300,10 @@ func isDataImportCronTemplateEnabled(dict hcov1beta1.DataImportCronTemplate) boo
 
 func getCustomDicts(list []hcov1beta1.DataImportCronTemplateStatus, crDicts map[string]hcov1beta1.DataImportCronTemplate) []hcov1beta1.DataImportCronTemplateStatus {
 	for dictName, crDict := range crDicts {
+		if !isDataImportCronTemplateEnabled(crDict) {
+			continue
+		}
+
 		if _, isCommon := dataImportCronTemplateHardCodedMap[dictName]; !isCommon {
 			list = append(list, hcov1beta1.DataImportCronTemplateStatus{
 				DataImportCronTemplate: *crDict.DeepCopy(),

--- a/controllers/operands/ssp_test.go
+++ b/controllers/operands/ssp_test.go
@@ -701,6 +701,29 @@ var _ = Describe("SSP Operands", func() {
 					Expect(goldenImageList).To(ContainElements(*statusImage2Enabled, statusImage3, statusImage4))
 				})
 
+				It("should not add user DIC template if it is disabled", func() {
+					dataImportCronTemplateHardCodedMap = nil
+					hco := commontestutils.NewHco()
+					hco.Spec.FeatureGates.EnableCommonBootImageImport = pointer.Bool(true)
+
+					disabledUserImage := image1.DeepCopy()
+					disableDict(disabledUserImage)
+					enabledUserImage := image2.DeepCopy()
+					enableDict(enabledUserImage)
+
+					hco.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{*disabledUserImage, *enabledUserImage}
+					goldenImageList, err := getDataImportCronTemplates(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(goldenImageList).To(HaveLen(1))
+
+					statusImageEnabled := hcov1beta1.DataImportCronTemplateStatus{
+						DataImportCronTemplate: *enabledUserImage,
+						Status:                 hcov1beta1.DataImportCronStatus{},
+					}
+
+					Expect(goldenImageList).To(ContainElements(statusImageEnabled))
+				})
+
 				It("Should reject if the CR list contain DIC templates with the same name, when there are also common DIC templates", func() {
 					dataImportCronTemplateHardCodedMap = map[string]hcov1beta1.DataImportCronTemplate{
 						image1.Name: image1,


### PR DESCRIPTION
Manual cherry-pick of #3105 

Replaces #3113 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow disabling of custom DICTs
```
