### PR TITLE
Upgrade operator-observability package and remove deprecated functions

### DIFF
--- a/controllers/alerts/metrics_test.go
+++ b/controllers/alerts/metrics_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -51,9 +50,6 @@ var _ = Describe("alert tests", func() {
 		}
 
 		req = commontestutils.NewReq(nil)
-
-		err := operatorrules.CleanRegistry()
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Context("test reconciler", func() {
@@ -348,13 +344,10 @@ var _ = Describe("alert tests", func() {
 		})
 
 		It("should use the desired runbook URL template when its ENV Variable is set", func() {
-			err := operatorrules.CleanRegistry()
-			Expect(err).ToNot(HaveOccurred())
-
 			desiredRunbookURLTemplate := "desired/runbookURL/template/%s"
 			os.Setenv(runbookURLTemplateEnv, desiredRunbookURLTemplate)
 
-			err = rules.SetupRules()
+			err := rules.SetupRules()
 			Expect(err).ToNot(HaveOccurred())
 
 			owner := getDeploymentReference(ci.GetDeployment())

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/kubevirt/cluster-network-addons-operator v0.96.0
 	github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20240505100225-e29dee0bb12b
-	github.com/machadovilaca/operator-observability v0.0.21
+	github.com/machadovilaca/operator-observability v0.0.23
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	github.com/openshift/api v3.9.1-0.20190517100836-d5b34b957e91+incompatible

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20240505100225-e29dee0b
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
-github.com/machadovilaca/operator-observability v0.0.21 h1:H0nH+45wtqsxCrJOm8wmcrJLuRZ5QY6iTlHKMlMEZss=
-github.com/machadovilaca/operator-observability v0.0.21/go.mod h1:trC+BjI6zhvZMBcX0q7vHrKKRX3lWZdwJxgVUmRJCfw=
+github.com/machadovilaca/operator-observability v0.0.23 h1:8n2FJ+dt1bHtb+E+PbNpmsWIQmf513WYWP58oGIpZ8M=
+github.com/machadovilaca/operator-observability v0.0.23/go.mod h1:trC+BjI6zhvZMBcX0q7vHrKKRX3lWZdwJxgVUmRJCfw=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=

--- a/pkg/monitoring/rules/alerts/alerts.go
+++ b/pkg/monitoring/rules/alerts/alerts.go
@@ -20,7 +20,7 @@ const (
 	runbookURLTemplateEnv          = "RUNBOOK_URL_TEMPLATE"
 )
 
-func Register() error {
+func Register(operatorRegistry *operatorrules.Registry) error {
 	alerts := [][]promv1.Rule{
 		operatorAlerts(),
 	}
@@ -35,7 +35,7 @@ func Register() error {
 
 	}
 
-	return operatorrules.RegisterAlerts(alerts...)
+	return operatorRegistry.RegisterAlerts(alerts...)
 }
 
 func getRunbookURLTemplate() string {

--- a/pkg/monitoring/rules/recordingrules/recordingrules.go
+++ b/pkg/monitoring/rules/recordingrules/recordingrules.go
@@ -2,8 +2,8 @@ package recordingrules
 
 import "github.com/machadovilaca/operator-observability/pkg/operatorrules"
 
-func Register() error {
-	return operatorrules.RegisterRecordingRules(
+func Register(operatorRegistry *operatorrules.Registry) error {
+	return operatorRegistry.RegisterRecordingRules(
 		operatorRecordingRules,
 	)
 }

--- a/pkg/monitoring/rules/rules.go
+++ b/pkg/monitoring/rules/rules.go
@@ -14,13 +14,15 @@ const (
 	ruleName = hcoutil.HyperConvergedName + "-prometheus-rule"
 )
 
+var operatorRegistry = operatorrules.NewRegistry()
+
 func SetupRules() error {
-	err := recordingrules.Register()
+	err := recordingrules.Register(operatorRegistry)
 	if err != nil {
 		return err
 	}
 
-	err = alerts.Register()
+	err = alerts.Register(operatorRegistry)
 	if err != nil {
 		return err
 	}
@@ -29,7 +31,7 @@ func SetupRules() error {
 }
 
 func BuildPrometheusRule(namespace string, owner metav1.OwnerReference) (*promv1.PrometheusRule, error) {
-	rules, err := operatorrules.BuildPrometheusRule(
+	rules, err := operatorRegistry.BuildPrometheusRule(
 		ruleName,
 		namespace,
 		hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring),
@@ -44,9 +46,9 @@ func BuildPrometheusRule(namespace string, owner metav1.OwnerReference) (*promv1
 }
 
 func ListRecordingRules() []operatorrules.RecordingRule {
-	return operatorrules.ListRecordingRules()
+	return operatorRegistry.ListRecordingRules()
 }
 
 func ListAlerts() []promv1.Rule {
-	return operatorrules.ListAlerts()
+	return operatorRegistry.ListAlerts()
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector.go
@@ -3,7 +3,6 @@ package operatormetrics
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -20,14 +19,6 @@ type Collector struct {
 	CollectCallback func() []CollectorResult
 }
 
-type CollectorResult struct {
-	Metric      Metric
-	Labels      []string
-	ConstLabels map[string]string
-	Value       float64
-	Timestamp   time.Time
-}
-
 func (c Collector) hash() string {
 	var sb strings.Builder
 
@@ -40,7 +31,7 @@ func (c Collector) hash() string {
 
 func (c Collector) Describe(ch chan<- *prometheus.Desc) {
 	for _, cm := range c.Metrics {
-		cm.getCollector().Describe(ch)
+		cm.GetCollector().Describe(ch)
 	}
 }
 

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector_result.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector_result.go
@@ -1,0 +1,24 @@
+package operatormetrics
+
+import (
+	"errors"
+	"time"
+)
+
+type CollectorResult struct {
+	Metric      Metric
+	Labels      []string
+	ConstLabels map[string]string
+	Value       float64
+	Timestamp   time.Time
+}
+
+func (cr CollectorResult) GetLabelValue(key string) (string, error) {
+	for i, label := range cr.Metric.GetOpts().labels {
+		if label == key {
+			return cr.Labels[i], nil
+		}
+	}
+
+	return "", errors.New("label not found")
+}

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter.go
@@ -31,6 +31,6 @@ func (c *Counter) GetBaseType() MetricType {
 	return CounterType
 }
 
-func (c *Counter) getCollector() prometheus.Collector {
+func (c *Counter) GetCollector() prometheus.Collector {
 	return c.Counter
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter_vec.go
@@ -33,6 +33,6 @@ func (c *CounterVec) GetBaseType() MetricType {
 	return CounterType
 }
 
-func (c *CounterVec) getCollector() prometheus.Collector {
+func (c *CounterVec) GetCollector() prometheus.Collector {
 	return c.CounterVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge.go
@@ -31,6 +31,6 @@ func (c *Gauge) GetBaseType() MetricType {
 	return GaugeType
 }
 
-func (c *Gauge) getCollector() prometheus.Collector {
+func (c *Gauge) GetCollector() prometheus.Collector {
 	return c.Gauge
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge_vec.go
@@ -33,6 +33,6 @@ func (c *GaugeVec) GetBaseType() MetricType {
 	return GaugeType
 }
 
-func (c *GaugeVec) getCollector() prometheus.Collector {
+func (c *GaugeVec) GetCollector() prometheus.Collector {
 	return c.GaugeVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram.go
@@ -46,6 +46,6 @@ func (c *Histogram) GetBaseType() MetricType {
 	return HistogramType
 }
 
-func (c *Histogram) getCollector() prometheus.Collector {
+func (c *Histogram) GetCollector() prometheus.Collector {
 	return c.Histogram
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram_vec.go
@@ -37,6 +37,6 @@ func (c *HistogramVec) GetBaseType() MetricType {
 	return HistogramType
 }
 
-func (c *HistogramVec) getCollector() prometheus.Collector {
+func (c *HistogramVec) GetCollector() prometheus.Collector {
 	return c.HistogramVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/metric.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/metric.go
@@ -15,8 +15,7 @@ type Metric interface {
 	GetOpts() MetricOpts
 	GetType() MetricType
 	GetBaseType() MetricType
-
-	getCollector() prometheus.Collector
+	GetCollector() prometheus.Collector
 }
 
 type MetricType string

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary.go
@@ -46,6 +46,6 @@ func (c *Summary) GetBaseType() MetricType {
 	return SummaryType
 }
 
-func (c *Summary) getCollector() prometheus.Collector {
+func (c *Summary) GetCollector() prometheus.Collector {
 	return c.Summary
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary_vec.go
@@ -37,6 +37,6 @@ func (c *SummaryVec) GetBaseType() MetricType {
 	return SummaryType
 }
 
-func (c *SummaryVec) getCollector() prometheus.Collector {
+func (c *SummaryVec) GetCollector() prometheus.Collector {
 	return c.SummaryVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/wrapper_registry.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/wrapper_registry.go
@@ -122,7 +122,7 @@ func metricExists(metric Metric) bool {
 }
 
 func unregisterMetric(metric Metric) error {
-	if succeeded := Unregister(metric.getCollector()); succeeded {
+	if succeeded := Unregister(metric.GetCollector()); succeeded {
 		delete(operatorRegistry.registeredMetrics, metric.GetOpts().Name)
 		return nil
 	}
@@ -131,7 +131,7 @@ func unregisterMetric(metric Metric) error {
 }
 
 func registerMetric(metric Metric) error {
-	err := Register(metric.getCollector())
+	err := Register(metric.GetCollector())
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/compatibility.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/compatibility.go
@@ -1,0 +1,37 @@
+package operatorrules
+
+import promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
+// Deprecated: operatorRegistry is deprecated.
+var operatorRegistry = NewRegistry()
+
+// Deprecated: RegisterRecordingRules is deprecated.
+func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
+	return operatorRegistry.RegisterRecordingRules(recordingRules...)
+}
+
+// Deprecated: RegisterAlerts is deprecated.
+func RegisterAlerts(alerts ...[]promv1.Rule) error {
+	return operatorRegistry.RegisterAlerts(alerts...)
+}
+
+// Deprecated: ListRecordingRules is deprecated.
+func ListRecordingRules() []RecordingRule {
+	return operatorRegistry.ListRecordingRules()
+}
+
+// Deprecated: ListAlerts is deprecated.
+func ListAlerts() []promv1.Rule {
+	return operatorRegistry.ListAlerts()
+}
+
+// Deprecated: CleanRegistry is deprecated.
+func CleanRegistry() error {
+	operatorRegistry = NewRegistry()
+	return nil
+}
+
+// Deprecated: BuildPrometheusRule is deprecated.
+func BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
+	return operatorRegistry.BuildPrometheusRule(name, namespace, labels)
+}

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/prometheusrules.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/prometheusrules.go
@@ -11,8 +11,8 @@ import (
 )
 
 // BuildPrometheusRule builds a PrometheusRule object from the registered recording rules and alerts.
-func BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
-	spec, err := buildPrometheusRuleSpec()
+func (r *Registry) BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
+	spec, err := r.buildPrometheusRuleSpec()
 	if err != nil {
 		return nil, err
 	}
@@ -31,20 +31,20 @@ func BuildPrometheusRule(name, namespace string, labels map[string]string) (*pro
 	}, nil
 }
 
-func buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
+func (r *Registry) buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
 	var groups []promv1.RuleGroup
 
-	if len(operatorRegistry.registeredRecordingRules) != 0 {
+	if len(r.registeredRecordingRules) != 0 {
 		groups = append(groups, promv1.RuleGroup{
 			Name:  "recordingRules.rules",
-			Rules: buildRecordingRulesRules(),
+			Rules: r.buildRecordingRulesRules(),
 		})
 	}
 
-	if len(operatorRegistry.registeredAlerts) != 0 {
+	if len(r.registeredAlerts) != 0 {
 		groups = append(groups, promv1.RuleGroup{
 			Name:  "alerts.rules",
-			Rules: ListAlerts(),
+			Rules: r.ListAlerts(),
 		})
 	}
 
@@ -55,10 +55,10 @@ func buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
 	return &promv1.PrometheusRuleSpec{Groups: groups}, nil
 }
 
-func buildRecordingRulesRules() []promv1.Rule {
+func (r *Registry) buildRecordingRulesRules() []promv1.Rule {
 	var rules []promv1.Rule
 
-	for _, recordingRule := range operatorRegistry.registeredRecordingRules {
+	for _, recordingRule := range r.registeredRecordingRules {
 		rules = append(rules, promv1.Rule{
 			Record: recordingRule.MetricsOpts.Name,
 			Expr:   recordingRule.Expr,

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/registry.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/registry.go
@@ -7,26 +7,24 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
-var operatorRegistry = newRegistry()
-
-type operatorRegisterer struct {
+type Registry struct {
 	registeredRecordingRules map[string]RecordingRule
 	registeredAlerts         map[string]promv1.Rule
 }
 
-func newRegistry() operatorRegisterer {
-	return operatorRegisterer{
+func NewRegistry() *Registry {
+	return &Registry{
 		registeredRecordingRules: map[string]RecordingRule{},
 		registeredAlerts:         map[string]promv1.Rule{},
 	}
 }
 
 // RegisterRecordingRules registers the given recording rules.
-func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
+func (r *Registry) RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
 	for _, recordingRuleList := range recordingRules {
 		for _, recordingRule := range recordingRuleList {
 			key := recordingRule.MetricsOpts.Name + ":" + recordingRule.Expr.String()
-			operatorRegistry.registeredRecordingRules[key] = recordingRule
+			r.registeredRecordingRules[key] = recordingRule
 		}
 	}
 
@@ -34,10 +32,11 @@ func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
 }
 
 // RegisterAlerts registers the given alerts.
-func RegisterAlerts(alerts ...[]promv1.Rule) error {
+func (r *Registry) RegisterAlerts(alerts ...[]promv1.Rule) error {
 	for _, alertList := range alerts {
 		for _, alert := range alertList {
-			operatorRegistry.registeredAlerts[alert.Alert] = alert
+			key := alert.Alert + ":" + alert.Expr.String()
+			r.registeredAlerts[key] = alert
 		}
 	}
 
@@ -45,9 +44,9 @@ func RegisterAlerts(alerts ...[]promv1.Rule) error {
 }
 
 // ListRecordingRules returns the registered recording rules.
-func ListRecordingRules() []RecordingRule {
+func (r *Registry) ListRecordingRules() []RecordingRule {
 	var rules []RecordingRule
-	for _, rule := range operatorRegistry.registeredRecordingRules {
+	for _, rule := range r.registeredRecordingRules {
 		rules = append(rules, rule)
 	}
 
@@ -62,9 +61,9 @@ func ListRecordingRules() []RecordingRule {
 }
 
 // ListAlerts returns the registered alerts.
-func ListAlerts() []promv1.Rule {
+func (r *Registry) ListAlerts() []promv1.Rule {
 	var alerts []promv1.Rule
-	for _, alert := range operatorRegistry.registeredAlerts {
+	for _, alert := range r.registeredAlerts {
 		alerts = append(alerts, alert)
 	}
 
@@ -73,10 +72,4 @@ func ListAlerts() []promv1.Rule {
 	})
 
 	return alerts
-}
-
-// CleanRegistry removes all registered rules and alerts.
-func CleanRegistry() error {
-	operatorRegistry = newRegistry()
-	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -132,7 +132,7 @@ github.com/kubevirt/cluster-network-addons-operator/pkg/names
 # github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20240505100225-e29dee0bb12b
 ## explicit; go 1.20
 github.com/kubevirt/monitoring/pkg/metrics/parser
-# github.com/machadovilaca/operator-observability v0.0.21
+# github.com/machadovilaca/operator-observability v0.0.23
 ## explicit; go 1.21
 github.com/machadovilaca/operator-observability/pkg/docs
 github.com/machadovilaca/operator-observability/pkg/operatormetrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

#3144 needs an upgrade to the operator-observability package, which deprecates some functions used by HCO.
If we keep using those functions golangci throws an error on the CI pipelines.
This PR upgrades the package and implements the new approach it suggests.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
-
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
