### PR TITLE
Enable Storage Live Migration by default

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -211,6 +211,8 @@ var _ = Describe("HyperconvergedController", func() {
 					"NetworkBindingPlugins",
 					"VMLiveUpdateFeatures",
 					"DynamicPodInterfaceNaming",
+					"VolumesUpdateStrategy",
+					"VolumeMigration",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -110,6 +110,12 @@ const (
 
 	// kvDynamicPodInterfaceNaming enables a mechanism to dynamically determine the primary pod interface for KubeVirt virtual machines.
 	kvDynamicPodInterfaceNamingGate = "DynamicPodInterfaceNaming"
+
+	// enables to specify the strategy on the volume updates.
+	kvVolumesUpdateStrategyGate = "VolumesUpdateStrategy"
+
+	// enables to migrate the storage. It depends on the VolumesUpdateStrategy feature.
+	kvVolumeMigrationGate = "VolumeMigration"
 )
 
 const (
@@ -132,6 +138,8 @@ var (
 		kvHNetworkBindingPluginsGate,
 		kvVMLiveUpdateFeatures,
 		kvDynamicPodInterfaceNamingGate,
+		kvVolumesUpdateStrategyGate,
+		kvVolumeMigrationGate,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of


### PR DESCRIPTION
Hard-coding the 'VolumesUpdateStrategy' and 'VolumeMigration' as the storage live migration has been graduated to GA in kubevirt.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-51446
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable storage live migration feature gates by default
```
