### PR TITLE
Add DataImportCron Source for CentOS Stream 10

### DIFF
--- a/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
+++ b/assets/dataImportCronTemplates/dataImportCronTemplates.yaml
@@ -18,6 +18,23 @@
 - metadata:
     annotations:
       cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+    name: centos-stream10-image-cron
+  spec:
+    schedule: "0 */12 * * *"
+    template:
+      spec:
+        source:
+          registry:
+            url: docker://quay.io/containerdisks/centos-stream:10
+        storage:
+          resources:
+            requests:
+              storage: 10Gi
+    garbageCollect: Outdated
+    managedDataSource: centos-stream10
+- metadata:
+    annotations:
+      cdi.kubevirt.io/storage.bind.immediate.requested: "true"
     name: fedora-image-cron
   spec:
     schedule: "0 */12 * * *"

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	expectedImages       = []string{"centos-stream9-image-cron", "centos-stream9-image-cron-is", "fedora-image-cron"}
+	expectedImages       = []string{"centos-stream10-image-cron", "centos-stream9-image-cron", "centos-stream9-image-cron-is", "fedora-image-cron"}
 	imageNamespace       = defaultImageNamespace
 	expectedImageStreams = []tests.ImageStreamConfig{
 		{


### PR DESCRIPTION

**What this PR does / why we need it**:

It adds the required DataImportCron to enable CentOS Stream 10.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-43154
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add CentOS Stream 10 golden image boot source
```
