### PR TITLE
Refactor: Simplify adding operand handler

### DIFF
--- a/controllers/operands/conditionalHandler.go
+++ b/controllers/operands/conditionalHandler.go
@@ -65,3 +65,7 @@ func (ch *conditionalHandler) ensureDeleted(req *common.HcoRequest) *EnsureResul
 
 	return res.SetUpgradeDone(req.ComponentUpgradeInProgress)
 }
+
+func (ch *conditionalHandler) getFullCr(hc *v1beta1.HyperConverged) (client.Object, error) {
+	return ch.operand.getFullCr(hc)
+}

--- a/controllers/operands/imageStream.go
+++ b/controllers/operands/imageStream.go
@@ -116,6 +116,10 @@ func (iso imageStreamOperand) reset() {
 	iso.operand.reset()
 }
 
+func (iso imageStreamOperand) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+	return iso.operand.getFullCr(hc)
+}
+
 func newImageStreamHandler(Client client.Client, Scheme *runtime.Scheme, required *imagev1.ImageStream, origNS string) Operand {
 	return &imageStreamOperand{
 		operand: &genericOperand{

--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -46,41 +46,33 @@ const (
 )
 
 // **** Kubevirt UI Plugin Deployment Handler ****
-func newKvUIPluginDeploymentHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
-	return []Operand{newDeploymentHandler(Client, Scheme, NewKvUIPluginDeployment, hc)}, nil
+func newKvUIPluginDeploymentHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
+	return newDeploymentHandler(Client, Scheme, NewKvUIPluginDeployment, hc), nil
 }
 
 // **** Kubevirt UI apiserver proxy Deployment Handler ****
-func newKvUIProxyDeploymentHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
-	return []Operand{newDeploymentHandler(Client, Scheme, NewKvUIProxyDeployment, hc)}, nil
+func newKvUIProxyDeploymentHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
+	return newDeploymentHandler(Client, Scheme, NewKvUIProxyDeployment, hc), nil
 }
 
 // **** nginx config map Handler ****
-func newKvUINginxCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
-	kvUINginxCM := NewKVUINginxCM(hc)
-
-	return []Operand{newCmHandler(Client, Scheme, kvUINginxCM)}, nil
+func newKvUINginxCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
+	return newCmHandler(Client, Scheme, NewKVUINginxCM(hc)), nil
 }
 
 // **** UI user settings config map Handler ****
-func newKvUIUserSettingsCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
-	kvUIUserSettingsCM := NewKvUIUserSettingsCM(hc)
-
-	return []Operand{newCmHandler(Client, Scheme, kvUIUserSettingsCM)}, nil
+func newKvUIUserSettingsCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
+	return newCmHandler(Client, Scheme, NewKvUIUserSettingsCM(hc)), nil
 }
 
 // **** UI features config map Handler ****
-func newKvUIFeaturesCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
-	kvUIFeaturesCM := NewKvUIFeaturesCM(hc)
-
-	return []Operand{newCmHandler(Client, Scheme, kvUIFeaturesCM)}, nil
+func newKvUIFeaturesCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
+	return newCmHandler(Client, Scheme, NewKvUIFeaturesCM(hc)), nil
 }
 
 // **** Kubevirt UI Console Plugin Custom Resource Handler ****
-func newKvUIPluginCRHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
-	kvUIConsolePluginCR := NewKVConsolePlugin(hc)
-
-	return []Operand{newConsolePluginHandler(Client, Scheme, kvUIConsolePluginCR)}, nil
+func newKvUIPluginCRHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
+	return newConsolePluginHandler(Client, Scheme, NewKVConsolePlugin(hc)), nil
 }
 
 func NewKvUIPluginDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
@@ -433,17 +425,13 @@ func newConsolePluginHandler(Client client.Client, Scheme *runtime.Scheme, requi
 }
 
 // **** UI configuration (user settings and features) ConfigMap Role Handler ****
-func newKvUIConfigReaderRoleHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
-	KvUIConfigReaderRole := NewKvUIConfigCMReaderRole(hc)
-
-	return []Operand{newRoleHandler(Client, Scheme, KvUIConfigReaderRole)}, nil
+func newKvUIConfigReaderRoleHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
+	return newRoleHandler(Client, Scheme, NewKvUIConfigCMReaderRole(hc)), nil
 }
 
 // **** UI configuration (user settings and features) ConfigMap RoleBinding Handler ****
-func newKvUIConfigReaderRoleBindingHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
-	kvUIConfigReaderRoleBinding := NewKvUIConfigCMReaderRoleBinding(hc)
-
-	return []Operand{newRoleBindingHandler(Client, Scheme, kvUIConfigReaderRoleBinding)}, nil
+func newKvUIConfigReaderRoleBindingHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
+	return newRoleBindingHandler(Client, Scheme, NewKvUIConfigCMReaderRoleBinding(hc)), nil
 }
 
 func NewKvUIConfigCMReaderRole(hc *hcov1beta1.HyperConverged) *rbacv1.Role {

--- a/controllers/operands/kubevirtConsolePlugin_test.go
+++ b/controllers/operands/kubevirtConsolePlugin_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			cl := commontestutils.InitClient([]client.Object{})
 			handler, _ := newKvUIPluginCRHandler(logger, cl, commontestutils.GetScheme(), hco)
 
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -71,7 +71,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource, expectedConsoleConfig})
 			handler, _ := newKvUIPluginCRHandler(logger, cl, commontestutils.GetScheme(), hco)
 
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -93,7 +93,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource, expectedConsoleConfig})
 			handler, _ := newKvUIPluginCRHandler(logger, cl, commontestutils.GetScheme(), hco)
 
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -126,7 +126,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource, expectedConsoleConfig})
 			handler, _ := newKvUIPluginCRHandler(logger, cl, commontestutils.GetScheme(), hco)
 
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -151,7 +151,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource, expectedConsoleConfig})
 			handler, _ := newKvUIPluginCRHandler(logger, cl, commontestutils.GetScheme(), hco)
 
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -175,7 +175,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource, expectedConsoleConfig})
 			handler, _ := newKvUIPluginCRHandler(logger, cl, commontestutils.GetScheme(), hco)
 
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -203,7 +203,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
 			handler, _ := newKvUIPluginCRHandler(logger, cl, commontestutils.GetScheme(), hco)
 
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -271,10 +271,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			expectedResource := deploymentManifestor(hco)
 
 			cl := commontestutils.InitClient([]client.Object{})
