### PR TITLE
Remove the unused MTQ CRDs on upgrade

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -87,7 +87,7 @@ const (
 	apiServerCRPrefix = "api-server-cr-"
 
 	// These group are no longer supported. Use these constants to remove unused resources
-	v2vGroup = "v2v.kubevirt.io"
+	mtqGroup = "mtq.kubevirt.io"
 
 	requestedStatusKey = "requested status"
 )
@@ -134,10 +134,8 @@ func newCRDremover(client client.Client) *CRDRemover {
 	crdRemover := &CRDRemover{
 		client: client,
 		crdsToRemove: []schema.GroupKind{
-			// These are the v2v CRDs we have to remove moving to MTV
-			{Group: v2vGroup, Kind: "V2VVmware"},
-			{Group: v2vGroup, Kind: "OVirtProvider"},
-			{Group: v2vGroup, Kind: "VMImportConfig"},
+			// These is the MTQ CRD we have to remove moving to AAQ
+			{Group: mtqGroup, Kind: "MTQ"},
 		},
 	}
 

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1791,7 +1791,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 			})
 
-			Context("Remove v2v CRDs and related objects", func() {
+			Context("Remove MTQ CRD and related objects", func() {
 
 				var (
 					currentCRDs          []*apiextensionsv1.CustomResourceDefinition
@@ -1831,17 +1831,7 @@ var _ = Describe("HyperconvergedController", func() {
 					oldCRDs = []*apiextensionsv1.CustomResourceDefinition{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "vmimportconfigs.v2v.kubevirt.io",
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "v2vvmwares.v2v.kubevirt.io",
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "ovirtproviders.v2v.kubevirt.io",
+								Name: "mtqs.mtq.kubevirt.io",
 							},
 						},
 						{
@@ -1852,9 +1842,9 @@ var _ = Describe("HyperconvergedController", func() {
 					}
 					oldCRDRelatedObjects = []corev1.ObjectReference{
 						{
-							APIVersion:      "v2v.kubevirt.io/v1alpha1",
-							Kind:            "VMImportConfig",
-							Name:            "vmimport-kubevirt-hyperconverged",
+							APIVersion:      "mtq.kubevirt.io/v1alpha1",
+							Kind:            "MTQ",
+							Name:            "mtq-kubevirt-hyperconverged",
 							ResourceVersion: "999",
 						},
 					}
@@ -1883,7 +1873,7 @@ var _ = Describe("HyperconvergedController", func() {
 					}
 				})
 
-				It("should remove v2v CRDs during upgrades", func() {
+				It("should remove the MTQ CRD during upgrades", func() {
 					// Simulate ongoing upgrade
 					UpdateVersion(&expected.hco.Status, hcoVersionName, "1.6.1")
 
@@ -1919,7 +1909,7 @@ var _ = Describe("HyperconvergedController", func() {
 					}
 				})
 
-				It("shouldn't remove v2v CRDs if upgrade isn't in progress", func() {
+				It("shouldn't remove the MTQ CRD if upgrade isn't in progress", func() {
 					resources := expected.toArray()
 					for _, r := range currentCRDs {
 						resources = append(resources, r)
@@ -1947,7 +1937,7 @@ var _ = Describe("HyperconvergedController", func() {
 					}
 				})
 
-				It("should remove v2v related objects if upgrade is in progress", func() {
+				It("should remove the MTQ related object if upgrade is in progress", func() {
 					// Simulate ongoing upgrade
 					UpdateVersion(&expected.hco.Status, hcoVersionName, oldVersion)
 
@@ -1990,7 +1980,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 				})
 
-				It("should remove v2v related objects if upgrade isn't in progress", func() {
+				It("should remove the MTQ related object if upgrade isn't in progress", func() {
 					// Initialize RelatedObjects with a bunch of objects
 					// including old SSP ones.
 					for _, objRef := range oldCRDRelatedObjects {


### PR DESCRIPTION
### What this PR does / why we need it
MTQ was dropped from HCO on 1.13, but if HCO was upgraded from previous version, the MTQ CRD is still deploy.

This PR removes the MTQ CRD on upgrade, if exists.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### Jira Ticket
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-52732
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove the unused MTQ CRD on upgrade
```

/cherry-pick release-1.13
