### PR TITLE
Fix smoke test on ocp-4.18

### DIFF
--- a/hack/kv-smoke-tests.sh
+++ b/hack/kv-smoke-tests.sh
@@ -249,7 +249,9 @@ ${TESTS_BINARY} \
     -ginkgo.flake-attempts=3 \
     -oc-path="$(which oc)" \
     -kubectl-path="$(which oc)" \
+    -container-tag="${KUBEVIRT_VERSION}" \
     -utility-container-prefix=quay.io/kubevirt \
+    -utility-container-tag="${KUBEVIRT_VERSION}" \
     -test.timeout=3h \
     -ginkgo.timeout=3h \
     -artifacts=${ARTIFACT_DIR}/kubevirt_dump


### PR DESCRIPTION
**What this PR does / why we need it**:
When trying to bump the ocp version to 4.18, the smoke test fails.

The cause is that for some unknown reason, the
`quay.io/kubevirt/fedora-with-test-tooling-container-disk:latest` image can't be pulled on 4.18. This image tag is misleading and it's actually very old image.

This PR is trying to fix the issue by setting the image tag to the KV release tag.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
