### PR TITLE
Manage Creation of UI configuration ConfigMaps by HCO

### DIFF
--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -162,6 +162,78 @@
         "name": "mtqs.mtq.kubevirt.io",
         "namespace": ""
       }
+    },
+    {
+      "semverRange": "<1.14.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "v1",
+        "kind": "ConfigMap"
+      },
+      "objectKey": {
+        "name": "kubevirt-ui-features",
+        "namespace": "default"
+      }
+    },
+    {
+      "semverRange": "<1.14.0",
+      "groupVersionKind": {
+        "group": "",
+        "version": "v1",
+        "kind": "ConfigMap"
+      },
+      "objectKey": {
+        "name": "kubevirt-user-settings",
+        "namespace": "default"
+      }
+    },
+    {
+      "semverRange": "<1.14.0",
+      "groupVersionKind": {
+        "group": "rbac.authorization.k8s.io",
+        "version": "v1",
+        "kind": "Role"
+      },
+      "objectKey": {
+        "name": "kubevirt-ui-features-reader",
+        "namespace": "default"
+      }
+    },
+    {
+      "semverRange": "<1.14.0",
+      "groupVersionKind": {
+        "group": "rbac.authorization.k8s.io",
+        "version": "v1",
+        "kind": "RoleBinding"
+      },
+      "objectKey": {
+        "name": "kubevirt-ui-features-reader-binding",
+        "namespace": "default"
+      }
+    },
+    {
+      "semverRange": "<1.14.0",
+      "groupVersionKind": {
+        "group": "rbac.authorization.k8s.io",
+        "version": "v1",
+        "kind": "Role"
+      },
+      "objectKey": {
+        "name": "kubevirt-user-settings-reader",
+        "namespace": "default"
+      }
+    },
+    {
+      "semverRange": "<1.14.0",
+      "groupVersionKind": {
+        "group": "rbac.authorization.k8s.io",
+        "version": "v1",
+        "kind": "RoleBinding"
+      },
+      "objectKey": {
+        "name": "kubevirt-user-settings-reader-binding",
+        "namespace": "default"
+      }
     }
   ]
 }

--- a/cmd/cmdcommon/cmdcommon.go
+++ b/cmd/cmdcommon/cmdcommon.go
@@ -124,7 +124,7 @@ func (h HcCmdHelper) checkNameSpace() {
 	requiredNS, err := hcoutil.GetOperatorNamespaceFromEnv()
 	h.ExitOnError(err, "Failed to get namespace from the environment")
 
-	// Get the namespace the we are currently deployed in.
+	// Get the namespace we are currently deployed in.
 	var actualNS string
 	if !h.runInLocal {
 		var err error

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -244,7 +244,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 				// Check conditions
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(22))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(26))
 				expectedRef := corev1.ObjectReference{
 					Kind:            "PrometheusRule",
 					Namespace:       namespace,
@@ -332,7 +332,7 @@ var _ = Describe("HyperconvergedController", func() {
 				).ToNot(HaveOccurred())
 				// Check conditions
 
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(23))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(27))
 
 				expectedRef := corev1.ObjectReference{
 					Kind:            "MTQ",

--- a/controllers/operands/operandHandler.go
+++ b/controllers/operands/operandHandler.go
@@ -104,6 +104,11 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 		h.addOperands(scheme, hc, newKvUIProxyDeploymentHandler)
 		h.addOperands(scheme, hc, newKvUINginxCMHandler)
 		h.addOperands(scheme, hc, newKvUIPluginCRHandler)
+		h.addOperands(scheme, hc, newKvUIUserSettingsCMHandler)
+		h.addOperands(scheme, hc, newKvUIFeaturesCMHandler)
+		h.addOperands(scheme, hc, newKvUIConfigReaderRoleHandler)
+		h.addOperands(scheme, hc, newKvUIConfigReaderRoleBindingHandler)
+
 	}
 }
 

