### PR TITLE
Stop checking for QuickStart CRD

### DIFF
--- a/controllers/operands/operandHandler_test.go
+++ b/controllers/operands/operandHandler_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Test operandHandler", func() {
 		It("should create all objects are created", func() {
 			hco := commontestutils.NewHco()
 			ci := commontestutils.ClusterInfoMock{}
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
 
@@ -135,7 +135,7 @@ var _ = Describe("Test operandHandler", func() {
 
 		It("should handle errors on ensure loop", func() {
 			hco := commontestutils.NewHco()
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco})
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
 			ci := commontestutils.ClusterInfoMock{}
@@ -176,7 +176,7 @@ var _ = Describe("Test operandHandler", func() {
 		It("make sure the all objects are deleted", func() {
 			hco := commontestutils.NewHco()
 			ci := commontestutils.ClusterInfoMock{}
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
 
@@ -264,7 +264,7 @@ var _ = Describe("Test operandHandler", func() {
 		It("delete KV error handling", func() {
 			hco := commontestutils.NewHco()
 			ci := commontestutils.ClusterInfoMock{}
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
 
@@ -313,7 +313,7 @@ var _ = Describe("Test operandHandler", func() {
 		It("delete CDI error handling", func() {
 			hco := commontestutils.NewHco()
 			ci := commontestutils.ClusterInfoMock{}
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
 
@@ -363,7 +363,7 @@ var _ = Describe("Test operandHandler", func() {
 		It("default delete error handling", func() {
 			hco := commontestutils.NewHco()
 			ci := commontestutils.ClusterInfoMock{}
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco, ci.GetCSV()})
 
 			fakeError := fmt.Errorf("fake CNA deletion error")
 			eventEmitter := commontestutils.NewEventEmitterMock()
@@ -413,7 +413,7 @@ var _ = Describe("Test operandHandler", func() {
 		It("delete timeout error handling", func() {
 			hco := commontestutils.NewHco()
 			ci := commontestutils.ClusterInfoMock{}
-			cli := commontestutils.InitClient([]client.Object{hcoNamespace, qsCrd, hco, ci.GetCSV()})
+			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco, ci.GetCSV()})
 
 			eventEmitter := commontestutils.NewEventEmitterMock()
 

--- a/controllers/operands/quickStart_test.go
+++ b/controllers/operands/quickStart_test.go
@@ -2,7 +2,6 @@ package operands
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -33,37 +32,13 @@ var _ = Describe("QuickStart tests", func() {
 		hco               = commontestutils.NewHco()
 	)
 
-	Context("test checkCrdExists", func() {
-		It("should return not-stop-processing if not exists", func() {
-			cli := commontestutils.InitClient([]client.Object{})
-
-			err := checkCrdExists(context.TODO(), cli, logger)
-			Expect(err).To(HaveOccurred())
-			Expect(errors.Unwrap(err)).ToNot(HaveOccurred())
-		})
-
-		It("should return true if CRD exists, with no error", func() {
-			cli := commontestutils.InitClient([]client.Object{qsCrd})
-
-			Expect(checkCrdExists(context.TODO(), cli, logger)).To(Succeed())
-		})
-	})
-
 	Context("test getQuickStartHandlers", func() {
 		It("should use env var to override the yaml locations", func() {
 			// create temp folder for the test
 			dir := path.Join(os.TempDir(), fmt.Sprint(time.Now().UTC().Unix()))
 			_ = os.Setenv(quickStartManifestLocationVarName, dir)
-			By("CRD is not deployed", func() {
-				cli := commontestutils.InitClient([]client.Object{})
-				handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
-
-				Expect(err).ToNot(HaveOccurred())
-				Expect(handlers).To(BeEmpty())
-			})
-
 			By("folder not exists", func() {
-				cli := commontestutils.InitClient([]client.Object{qsCrd})
+				cli := commontestutils.InitClient([]client.Object{})
 				handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -74,7 +49,7 @@ var _ = Describe("QuickStart tests", func() {
 			defer os.RemoveAll(dir)
 
 			By("folder is empty", func() {
-				cli := commontestutils.InitClient([]client.Object{qsCrd})
+				cli := commontestutils.InitClient([]client.Object{})
 				handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -90,7 +65,7 @@ var _ = Describe("QuickStart tests", func() {
 			_ = nonYaml.Close()
 
 			By("no yaml files", func() {
-				cli := commontestutils.InitClient([]client.Object{qsCrd})
+				cli := commontestutils.InitClient([]client.Object{})
 				handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -100,7 +75,7 @@ var _ = Describe("QuickStart tests", func() {
 			Expect(commontestutils.CopyFile(path.Join(dir, "quickStart.yaml"), path.Join(testFilesLocation, "quickstart.yaml"))).To(Succeed())
 
 			By("yaml file exists", func() {
-				cli := commontestutils.InitClient([]client.Object{qsCrd})
+				cli := commontestutils.InitClient([]client.Object{})
 				handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -122,7 +97,7 @@ var _ = Describe("QuickStart tests", func() {
 			// quickstart directory path of a file
 			_ = os.Setenv(quickStartManifestLocationVarName, filePath)
 			By("check that getQuickStartHandlers returns error", func() {
-				cli := commontestutils.InitClient([]client.Object{qsCrd})
+				cli := commontestutils.InitClient([]client.Object{})
 				handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 
 				Expect(err).To(HaveOccurred())
@@ -137,7 +112,7 @@ var _ = Describe("QuickStart tests", func() {
 		It("should create the ConsoleQuickStart resource if not exists", func() {
 			_ = os.Setenv(quickStartManifestLocationVarName, testFilesLocation)
 
-			cli := commontestutils.InitClient([]client.Object{qsCrd})
+			cli := commontestutils.InitClient([]client.Object{})
 			handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(handlers).To(HaveLen(1))
@@ -172,7 +147,7 @@ var _ = Describe("QuickStart tests", func() {
 
 			_ = os.Setenv(quickStartManifestLocationVarName, testFilesLocation)
 
-			cli := commontestutils.InitClient([]client.Object{qsCrd, exists})
+			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(handlers).To(HaveLen(1))
@@ -209,7 +184,7 @@ var _ = Describe("QuickStart tests", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 
-			cli := commontestutils.InitClient([]client.Object{qsCrd})
+			cli := commontestutils.InitClient([]client.Object{})
 			handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(handlers).To(HaveLen(1))
@@ -273,7 +248,7 @@ var _ = Describe("QuickStart tests", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 
-			cli := commontestutils.InitClient([]client.Object{qsCrd})
+			cli := commontestutils.InitClient([]client.Object{})
 			handlers, err := getQuickStartHandlers(logger, cli, schemeForTest, hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(handlers).To(HaveLen(1))

--- a/controllers/operands/utils_test.go
+++ b/controllers/operands/utils_test.go
@@ -5,26 +5,12 @@ import (
 	"path"
 	"strings"
 
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	. "github.com/onsi/gomega"
 )
 
 const (
 	pkgDirectory = "controllers/operands"
 	testFilesLoc = "testFiles"
-)
-
-var (
-	qsCrd = &extv1.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			Kind: "CustomResourceDefinition",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: consoleQuickStartCrdName,
-		},
-	}
 )
 
 func getTestFilesLocation() string {


### PR DESCRIPTION
The quick start feature is mature and there is no reason to check if the CRD exists. If HCO is running on OCP/OKD, we assumes that quickstart is deployed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
