### PR TITLE
Fix the override bot

### DIFF
--- a/.github/workflows/override-bot.yaml
+++ b/.github/workflows/override-bot.yaml
@@ -8,7 +8,8 @@ on:
 jobs:
   override:
     name: Check for redundant CI lanes for override
-    if: (github.event.issue.pull_request != '') && (contains(github.event.comment.body, '/override-bot')) && (github.repository == 'kubevirt/hyperconverged-cluster-operator')
+    if: (github.event_name != 'issue_comment') ||
+        ((github.event.issue.pull_request != '') && (contains(github.event.comment.body, '/override-bot')) && (github.repository == 'kubevirt/hyperconverged-cluster-operator'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code


### PR DESCRIPTION
**What this PR does / why we need it**:

The bot now can run from a comment in the PR, from a schedul, or
manually from github ui.

But the action condition requires a PR number to not be empty. That
makes the schedule and the manual triggers to be ignored and skipped.

This PR fixes the condition to allow the other 2 triggers.

In addition, this PR also improves the bot by:
1. add Authorization header to the HTTP calls to github, to prevent 401
   error as results of too many requests.
2. move some loops to lambdas, for better performance

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
