### PR TITLE
Fix hco system health metric values

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -192,7 +192,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: "Initializing HyperConverged cluster",
 				})))
 
-				verifySystemHealthStatusError(foundResource, reconcileInit)
+				verifySystemHealthStatusError(foundResource)
 
 				expectedFeatureGates := []string{
 					"CPUManager",
@@ -307,7 +307,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Message: reconcileCompletedMessage,
 				})))
 
-				verifySystemHealthStatusError(foundResource, "SSPConditions")
+				verifySystemHealthStatusError(foundResource)
 
 				Expect(foundResource.Status.RelatedObjects).To(HaveLen(21))
 				expectedRef := corev1.ObjectReference{
@@ -3794,15 +3794,15 @@ func verifyHyperConvergedCRExistsMetricFalse() {
 func verifySystemHealthStatusHealthy(hco *hcov1beta1.HyperConverged) {
 	ExpectWithOffset(1, hco.Status.SystemHealthStatus).To(Equal(systemHealthStatusHealthy))
 
-	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus("healthy")
+	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, systemHealthStatusMetric).To(Equal(metrics.SystemHealthStatusHealthy))
 }
 
-func verifySystemHealthStatusError(hco *hcov1beta1.HyperConverged, reason string) {
+func verifySystemHealthStatusError(hco *hcov1beta1.HyperConverged) {
 	ExpectWithOffset(1, hco.Status.SystemHealthStatus).To(Equal(systemHealthStatusError))
 
-	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus(reason)
+	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, systemHealthStatusMetric).To(Equal(metrics.SystemHealthStatusError))
 }

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -610,7 +610,7 @@ tests:
   input_series:
   - series: 'kubevirt_hco_system_health_status'
     # time:  0     1     2     3     4     5     6     7     8     9     10     11
-    values: "1     1     1     1     2     2     2     2     3     3      3      3"
+    values: "0     0     0     0     1     1     1     1     2     2      2      2"
   - series: 'ALERTS{kubernetes_operator_part_of="kubevirt", alertstate="firing", operator_health_impact="warning"}'
     # time:  0     1     2     3     4     5     6     7     8     9     10     11
     values: "1     1   stale stale   1     1   stale stale   1     1    stale  stale"
@@ -771,47 +771,46 @@ tests:
             kubernetes_operator_part_of: "kubevirt"
             kubernetes_operator_component: "hyperconverged-cluster-operator"
 
-# Test OperatorConditionsUnhealthy
+# Test HCOOperatorConditionsUnhealthy
 - interval: 1m
   input_series:
-    - series: 'kubevirt_hco_system_health_status{reason="healthy"}'
-    - values: "stale 1 stale stale stale"
+    - series: 'kubevirt_hco_system_health_status'
+    - values: "stale stale 2 stale"
 
-    - series: 'kubevirt_hco_system_health_status{reason="SOME_ERROR"}'
-      values: "stale stale stale 3 stale"
-
-    - series: 'kubevirt_hco_system_health_status{reason="SOME_WARNING"}'
-      values: "stale stale stale stale stale 2 stale"
+    - series: 'kubevirt_hco_system_health_status'
+      values: "stale stale 2 stale 1 stale"
 
   alert_rule_test:
     - eval_time: 1m
-      alertname: OperatorConditionsUnhealthy
+      alertname: HCOOperatorConditionsUnhealthy
       exp_alerts: [ ]
 
-    - eval_time: 3m
-      alertname: OperatorConditionsUnhealthy
+    - eval_time: 1m
+      alertname: HCOOperatorConditionsUnhealthy
+      exp_alerts: [ ]
+
+    - eval_time: 2m
+      alertname: HCOOperatorConditionsUnhealthy
       exp_alerts:
         - exp_annotations:
-            description: "HCO and its secondary resources are in a critical state due to SOME_ERROR."
+            description: "HCO and its secondary resources are in a critical state due to system error."
             summary: "HCO and its secondary resources are in a critical state."
-            runbook_url: "https://kubevirt.io/monitoring/runbooks/OperatorConditionsUnhealthy"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOOperatorConditionsUnhealthy"
           exp_labels:
             severity: "critical"
             operator_health_impact: "critical"
             kubernetes_operator_part_of: "kubevirt"
             kubernetes_operator_component: "hyperconverged-cluster-operator"
-            reason: "SOME_ERROR"
 
-    - eval_time: 5m
-      alertname: OperatorConditionsUnhealthy
+    - eval_time: 4m
+      alertname: HCOOperatorConditionsUnhealthy
       exp_alerts:
         - exp_annotations:
-            description: "HCO and its secondary resources are in a warning state due to SOME_WARNING."
+            description: "HCO and its secondary resources are in a warning state due to system warning."
             summary: "HCO and its secondary resources are in a warning state."
-            runbook_url: "https://kubevirt.io/monitoring/runbooks/OperatorConditionsUnhealthy"
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOOperatorConditionsUnhealthy"
           exp_labels:
             severity: "warning"
             operator_health_impact: "warning"
             kubernetes_operator_part_of: "kubevirt"
             kubernetes_operator_component: "hyperconverged-cluster-operator"
-            reason: "SOME_WARNING"

--- a/pkg/monitoring/metrics/operator_metrics_test.go
+++ b/pkg/monitoring/metrics/operator_metrics_test.go
@@ -9,20 +9,16 @@ import (
 
 var _ = Describe("Operator Metrics", func() {
 	Context("kubevirt_hco_system_health_status", func() {
-		It("should set system error reason correctly", func() {
-			metrics.SetHCOSystemError("Reason1")
-			v, err := metrics.GetHCOMetricSystemHealthStatus("Reason1")
+		It("should set the correct system health status", func() {
+			metrics.SetHCOMetricSystemHealthStatus(metrics.SystemHealthStatusError)
+			v, err := metrics.GetHCOMetricSystemHealthStatus()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(v).To(Equal(metrics.SystemHealthStatusError))
 
-			metrics.SetHCOSystemError("Reason2")
-			v, err = metrics.GetHCOMetricSystemHealthStatus("Reason2")
+			metrics.SetHCOMetricSystemHealthStatus(metrics.SystemHealthStatusWarning)
+			v, err = metrics.GetHCOMetricSystemHealthStatus()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(v).To(Equal(metrics.SystemHealthStatusError))
-
-			v, err = metrics.GetHCOMetricSystemHealthStatus("Reason1")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(v).To(Equal(metrics.SystemHealthStatusUnknown))
+			Expect(v).To(Equal(metrics.SystemHealthStatusWarning))
 		})
 	})
 })

--- a/pkg/monitoring/rules/alerts/health_alerts.go
+++ b/pkg/monitoring/rules/alerts/health_alerts.go
@@ -12,10 +12,10 @@ import (
 func healthAlerts() []promv1.Rule {
 	return []promv1.Rule{
 		{
-			Alert: "OperatorConditionsUnhealthy",
+			Alert: "HCOOperatorConditionsUnhealthy",
 			Expr:  intstr.FromString(fmt.Sprintf("kubevirt_hco_system_health_status == %f", metrics.SystemHealthStatusError)),
 			Annotations: map[string]string{
-				"description": "HCO and its secondary resources are in a critical state due to {{ $labels.reason }}.",
+				"description": "HCO and its secondary resources are in a critical state due to system error.",
 				"summary":     "HCO and its secondary resources are in a critical state.",
 			},
 			Labels: map[string]string{
@@ -24,10 +24,10 @@ func healthAlerts() []promv1.Rule {
 			},
 		},
 		{
-			Alert: "OperatorConditionsUnhealthy",
+			Alert: "HCOOperatorConditionsUnhealthy",
 			Expr:  intstr.FromString(fmt.Sprintf("kubevirt_hco_system_health_status == %f", metrics.SystemHealthStatusWarning)),
 			Annotations: map[string]string{
-				"description": "HCO and its secondary resources are in a warning state due to {{ $labels.reason }}.",
+				"description": "HCO and its secondary resources are in a warning state due to system warning.",
 				"summary":     "HCO and its secondary resources are in a warning state.",
 			},
 			Labels: map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
kubevirt_hco_system_health_status values changed to value+1,
this pr: 

- remove unknown from the values options
- metric values is changeed back the values to be 0 for healthy, 1 for warning and 2 for error. 
- remove reason label
- change alert name from OperatorConditionsUnhealth to HCOOperatorConditionsUnhealth.

also tests and related recording rules and alerts updated accordingly.

updated metric (before was 1):
![Screenshot from 2024-12-23 20-06-01](https://github.com/user-attachments/assets/3f6dcf46-6610-4296-bae8-1a9ff1ef7abc)


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
jira-ticket: https://issues.redhat.com/browse/CNV-52735

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none

```