-			handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+			handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 
-			res := handlers[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -303,10 +303,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			expectedResource := deploymentManifestor(hco)
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
-			handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+			handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 			Expect(err).ToNot(HaveOccurred())
 
-			res := handlers[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -340,10 +340,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Spec.Template.Spec.Containers[0].Image = "quay.io/fake/image:latest"
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+			handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 			Expect(err).ToNot(HaveOccurred())
-			res := handlers[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -389,10 +389,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Spec.Template.Labels[hcoutil.AppLabel] = "wrong label"
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+			handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 			Expect(err).ToNot(HaveOccurred())
-			res := handlers[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -447,10 +447,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				outdatedResource.Labels[userLabelKey] = userLabelValue
 
 				cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.UpgradeDone).To(BeFalse())
 				Expect(res.Err).ToNot(HaveOccurred())
 
@@ -484,10 +484,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				outdatedResource.Data[userAddedDataKey] = userAddedDataValue
 
 				cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.UpgradeDone).To(BeFalse())
 				Expect(res.Err).ToNot(HaveOccurred())
 
@@ -517,10 +517,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				hco.Spec.Infra.NodePlacement = commontestutils.NewOtherNodePlacement()
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 				Expect(err).ToNot(HaveOccurred())
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
 				Expect(res.Overwritten).To(BeFalse())
@@ -555,10 +555,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingResource := deploymentManifestor(hcoNodePlacement)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 				Expect(err).ToNot(HaveOccurred())
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
 				Expect(res.Overwritten).To(BeFalse())
@@ -599,10 +599,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				hco.Spec.Infra.NodePlacement.NodeSelector["key3"] = "something entirely else"
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 				Expect(err).ToNot(HaveOccurred())
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
 				Expect(res.Overwritten).To(BeFalse())
@@ -647,10 +647,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingResource.Spec.Template.Spec.NodeSelector["key3"] = "BADvalue3"
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 				Expect(err).ToNot(HaveOccurred())
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.UpgradeDone).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
 				Expect(res.Overwritten).To(BeTrue())
@@ -683,10 +683,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				hco.Spec.Infra.NodePlacement.NodeSelector = commontestutils.NewNodePlacement().NodeSelector
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 				Expect(err).ToNot(HaveOccurred())
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
 				Expect(res.Overwritten).To(BeFalse())
@@ -715,10 +715,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				hco.Spec.Infra.NodePlacement.Affinity = commontestutils.NewNodePlacement().Affinity
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 				Expect(err).ToNot(HaveOccurred())
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
 				Expect(res.Overwritten).To(BeFalse())
@@ -747,10 +747,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				hco.Spec.Infra.NodePlacement.Tolerations = commontestutils.NewNodePlacement().Tolerations
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 				Expect(err).ToNot(HaveOccurred())
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
 				Expect(res.Overwritten).To(BeFalse())
@@ -790,10 +790,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingResource.Spec.Replicas = ptr.To(int32(1))
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 				Expect(err).ToNot(HaveOccurred())
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
 				Expect(res.Overwritten).To(BeFalse())
@@ -834,10 +834,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingResource.Spec.Replicas = ptr.To(int32(3))
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handlers, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
+				handler, err := handlerFunc(logger, cl, commontestutils.GetScheme(), hco)
 
 				Expect(err).ToNot(HaveOccurred())
-				res := handlers[0].ensure(req)
+				res := handler.ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
 				Expect(res.Overwritten).To(BeFalse())

--- a/controllers/operands/operand.go
+++ b/controllers/operands/operand.go
@@ -39,10 +39,15 @@ type genericOperand struct {
 	hooks hcoResourceHooks
 }
 
-// Set of resource handler hooks, to be implement in each handler
-type hcoResourceHooks interface {
+type crGetter interface {
 	// Generate the required resource, with all the required fields)
 	getFullCr(*hcov1beta1.HyperConverged) (client.Object, error)
+}
+
+// Set of resource handler hooks, to be implement in each handler
+type hcoResourceHooks interface {
+	crGetter
+
 	// Generate an empty resource, to be used as the input of the client.Get method. After calling this method, it will
 	// contain the actual values in K8s.
 	getEmptyCr() client.Object
@@ -230,6 +235,10 @@ func (h *genericOperand) reset() {
 	if r, ok := h.hooks.(reseter); ok {
 		r.reset()
 	}
+}
+
+func (h *genericOperand) getFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+	return h.hooks.getFullCr(hc)
 }
 
 // handleComponentConditions - read and process a sub-component conditions.

--- a/controllers/operands/rbac.go
+++ b/controllers/operands/rbac.go
@@ -30,10 +30,10 @@ type roleHooks struct {
 	required *rbacv1.Role
 }
 
-func (h roleHooks) getFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *roleHooks) getFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
 	return h.required.DeepCopy(), nil
 }
