### PR TITLE
Introduce the EnableDynamicPodInterfaceNaming enabler

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -486,6 +486,13 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=false
 	// +default=false
 	PrimaryUserDefinedNetworkBinding *bool `json:"primaryUserDefinedNetworkBinding,omitempty"`
+
+	// Enable KubeVirt to dynamically detect the pod's primary NIC name.
+	// Note: this feature is in Developer Preview.
+	// +optional
+	// +kubebuilder:default=false
+	// +default=false
+	EnableDynamicPodInterfaceNaming *bool `json:"enableDynamicPodInterfaceNaming,omitempty"`
 }
 
 // PermittedHostDevices holds information about devices allowed for passthrough

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -313,6 +313,11 @@ func (in *HyperConvergedFeatureGates) DeepCopyInto(out *HyperConvergedFeatureGat
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableDynamicPodInterfaceNaming != nil {
+		in, out := &in.EnableDynamicPodInterfaceNaming, &out.EnableDynamicPodInterfaceNaming
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1beta1/zz_generated.defaults.go
+++ b/api/v1beta1/zz_generated.defaults.go
@@ -84,6 +84,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.FeatureGates.PrimaryUserDefinedNetworkBinding = &ptrVar1
 	}
+	if in.Spec.FeatureGates.EnableDynamicPodInterfaceNaming == nil {
+		var ptrVar1 bool = false
+		in.Spec.FeatureGates.EnableDynamicPodInterfaceNaming = &ptrVar1
+	}
 	if in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster == nil {
 		var ptrVar1 uint32 = 5
 		in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster = &ptrVar1

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -326,6 +326,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 							Format:      "",
 						},
 					},
+					"enableDynamicPodInterfaceNaming": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Enable KubeVirt to dynamically detect the pod's primary NIC name. Note: this feature is in Developer Preview.",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -1104,6 +1104,12 @@ spec:
                       templates that can be added to the dataImportCronTemplates field. This feature gates only control the common
                       templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.
                     type: boolean
