### PR TITLE
NIC Hotplug graduation to GA: remove FG from kubevirt

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -207,7 +207,6 @@ var _ = Describe("HyperconvergedController", func() {
 					"VMExport",
 					"DisableCustomSELinuxPolicy",
 					"KubevirtSeccompProfile",
-					"HotplugNICs",
 					"VMPersistentState",
 					"NetworkBindingPlugins",
 					"CommonInstancetypesDeploymentGate",

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -98,9 +98,6 @@ const (
 	// Enable the installation of the KubeVirt seccomp profile
 	kvKubevirtSeccompProfile = "KubevirtSeccompProfile"
 
-	// Allow attaching a NIC to a running VMI
-	kvHotplugNicsGate = "HotplugNICs"
-
 	// Enable VM state persistence
 	kvVMPersistentState = "VMPersistentState"
 
@@ -130,7 +127,6 @@ var (
 		kvVMExportGate,
 		kvDisableCustomSELinuxPolicyGate,
 		kvKubevirtSeccompProfile,
-		kvHotplugNicsGate,
 		kvVMPersistentState,
 		kvHNetworkBindingPluginsGate,
 		kvDeployCommonInstancetypes,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
NIC Hotplug [is GA]( https://github.com/kubevirt/kubevirt/pull/13059) , no need to set the feature gate in kubevirt. Target kubevirt version is 1.4
**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
