### PR TITLE
Don't rely on InfraStructureTopology for infra HA

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -729,6 +729,11 @@ type HyperConvergedStatus struct {
 	// SystemHealthStatus reflects the health of HCO and its secondary resources, based on the aggregated conditions.
 	// +optional
 	SystemHealthStatus string `json:"systemHealthStatus,omitempty"`
+
+	// InfrastructureHighlyAvailable describes whether the cluster has only one worker node
+	// (false) or more (true).
+	// +optional
+	InfrastructureHighlyAvailable bool `json:"infrastructureHighlyAvailable,omitempty"`
 }
 
 type Version struct {

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -737,6 +737,13 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 							Format:      "",
 						},
 					},
+					"infrastructureHighlyAvailable": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InfrastructureHighlyAvailable describes whether the cluster has only one worker node (false) or more (true).",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/crd"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/descheduler"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/hyperconverged"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/nodes"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/observability"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/metrics"
@@ -201,6 +202,13 @@ func main() {
 			eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to register KubeDescheduler controller; "+err.Error())
 			os.Exit(1)
 		}
+	}
+
+	// Create a new Nodes reconciler
+	if err := nodes.RegisterReconciler(mgr); err != nil {
+		logger.Error(err, "failed to register the Nodes controller")
+		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to register Nodes controller; "+err.Error())
+		os.Exit(1)
 	}
 
 	err = createPriorityClass(ctx, mgr)

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -4876,6 +4876,11 @@ spec:
                   DataImportSchedule is the cron expression that is used in for the hard-coded data import cron templates. HCO
                   generates the value of this field once and stored in the status field, so will survive restart.
                 type: string
+              infrastructureHighlyAvailable:
+                description: |-
+                  InfrastructureHighlyAvailable describes whether the cluster has only one worker node
+                  (false) or more (true).
+                type: boolean
               observedGeneration:
                 description: |-
                   ObservedGeneration reflects the HyperConverged resource generation. If the ObservedGeneration is less than the