-func (h roleHooks) getEmptyCr() client.Object {
+func (h *roleHooks) getEmptyCr() client.Object {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: h.required.Name,
@@ -68,7 +68,7 @@ func (h *roleHooks) updateCr(req *common.HcoRequest, Client client.Client, exist
 	return false, false, nil
 }
 
-func (roleHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
+func (*roleHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 // ********* Role Binding Handler *****************************
 

--- a/controllers/operands/virtio_win_ConfigMap.go
+++ b/controllers/operands/virtio_win_ConfigMap.go
@@ -18,26 +18,22 @@ import (
 const virtioWinCmName = "virtio-win"
 
 // **** Virtio-Win ConfigMap Handler ****
-func newVirtioWinCmHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
+func newVirtioWinCmHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
 	virtioWincm, err := NewVirtioWinCm(hc)
 	if err != nil {
 		return nil, err
 	}
-	return []Operand{newCmHandler(Client, Scheme, virtioWincm)}, nil
+	return newCmHandler(Client, Scheme, virtioWincm), nil
 }
 
 // **** Virtio-Win ConfigMap Role Handler ****
-func newVirtioWinCmReaderRoleHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
-	virtioWinRole := NewVirtioWinCmReaderRole(hc)
-
-	return []Operand{newRoleHandler(Client, Scheme, virtioWinRole)}, nil
+func newVirtioWinCmReaderRoleHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
+	return newRoleHandler(Client, Scheme, NewVirtioWinCmReaderRole(hc)), nil
 }
 
 // **** Virtio-Win ConfigMap RoleBinding Handler ****
-func newVirtioWinCmReaderRoleBindingHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) ([]Operand, error) {
-	virtioWinRoleBinding := NewVirtioWinCmReaderRoleBinding(hc)
-
-	return []Operand{newRoleBindingHandler(Client, Scheme, virtioWinRoleBinding)}, nil
+func newVirtioWinCmReaderRoleBindingHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (Operand, error) {
+	return newRoleBindingHandler(Client, Scheme, NewVirtioWinCmReaderRoleBinding(hc)), nil
 }
 
 func NewVirtioWinCm(hc *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {

--- a/controllers/operands/virtio_win_ConfigMap_test.go
+++ b/controllers/operands/virtio_win_ConfigMap_test.go
@@ -49,7 +49,7 @@ var _ = Describe("VirtioWin", func() {
 			Expect(err).ToNot(HaveOccurred())
 			cl := commontestutils.InitClient([]client.Object{})
 			handler, _ := newVirtioWinCmHandler(logger, cl, commontestutils.GetScheme(), hco)
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -70,7 +70,7 @@ var _ = Describe("VirtioWin", func() {
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
 			handler, _ := newVirtioWinCmHandler(logger, cl, commontestutils.GetScheme(), hco)
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -101,7 +101,7 @@ var _ = Describe("VirtioWin", func() {
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
 			handler, _ := newVirtioWinCmHandler(logger, cl, commontestutils.GetScheme(), hco)
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -143,7 +143,7 @@ var _ = Describe("VirtioWin", func() {
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
 			handler, _ := newVirtioWinCmHandler(logger, cl, commontestutils.GetScheme(), hco)
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -172,7 +172,7 @@ var _ = Describe("VirtioWin", func() {
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
 			handler, _ := newVirtioWinCmHandler(logger, cl, commontestutils.GetScheme(), hco)
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -206,7 +206,7 @@ var _ = Describe("VirtioWin", func() {
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRole})
 
 			handler, _ := newVirtioWinCmReaderRoleHandler(logger, cl, commontestutils.GetScheme(), hco)
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
 			foundRole := &rbacv1.Role{}
@@ -228,7 +228,7 @@ var _ = Describe("VirtioWin", func() {
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRole})
 
 			handler, _ := newVirtioWinCmReaderRoleHandler(logger, cl, commontestutils.GetScheme(), hco)
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
 			foundRole := &rbacv1.Role{}
@@ -257,7 +257,7 @@ var _ = Describe("VirtioWin", func() {
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRoleBinding})
 
 			handler, _ := newVirtioWinCmReaderRoleBindingHandler(logger, cl, commontestutils.GetScheme(), hco)
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
 			foundRoleBinding := &rbacv1.RoleBinding{}
@@ -278,7 +278,7 @@ var _ = Describe("VirtioWin", func() {
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRoleBinding})
 
 			handler, _ := newVirtioWinCmReaderRoleBindingHandler(logger, cl, commontestutils.GetScheme(), hco)
-			res := handler[0].ensure(req)
+			res := handler.ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
 			foundRoleBinding := &rbacv1.RoleBinding{}


### PR DESCRIPTION
Allow adding a single handler, in addition to the exsisting adding of multiple handlers.

The original `addOperands` handlers was desiged for unknown number of handlers to be initiated on runtime. But for single handlers, there is no reason to do that.

This PR adds an option to add a single handler for the regular use-case, when just adding a new known handler.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
