### PR TITLE
[Release-1.11]Bug fix: Allow setting vmiCPUAllocationRatio to 1 

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -91,7 +91,7 @@ type HyperConvergedSpec struct {
 
 	// ResourceRequirements describes the resource requirements for the operand workloads.
 	// +kubebuilder:default={"vmiCPUAllocationRatio": 10}
-	// +kubebuilder:validation:XValidation:rule="!has(self.vmiCPUAllocationRatio) || self.vmiCPUAllocationRatio != 1",message="Automatic CPU limits are incompatible with a VMI CPU allocation ratio of 1"
+	// +kubebuilder:validation:XValidation:rule="!has(self.vmiCPUAllocationRatio) || self.vmiCPUAllocationRatio > 0",message="vmiCPUAllocationRatio must be greater than 0"
 	// +optional
 	ResourceRequirements *OperandResourceRequirements `json:"resourceRequirements,omitempty"`
 

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2690,10 +2690,9 @@ spec:
                     type: integer
                 type: object
                 x-kubernetes-validations:
-                - message: Automatic CPU limits are incompatible with a VMI CPU allocation
-                    ratio of 1
+                - message: vmiCPUAllocationRatio must be greater than 0
                   rule: '!has(self.vmiCPUAllocationRatio) || self.vmiCPUAllocationRatio
-                    != 1'
+                    > 0'
               scratchSpaceStorageClass:
                 description: 'Override the storage class used for scratch space during
                   transfer operations. The scratch space storage class is determined

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2690,10 +2690,9 @@ spec:
                     type: integer
                 type: object
                 x-kubernetes-validations:
-                - message: Automatic CPU limits are incompatible with a VMI CPU allocation
-                    ratio of 1
+                - message: vmiCPUAllocationRatio must be greater than 0
                   rule: '!has(self.vmiCPUAllocationRatio) || self.vmiCPUAllocationRatio
-                    != 1'
+                    > 0'
               scratchSpaceStorageClass:
                 description: 'Override the storage class used for scratch space during
                   transfer operations. The scratch space storage class is determined

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.11.2/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.11.2/manifests/hco00.crd.yaml
@@ -2690,10 +2690,9 @@ spec:
                     type: integer
                 type: object
                 x-kubernetes-validations:
-                - message: Automatic CPU limits are incompatible with a VMI CPU allocation
-                    ratio of 1
+                - message: vmiCPUAllocationRatio must be greater than 0
                   rule: '!has(self.vmiCPUAllocationRatio) || self.vmiCPUAllocationRatio
-                    != 1'
+                    > 0'
               scratchSpaceStorageClass:
                 description: 'Override the storage class used for scratch space during
                   transfer operations. The scratch space storage class is determined

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.11.2/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.11.2/manifests/hco00.crd.yaml
@@ -2690,10 +2690,9 @@ spec:
                     type: integer
                 type: object
                 x-kubernetes-validations:
-                - message: Automatic CPU limits are incompatible with a VMI CPU allocation
-                    ratio of 1
+                - message: vmiCPUAllocationRatio must be greater than 0
                   rule: '!has(self.vmiCPUAllocationRatio) || self.vmiCPUAllocationRatio
-                    != 1'
+                    > 0'
               scratchSpaceStorageClass:
                 description: 'Override the storage class used for scratch space during
                   transfer operations. The scratch space storage class is determined

--- a/tests/func-tests/validation_test.go
+++ b/tests/func-tests/validation_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Check CR validation", Label("validation"), Serial, func() {
 			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(outcome)
 		},
 			Entry("succeed when VMI CPU allocation is nil", nil, Succeed()),
-			Entry("fail when VMI CPU allocation is 1", ptr.To(1), MatchError(ContainSubstring("Automatic CPU limits are incompatible with a VMI CPU allocation ratio of 1"))),
+			Entry("fail when VMI CPU allocation is 0", ptr.To(0), MatchError(ContainSubstring("vmiCPUAllocationRatio must be greater than 0"))),
 			Entry("succeed when VMI CPU allocation is 2", ptr.To(2), Succeed()),
 		)
 	})

--- a/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
+++ b/tests/vendor/github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1/hyperconverged_types.go
@@ -91,7 +91,7 @@ type HyperConvergedSpec struct {
 
 	// ResourceRequirements describes the resource requirements for the operand workloads.
 	// +kubebuilder:default={"vmiCPUAllocationRatio": 10}
-	// +kubebuilder:validation:XValidation:rule="!has(self.vmiCPUAllocationRatio) || self.vmiCPUAllocationRatio != 1",message="Automatic CPU limits are incompatible with a VMI CPU allocation ratio of 1"
+	// +kubebuilder:validation:XValidation:rule="!has(self.vmiCPUAllocationRatio) || self.vmiCPUAllocationRatio > 0",message="vmiCPUAllocationRatio must be greater than 0"
 	// +optional
 	ResourceRequirements *OperandResourceRequirements `json:"resourceRequirements,omitempty"`
 


### PR DESCRIPTION
The value of vmiCPUAllocationRatio should be greater than 0, vmiCPUAllocationRatio=1 is valid as describe in the docs example:

https://docs.openshift.com/container-platform/4.15/virt/virtual_machines/advanced_vm_management/virt-assigning-compute-resources.html#virt-setting-cpu-allocation-ratio_virt-assigning-compute-resources

and also in kubevirt test:
https://github.com/kubevirt/kubevirt/blob/5a77180647d7f131c15afe13ab9063034b88c0b6/pkg/virt-controller/services/template_test.go#L2049

This PR is manual backport of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3211

/cc @nunnatsa 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