--- a/controllers/commontestutils/testUtils.go
+++ b/controllers/commontestutils/testUtils.go
@@ -297,6 +297,9 @@ func (ClusterInfoMock) IsControlPlaneHighlyAvailable() bool {
 func (ClusterInfoMock) IsInfrastructureHighlyAvailable() bool {
 	return true
 }
+func (ClusterInfoMock) SetHighAvailabilityMode(_ context.Context, _ client.Client) error {
+	return nil
+}
 func (ClusterInfoMock) GetDomain() string {
 	return "domain"
 }
@@ -366,6 +369,9 @@ func (ClusterInfoSNOMock) IsControlPlaneHighlyAvailable() bool {
 func (ClusterInfoSNOMock) IsInfrastructureHighlyAvailable() bool {
 	return false
 }
+func (ClusterInfoSNOMock) SetHighAvailabilityMode(_ context.Context, _ client.Client) error {
+	return nil
+}
 func (ClusterInfoSNOMock) GetDomain() string {
 	return "domain"
 }
@@ -434,6 +440,9 @@ func (ClusterInfoSRCPHAIMock) IsControlPlaneHighlyAvailable() bool {
 }
 func (ClusterInfoSRCPHAIMock) IsInfrastructureHighlyAvailable() bool {
 	return true
+}
+func (ClusterInfoSRCPHAIMock) SetHighAvailabilityMode(_ context.Context, _ client.Client) error {
+	return nil
 }
 func (ClusterInfoSRCPHAIMock) GetPod() *corev1.Pod {
 	return pod

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -162,7 +162,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo) er
 		source.Kind(
 			mgr.GetCache(), client.Object(&hcov1beta1.HyperConverged{}),
 			&operatorhandler.InstrumentedEnqueueRequestForObject[client.Object]{},
-			predicate.Or[client.Object](predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}),
+			predicate.Or[client.Object](predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{},
+				predicate.ResourceVersionChangedPredicate{}),
 		))
 	if err != nil {
 		return err

--- a/controllers/nodes/nodes_controller.go
+++ b/controllers/nodes/nodes_controller.go
@@ -1,0 +1,127 @@
+package nodes
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+
+	operatorhandler "github.com/operator-framework/operator-lib/handler"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+var (
+	log = logf.Log.WithName("controller_nodes")
+)
+
+// RegisterReconciler creates a new Nodes Reconciler and registers it into manager.
+func RegisterReconciler(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	r := &ReconcileNodeCounter{
+		client: mgr.GetClient(),
+	}
+
+	return r
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("nodes-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to the cluster's nodes
+	err = c.Watch(
+		source.Kind(
+			mgr.GetCache(), client.Object(&corev1.Node{}),
+			&operatorhandler.InstrumentedEnqueueRequestForObject[client.Object]{},
+			nodeCountChangePredicate{},
+		))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Custom predicate to detect changes in node count
+type nodeCountChangePredicate struct {
+	predicate.Funcs
+}
+
+func (nodeCountChangePredicate) Update(e event.UpdateEvent) bool {
+	return false
+}
+
+func (nodeCountChangePredicate) Create(e event.CreateEvent) bool {
+	// node is added
+	return true
+}
+
+func (nodeCountChangePredicate) Delete(e event.DeleteEvent) bool {
+	// node is removed
+	return true
+}
+
+func (nodeCountChangePredicate) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+// ReconcileNodeCounter reconciles the nodes count
+type ReconcileNodeCounter struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client              client.Client
+	HyperConvergedQueue workqueue.TypedRateLimitingInterface[reconcile.Request]
+}
+
+// Reconcile updates the nodes count on ClusterInfo singleton
+func (r *ReconcileNodeCounter) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	log.Info("Triggered by a node count change")
+	clusterInfo := hcoutil.GetClusterInfo()
+	err := clusterInfo.SetHighAvailabilityMode(ctx, r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	hco := &hcov1beta1.HyperConverged{}
+	namespace, err := hcoutil.GetOperatorNamespaceFromEnv()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	hcoKey := types.NamespacedName{
+		Name:      hcoutil.HyperConvergedName,
+		Namespace: namespace,
+	}
+	err = r.client.Get(ctx, hcoKey, hco)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if hco.Status.InfrastructureHighlyAvailable != clusterInfo.IsInfrastructureHighlyAvailable() {
+		hco.Status.InfrastructureHighlyAvailable = clusterInfo.IsInfrastructureHighlyAvailable()
+		err = r.client.Status().Update(ctx, hco)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+	return reconcile.Result{}, nil
+}

--- a/controllers/nodes/nodes_controller_test.go
+++ b/controllers/nodes/nodes_controller_test.go
@@ -1,0 +1,126 @@
+package nodes
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+// Mock TestRequest to simulate Reconcile() being called on an event for a watched resource
+var (
+	request = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "nodes-controller",
+			Namespace: commontestutils.Namespace,
+		},
+	}
+)
+
+var _ = Describe("NodesController", func() {
+
+	getClusterInfo := hcoutil.GetClusterInfo
+
+	Describe("Reconcile NodesController", func() {
+
+		BeforeEach(func() {
+			hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
+				return commontestutils.ClusterInfoMock{}
+			}
+			_ = os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)
+		})
+
+		AfterEach(func() {
+			hcoutil.GetClusterInfo = getClusterInfo
+		})
+
+		Context("Node Count Change", func() {
+			It("Should update InfrastructureHighlyAvailable to true if there are two or more worker nodes", func() {
+				hco := commontestutils.NewHco()
+				numWorkerNodes := 3
+				var nodesArray []client.Object
+				for i := range numWorkerNodes {
+					workerNode := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("worker%d", i),
+							Labels: map[string]string{
+								"node-role.kubernetes.io/worker": "",
+							},
+						},
+					}
+					nodesArray = append(nodesArray, workerNode)
+				}
+
+				resources := []client.Object{hco, nodesArray[0], nodesArray[1], nodesArray[2]}
+				cl := commontestutils.InitClient(resources)
+				logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("nodes_controller_test")
+				Expect(hcoutil.GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
+				r := &ReconcileNodeCounter{
+					client: cl,
+				}
+
+				// Reconcile to update HCO's status with the correct InfrastructureHighlyAvailable value
+				res, err := r.Reconcile(context.TODO(), request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Requeue).To(BeFalse())
+
+				latestHCO := &hcov1beta1.HyperConverged{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: commontestutils.Name, Namespace: commontestutils.Namespace},
+						latestHCO),
+				).ToNot(HaveOccurred())
+
+				Expect(latestHCO.Status.InfrastructureHighlyAvailable).To(BeTrue())
+				Expect(res).To(Equal(reconcile.Result{}))
+			})
+			It("Should update InfrastructureHighlyAvailable to false if there is only one worker node", func() {
+				hco := commontestutils.NewHco()
+				workerNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+				}
+				resources := []client.Object{hco, workerNode}
+				cl := commontestutils.InitClient(resources)
+				logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("nodes_controller_test")
+				Expect(hcoutil.GetClusterInfo().Init(context.TODO(), cl, logger)).To(Succeed())
+				r := &ReconcileNodeCounter{
+					client: cl,
+				}
+
+				// Reconcile to update HCO's status with the correct InfrastructureHighlyAvailable value
+				res, err := r.Reconcile(context.TODO(), request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Requeue).To(BeFalse())
+
+				latestHCO := &hcov1beta1.HyperConverged{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: commontestutils.Name, Namespace: commontestutils.Namespace},
+						latestHCO),
+				).ToNot(HaveOccurred())
+
+				Expect(hco.Status.InfrastructureHighlyAvailable).To(BeFalse())
+				Expect(res).To(Equal(reconcile.Result{}))
+			})
+		})
+
+	})
+})

