### PR TITLE
instancetypes: Remove common-instancetypes FG from KubeVirt

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -209,7 +209,6 @@ var _ = Describe("HyperconvergedController", func() {
 					"KubevirtSeccompProfile",
 					"VMPersistentState",
 					"NetworkBindingPlugins",
-					"CommonInstancetypesDeploymentGate",
 					"VMLiveUpdateFeatures",
 				}
 				// Get the KV

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -104,9 +104,6 @@ const (
 	// Enable using a plugin to bind the pod and the VM network
 	kvHNetworkBindingPluginsGate = "NetworkBindingPlugins"
 
-	// Deploy common-instancetypes using virt-operator
-	kvDeployCommonInstancetypes = "CommonInstancetypesDeploymentGate"
-
 	// Enable VM live update, to allow live propagation of VM changes to their VMI
 	kvVMLiveUpdateFeatures = "VMLiveUpdateFeatures"
 )
@@ -129,7 +126,6 @@ var (
 		kvKubevirtSeccompProfile,
 		kvVMPersistentState,
 		kvHNetworkBindingPluginsGate,
-		kvDeployCommonInstancetypes,
 		kvVMLiveUpdateFeatures,
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The KubeVirt FG has now GA'd with v1.4.0 and is enabled by default.

https://github.com/kubevirt/kubevirt/pull/12753

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-44451
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
