### PR TITLE
[Release 1.13] Fix the publish community operators bot

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -13,7 +13,7 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       REGISTRY_NAMESPACE: kubevirt
-      OPM_VERSION: v1.35.0
+      OPM_VERSION: v1.47.0
     steps:
       - name: resolve the correct branch of the tag
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

The publish community operator github action failed.

The scripts relay in OPM version 1.47, while the OPM version in the publish-community-operators.yaml github action is 1.35.

This PR fixes the OPM version to fix this issue.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-51313
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
