### PR TITLE
fix the component release bump bot

### DIFF
--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -94,6 +94,6 @@ jobs:
             ```release-note
             Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}
             ```
-          assignees: tiraboschi,orenc1,nunnatsa,machadovilaca,dharmit
-          reviewers: tiraboschi,orenc1,nunnatsa,machadovilaca,dharmit
+          assignees: orenc1,nunnatsa,machadovilaca,avlitman
+          reviewers: orenc1,nunnatsa,machadovilaca,avlitman
           branch: bump_${{ env.UPDATED_COMPONENT }}_${{ env.UPDATED_VERSION }}_${{ matrix.branches.branch }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the reviewer and the assignees in the new PR that opened by the bot, to match the collaborators list, because now, the bot always fails for non collaborator assignee.
**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
