### PR TITLE
Use larger cluster for the deployment test

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -100,7 +100,10 @@ chmod +x operator-sdk
 
 # start K8s cluster
 export KUBEVIRT_PROVIDER=k8s-1.31
+export KUBEVIRT_MEMORY_SIZE=12G
+export KUBEVIRT_NUM_NODES=4
 make cluster-up
+
 export KUBECONFIG=$(_kubevirtci/cluster-up/kubeconfig.sh)
 
 export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
@@ -115,7 +118,7 @@ trap "dump" INT TERM EXIT
 
 # install HCO on the cluster
 $KUBECTL create ns kubevirt-hyperconverged
-./operator-sdk run bundle -n kubevirt-hyperconverged --timeout=15m ${BUNDLE_IMAGE_NAME}
+./operator-sdk run bundle -n kubevirt-hyperconverged --timeout=30m ${BUNDLE_IMAGE_NAME}
 
 # deploy the HyperConverged CR
 $KUBECTL apply -n kubevirt-hyperconverged -f deploy/hco.cr.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
The test is currenly failing on HCO install by the operator-sdk, because of a timeout.

Trying to fix it by using larger cluster with 4 nodes and 12G of memory. Also, increase the install timeout to 30 minutes.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-48505
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
