### PR TITLE
cliDownloads: Add virtctl for s390x

### DIFF
--- a/build/Dockerfile.artifacts
+++ b/build/Dockerfile.artifacts
@@ -14,10 +14,12 @@ ARG download_url=https://github.com/kubevirt/kubevirt/releases/download
 
 RUN eval $(cat /tmp/config  |grep KUBEVIRT_VERSION=) && \
     echo "KUBEVIRT_VERSION: $KUBEVIRT_VERSION" && \
-    for arch in amd64 arm64; do \
+    for arch in amd64 arm64 s390x; do \
         for os in linux darwin windows; do \
             if [[ ${os} == "windows" && ${arch} == "arm64" ]]; then \
                 printf "\n\n### Skipping virctl for Windows on ARM64\n"; \
+            elif [[ ${os} != "linux" && ${arch} == "s390x" ]]; then \
+                printf "\n\n### Skipping virctl for non-Linux OS on s390x\n"; \
             else \
                 extension=""; \
                 archive_extension=".zip"; \

--- a/controllers/operands/cliDownload.go
+++ b/controllers/operands/cliDownload.go
@@ -98,6 +98,10 @@ func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLID
 					Text: "Download virtctl for Linux for ARM 64",
 				},
 				{
+					Href: baseURL + "/s390x/linux/virtctl.tar.gz",
+					Text: "Download virtctl for Linux for IBM Z",
+				},
+				{
 					Href: baseURL + "/amd64/mac/virtctl.zip",
 					Text: "Download virtctl for Mac for x86_64",
 				},

--- a/controllers/operands/cliDownload_test.go
+++ b/controllers/operands/cliDownload_test.go
@@ -44,7 +44,7 @@ var _ = Describe("CLI Download", func() {
 			Expect(cl.Get(context.TODO(), key, foundResource)).ToNot(HaveOccurred())
 			Expect(foundResource.Name).To(Equal(expectedResource.Name))
 			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
-			Expect(foundResource.Spec.Links).To(HaveLen(6))
+			Expect(foundResource.Spec.Links).To(HaveLen(7))
 			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
 		})
 

--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -49,7 +49,7 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 
 		Expect(cli.Get(ctx, client.ObjectKeyFromObject(ccd), ccd)).To(Succeed())
 
-		Expect(ccd.Spec.Links).To(HaveLen(6))
+		Expect(ccd.Spec.Links).To(HaveLen(7))
 
 		for _, link := range ccd.Spec.Links {
 			// virtctl for Windows for ARM 64 is still not shipped, avoid checking it


### PR DESCRIPTION
With kubevirt v1.4.0-alpha.1 virtctl is now also available for linux on IBM Z. Add the binary to the cliDownloads.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add virtctl download for linux on IBM Z (s390x)
```
