### PR TITLE
Skip observability controller tests if no SA TLS cert

### DIFF
--- a/controllers/observability/pod_disruption_budget_at_limit.go
+++ b/controllers/observability/pod_disruption_budget_at_limit.go
@@ -12,8 +12,11 @@ import (
 )
 
 const (
+	// ServiceAccountTlsCertPath is the path to the service account TLS certificate
+	// used for TLS communication with the alertmanager API
+	ServiceAccountTlsCertPath = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+
 	alertmanagerSvcHost = "https://alertmanager-main.openshift-monitoring.svc.cluster.local:9094"
-	tlsCertPath         = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 )
 
 func (r *Reconciler) ensurePodDisruptionBudgetAtLimitIsSilenced() error {
@@ -64,7 +67,7 @@ func (r *Reconciler) ensurePodDisruptionBudgetAtLimitIsSilenced() error {
 }
 
 func (r *Reconciler) NewAlertmanagerApi() (*alertmanager.Api, error) {
-	caCert, err := os.ReadFile(tlsCertPath)
+	caCert, err := os.ReadFile(ServiceAccountTlsCertPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read ca cert: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Stop tests from failing if setups without SA TLS certificates

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
none
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
