### PR TITLE
Fix issues with high availability detection

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -736,7 +736,7 @@ type HyperConvergedStatus struct {
 	// InfrastructureHighlyAvailable describes whether the cluster has only one worker node
 	// (false) or more (true).
 	// +optional
-	InfrastructureHighlyAvailable bool `json:"infrastructureHighlyAvailable,omitempty"`
+	InfrastructureHighlyAvailable *bool `json:"infrastructureHighlyAvailable,omitempty"`
 }
 
 type Version struct {

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -573,6 +573,11 @@ func (in *HyperConvergedStatus) DeepCopyInto(out *HyperConvergedStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.InfrastructureHighlyAvailable != nil {
+		in, out := &in.InfrastructureHighlyAvailable, &out.InfrastructureHighlyAvailable
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -423,6 +424,9 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 	if init {
 		r.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "InitHCO", "Initiating the HyperConverged")
 		r.setInitialConditions(req)
+
+		req.Instance.Status.InfrastructureHighlyAvailable = ptr.To(hcoutil.GetClusterInfo().IsInfrastructureHighlyAvailable())
+		req.StatusDirty = true
 	}
 
 	r.setLabels(req)

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -857,6 +857,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.14.0/manifests/kubevirt-hyperconverged-operator.v1.14.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.14.0/manifests/kubevirt-hyperconverged-operator.v1.14.0.clusterserviceversion.yaml
@@ -327,6 +327,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.14.0/manifests/kubevirt-hyperconverged-operator.v1.14.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.14.0/manifests/kubevirt-hyperconverged-operator.v1.14.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.14.0-unstable
-    createdAt: "2024-12-13 05:05:26"
+    createdAt: "2024-12-15 07:54:32"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -327,6 +327,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/docs/api.md
+++ b/docs/api.md
@@ -249,7 +249,7 @@ HyperConvergedStatus defines the observed state of HyperConverged
 | dataImportSchedule | DataImportSchedule is the cron expression that is used in for the hard-coded data import cron templates. HCO generates the value of this field once and stored in the status field, so will survive restart. | string |  | false |
 | dataImportCronTemplates | DataImportCronTemplates is a list of the actual DataImportCronTemplates as HCO update in the SSP CR. The list contains both the common and the custom templates, including any modification done by HCO. | [][DataImportCronTemplateStatus](#dataimportcrontemplatestatus) |  | false |
 | systemHealthStatus | SystemHealthStatus reflects the health of HCO and its secondary resources, based on the aggregated conditions. | string |  | false |
-| infrastructureHighlyAvailable | InfrastructureHighlyAvailable describes whether the cluster has only one worker node (false) or more (true). | bool |  | false |
+| infrastructureHighlyAvailable | InfrastructureHighlyAvailable describes whether the cluster has only one worker node (false) or more (true). | *bool |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -516,7 +516,7 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		{
 			APIGroups: emptyAPIGroup,
 			Resources: stringListToSlice("nodes"),
-			Verbs:     stringListToSlice("get", "list"),
+			Verbs:     stringListToSlice("get", "list", "watch"),
 		},
 		{
 			APIGroups: emptyAPIGroup,

--- a/pkg/webhooks/mutator/hyperConvergedMutator.go
+++ b/pkg/webhooks/mutator/hyperConvergedMutator.go
@@ -5,17 +5,16 @@ import (
 	"fmt"
 	"net/http"
 
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	kubevirtcorev1 "kubevirt.io/api/core/v1"
+
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
-	kubevirtcorev1 "kubevirt.io/api/core/v1"
 )
 
 var (
@@ -79,23 +78,7 @@ func (hcm *HyperConvergedMutator) mutateHyperConverged(_ context.Context, req ad
 		}
 	}
 
-	if hc.Spec.EvictionStrategy == nil {
-		ci := hcoutil.GetClusterInfo()
-		if ci.IsInfrastructureHighlyAvailable() {
-			patches = append(patches, jsonpatch.JsonPatchOperation{
-				Operation: "add",
-				Path:      "/spec/evictionStrategy",
-				Value:     kubevirtcorev1.EvictionStrategyLiveMigrate,
-			})
-		} else {
-			patches = append(patches, jsonpatch.JsonPatchOperation{
-				Operation: "add",
-				Path:      "/spec/evictionStrategy",
-				Value:     kubevirtcorev1.EvictionStrategyNone,
-			})
-		}
-
-	}
+	patches = mutateEvictionStrategy(hc, patches)
 
 	if hc.Spec.MediatedDevicesConfiguration != nil {
 		if len(hc.Spec.MediatedDevicesConfiguration.MediatedDevicesTypes) > 0 && len(hc.Spec.MediatedDevicesConfiguration.MediatedDeviceTypes) == 0 { //nolint SA1019
@@ -121,4 +104,23 @@ func (hcm *HyperConvergedMutator) mutateHyperConverged(_ context.Context, req ad
 	}
 
 	return admission.Allowed("")
+}
+
+func mutateEvictionStrategy(hc *hcov1beta1.HyperConverged, patches []jsonpatch.JsonPatchOperation) []jsonpatch.JsonPatchOperation {
+	if hc.Status.InfrastructureHighlyAvailable == nil || hc.Spec.EvictionStrategy != nil { // New HyperConverged CR
+		return patches
+	}
+
+	var value = kubevirtcorev1.EvictionStrategyNone
+	if *hc.Status.InfrastructureHighlyAvailable {
+		value = kubevirtcorev1.EvictionStrategyLiveMigrate
+	}
+
+	patches = append(patches, jsonpatch.JsonPatchOperation{
+		Operation: "replace",
+		Path:      "/spec/evictionStrategy",
+		Value:     value,
+	})
+
+	return patches
 }

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -44,7 +44,7 @@ var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 		cliSet = tests.GetK8sClientSet()
 
 		workerNodes = listNodesByLabels(ctx, cliSet, "node-role.kubernetes.io/worker")
-		tests.FailIfSingleNode(len(workerNodes.Items) < 2)
+		tests.FailIfSingleNodeCluster(len(workerNodes.Items) < 2)
 
 		// Label all but the last node with "node.kubernetes.io/hco-test-node-type=infra"
 		Eventually(func(g Gomega, ctx context.Context) {

--- a/tests/func-tests/utils.go
+++ b/tests/func-tests/utils.go
@@ -65,8 +65,12 @@ func FailIfNotOpenShift(ctx context.Context, cli client.Client, testName string)
 	ExpectWithOffset(1, isOpenShift).To(BeTrue(), `the %q test must run on openshift cluster. Use the "!%s" label filter in order to skip this test`, testName, OpenshiftLabel)
 }
 
-func FailIfSingleNode(singleWorkerCluster bool) {
-	ExpectWithOffset(1, singleWorkerCluster).To(BeFalse(), `this test requires a single worker cluster; use the "!%s" label filter to skip this test`, SingleNodeLabel)
+func FailIfSingleNodeCluster(singleWorkerCluster bool) {
+	ExpectWithOffset(1, singleWorkerCluster).To(BeFalse(), `this test requires a highly available cluster; use the "!%s" label filter to skip this test`, HighlyAvailableClusterLabel)
+}
+
+func FailIfHighAvailableCluster(singleWorkerCluster bool) {
+	ExpectWithOffset(1, singleWorkerCluster).To(BeTrue(), `this test requires a single worker cluster; use the "!%s" label filter to skip this test`, SingleNodeLabel)
 }
 
 type cacheIsOpenShift struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
* make the status field a pointer to bool, to distinglish between false and field not set.
* On mutation webhook, fix the eviction strategy if SNO becam HA.
* fix an issue where the status field is not set if no node is added or deleted.
* fix unit test (assert old HCO instead of HCO from client)
* fix issue in the node controller, to ignore error if HCO is not present.


**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
none
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
