### PR TITLE
wip: Fix the monitoring test

### DIFF
--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -165,6 +165,10 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			return alert
 		}).WithTimeout(60 * time.Second).WithPolling(time.Second).WithContext(ctx).ShouldNot(BeNil())
 
+		/// DEBUG
+		Expect(hcoClient.GetHCOMetricDebug(ctx, "kubevirt_hyperconverged_operator_health_status")).To(Succeed())
+		/// END DEBUG
+
 		verifyOperatorHealthMetricValue(ctx, promClient, initialOperatorHealthMetricValue, recordingrules.WarningImpact)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The "KubeVirtCRModified alert should fired when there is a modification on a CR" functional test became flacky.

The test changes the KubeVirt CR, and then checks several metrics and alerts. When checking the "kubevirt_hyperconverged_operator_health_status" alert, the test sometimes fails, as KubeVirt get into non stable state for a short while for every chenage in the KubeVirt CR, making the health alret to be in "critical" status, instead of "warning".

This PR fixes the issue by modifiying the CDI CR instead of the KubeVirt CR, to get the same effect.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
