### PR TITLE
Enable KV DynamicPodInterfaceNaming FG by default

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -210,6 +210,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"VMPersistentState",
 					"NetworkBindingPlugins",
 					"VMLiveUpdateFeatures",
+					"DynamicPodInterfaceNaming",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -106,6 +106,9 @@ const (
 
 	// Enable VM live update, to allow live propagation of VM changes to their VMI
 	kvVMLiveUpdateFeatures = "VMLiveUpdateFeatures"
+
+	// kvDynamicPodInterfaceNaming enables a mechanism to dynamically determine the primary pod interface for KubeVirt virtual machines.
+	kvDynamicPodInterfaceNamingGate = "DynamicPodInterfaceNaming"
 )
 
 const (
@@ -127,6 +130,7 @@ var (
 		kvVMPersistentState,
 		kvHNetworkBindingPluginsGate,
 		kvVMLiveUpdateFeatures,
+		kvDynamicPodInterfaceNamingGate,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following the graduation of KubeVirt's `DynamicPodInterfaceNaming` feature gate[1], enable it by default.

[1] https://github.com/kubevirt/kubevirt/pull/13243

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable KubeVirt's DynamicPodInterfaceNaming feature gate by default
```
