### PR TITLE
Fix nightly test: use operator-sdk v1.37, instead of latest

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -101,7 +101,8 @@ gsutil cp ./hco-bundle "gs://${hco_bucket}/${build_date}/hco-bundle-image"
 gsutil cp ./hco-index "gs://${hco_bucket}/${build_date}/hco-index-image"
 
 # download operator-sdk
-sdk_url=$(curl https://api.github.com/repos/operator-framework/operator-sdk/releases/latest | jq -rM '.assets[] | select(.name == "operator-sdk_linux_amd64") | .browser_download_url')
+#sdk_url=$(curl https://api.github.com/repos/operator-framework/operator-sdk/releases/latest | jq -rM '.assets[] | select(.name == "operator-sdk_linux_amd64") | .browser_download_url')
+sdk_url=https://github.com/operator-framework/operator-sdk/releases/download/v1.37.0/operator-sdk_linux_amd64
 wget $sdk_url -O operator-sdk
 chmod +x operator-sdk
 


### PR DESCRIPTION
**What this PR does / why we need it**:

operator-sdk v1.38 does not support kubebuilder's go v3 in the PROJECT file, and so it fails to run in this project, even to just install OLM.

Until we'll move to kubebuilder's go v4, we need to use older operator-sdk.

This PR changes the nightly test to use oprator-sdk v1.37.0, instead of taking the latest version.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
