### PR TITLE
Fix the override-bot

### DIFF
--- a/.github/workflows/override-bot.yaml
+++ b/.github/workflows/override-bot.yaml
@@ -2,6 +2,9 @@ name: Override Bot
 on:
   issue_comment:
     types: [created]
+  schedule:
+    - cron:  '0/10 * * * *'
+  workflow_dispatch:
 jobs:
   override:
     name: Check for redundant CI lanes for override

--- a/.github/workflows/override-bot.yaml
+++ b/.github/workflows/override-bot.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.13'
           architecture: 'x64'
       - name: Install dependencies
         run: |

--- a/automation/override-bot/override-bot.py
+++ b/automation/override-bot/override-bot.py
@@ -55,8 +55,19 @@ class PullRequest:
         self.override_list = []
 
     def get_ci_tests(self):
-        statuses_raw = requests.get(self.statuses_url).text
+        statuses_req = requests.get(self.statuses_url)
+        statuses_raw = statuses_req.text
         statuses = json.loads(statuses_raw)
+
+        while True:
+            link = statuses_req.links.get('next')
+            next_link = link.get('url') if link else None
+            if next_link is None:
+                break
+            statuses_req = requests.get(next_link)
+            statuses_raw = statuses_req.text
+            statuses = statuses + json.loads(statuses_raw)
+
         for status in statuses:
             context = status['context']
             if 'ci-index' in context or 'images' in context or 'prow' not in context:


### PR DESCRIPTION
**What this PR does / why we need it**:
1. The override bot sometimes fail, if it runs on ubunto 24.04, and then the python version is not supported.

   Fixed it by bumping the python version to 3.13

2. The override bot sometimes works, but not performing override. The reason for that is that the statuses github API only returns the first 30 statuses. Somtimes the succeeded lane status is not in the first page, and then the code can't find it.

   Fixed it by reading all the pages of the statuses API.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
