### PR TITLE
Restore deprecated feature gates

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -403,9 +403,6 @@ type HyperConvergedFeatureGates struct {
 	// +default=false
 	DownwardMetrics *bool `json:"downwardMetrics,omitempty"`
 
-	// Allow migrating a virtual machine with CPU host-passthrough mode. This should be
-	// enabled only when the Cluster is homogeneous from CPU HW perspective doc here
-	// +optional
 	// Deprecated: there is no such FG in KubeVirt. This field is ignored
 	WithHostPassthroughCPU *bool `json:"withHostPassthroughCPU,omitempty"`
 
@@ -417,6 +414,9 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=true
 	// +default=true
 	EnableCommonBootImageImport *bool `json:"enableCommonBootImageImport,omitempty"`
+
+	// Deprecated: This field is ignored and will be removed on the next version of the API.
+	DeployTektonTaskResources *bool `json:"deployTektonTaskResources,omitempty"`
 
 	// deploy VM console proxy resources in SSP operator
 	// +optional
@@ -434,6 +434,9 @@ type HyperConvergedFeatureGates struct {
 	// Deprecated: this field is ignored and will be removed in the next version of the API.
 	DeployKubevirtIpamController *bool `json:"deployKubevirtIpamController,omitempty"`
 
+	// Deprecated: // Deprecated: This field is ignored and will be removed on the next version of the API.
+	NonRoot *bool `json:"nonRoot,omitempty"`
+
 	// Disable mediated devices handling on KubeVirt
 	// +optional
 	// +kubebuilder:default=false
@@ -448,6 +451,9 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=false
 	// +default=false
 	PersistentReservation *bool `json:"persistentReservation,omitempty"`
+
+	// Deprecated: This field is ignored and will be removed on the next version of the API.
+	EnableManagedTenantQuota *bool `json:"enableManagedTenantQuota,omitempty"`
 
 	// TODO update description to also include cpu limits as well, after 4.14
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -268,6 +268,11 @@ func (in *HyperConvergedFeatureGates) DeepCopyInto(out *HyperConvergedFeatureGat
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DeployTektonTaskResources != nil {
+		in, out := &in.DeployTektonTaskResources, &out.DeployTektonTaskResources
+		*out = new(bool)
+		**out = **in
+	}
 	if in.DeployVMConsoleProxy != nil {
 		in, out := &in.DeployVMConsoleProxy, &out.DeployVMConsoleProxy
 		*out = new(bool)
@@ -283,6 +288,11 @@ func (in *HyperConvergedFeatureGates) DeepCopyInto(out *HyperConvergedFeatureGat
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NonRoot != nil {
+		in, out := &in.NonRoot, &out.NonRoot
+		*out = new(bool)
+		**out = **in
+	}
 	if in.DisableMDevConfiguration != nil {
 		in, out := &in.DisableMDevConfiguration, &out.DisableMDevConfiguration
 		*out = new(bool)
@@ -290,6 +300,11 @@ func (in *HyperConvergedFeatureGates) DeepCopyInto(out *HyperConvergedFeatureGat
 	}
 	if in.PersistentReservation != nil {
 		in, out := &in.PersistentReservation, &out.PersistentReservation
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableManagedTenantQuota != nil {
+		in, out := &in.EnableManagedTenantQuota, &out.EnableManagedTenantQuota
 		*out = new(bool)
 		**out = **in
 	}

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -241,7 +241,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 					},
 					"withHostPassthroughCPU": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here Deprecated: there is no such FG in KubeVirt. This field is ignored",
+							Description: "Deprecated: there is no such FG in KubeVirt. This field is ignored",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -250,6 +250,13 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 						SchemaProps: spec.SchemaProps{
 							Description: "Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.",
 							Default:     true,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"deployTektonTaskResources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Deprecated: This field is ignored and will be removed on the next version of the API.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -277,6 +284,13 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 							Format:      "",
 						},
 					},
+					"nonRoot": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Deprecated: // Deprecated: This field is ignored and will be removed on the next version of the API.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"disableMDevConfiguration": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Disable mediated devices handling on KubeVirt",
@@ -289,6 +303,13 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 						SchemaProps: spec.SchemaProps{
 							Description: "Enable persistent reservation of a LUN through the SCSI Persistent Reserve commands on Kubevirt. In order to issue privileged SCSI ioctls, the VM requires activation of the persistent reservation flag. Once this feature gate is enabled, then the additional container with the qemu-pr-helper is deployed inside the virt-handler pod. Enabling (or removing) the feature gate causes the redeployment of the virt-handler pod.",
 							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"enableManagedTenantQuota": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Deprecated: This field is ignored and will be removed on the next version of the API.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -52,6 +52,42 @@
       "jsonPatchApplyOptions": {
         "allowMissingPathOnRemove": true
       }
+    },
+    {
+      "semverRange": "<=1.14.0",
+      "jsonPatch": [
+        {
+          "op": "remove",
+          "path": "/spec/featureGates/deployTektonTaskResources"
+        }
+      ],
+      "jsonPatchApplyOptions": {
+        "allowMissingPathOnRemove": true
+      }
+    },
+    {
+      "semverRange": "<=1.14.0",
+      "jsonPatch": [
+        {
+          "op": "remove",
+          "path": "/spec/featureGates/nonRoot"
+        }
+      ],
+      "jsonPatchApplyOptions": {
+        "allowMissingPathOnRemove": true
+      }
+    },
+    {
+      "semverRange": "<=1.14.0",
+      "jsonPatch": [
+        {
+          "op": "remove",
+          "path": "/spec/featureGates/enableManagedTenantQuota"
+        }
+      ],
+      "jsonPatchApplyOptions": {
+        "allowMissingPathOnRemove": true
+      }
     }
   ],
   "objectsToBeRemoved": [

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -1075,6 +1075,10 @@ spec:
                       Deploy KubevirtIpamController by CNAO.
                       Deprecated: this field is ignored and will be removed in the next version of the API.
                     type: boolean
+                  deployTektonTaskResources:
+                    description: 'Deprecated: This field is ignored and will be removed
+                      on the next version of the API.'
+                    type: boolean
                   deployVmConsoleProxy:
                     default: false
                     description: deploy VM console proxy resources in SSP operator
@@ -1101,6 +1105,14 @@ spec:
                       templates that can be added to the dataImportCronTemplates field. This feature gates only control the common
                       templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.
                     type: boolean
+                  enableManagedTenantQuota:
+                    description: 'Deprecated: This field is ignored and will be removed
+                      on the next version of the API.'
+                    type: boolean
+                  nonRoot:
+                    description: 'Deprecated: // Deprecated: This field is ignored
+                      and will be removed on the next version of the API.'
+                    type: boolean
                   persistentReservation:
                     default: false
                     description: |-
@@ -1117,10 +1129,8 @@ spec:
                       Note: this feature is in Developer Preview.
                     type: boolean
                   withHostPassthroughCPU:
-                    description: |-
-                      Allow migrating a virtual machine with CPU host-passthrough mode. This should be
-                      enabled only when the Cluster is homogeneous from CPU HW perspective doc here
-                      Deprecated: there is no such FG in KubeVirt. This field is ignored
+                    description: 'Deprecated: there is no such FG in KubeVirt. This
+                      field is ignored'
                     type: boolean
                 type: object
               filesystemOverhead:

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1075,6 +1075,10 @@ spec:
                       Deploy KubevirtIpamController by CNAO.
                       Deprecated: this field is ignored and will be removed in the next version of the API.
                     type: boolean
+                  deployTektonTaskResources:
+                    description: 'Deprecated: This field is ignored and will be removed
+                      on the next version of the API.'
+                    type: boolean
                   deployVmConsoleProxy:
                     default: false
                     description: deploy VM console proxy resources in SSP operator
@@ -1101,6 +1105,14 @@ spec:
                       templates that can be added to the dataImportCronTemplates field. This feature gates only control the common
                       templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.
                     type: boolean
+                  enableManagedTenantQuota:
+                    description: 'Deprecated: This field is ignored and will be removed
+                      on the next version of the API.'
+                    type: boolean
+                  nonRoot:
+                    description: 'Deprecated: // Deprecated: This field is ignored
+                      and will be removed on the next version of the API.'
+                    type: boolean
                   persistentReservation:
                     default: false
                     description: |-
@@ -1117,10 +1129,8 @@ spec:
                       Note: this feature is in Developer Preview.
                     type: boolean
                   withHostPassthroughCPU:
-                    description: |-
-                      Allow migrating a virtual machine with CPU host-passthrough mode. This should be
-                      enabled only when the Cluster is homogeneous from CPU HW perspective doc here
-                      Deprecated: there is no such FG in KubeVirt. This field is ignored
+                    description: 'Deprecated: there is no such FG in KubeVirt. This
+                      field is ignored'
                     type: boolean
                 type: object
               filesystemOverhead:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
@@ -1075,6 +1075,10 @@ spec:
                       Deploy KubevirtIpamController by CNAO.
                       Deprecated: this field is ignored and will be removed in the next version of the API.
                     type: boolean
+                  deployTektonTaskResources:
+                    description: 'Deprecated: This field is ignored and will be removed
+                      on the next version of the API.'
+                    type: boolean
                   deployVmConsoleProxy:
                     default: false
                     description: deploy VM console proxy resources in SSP operator
@@ -1101,6 +1105,14 @@ spec:
                       templates that can be added to the dataImportCronTemplates field. This feature gates only control the common
                       templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.
                     type: boolean
+                  enableManagedTenantQuota:
+                    description: 'Deprecated: This field is ignored and will be removed
+                      on the next version of the API.'
+                    type: boolean
+                  nonRoot:
+                    description: 'Deprecated: // Deprecated: This field is ignored
+                      and will be removed on the next version of the API.'
+                    type: boolean
                   persistentReservation:
                     default: false
                     description: |-
@@ -1117,10 +1129,8 @@ spec:
                       Note: this feature is in Developer Preview.
                     type: boolean
                   withHostPassthroughCPU:
-                    description: |-
-                      Allow migrating a virtual machine with CPU host-passthrough mode. This should be
-                      enabled only when the Cluster is homogeneous from CPU HW perspective doc here
-                      Deprecated: there is no such FG in KubeVirt. This field is ignored
+                    description: 'Deprecated: there is no such FG in KubeVirt. This
+                      field is ignored'
                     type: boolean
                 type: object
               filesystemOverhead:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.14.0/manifests/hco00.crd.yaml
@@ -1075,6 +1075,10 @@ spec:
                       Deploy KubevirtIpamController by CNAO.
                       Deprecated: this field is ignored and will be removed in the next version of the API.
                     type: boolean
+                  deployTektonTaskResources:
+                    description: 'Deprecated: This field is ignored and will be removed
+                      on the next version of the API.'
+                    type: boolean
                   deployVmConsoleProxy:
                     default: false
                     description: deploy VM console proxy resources in SSP operator
@@ -1101,6 +1105,14 @@ spec:
                       templates that can be added to the dataImportCronTemplates field. This feature gates only control the common
                       templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field.
                     type: boolean
+                  enableManagedTenantQuota:
+                    description: 'Deprecated: This field is ignored and will be removed
+                      on the next version of the API.'
+                    type: boolean
+                  nonRoot:
+                    description: 'Deprecated: // Deprecated: This field is ignored
+                      and will be removed on the next version of the API.'
+                    type: boolean
                   persistentReservation:
                     default: false
                     description: |-
@@ -1117,10 +1129,8 @@ spec:
                       Note: this feature is in Developer Preview.
                     type: boolean
                   withHostPassthroughCPU:
-                    description: |-
-                      Allow migrating a virtual machine with CPU host-passthrough mode. This should be
-                      enabled only when the Cluster is homogeneous from CPU HW perspective doc here
-                      Deprecated: there is no such FG in KubeVirt. This field is ignored
+                    description: 'Deprecated: there is no such FG in KubeVirt. This
+                      field is ignored'
                     type: boolean
                 type: object
               filesystemOverhead:

--- a/docs/api.md
+++ b/docs/api.md
@@ -154,13 +154,16 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | downwardMetrics | Allow to expose a limited set of host metrics to guests. | *bool | false | false |
-| withHostPassthroughCPU | Allow migrating a virtual machine with CPU host-passthrough mode. This should be enabled only when the Cluster is homogeneous from CPU HW perspective doc here Deprecated: there is no such FG in KubeVirt. This field is ignored | *bool |  | false |
+| withHostPassthroughCPU | Deprecated: there is no such FG in KubeVirt. This field is ignored | *bool |  | false |
 | enableCommonBootImageImport | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom templates that can be added to the dataImportCronTemplates field. This feature gates only control the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | *bool | true | false |
+| deployTektonTaskResources | Deprecated: This field is ignored and will be removed on the next version of the API. | *bool |  | false |
 | deployVmConsoleProxy | deploy VM console proxy resources in SSP operator | *bool | false | false |
 | deployKubeSecondaryDNS | Deploy KubeSecondaryDNS by CNAO | *bool | false | false |
 | deployKubevirtIpamController | Deploy KubevirtIpamController by CNAO. Deprecated: this field is ignored and will be removed in the next version of the API. | *bool |  | false |
+| nonRoot | Deprecated: // Deprecated: This field is ignored and will be removed on the next version of the API. | *bool |  | false |
 | disableMDevConfiguration | Disable mediated devices handling on KubeVirt | *bool | false | false |
 | persistentReservation | Enable persistent reservation of a LUN through the SCSI Persistent Reserve commands on Kubevirt. In order to issue privileged SCSI ioctls, the VM requires activation of the persistent reservation flag. Once this feature gate is enabled, then the additional container with the qemu-pr-helper is deployed inside the virt-handler pod. Enabling (or removing) the feature gate causes the redeployment of the virt-handler pod. | *bool | false | false |
+| enableManagedTenantQuota | Deprecated: This field is ignored and will be removed on the next version of the API. | *bool |  | false |
 | autoResourceLimits | Enable KubeVirt to set automatic limits when they are needed. If ResourceQuota with set memory limits is associated with a namespace, each pod in that namespace must have memory limits set. By default, KubeVirt does not set such limits to the virt-launcher pod. When this feature gate is enabled, KubeVirt will set limits to the virt-launcher pod if they are not set manually and if a resource quota with memory limits is associated with the creation namespace. Note: this feature is in Developer Preview. | *bool | false | false |
 | alignCPUs | Enable KubeVirt to request up to two additional dedicated CPUs in order to complete the total CPU count to an even parity when using emulator thread isolation. Note: this feature is in Developer Preview. | *bool | false | false |
 | enableApplicationAwareQuota | EnableApplicationAwareQuota if true, enables the Application Aware Quota feature | *bool | false | false |


### PR DESCRIPTION
### What this PR does / why we need it

PR #3175 removed 3 feature gates from HCO API.

We must not remove fields from the API, without changing the API version (see here: https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecating-parts-of-the-api)

This PR restores 3 dropped feature gates. We'll remove them at the next API version.

Instead, this PR return a warning when these FGs are set in the HyperConverged CR, and also removes them from the CR on upgrade.

### Jira Ticket
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-51981
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Restore deprecated feature gates
```
