### PR TITLE
Handle kubevirt control plane NodePlacement on hypershift clusters

### DIFF
--- a/controllers/commontestutils/testUtils.go
+++ b/controllers/commontestutils/testUtils.go
@@ -294,6 +294,9 @@ func (ClusterInfoMock) IsManagedByOLM() bool {
 func (ClusterInfoMock) IsControlPlaneHighlyAvailable() bool {
 	return true
 }
+func (ClusterInfoMock) IsControlPlaneNodeExists() bool {
+	return true
+}
 func (ClusterInfoMock) IsInfrastructureHighlyAvailable() bool {
 	return true
 }
@@ -366,6 +369,9 @@ func (ClusterInfoSNOMock) IsManagedByOLM() bool {
 func (ClusterInfoSNOMock) IsControlPlaneHighlyAvailable() bool {
 	return false
 }
+func (ClusterInfoSNOMock) IsControlPlaneNodeExists() bool {
+	return true
+}
 func (ClusterInfoSNOMock) IsInfrastructureHighlyAvailable() bool {
 	return false
 }
@@ -437,6 +443,9 @@ func (ClusterInfoSRCPHAIMock) IsManagedByOLM() bool {
 }
 func (ClusterInfoSRCPHAIMock) IsControlPlaneHighlyAvailable() bool {
 	return false
+}
+func (ClusterInfoSRCPHAIMock) IsControlPlaneNodeExists() bool {
+	return true
 }
 func (ClusterInfoSRCPHAIMock) IsInfrastructureHighlyAvailable() bool {
 	return true

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -3015,14 +3015,14 @@ Version: 1.2.3`)
 					Expect(kv.Spec.Workloads).To(BeNil())
 				})
 
-				It("should not set replica with SingleReplica ControlPlane but HighAvailable Infrastructure ", func() {
+				It("should set replica=1 with SingleReplica ControlPlane and HighAvailable Infrastructure ", func() {
 					hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
 						return &commontestutils.ClusterInfoSRCPHAIMock{}
 					}
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(kv.Spec.Infra).To(Not(BeNil()))
-					Expect(kv.Spec.Infra.Replicas).To(BeNil())
+					Expect(*kv.Spec.Infra.Replicas).To(Equal(uint8(1)))
 					Expect(kv.Spec.Workloads).To(BeNil())
 				})
 
@@ -3059,13 +3059,15 @@ Version: 1.2.3`)
 					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
 				})
 
-				It("should not set replica with SingleReplica ControlPlane but HighAvailable Infrastructure ", func() {
+				It("should set replica=1 with SingleReplica ControlPlane but HighAvailable Infrastructure ", func() {
 					hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
 						return &commontestutils.ClusterInfoSRCPHAIMock{}
 					}
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(kv.Spec.Infra).To(BeNil())
+					Expect(kv.Spec.Infra).To(Not(BeNil()))
+					Expect(kv.Spec.Infra.Replicas).To(Not(BeNil()))
+					Expect(*kv.Spec.Infra.Replicas).To(Equal(uint8(1)))
 					Expect(kv.Spec.Workloads).To(Not(BeNil()))
 					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
 				})
@@ -3098,13 +3100,15 @@ Version: 1.2.3`)
 					Expect(kv.Spec.Workloads).To(BeNil())
 				})
 
-				It("should not set replica with SingleReplica ControlPlane but HighAvailable Infrastructure ", func() {
+				It("should set replica=1 with SingleReplica ControlPlane but HighAvailable Infrastructure ", func() {
 					hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
 						return &commontestutils.ClusterInfoSRCPHAIMock{}
 					}
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(kv.Spec.Infra).To(BeNil())
+					Expect(kv.Spec.Infra).To(Not(BeNil()))
+					Expect(kv.Spec.Infra.Replicas).To(Not(BeNil()))
+					Expect(*kv.Spec.Infra.Replicas).To(Equal(uint8(1)))
 					Expect(kv.Spec.Workloads).To(BeNil())
 				})
 
@@ -3143,14 +3147,14 @@ Version: 1.2.3`)
 					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
 				})
 
-				It("should not set replica with SingleReplica ControlPlane but HighAvailable Infrastructure ", func() {
+				It("should set replica=1 with SingleReplica ControlPlane and HighAvailable Infrastructure ", func() {
 					hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
 						return &commontestutils.ClusterInfoSRCPHAIMock{}
 					}
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(kv.Spec.Infra).To(Not(BeNil()))
-					Expect(kv.Spec.Infra.Replicas).To(BeNil())
+					Expect(*kv.Spec.Infra.Replicas).To(Equal(uint8(1)))
 					Expect(kv.Spec.Workloads).To(Not(BeNil()))
 					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
 				})

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -32,6 +32,7 @@ type ClusterInfo interface {
 	GetBaseDomain() string
 	IsManagedByOLM() bool
 	IsControlPlaneHighlyAvailable() bool
+	IsControlPlaneNodeExists() bool
 	IsInfrastructureHighlyAvailable() bool
 	SetHighAvailabilityMode(ctx context.Context, cl client.Client) error
 	IsConsolePluginImageProvided() bool
@@ -53,6 +54,7 @@ type ClusterInfoImp struct {
 	managedByOLM                  bool
 	runningLocally                bool
 	controlPlaneHighlyAvailable   atomic.Bool
+	controlPlaneNodeExist         atomic.Bool
 	infrastructureHighlyAvailable atomic.Bool
 	consolePluginImageProvided    bool
 	monitoringAvailable           bool
@@ -205,6 +207,10 @@ func (c *ClusterInfoImp) IsControlPlaneHighlyAvailable() bool {
 	return c.controlPlaneHighlyAvailable.Load()
 }
 
+func (c *ClusterInfoImp) IsControlPlaneNodeExists() bool {
+	return c.controlPlaneNodeExist.Load()
+}
+
 func (c *ClusterInfoImp) IsInfrastructureHighlyAvailable() bool {
 	return c.infrastructureHighlyAvailable.Load()
 }
@@ -217,6 +223,7 @@ func (c *ClusterInfoImp) SetHighAvailabilityMode(ctx context.Context, cl client.
 	}
 
 	c.controlPlaneHighlyAvailable.Store(masterNodeCount >= 3)
+	c.controlPlaneNodeExist.Store(masterNodeCount >= 1)
 	c.infrastructureHighlyAvailable.Store(workerNodeCount >= 2)
 	return nil
 }


### PR DESCRIPTION
Since kubevirt v1.3, the kubevirt control plane components (e.g. virt-controller and virt-api) are getting schdeuled by default on the control-plane/master nodes, not regular worker nodes.
In hypershift (Hosted Control Planes) clusters, there are no control plane nodes at all (the control plane is hosted as pods on the management cluster). Therefore, in case there are no control plane nodes, we're setting the kubevirt's node placement as an empty struct to avoid any predefined scheduling/affinity rules that might prevent the pods to be scheduled on the cluster.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-52266
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid scheduling kubevirt components on control-plane nodes if there are no control-plane nodes in the cluster.
```
