### PR TITLE
Temporary set KVCI tag to 2412041602-733e595f

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -113,7 +113,8 @@ make cluster-up
 
 export KUBECONFIG=$(_kubevirtci/cluster-up/kubeconfig.sh)
 
-export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+# export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+export KUBEVIRTCI_TAG=2412041602-733e595f
 export KUBECTL=$(pwd)/_kubevirtci/cluster-up/kubectl.sh
 
 # install OLM on the cluster

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.30'}
-export LATEST_KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-${LATEST_KUBEVIRTCI_TAG}}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.31'}
+# export LATEST_KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+# export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-${LATEST_KUBEVIRTCI_TAG}}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2412041602-733e595f}
+
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 


### PR DESCRIPTION
Currently, https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest returns 404. That breaks the CI.

This PR set the KVCI tag to the latest working version, to avoid this failure.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
