### PR TITLE
Reset kubevirt_hco_system_health_status on update

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -192,7 +192,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "Initializing HyperConverged cluster",
 				})))
 
-				verifySystemHealthStatusError(foundResource)
+				verifySystemHealthStatusError(foundResource, reconcileInit)
 
 				expectedFeatureGates := []string{
 					"CPUManager",
@@ -314,7 +314,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "Initializing HyperConverged cluster",
 				})))
 
-				verifySystemHealthStatusError(foundResource)
+				verifySystemHealthStatusError(foundResource, reconcileInit)
 
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
@@ -401,7 +401,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: reconcileCompletedMessage,
 				})))
 
-				verifySystemHealthStatusError(foundResource)
+				verifySystemHealthStatusError(foundResource, "SSPConditions")
 
 				Expect(foundResource.Status.RelatedObjects).To(HaveLen(21))
 				expectedRef := corev1.ObjectReference{
@@ -3893,10 +3893,10 @@ func verifySystemHealthStatusHealthy(hco *hcov1beta1.HyperConverged) {
 	ExpectWithOffset(1, systemHealthStatusMetric).To(Equal(metrics.SystemHealthStatusHealthy))
 }
 
-func verifySystemHealthStatusError(hco *hcov1beta1.HyperConverged) {
+func verifySystemHealthStatusError(hco *hcov1beta1.HyperConverged, reason string) {
 	ExpectWithOffset(1, hco.Status.SystemHealthStatus).To(Equal(systemHealthStatusError))
 
-	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus(reconcileInit)
+	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus(reason)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, systemHealthStatusMetric).To(Equal(metrics.SystemHealthStatusError))
 }

--- a/pkg/monitoring/metrics/metrics_suite_test.go
+++ b/pkg/monitoring/metrics/metrics_suite_test.go
@@ -1,0 +1,13 @@
+package metrics_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}

--- a/pkg/monitoring/metrics/operator_metrics.go
+++ b/pkg/monitoring/metrics/operator_metrics.go
@@ -16,6 +16,7 @@ const (
 )
 
 const (
+	SystemHealthStatusUnknown float64 = 0
 	SystemHealthStatusHealthy float64 = iota
 	SystemHealthStatusWarning
 	SystemHealthStatusError
@@ -119,14 +120,17 @@ func IsHCOMetricHyperConvergedExists() (bool, error) {
 }
 
 func SetHCOSystemHealthy() {
+	systemHealthStatus.Reset()
 	systemHealthStatus.WithLabelValues("healthy").Set(SystemHealthStatusHealthy)
 }
 
 func SetHCOSystemWarning(reason string) {
+	systemHealthStatus.Reset()
 	systemHealthStatus.WithLabelValues(reason).Set(SystemHealthStatusWarning)
 }
 
 func SetHCOSystemError(reason string) {
+	systemHealthStatus.Reset()
 	systemHealthStatus.WithLabelValues(reason).Set(SystemHealthStatusError)
 }
 
@@ -137,7 +141,7 @@ func GetHCOMetricSystemHealthStatus(reason string) (float64, error) {
 	value := dto.Gauge.GetValue()
 
 	if err != nil {
-		return 0, err
+		return SystemHealthStatusUnknown, err
 	}
 	return value, nil
 }

--- a/pkg/monitoring/metrics/operator_metrics_test.go
+++ b/pkg/monitoring/metrics/operator_metrics_test.go
@@ -1,0 +1,28 @@
+package metrics_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/metrics"
+)
+
+var _ = Describe("Operator Metrics", func() {
+	Context("kubevirt_hco_system_health_status", func() {
+		It("should set system error reason correctly", func() {
+			metrics.SetHCOSystemError("Reason1")
+			v, err := metrics.GetHCOMetricSystemHealthStatus("Reason1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v).To(Equal(metrics.SystemHealthStatusError))
+
+			metrics.SetHCOSystemError("Reason2")
+			v, err = metrics.GetHCOMetricSystemHealthStatus("Reason2")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v).To(Equal(metrics.SystemHealthStatusError))
+
+			v, err = metrics.GetHCOMetricSystemHealthStatus("Reason1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v).To(Equal(metrics.SystemHealthStatusUnknown))
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

kubevirt_hco_system_health_status old error/warning values with different reasons still show after conditions are update. This PR resets the vector on each update. 

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-51403
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reset kubevirt_hco_system_health_status on update
```

/cc @sradco @avlitman 
