### PR TITLE
Add OperatorConditionsUnhealthy alerts

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -3888,7 +3888,7 @@ func verifyHyperConvergedCRExistsMetricFalse() {
 func verifySystemHealthStatusHealthy(hco *hcov1beta1.HyperConverged) {
 	ExpectWithOffset(1, hco.Status.SystemHealthStatus).To(Equal(systemHealthStatusHealthy))
 
-	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus()
+	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus("healthy")
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, systemHealthStatusMetric).To(Equal(metrics.SystemHealthStatusHealthy))
 }
@@ -3896,7 +3896,7 @@ func verifySystemHealthStatusHealthy(hco *hcov1beta1.HyperConverged) {
 func verifySystemHealthStatusError(hco *hcov1beta1.HyperConverged) {
 	ExpectWithOffset(1, hco.Status.SystemHealthStatus).To(Equal(systemHealthStatusError))
 
-	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus()
+	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus(reconcileInit)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, systemHealthStatusMetric).To(Equal(metrics.SystemHealthStatusError))
 }

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -691,7 +691,7 @@ tests:
       - labels: 'kubevirt_hyperconverged_operator_health_status{name="kubevirt-hyperconverged"}'
         value: 2
 
-  # Test kubevirt_hco_misconfigured_descheduler
+# Test kubevirt_hco_misconfigured_descheduler
 - interval: 1m
   input_series:
     - series: 'kubevirt_hco_misconfigured_descheduler'
@@ -770,3 +770,49 @@ tests:
             operator_health_impact: "critical"
             kubernetes_operator_part_of: "kubevirt"
             kubernetes_operator_component: "hyperconverged-cluster-operator"
+
+# Test OperatorConditionsUnhealthy
+- interval: 1m
+  input_series:
+    - series: 'kubevirt_hco_system_health_status{reason="SOME_ERROR"}'
+      values: "stale stale 2 stale"
+
+    - series: 'kubevirt_hco_system_health_status{reason="SOME_WARNING"}'
+      values: "stale stale stale stale 1 stale"
+
+  alert_rule_test:
+    - eval_time: 1m
+      alertname: OperatorConditionsUnhealthy
+      exp_alerts: [ ]
+
+    - eval_time: 1m
+      alertname: OperatorConditionsUnhealthy
+      exp_alerts: [ ]
+
+    - eval_time: 2m
+      alertname: OperatorConditionsUnhealthy
+      exp_alerts:
+        - exp_annotations:
+            description: "HCO and its secondary resources are in a critical state due to SOME_ERROR."
+            summary: "HCO and its secondary resources are in a critical state."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/OperatorConditionsUnhealthy"
+          exp_labels:
+            severity: "critical"
+            operator_health_impact: "critical"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            reason: "SOME_ERROR"
+
+    - eval_time: 4m
+      alertname: OperatorConditionsUnhealthy
+      exp_alerts:
+        - exp_annotations:
+            description: "HCO and its secondary resources are in a warning state due to SOME_WARNING."
+            summary: "HCO and its secondary resources are in a warning state."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/OperatorConditionsUnhealthy"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "warning"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            reason: "SOME_WARNING"

--- a/pkg/monitoring/rules/alerts/alerts.go
+++ b/pkg/monitoring/rules/alerts/alerts.go
@@ -23,6 +23,7 @@ const (
 func Register(operatorRegistry *operatorrules.Registry) error {
 	alerts := [][]promv1.Rule{
 		operatorAlerts(),
+		healthAlerts(),
 	}
 
 	runbookURLTemplate := getRunbookURLTemplate()

--- a/pkg/monitoring/rules/alerts/health_alerts.go
+++ b/pkg/monitoring/rules/alerts/health_alerts.go
@@ -1,0 +1,35 @@
+package alerts
+
+import (
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func healthAlerts() []promv1.Rule {
+	return []promv1.Rule{
+		{
+			Alert: "OperatorConditionsUnhealthy",
+			Expr:  intstr.FromString("kubevirt_hco_system_health_status == 2"),
+			Annotations: map[string]string{
+				"description": "HCO and its secondary resources are in a critical state due to {{ $labels.reason }}.",
+				"summary":     "HCO and its secondary resources are in a critical state.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:     "critical",
+				healthImpactAlertLabelKey: "critical",
+			},
+		},
+		{
+			Alert: "OperatorConditionsUnhealthy",
+			Expr:  intstr.FromString("kubevirt_hco_system_health_status == 1"),
+			Annotations: map[string]string{
+				"description": "HCO and its secondary resources are in a warning state due to {{ $labels.reason }}.",
+				"summary":     "HCO and its secondary resources are in a warning state.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "warning",
+			},
+		},
+	}
+}

--- a/tests/func-tests/hco_prometheus_route.go
+++ b/tests/func-tests/hco_prometheus_route.go
@@ -96,7 +96,11 @@ func (hcoCli HCOPrometheusClient) GetHCOMetric(ctx context.Context, query string
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, query) {
-			res, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimPrefix(line, query)), 64)
+			parts := strings.Fields(line)
+			if len(parts) < 2 {
+				return 0, fmt.Errorf("metric line does not contain a value")
+			}
+			res, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
 			if err != nil {
 				return 0, fmt.Errorf("error converting %s to int: %v\n", line, err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add alerts based on kubevirt_hco_system_health_status

The alert includes the reason of the condition that sets the health to a given status. For that, `kubevirt_hco_system_health_status` was updated to add a `reason` label, that has the value of the reason field in the underlying condition

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-48799
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add OperatorConditionsUnhealthy alerts
```