+                  enableDynamicPodInterfaceNaming:
+                    default: false
+                    description: |-
+                      Enable KubeVirt to dynamically detect the pod's primary NIC name.
+                      Note: this feature is in Developer Preview.
+                    type: boolean
                   persistentReservation:
                     default: false
                     description: |-

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -106,6 +106,9 @@ const (
 
 	// Enable VM live update, to allow live propagation of VM changes to their VMI
 	kvVMLiveUpdateFeatures = "VMLiveUpdateFeatures"
+
+	// kvDynamicPodInterfaceNaming enables a mechanism to dynamically determine the primary pod interface for KubeVirt virtual machines.
+	kvDynamicPodInterfaceNamingGate = "DynamicPodInterfaceNaming"
 )
 
 const (
@@ -833,6 +836,9 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) [
 	}
 	if featureGates.AlignCPUs != nil && *featureGates.AlignCPUs {
 		fgs = append(fgs, kvAlignCPUs)
+	}
+	if featureGates.EnableDynamicPodInterfaceNaming != nil && *featureGates.EnableDynamicPodInterfaceNaming {
+		fgs = append(fgs, kvDynamicPodInterfaceNamingGate)
 	}
 
 	return fgs

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -2088,6 +2088,45 @@ Version: 1.2.3`)
 					Expect(existingResource.Spec.Configuration.NetworkConfiguration.Binding).To(BeNil())
 				})
 
+				It("should add the DynamicPodInterfaceNaming feature gate if EnableDynamicPodInterfaceNaming is true in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						EnableDynamicPodInterfaceNaming: ptr.To(true),
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should contain the DynamicPodInterfaceNaming feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvDynamicPodInterfaceNamingGate))
+					})
+				})
+
+				It("should not add the DynamicPodInterfaceNaming feature gate if EnableDynamicPodInterfaceNaming is false in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						EnableDynamicPodInterfaceNaming: ptr.To(false),
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should not contain the DynamicPodInterfaceNaming feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvDynamicPodInterfaceNamingGate))
+					})
+				})
+
+				It("should not add the DynamicPodInterfaceNaming feature gate if EnableDynamicPodInterfaceNaming is not set in HyperConverged CR", func() {
+					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+						EnableDynamicPodInterfaceNaming: nil,
+					}
+
+					existingResource, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					By("KV CR should not contain the DynamicPodInterfaceNaming feature gate", func() {
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
+						Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvDynamicPodInterfaceNamingGate))
+					})
+				})
+
 				It("should not add the feature gates if FeatureGates field is empty", func() {
 					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
 					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{}

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1104,6 +1104,12 @@ spec:
                       templates that can be added to the dataImportCronTemplates field. This feature gates only control the common
                       templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.
                     type: boolean
+                  enableDynamicPodInterfaceNaming:
+                    default: false
+                    description: |-
+                      Enable KubeVirt to dynamically detect the pod's primary NIC name.
+                      Note: this feature is in Developer Preview.
+                    type: boolean
                   persistentReservation:
                     default: false
                     description: |-

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -21,6 +21,7 @@ spec:
     downwardMetrics: false
     enableApplicationAwareQuota: false
     enableCommonBootImageImport: true
+    enableDynamicPodInterfaceNaming: false
     persistentReservation: false
     primaryUserDefinedNetworkBinding: false
   higherWorkloadDensity:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
@@ -1104,6 +1104,12 @@ spec:
                       templates that can be added to the dataImportCronTemplates field. This feature gates only control the common
                       templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.
                     type: boolean
+                  enableDynamicPodInterfaceNaming:
+                    default: false
+                    description: |-
+                      Enable KubeVirt to dynamically detect the pod's primary NIC name.
+                      Note: this feature is in Developer Preview.
+                    type: boolean
                   persistentReservation:
                     default: false
                     description: |-

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
@@ -1104,6 +1104,12 @@ spec:
                       templates that can be added to the dataImportCronTemplates field. This feature gates only control the common
                       templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.
                     type: boolean
+                  enableDynamicPodInterfaceNaming:
+                    default: false
+                    description: |-
+                      Enable KubeVirt to dynamically detect the pod's primary NIC name.
+                      Note: this feature is in Developer Preview.
+                    type: boolean
                   persistentReservation:
                     default: false
                     description: |-

--- a/docs/api.md
+++ b/docs/api.md
@@ -165,6 +165,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | alignCPUs | Enable KubeVirt to request up to two additional dedicated CPUs in order to complete the total CPU count to an even parity when using emulator thread isolation. Note: this feature is in Developer Preview. | *bool | false | false |
 | enableApplicationAwareQuota | EnableApplicationAwareQuota if true, enables the Application Aware Quota feature | *bool | false | false |
 | primaryUserDefinedNetworkBinding | primaryUserDefinedNetworkBinding deploys the needed configurations for kubevirt users to be able to bind their VM to a UDN network on the VM's primary interface. Note: this feature is in Developer Preview. | *bool | false | false |
+| enableDynamicPodInterfaceNaming | Enable KubeVirt to dynamically detect the pod's primary NIC name. Note: this feature is in Developer Preview. | *bool | false | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -77,6 +77,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			AlignCPUs:                        ptr.To(false),
 			EnableApplicationAwareQuota:      ptr.To(false),
 			PrimaryUserDefinedNetworkBinding: ptr.To(false),
+			EnableDynamicPodInterfaceNaming:  ptr.To(false),
 		}
 
 		DescribeTable("Check that featureGates defaults are behaving as expected", func(ctx context.Context, path string) {
@@ -99,6 +100,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			Entry("when removing /spec/featureGates/autoResourceLimits", "/spec/featureGates/autoResourceLimits"),
 			Entry("when removing /spec/featureGates/alignCPUs", "/spec/featureGates/alignCPUs"),
 			Entry("when removing /spec/featureGates/primaryUserDefinedNetworkBinding", "/spec/featureGates/primaryUserDefinedNetworkBinding"),
+			Entry("when removing /spec/featureGates/enableDynamicPodInterfaceNaming", "/spec/featureGates/enableDynamicPodInterfaceNaming"),
 			Entry("when removing /spec/featureGates", "/spec/featureGates"),
 			Entry("when removing /spec", "/spec"),
 		)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add the `EnableDynamicPodInterfaceNaming` enabler to control KubeVirt's `DynamicPodInterfaceNaming` feature gate.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce the EnableDynamicPodInterfaceNaming enabler
```