--- a/controllers/operands/virtio_win_ConfigMap.go
+++ b/controllers/operands/virtio_win_ConfigMap.go
@@ -18,7 +18,6 @@ import (
 const virtioWinCmName = "virtio-win"
 
 // **** Virtio-Win ConfigMap Handler ****
-
 func newVirtioWinCmHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
 	virtioWincm, err := NewVirtioWinCm(hc)
 	if err != nil {
@@ -28,7 +27,6 @@ func newVirtioWinCmHandler(_ log.Logger, Client client.Client, Scheme *runtime.S
 }
 
 // **** Virtio-Win ConfigMap Role Handler ****
-
 func newVirtioWinCmReaderRoleHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
 	virtioWinRole := NewVirtioWinCmReaderRole(hc)
 

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -755,6 +755,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - cdi.kubevirt.io
   resources:
@@ -767,6 +768,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - ssp.kubevirt.io
   resources:
@@ -779,6 +781,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - networkaddonsoperator.network.kubevirt.io
   resources:
@@ -791,6 +794,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - aaq.kubevirt.io
   resources:
@@ -803,6 +807,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -814,6 +819,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -835,6 +841,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -893,6 +900,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -924,6 +932,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - operators.coreos.com
   resources:
@@ -966,6 +975,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - config.openshift.io
   resources:
@@ -1009,6 +1019,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - route.openshift.io
   resources:
@@ -1020,6 +1031,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - operators.coreos.com
   resources:
@@ -1041,6 +1053,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - console.openshift.io
   resources:
@@ -1052,6 +1065,7 @@ rules:
   - create
   - update
   - delete
+  - patch
 - apiGroups:
   - operator.openshift.io
   resources:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.14.0/manifests/kubevirt-hyperconverged-operator.v1.14.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.14.0/manifests/kubevirt-hyperconverged-operator.v1.14.0.clusterserviceversion.yaml
@@ -225,6 +225,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - cdi.kubevirt.io
           resources:
@@ -237,6 +238,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - ssp.kubevirt.io
           resources:
@@ -249,6 +251,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - networkaddonsoperator.network.kubevirt.io
           resources:
@@ -261,6 +264,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - aaq.kubevirt.io
           resources:
@@ -273,6 +277,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -284,6 +289,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -305,6 +311,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -363,6 +370,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - apiextensions.k8s.io
           resources:
@@ -394,6 +402,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - operators.coreos.com
           resources:
@@ -436,6 +445,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - config.openshift.io
           resources:
@@ -479,6 +489,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - route.openshift.io
           resources:
@@ -490,6 +501,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - operators.coreos.com
           resources:
@@ -511,6 +523,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - console.openshift.io
           resources:
@@ -522,6 +535,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - operator.openshift.io
           resources:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.14.0/manifests/kubevirt-hyperconverged-operator.v1.14.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.14.0/manifests/kubevirt-hyperconverged-operator.v1.14.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.14.0-unstable
-    createdAt: "2024-10-09 05:05:23"
+    createdAt: "2024-10-10 16:49:38"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -225,6 +225,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - cdi.kubevirt.io
           resources:
@@ -237,6 +238,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - ssp.kubevirt.io
           resources:
@@ -249,6 +251,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - networkaddonsoperator.network.kubevirt.io
           resources:
@@ -261,6 +264,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - aaq.kubevirt.io
           resources:
@@ -273,6 +277,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -284,6 +289,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -305,6 +311,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -363,6 +370,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - apiextensions.k8s.io
           resources:
@@ -394,6 +402,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - operators.coreos.com
           resources:
@@ -436,6 +445,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - config.openshift.io
           resources:
@@ -479,6 +489,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - route.openshift.io
           resources:
@@ -490,6 +501,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - operators.coreos.com
           resources:
@@ -511,6 +523,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - console.openshift.io
           resources:
@@ -522,6 +535,7 @@ spec:
           - create
           - update
           - delete
+          - patch
         - apiGroups:
           - operator.openshift.io
           resources:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -607,7 +607,7 @@ func roleWithAllPermissions(apiGroup string, resources []string) rbacv1.PolicyRu
 	return rbacv1.PolicyRule{
 		APIGroups: stringListToSlice(apiGroup),
 		Resources: resources,
-		Verbs:     stringListToSlice("get", "list", "watch", "create", "update", "delete"),
+		Verbs:     stringListToSlice("get", "list", "watch", "create", "update", "delete", "patch"),
 	}
 }
 

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -81,15 +81,14 @@ const (
 type AppComponent string
 
 const (
-	AppComponentCompute     AppComponent = "compute"
-	AppComponentStorage     AppComponent = "storage"
-	AppComponentNetwork     AppComponent = "network"
-	AppComponentMonitoring  AppComponent = "monitoring"
-	AppComponentSchedule    AppComponent = "schedule"
-	AppComponentDeployment  AppComponent = "deployment"
-	AppComponentUIPlugin    AppComponent = "kubevirt-console-plugin"
-	AppComponentUIProxy     AppComponent = "kubevirt-apiserver-proxy"
-	AppComponentMultiTenant AppComponent = "multi-tenant"
-	AppComponentQuotaMngt   AppComponent = "quota-management"
-	AppComponentWasp        AppComponent = "wasp-agent"
+	AppComponentCompute    AppComponent = "compute"
+	AppComponentStorage    AppComponent = "storage"
+	AppComponentNetwork    AppComponent = "network"
+	AppComponentMonitoring AppComponent = "monitoring"
+	AppComponentSchedule   AppComponent = "schedule"
+	AppComponentDeployment AppComponent = "deployment"
+	AppComponentUIPlugin   AppComponent = "kubevirt-console-plugin"
+	AppComponentUIProxy    AppComponent = "kubevirt-apiserver-proxy"
+	AppComponentUIConfig   AppComponent = "kubevirt-ui-config"
+	AppComponentQuotaMngt  AppComponent = "quota-management"
 )


### PR DESCRIPTION
Currently, when kubevirt-hco is installed, the console-plugin configuration configmaps are created only when a cluster-admin opens the Virtualization tab for the first time. At that point two ConfigMaps are created in the installation namespace:
- kubevirt-user-settings
- kubevirt-ui-features

And also their RBACs to be reachable by regular users are created. Without login by an admin, the config maps are missing, and regular users cannot use the UI at that point.

This PR adds logic to create those configmaps and associated RBACs, if they are not already exist.
Also, remove the ConfigMaps from their previous location at the default namespace, used in v1.12.0 and below.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-49492
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Manage Creation of UI configuration ConfigMaps by HCO
```
