### PR TITLE
ExpectWithOffset().Should() => ExpectWithOffset().To()

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -3870,20 +3870,20 @@ var _ = Describe("HyperconvergedController", func() {
 
 func verifyUnsafeMetrics(expected int, annotation string) {
 	count, err := metrics.GetUnsafeModificationsCount(annotation)
-	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
-	ExpectWithOffset(1, count).Should(BeEquivalentTo(expected))
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, count).To(BeEquivalentTo(expected))
 }
 
 func verifyHyperConvergedCRExistsMetricTrue() {
 	hcExists, err := metrics.IsHCOMetricHyperConvergedExists()
-	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
-	ExpectWithOffset(1, hcExists).Should(BeTrue())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, hcExists).To(BeTrue())
 }
 
 func verifyHyperConvergedCRExistsMetricFalse() {
 	hcExists, err := metrics.IsHCOMetricHyperConvergedExists()
-	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
-	ExpectWithOffset(1, hcExists).Should(BeFalse())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, hcExists).To(BeFalse())
 }
 
 func verifySystemHealthStatusHealthy(hco *hcov1beta1.HyperConverged) {

--- a/controllers/operands/imageStream_test.go
+++ b/controllers/operands/imageStream_test.go
@@ -1170,8 +1170,8 @@ func validateImageStream(found *imagev1.ImageStream, hook *isHooks) {
 		Expect(tag).ToNot(BeNil())
 		validationTagMap[tagName] = true
 
-		ExpectWithOffset(1, tag.From).Should(Equal(hook.tags[tagName].From))
-		ExpectWithOffset(1, tag.ImportPolicy).Should(Equal(imagev1.TagImportPolicy{Scheduled: true}))
+		ExpectWithOffset(1, tag.From).To(Equal(hook.tags[tagName].From))
+		ExpectWithOffset(1, tag.ImportPolicy).To(Equal(imagev1.TagImportPolicy{Scheduled: true}))
 	}
 
 	ExpectWithOffset(1, validateAllTags(validationTagMap)).To(BeTrue())

--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -64,7 +64,7 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 				_ = resp.Body.Close()
 
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				ExpectWithOffset(1, resp).Should(HaveHTTPStatus(http.StatusOK))
+				ExpectWithOffset(1, resp).To(HaveHTTPStatus(http.StatusOK))
 			}
 		}
 	})

--- a/tests/func-tests/dashboard_test.go
+++ b/tests/func-tests/dashboard_test.go
@@ -40,7 +40,7 @@ var _ = Describe("[rfe_id:5108][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			for _, key := range item.Keys {
 				_, ok := cm.Data[key]
-				ExpectWithOffset(1, ok).Should(BeTrue())
+				ExpectWithOffset(1, ok).To(BeTrue())
 			}
 		}
 	})

