### PR TITLE
Remove deprecated DataVolume garbage collection doc

### DIFF
--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -1341,28 +1341,6 @@ metadata:
         }
       ]
 ```
-##### Disable DataVolume garbage collection
-To disable [DataVolume garbage collection](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/datavolumes.md#garbage-collection-of-successfully-completed-datavolumes), the following annotation should be added to the HyperConverged CR:
-```yaml
-metadata:
-  annotations:
-    containerizeddataimporter.kubevirt.io/jsonpatch: |-
-      [
-        {
-          "op": "add",
-          "path": "/spec/config/dataVolumeTTLSeconds",
-          "value": -1
-        }
-      ]
-```
-Or from CLI:
-```bash
-$ kubectl annotate --overwrite -n kubevirt-hyperconverged hco kubevirt-hyperconverged \
-  containerizeddataimporter.kubevirt.io/jsonpatch='[{"op": "add", \
-    "path": "/spec/config/dataVolumeTTLSeconds", \
-    "value": -1 }]'
-```
-To enable DataVolume garbage collection put any non-negative value for the `dataVolumeTTLSeconds`, which is the time in seconds after DataVolume completion it can be garbage collected.
 ##### Modify DataVolume Upload URL
 The user wants to override the default URL used when uploading to a DataVolume, by setting the CDI CR's `spec.config.uploadProxyURLOverride` to `myproxy.example.com`. In order to do that, the following annotation should be added to the HyperConverged CR:
 ```yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
After several releases with CDI DataVolume garbage collection disabled by default, we decided to [deprecate](https://github.com/kubevirt/containerized-data-importer/pull/3552) it, as unfortunately it violates fundamental principle of Kubernetes. CR should not be auto-deleted when it completes its role (Job with TTLSecondsAfterFinished is an exception), and once CR was created we can assume it is there until explicitly deleted. In addition, CR should keep idempotency, so the same CR manifest can be applied multiple times, as long as it is a valid update (e.g. DataVolume validation webhook does not allow updating the spec).

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-30806
```

**Release note**:
```release-note
NONE
```