### PR TITLE
Bump golangci-lint to v1.62.2

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22" # The Go version to download (if necessary) and use.
+          go-version-file: go.mod # The Go version to download (if necessary) and use.
 
       - name: Do sanity checks
         run: make sanity
@@ -67,6 +67,6 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.59.0
+          version: v1.62.2
           skip-pkg-cache: true
           args: --timeout=5m --out-${NO_FUTURE}format line-number


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