--- a/controllers/nodes/nodes_suite_test.go
+++ b/controllers/nodes/nodes_suite_test.go
@@ -1,0 +1,13 @@
+package nodes_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNodes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Nodes Controller Suite")
+}

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -4876,6 +4876,11 @@ spec:
                   DataImportSchedule is the cron expression that is used in for the hard-coded data import cron templates. HCO
                   generates the value of this field once and stored in the status field, so will survive restart.
                 type: string
+              infrastructureHighlyAvailable:
+                description: |-
+                  InfrastructureHighlyAvailable describes whether the cluster has only one worker node
+                  (false) or more (true).
+                type: boolean
               observedGeneration:
                 description: |-
                   ObservedGeneration reflects the HyperConverged resource generation. If the ObservedGeneration is less than the

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
@@ -4876,6 +4876,11 @@ spec:
                   DataImportSchedule is the cron expression that is used in for the hard-coded data import cron templates. HCO
                   generates the value of this field once and stored in the status field, so will survive restart.
                 type: string
+              infrastructureHighlyAvailable:
+                description: |-
+                  InfrastructureHighlyAvailable describes whether the cluster has only one worker node
+                  (false) or more (true).
+                type: boolean
               observedGeneration:
                 description: |-
                   ObservedGeneration reflects the HyperConverged resource generation. If the ObservedGeneration is less than the

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
@@ -4876,6 +4876,11 @@ spec:
                   DataImportSchedule is the cron expression that is used in for the hard-coded data import cron templates. HCO
                   generates the value of this field once and stored in the status field, so will survive restart.
                 type: string
+              infrastructureHighlyAvailable:
+                description: |-
+                  InfrastructureHighlyAvailable describes whether the cluster has only one worker node
+                  (false) or more (true).
+                type: boolean
               observedGeneration:
                 description: |-
                   ObservedGeneration reflects the HyperConverged resource generation. If the ObservedGeneration is less than the

--- a/docs/api.md
+++ b/docs/api.md
@@ -246,6 +246,7 @@ HyperConvergedStatus defines the observed state of HyperConverged
 | dataImportSchedule | DataImportSchedule is the cron expression that is used in for the hard-coded data import cron templates. HCO generates the value of this field once and stored in the status field, so will survive restart. | string |  | false |
 | dataImportCronTemplates | DataImportCronTemplates is a list of the actual DataImportCronTemplates as HCO update in the SSP CR. The list contains both the common and the custom templates, including any modification done by HCO. | [][DataImportCronTemplateStatus](#dataimportcrontemplatestatus) |  | false |
 | systemHealthStatus | SystemHealthStatus reflects the health of HCO and its secondary resources, based on the aggregated conditions. | string |  | false |
+| infrastructureHighlyAvailable | InfrastructureHighlyAvailable describes whether the cluster has only one worker node (false) or more (true). | bool |  | false |
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
There are some cases in which the number of worker nodes are changing throughout the lifecycle of the cluster, and the `InfrastructureTopology` in the Infrastructure resource is statically set at cluster installation type and it is not getting updated dynamically. For example, an SNO cluster that is being added a new worker node. In that case, the infrastructure topology should be updated to `HighlyAvailable` and don't remain `SingleReplica`.
Instead, we should count the worker nodes, same as we do in case of a k8s cluster.

In addition, fixing a potential bug were we used only the `node-role.kubernetes.io/master` label to find and count the masters/control-plane nodes.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-50027
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