--- a/tests/func-tests/labels_test.go
+++ b/tests/func-tests/labels_test.go
@@ -106,9 +106,9 @@ var _ = Describe("Check that all the sub-resources have the required labels", La
 })
 
 func checkLabels(labels map[string]string) {
-	ExpectWithOffset(1, labels).Should(HaveKey("app.kubernetes.io/component"))
-	ExpectWithOffset(1, labels).Should(HaveKey("app.kubernetes.io/version"))
-	ExpectWithOffset(1, labels).Should(HaveKeyWithValue("app", "kubevirt-hyperconverged"))
-	ExpectWithOffset(1, labels).Should(HaveKeyWithValue("app.kubernetes.io/part-of", "hyperconverged-cluster"))
-	ExpectWithOffset(1, labels).Should(HaveKeyWithValue("app.kubernetes.io/managed-by", "hco-operator"))
+	ExpectWithOffset(1, labels).To(HaveKey("app.kubernetes.io/component"))
+	ExpectWithOffset(1, labels).To(HaveKey("app.kubernetes.io/version"))
+	ExpectWithOffset(1, labels).To(HaveKeyWithValue("app", "kubevirt-hyperconverged"))
+	ExpectWithOffset(1, labels).To(HaveKeyWithValue("app.kubernetes.io/part-of", "hyperconverged-cluster"))
+	ExpectWithOffset(1, labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "hco-operator"))
 }

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -404,7 +404,7 @@ func verifyOperatorHealthMetricValue(ctx context.Context, promClient promApiv1.A
 
 func getMetricValue(ctx context.Context, promClient promApiv1.API, metricName string) float64 {
 	queryResult, _, err := promClient.Query(ctx, metricName, time.Now())
-	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	resultVector := queryResult.(promModel.Vector)
 	if len(resultVector) == 0 {
@@ -414,7 +414,7 @@ func getMetricValue(ctx context.Context, promClient promApiv1.API, metricName st
 	ExpectWithOffset(1, resultVector).To(HaveLen(1))
 
 	metricValue, err := strconv.ParseFloat(resultVector[0].Value.String(), 64)
-	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	return metricValue
 }
@@ -428,14 +428,14 @@ func getPrometheusRule(ctx context.Context, cli rest.Interface) monitoringv1.Pro
 		Namespace(tests.InstallNamespace).
 		AbsPath("/apis", monitoringv1.SchemeGroupVersion.Group, monitoringv1.SchemeGroupVersion.Version).
 		Timeout(10*time.Second).
-		Do(ctx).Into(&prometheusRule)).Should(Succeed())
+		Do(ctx).Into(&prometheusRule)).To(Succeed())
 	return prometheusRule
 }
 
 func checkRunbookURLAvailability(rule monitoringv1.Rule) {
 	resp, err := runbookClient.Head(rule.Annotations["runbook_url"])
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), fmt.Sprintf("%s runbook is not available", rule.Alert))
-	ExpectWithOffset(1, resp.StatusCode).Should(Equal(http.StatusOK), fmt.Sprintf("%s runbook is not available", rule.Alert))
+	ExpectWithOffset(1, resp.StatusCode).To(Equal(http.StatusOK), fmt.Sprintf("%s runbook is not available", rule.Alert))
 }
 
 func initializePromClient(prometheusURL string, token string) promApiv1.API {

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -253,7 +253,7 @@ func listInfraNodes(ctx context.Context, cli *kubernetes.Clientset) *v1.NodeList
 	infraNodes, err := cli.CoreV1().Nodes().List(ctx, k8smetav1.ListOptions{
 		LabelSelector: "node.kubernetes.io/hco-test-node-type==infra",
 	})
-	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	return infraNodes
 }

--- a/tests/func-tests/tuningpolicy_test.go
+++ b/tests/func-tests/tuningpolicy_test.go
@@ -93,8 +93,8 @@ func checkTuningPolicy(ctx context.Context, cli client.Client, expected kvv1.Tok
 }
 
 func checkReloadableComponentConfiguration(g Gomega, actual *kvv1.ReloadableComponentConfiguration, expected kvv1.TokenBucketRateLimiter) {
-	g.ExpectWithOffset(1, actual).ShouldNot(BeNil())
-	g.ExpectWithOffset(1, actual.RestClient).ShouldNot(BeNil())
-	g.ExpectWithOffset(1, actual.RestClient.RateLimiter).ShouldNot(BeNil())
-	g.ExpectWithOffset(1, actual.RestClient.RateLimiter.TokenBucketRateLimiter).Should(HaveValue(Equal(expected)))
+	g.ExpectWithOffset(1, actual).ToNot(BeNil())
+	g.ExpectWithOffset(1, actual.RestClient).ToNot(BeNil())
+	g.ExpectWithOffset(1, actual.RestClient.RateLimiter).ToNot(BeNil())
+	g.ExpectWithOffset(1, actual.RestClient.RateLimiter.TokenBucketRateLimiter).To(HaveValue(Equal(expected)))
 }


### PR DESCRIPTION
# What this PR does / why we need it

Follow up of #2845 

ginkgolinter configurations does not allow using `Should()`/`ShouldNot()` with `Expect()`, but requires using `To`, `ToNot` or `NotTo`.

But the next version of the ginkgolinter will introduce a bug fix to also require the same for `ExpectWithOffset()`.

This PR fixes these cases in advanse.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
