### PR TITLE
Stop using the deprecated vm.spec.running field

### DIFF
--- a/hack/vm.yaml
+++ b/hack/vm.yaml
@@ -3,7 +3,7 @@ kind: VirtualMachine
 metadata:
   name: testvm
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

Stop using the deprecated vm.spec.running field. Use the new vm.spec.runStrategy API instead.

**Release note**:
```release-note
None
```
