### PR TITLE
Allow customizing the CLI download link

### DIFF
--- a/cmd/cmdcommon/cmdcommon.go
+++ b/cmd/cmdcommon/cmdcommon.go
@@ -8,6 +8,7 @@ import (
 	"net/http/pprof"
 	"os"
 	"runtime"
+	"slices"
 
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -144,7 +145,7 @@ func (h HcCmdHelper) checkNameSpace() {
 		communityHubNamespace,
 		communityHubTargetNamespace,
 	}
-	if !StringInSlice(actualNS, nsAllowList) {
+	if !slices.Contains(nsAllowList, actualNS) {
 		err := fmt.Errorf("%s is running in different namespace than expected", h.Name)
 		msg := fmt.Sprintf("Please re-deploy this %s into %v namespace", h.Name, requiredNS)
 		h.ExitOnError(err, msg, "Expected.Namespace", requiredNS, "Deployed.Namespace", actualNS)
@@ -164,13 +165,4 @@ func updateFlagSet(flags ...*flag.FlagSet) {
 	for _, f := range flags {
 		pflag.CommandLine.AddGoFlagSet(f)
 	}
-}
-
-func StringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/cmdcommon/cmdcommon.go
+++ b/cmd/cmdcommon/cmdcommon.go
@@ -10,15 +10,14 @@ import (
 	"runtime"
 	"slices"
 
+	"github.com/go-logr/logr"
+	"github.com/spf13/pflag"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-
-	"github.com/go-logr/logr"
-	"github.com/spf13/pflag"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // list of namespace allowed for HCO installations (for tests)
@@ -122,7 +121,7 @@ func (h HcCmdHelper) printVersion() {
 
 func (h HcCmdHelper) checkNameSpace() {
 	// Get the namespace that we should be deployed in.
-	requiredNS, err := hcoutil.GetOperatorNamespaceFromEnv()
+	requiredNS, err := getOperatorNamespaceFromEnv()
 	h.ExitOnError(err, "Failed to get namespace from the environment")
 
 	// Get the namespace we are currently deployed in.
@@ -165,4 +164,13 @@ func updateFlagSet(flags ...*flag.FlagSet) {
 	for _, f := range flags {
 		pflag.CommandLine.AddGoFlagSet(f)
 	}
+}
+
+func getOperatorNamespaceFromEnv() (string, error) {
+	namespace := os.Getenv(hcoutil.OperatorNamespaceEnv)
+	if len(namespace) == 0 {
+		return "", fmt.Errorf("%s unset or empty in environment", hcoutil.OperatorNamespaceEnv)
+	}
+
+	return namespace, nil
 }

--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -98,8 +98,7 @@ var (
 func main() {
 	cmdHelper.InitiateCommand()
 
-	operatorNamespace, err := hcoutil.GetOperatorNamespaceFromEnv()
-	cmdHelper.ExitOnError(err, "can't get operator expected namespace")
+	operatorNamespace := hcoutil.GetOperatorNamespaceFromEnv()
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -54,6 +55,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/crd"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/descheduler"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/hyperconverged"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/ingresscluster"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/nodes"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/observability"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
@@ -175,16 +177,20 @@ func main() {
 	upgradeableCondition, err = hcoutil.NewOperatorCondition(ci, mgr.GetClient(), operatorsapiv2.Upgradeable)
 	cmdHelper.ExitOnError(err, "Cannot create Upgradeable Operator Condition")
 
-	// a channel to trigger a restart of the operator
-	// via a clean cancel of the manager
-	restartCh := make(chan struct{})
+	ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 10)
+	defer close(ingressEventCh)
 
 	// Create a new reconciler
-	if err := hyperconverged.RegisterReconciler(mgr, ci, upgradeableCondition); err != nil {
+	if err := hyperconverged.RegisterReconciler(mgr, ci, upgradeableCondition, ingressEventCh); err != nil {
 		logger.Error(err, "failed to register the HyperConverged controller")
 		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to register HyperConverged controller; "+err.Error())
 		os.Exit(1)
 	}
+
+	// a channel to trigger a restart of the operator
+	// via a clean cancel of the manager
+	restartCh := make(chan struct{})
+	defer close(restartCh)
 
 	// Create a new CRD reconciler
 	if err := crd.RegisterReconciler(mgr, restartCh); err != nil {
@@ -214,6 +220,14 @@ func main() {
 		logger.Error(err, "failed to register the Nodes controller")
 		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to register Nodes controller; "+err.Error())
 		os.Exit(1)
+	}
+
+	if ci.IsOpenshift() {
+		if err = ingresscluster.RegisterReconciler(mgr, ingressEventCh); err != nil {
+			logger.Error(err, "failed to register the IngressCluster controller")
+			eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "InitError", "Unable to register Ingress controller; "+err.Error())
+			os.Exit(1)
+		}
 	}
 
 	err = createPriorityClass(ctx, mgr)

--- a/cmd/hyperconverged-cluster-webhook/main.go
+++ b/cmd/hyperconverged-cluster-webhook/main.go
@@ -66,8 +66,7 @@ func main() {
 
 	cmdHelper.InitiateCommand()
 
-	operatorNamespace, err := hcoutil.GetOperatorNamespaceFromEnv()
-	cmdHelper.ExitOnError(err, "can't get operator expected namespace")
+	operatorNamespace := hcoutil.GetOperatorNamespaceFromEnv()
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/controllers/commontestutils/testUtils.go
+++ b/controllers/commontestutils/testUtils.go
@@ -303,9 +303,6 @@ func (ClusterInfoMock) IsInfrastructureHighlyAvailable() bool {
 func (ClusterInfoMock) SetHighAvailabilityMode(_ context.Context, _ client.Client) error {
 	return nil
 }
-func (ClusterInfoMock) GetDomain() string {
-	return "domain"
-}
 func (ClusterInfoMock) GetBaseDomain() string {
 	return BaseDomain
 }
@@ -377,9 +374,6 @@ func (ClusterInfoSNOMock) IsInfrastructureHighlyAvailable() bool {
 }
 func (ClusterInfoSNOMock) SetHighAvailabilityMode(_ context.Context, _ client.Client) error {
 	return nil
-}
-func (ClusterInfoSNOMock) GetDomain() string {
-	return "domain"
 }
 func (ClusterInfoSNOMock) GetBaseDomain() string {
 	return BaseDomain
@@ -463,9 +457,6 @@ func (ClusterInfoSRCPHAIMock) GetDeployment() *appsv1.Deployment {
 
 func (ClusterInfoSRCPHAIMock) GetCSV() *csvv1alpha1.ClusterServiceVersion {
 	return csv
-}
-func (ClusterInfoSRCPHAIMock) GetDomain() string {
-	return "domain"
 }
 func (ClusterInfoSRCPHAIMock) GetBaseDomain() string {
 	return BaseDomain

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -383,8 +383,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cl.Update(context.TODO(), foundKubevirt)).ToNot(HaveOccurred())
 
 				// mock a reconciliation triggered by a change in secondary CR
-				ph, err := getSecondaryCRPlaceholder()
-				Expect(err).ToNot(HaveOccurred())
+				ph := getSecondaryCRPlaceholder()
 				rq := request
 				rq.NamespacedName = ph
 
@@ -470,8 +469,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cl.Update(context.TODO(), foundKubevirt)).ToNot(HaveOccurred())
 
 				// mock a reconciliation triggered by a change in secondary CR
-				ph, err := getSecondaryCRPlaceholder()
-				Expect(err).ToNot(HaveOccurred())
+				ph := getSecondaryCRPlaceholder()
 				rq := request
 				rq.NamespacedName = ph
 
@@ -515,8 +513,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cl.Update(context.TODO(), foundKubevirt)).ToNot(HaveOccurred())
 
 				// mock a reconciliation triggered by a change in secondary CR
-				ph, err := getSecondaryCRPlaceholder()
-				Expect(err).ToNot(HaveOccurred())
+				ph := getSecondaryCRPlaceholder()
 				rq := request
 				rq.NamespacedName = ph
 
@@ -644,8 +641,7 @@ var _ = Describe("HyperconvergedController", func() {
 				r := initReconciler(cl, nil)
 
 				// mock a reconciliation triggered by a change in secondary CR
-				ph, err := getSecondaryCRPlaceholder()
-				Expect(err).ToNot(HaveOccurred())
+				ph := getSecondaryCRPlaceholder()
 				rq := request
 				rq.NamespacedName = ph
 
@@ -1127,8 +1123,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(hcoutil.GetClusterInfo().GetTLSSecurityProfile(expected.hco.Spec.TLSSecurityProfile)).To(Equal(initialTLSSecurityProfile), "should still return the cached value (initial value)")
 
 				// mock a reconciliation triggered by a change in the APIServer CR
-				ph, err := getAPIServerCRPlaceholder()
-				Expect(err).ToNot(HaveOccurred())
+				ph := getAPIServerCRPlaceholder()
 				rq := request
 				rq.NamespacedName = ph
 
@@ -1391,8 +1386,7 @@ var _ = Describe("HyperconvergedController", func() {
 				cl := expected.initClient()
 				r := initReconciler(cl, nil)
 
-				ph, err := getSecondaryCRPlaceholder()
-				Expect(err).ToNot(HaveOccurred())
+				ph := getSecondaryCRPlaceholder()
 				rq := reconcile.Request{
 					NamespacedName: ph,
 				}

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/reqresolver"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/metrics"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"github.com/kubevirt/hyperconverged-cluster-operator/version"
@@ -83,6 +84,8 @@ var _ = Describe("HyperconvergedController", func() {
 				_ = os.Setenv("OPERATOR_NAMESPACE", namespace)
 				_ = os.Setenv(hcoutil.HcoKvIoVersionName, version.Version)
 				hcoNamespace = commontestutils.NewHcoNamespace()
+
+				reqresolver.GeneratePlaceHolders()
 			})
 
 			It("should handle not found", func() {
@@ -383,12 +386,10 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cl.Update(context.TODO(), foundKubevirt)).ToNot(HaveOccurred())
 
 				// mock a reconciliation triggered by a change in secondary CR
-				ph := getSecondaryCRPlaceholder()
-				rq := request
-				rq.NamespacedName = ph
+				rq := reqresolver.GetSecondaryCRRequest()
 
 				// Reconcile again to update HCO's status
-				res, err = r.Reconcile(context.TODO(), request)
+				res, err = r.Reconcile(context.TODO(), rq)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{}))
 
@@ -469,12 +470,10 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cl.Update(context.TODO(), foundKubevirt)).ToNot(HaveOccurred())
 
 				// mock a reconciliation triggered by a change in secondary CR
-				ph := getSecondaryCRPlaceholder()
-				rq := request
-				rq.NamespacedName = ph
+				rq := reqresolver.GetSecondaryCRRequest()
 
 				// Reconcile again to update HCO's status
-				res, err = r.Reconcile(context.TODO(), request)
+				res, err = r.Reconcile(context.TODO(), rq)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{}))
 
@@ -513,12 +512,10 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cl.Update(context.TODO(), foundKubevirt)).ToNot(HaveOccurred())
 
 				// mock a reconciliation triggered by a change in secondary CR
-				ph := getSecondaryCRPlaceholder()
-				rq := request
-				rq.NamespacedName = ph
+				rq := reqresolver.GetSecondaryCRRequest()
 
 				// Reconcile again to update HCO's status
-				res, err = r.Reconcile(context.TODO(), request)
+				res, err = r.Reconcile(context.TODO(), rq)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{}))
 
@@ -641,9 +638,7 @@ var _ = Describe("HyperconvergedController", func() {
 				r := initReconciler(cl, nil)
 
 				// mock a reconciliation triggered by a change in secondary CR
-				ph := getSecondaryCRPlaceholder()
-				rq := request
-				rq.NamespacedName = ph
+				rq := reqresolver.GetSecondaryCRRequest()
 
 				counterValueBefore, err := metrics.GetOverwrittenModificationsCount(existingResource.Kind, existingResource.Name)
 				Expect(err).ToNot(HaveOccurred())
@@ -1123,9 +1118,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(hcoutil.GetClusterInfo().GetTLSSecurityProfile(expected.hco.Spec.TLSSecurityProfile)).To(Equal(initialTLSSecurityProfile), "should still return the cached value (initial value)")
 
 				// mock a reconciliation triggered by a change in the APIServer CR
-				ph := getAPIServerCRPlaceholder()
-				rq := request
-				rq.NamespacedName = ph
+				rq := reqresolver.GetAPIServerCRRequest()
 
 				// Reconcile again to refresh ApiServer CR in memory
 				res, err = r.Reconcile(context.TODO(), rq)
@@ -1386,10 +1379,7 @@ var _ = Describe("HyperconvergedController", func() {
 				cl := expected.initClient()
 				r := initReconciler(cl, nil)
 
-				ph := getSecondaryCRPlaceholder()
-				rq := reconcile.Request{
-					NamespacedName: ph,
-				}
+				rq := reqresolver.GetSecondaryCRRequest()
 
 				counterValueBefore, err := metrics.GetOverwrittenModificationsCount(expected.cdi.Kind, expected.cdi.Name)
 				Expect(err).ToNot(HaveOccurred())

--- a/controllers/ingresscluster/ingress-cluster-controller.go
+++ b/controllers/ingresscluster/ingress-cluster-controller.go
@@ -1,0 +1,300 @@
+package ingresscluster
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	operatorhandler "github.com/operator-framework/operator-lib/handler"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/reqresolver"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	ingressName     = "cluster"
+	componentName   = "virt-downloads"
+	secretNamespace = "openshift-config"
+
+	validConditionReason = "AsExpected"
+	validConditionMsg    = "All is well"
+)
+
+var (
+	selfNamespace = hcoutil.GetOperatorNamespaceFromEnv()
+	logger        = logf.Log.WithName("controller_ingress_cluster")
+)
+
+type ReconcileIngressCluster struct {
+	client.Client
+	// used to trigger events in the hyperconverged-controller
+	ingressEventCh chan<- event.TypedGenericEvent[client.Object]
+}
+
+func newIngressClusterController(cl client.Client, ingressEventCh chan<- event.TypedGenericEvent[client.Object]) *ReconcileIngressCluster {
+	return &ReconcileIngressCluster{
+		Client:         cl,
+		ingressEventCh: ingressEventCh,
+	}
+}
+
+func RegisterReconciler(mgr manager.Manager, ingressEventCh chan<- event.TypedGenericEvent[client.Object]) error {
+	return add(mgr, newIngressClusterController(mgr.GetClient(), ingressEventCh))
+}
+
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	c, err := controller.New("ingress-cluster", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(source.Kind(mgr.GetCache(), client.Object(&configv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ingressName,
+		},
+	}),
+		&operatorhandler.InstrumentedEnqueueRequestForObject[client.Object]{},
+		predicate.ResourceVersionChangedPredicate{}),
+	)
+}
+
+func (r *ReconcileIngressCluster) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+
+	clusterIngress := &configv1.Ingress{}
+
+	if err := r.Get(ctx, client.ObjectKey{Name: ingressName}, clusterIngress); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("Ingress resource not found. Ignoring since object must be deleted")
+			return reconcile.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	hcExists, err := r.hyperConvergedExists(ctx, logger)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	dh, dhErr := r.getDownloadHost(ctx, clusterIngress)
+
+	if downloadhost.Set(dh) {
+		logger.Info("Notifying the hyperconverged controller about the new hostname")
+		r.ingressEventCh <- event.TypedGenericEvent[client.Object]{Object: clusterIngress}
+	}
+
+	routeInd, needUpdate := updateComponentInStatus(clusterIngress, hcExists, dh)
+
+	if needUpdate {
+		if dhErr != nil {
+			meta.SetStatusCondition(&clusterIngress.Status.ComponentRoutes[routeInd].Conditions, metav1.Condition{
+				Type:    "Degraded",
+				Status:  metav1.ConditionTrue,
+				Reason:  "WrongConfiguration",
+				Message: dhErr.Error(),
+			})
+		} else {
+			meta.SetStatusCondition(&clusterIngress.Status.ComponentRoutes[routeInd].Conditions, metav1.Condition{
+				Type:    "Degraded",
+				Status:  metav1.ConditionFalse,
+				Reason:  validConditionReason,
+				Message: validConditionMsg,
+			})
+		}
+
+		meta.SetStatusCondition(&clusterIngress.Status.ComponentRoutes[routeInd].Conditions, metav1.Condition{
+			Type:    "Progressing",
+			Status:  metav1.ConditionFalse,
+			Reason:  validConditionReason,
+			Message: validConditionMsg,
+		})
+		meta.SetStatusCondition(&clusterIngress.Status.ComponentRoutes[routeInd].Conditions, metav1.Condition{
+			Type:    "Available",
+			Status:  metav1.ConditionTrue,
+			Reason:  validConditionReason,
+			Message: validConditionMsg,
+		})
+		err = r.Status().Update(ctx, clusterIngress)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func updateComponentInStatus(clusterIngress *configv1.Ingress, hcExists bool, dh downloadhost.CLIDownloadHost) (int, bool) {
+	needUpdate := false
+	routeInd := slices.IndexFunc(clusterIngress.Status.ComponentRoutes, func(component configv1.ComponentRouteStatus) bool {
+		return component.Name == componentName && component.Namespace == selfNamespace
+	})
+
+	if !hcExists {
+		if routeInd >= 0 {
+			clusterIngress.Status.ComponentRoutes = slices.Delete(clusterIngress.Status.ComponentRoutes, routeInd, routeInd+1)
+			needUpdate = true
+			logger.Info(fmt.Sprintf("HyperConverged wasn't found; removing the %s component from the cluster Ingress", componentName))
+		}
+	} else {
+		defaultRoute := generateDefaultRouteStatus(dh)
+		if routeInd == -1 {
+			logger.Info(fmt.Sprintf("Adding the %s component to the cluster Ingress", componentName))
+			clusterIngress.Status.ComponentRoutes = append(clusterIngress.Status.ComponentRoutes, defaultRoute)
+			needUpdate = true
+			routeInd = len(clusterIngress.Status.ComponentRoutes) - 1
+
+		} else if !reflect.DeepEqual(clusterIngress.Status.ComponentRoutes[routeInd], defaultRoute) {
+			logger.Info(fmt.Sprintf("Updating the %s component to the cluster Ingress", componentName))
+			clusterIngress.Status.ComponentRoutes[routeInd] = defaultRoute
+			needUpdate = true
+		}
+	}
+	return routeInd, needUpdate
+}
+
+func (r *ReconcileIngressCluster) hyperConvergedExists(ctx context.Context, looger logr.Logger) (bool, error) {
+	hc := &v1beta1.HyperConverged{}
+	err := r.Get(ctx, reqresolver.GetHyperConvergedNamespacedName(), hc)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("HyperConverged resource not found.")
+			return false, nil
+		}
+		looger.Error(err, "Failed to get HyperConverged resource.")
+		return false, err
+	}
+
+	hcExists := hc.ObjectMeta.DeletionTimestamp.IsZero()
+	if !hcExists {
+		looger.Info("HyperConverged resource found, but it was already been deleted.")
+	}
+	return hcExists, nil
+}
+
+func generateDefaultRouteStatus(host downloadhost.CLIDownloadHost) configv1.ComponentRouteStatus {
+	serviceAccount := configv1.ConsumingUser(fmt.Sprintf("system:serviceaccount:%s:hyperconverged-cluster-operator", selfNamespace))
+
+	currentHostName := host.DefaultHost
+	if len(host.CurrentHost) > 0 {
+		currentHostName = host.CurrentHost
+	}
+
+	return configv1.ComponentRouteStatus{
+		Name:             componentName,
+		Namespace:        selfNamespace,
+		DefaultHostname:  host.DefaultHost,
+		CurrentHostnames: []configv1.Hostname{currentHostName},
+		ConsumingUsers:   []configv1.ConsumingUser{serviceAccount},
+		RelatedObjects: []configv1.ObjectReference{
+			{
+				Group:     routev1.GroupName,
+				Resource:  "routes",
+				Namespace: selfNamespace,
+				Name:      downloadhost.CLIDownloadsServiceName,
+			},
+		},
+	}
+}
+
+func getDefaultCLIIDownloadHost(domain string) configv1.Hostname {
+	return configv1.Hostname(fmt.Sprintf("%s-%s.%s", downloadhost.CLIDownloadsServiceName, selfNamespace, domain))
+}
+
+func (r *ReconcileIngressCluster) getDownloadHost(ctx context.Context, clusterIngress *configv1.Ingress) (downloadhost.CLIDownloadHost, error) {
+	defaultHost := getDefaultCLIIDownloadHost(clusterIngress.Spec.Domain)
+	dh := downloadhost.CLIDownloadHost{
+		DefaultHost: defaultHost,
+		CurrentHost: defaultHost,
+	}
+
+	routeInd := slices.IndexFunc(clusterIngress.Spec.ComponentRoutes, func(component configv1.ComponentRouteSpec) bool {
+		return component.Name == componentName && component.Namespace == selfNamespace
+	})
+
+	if routeInd >= 0 {
+		customHost := clusterIngress.Spec.ComponentRoutes[routeInd].Hostname
+		secretName := clusterIngress.Spec.ComponentRoutes[routeInd].ServingCertKeyPairSecret.Name
+
+		if len(customHost) > 0 {
+			if !strings.HasSuffix(string(customHost), "."+clusterIngress.Spec.Domain) && len(secretName) == 0 {
+				// ignore the customization, keep use the default host
+				return dh, fmt.Errorf("must use a secret if the custom host is not a subdomain of the domain name")
+			}
+		}
+
+		crt, key, err := r.getSecret(ctx, secretName)
+		if err != nil {
+			return dh, err
+		}
+
+		dh.CurrentHost = customHost
+		dh.Cert = crt
+		dh.Key = key
+	}
+
+	return dh, nil
+}
+
+func (r *ReconcileIngressCluster) getSecret(ctx context.Context, secretName string) (string, string, error) {
+	lgr, err := logr.FromContext(ctx)
+	if err != nil {
+		return "", "", err
+	}
+
+	if len(secretName) > 0 {
+		secret := &corev1.Secret{}
+		err := r.Get(ctx, client.ObjectKey{Namespace: secretNamespace, Name: secretName}, secret)
+		if err != nil {
+			lgr.Error(err, "can't get secret", "secret name", secretName, "namespace", secretNamespace)
+			return "", "", fmt.Errorf("can't get secret %s; %v", secretName, err)
+		} else {
+			if secret.Type != corev1.SecretTypeTLS {
+				err = fmt.Errorf("non-TLS secret")
+				lgr.Error(err, "the secret is with a wrong type", "secret name", secretName, "namespace", secretNamespace)
+				return "", "", err
+			}
+
+			crt, ok1 := secret.Data["tls.crt"]
+			key, ok2 := secret.Data["tls.key"]
+			if !ok1 || !ok2 {
+				err = fmt.Errorf("wrong TLS secret")
+				lgr.Error(err, "can't find required data in the secret", "secret name", secretName, "namespace", secretNamespace)
+				return "", "", err
+			}
+
+			if err = verifyCertificate(crt); err != nil {
+				lgr.Error(err, "wrong secret: can't verify certificate", "secret name", secretName, "namespace", secretNamespace)
+				return "", "", err
+			}
+
+			if err = verifyPrivateKey(key); err != nil {
+				lgr.Error(err, "wrong secret: can't verify the private key", "secret name", secretName, "namespace", secretNamespace)
+				return "", "", err
+			}
+
+			return string(crt), string(key), nil
+		}
+	}
+
+	return "", "", nil
+}

--- a/controllers/ingresscluster/ingress-cluster-controller_test.go
+++ b/controllers/ingresscluster/ingress-cluster-controller_test.go
@@ -1,0 +1,658 @@
+package ingresscluster
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/reqresolver"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
+	hcoutils "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	testDomain = "apps.my-domain.com"
+	testNS     = "test-ns"
+)
+
+func TestIngressClusterController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "IngressClusterController Suite")
+}
+
+var (
+	scheme    *runtime.Scheme
+	cert, key []byte
+)
+
+var _ = BeforeSuite(func() {
+	scheme = runtime.NewScheme()
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	Expect(configv1.Install(scheme)).To(Succeed())
+	Expect(hcov1beta1.AddToScheme(scheme)).To(Succeed())
+
+	var err error
+	cert, key, err = generateCert()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = Describe("IngressClusterController", func() {
+
+	var (
+		ingress                 *configv1.Ingress
+		hostBeforeTest          downloadhost.CLIDownloadHost
+		selfNamespaceBeforeTest string
+		defaultDomain           configv1.Hostname
+	)
+
+	BeforeEach(func() {
+		hostBeforeTest = downloadhost.Get()
+		ingress = getIngress()
+		selfNamespaceBeforeTest = hcoutils.GetOperatorNamespaceFromEnv()
+		Expect(os.Setenv("OPERATOR_NAMESPACE", testNS)).To(Succeed())
+		reqresolver.GeneratePlaceHolders()
+		selfNamespace = testNS
+		defaultDomain = getDefaultCLIIDownloadHost(testDomain)
+	})
+
+	AfterEach(func() {
+		downloadhost.Set(hostBeforeTest)
+		selfNamespace = selfNamespaceBeforeTest
+		Expect(os.Setenv("OPERATOR_NAMESPACE", selfNamespace)).To(Succeed())
+		reqresolver.GeneratePlaceHolders()
+	})
+
+	It("should not add virt-downloads component to the ingress status, if no HC CR", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: defaultDomain,
+			DefaultHost: defaultDomain,
+		})
+
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		cl := fake.NewClientBuilder().WithObjects(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+		Expect(ingressAfter.Status.ComponentRoutes).To(BeEmpty())
+		Expect(ingressEventCh).To(BeEmpty())
+	})
+
+	It("should add virt-downloads component to the ingress status, if HC CR exists", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: defaultDomain,
+			DefaultHost: defaultDomain,
+		})
+
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		hc := &hcov1beta1.HyperConverged{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hcoutils.HyperConvergedName,
+				Namespace: testNS,
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithObjects(hc, ingress).WithStatusSubresource(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+
+		Expect(ingressAfter.Status.ComponentRoutes).To(HaveLen(1))
+
+		component := ingressAfter.Status.ComponentRoutes[0]
+		Expect(component.Name).To(Equal(componentName))
+		Expect(component.Namespace).To(Equal(testNS))
+		Expect(component.DefaultHostname).To(Equal(defaultDomain))
+		Expect(component.CurrentHostnames).To(HaveLen(1))
+		Expect(component.CurrentHostnames[0]).To(Equal(defaultDomain))
+		Expect(meta.IsStatusConditionFalse(component.Conditions, "Degraded")).To(BeTrueBecause("Degraded condition should be False"))
+		Expect(ingressEventCh).To(BeEmpty())
+	})
+
+	It("should notify for hostname changes, even if no HC CR", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: "something-else.com",
+			DefaultHost: "something-else.com",
+		})
+
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		cl := fake.NewClientBuilder().WithObjects(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+		Expect(ingressAfter.Status.ComponentRoutes).To(BeEmpty())
+		Eventually(ingressEventCh).Should(Receive())
+		Expect(downloadhost.Get().CurrentHost).To(Equal(defaultDomain))
+	})
+
+	It("should add virt-downloads component to the ingress status, if HC CR exists", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: "something-else.com",
+			DefaultHost: "something-else.com",
+		})
+
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		hc := &hcov1beta1.HyperConverged{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hcoutils.HyperConvergedName,
+				Namespace: testNS,
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithObjects(hc, ingress).WithStatusSubresource(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+
+		Expect(ingressAfter.Status.ComponentRoutes).To(HaveLen(1))
+
+		Eventually(ingressEventCh).Should(Receive())
+		Expect(downloadhost.Get().CurrentHost).To(Equal(defaultDomain))
+	})
+
+	It("should notify for hostname changes, even if domain was customized, and no HC CR", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: defaultDomain,
+			DefaultHost: defaultDomain,
+		})
+
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		const modifiedDomain = configv1.Hostname("my-dl-link." + testDomain)
+		ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{
+			{
+				Hostname:  modifiedDomain,
+				Name:      componentName,
+				Namespace: testNS,
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithObjects(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+		Expect(ingressAfter.Status.ComponentRoutes).To(BeEmpty())
+		Eventually(ingressEventCh).Should(Receive())
+		Expect(downloadhost.Get().DefaultHost).To(Equal(defaultDomain))
+		Expect(downloadhost.Get().CurrentHost).To(Equal(modifiedDomain))
+	})
+
+	It("should add virt-downloads component to the ingress status, if domain was customized and HC CR exists", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: defaultDomain,
+			DefaultHost: defaultDomain,
+		})
+
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		const modifiedDomain = configv1.Hostname("my-dl-link." + testDomain)
+		ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{
+			{
+				Hostname:  modifiedDomain,
+				Name:      componentName,
+				Namespace: testNS,
+			},
+		}
+
+		hc := &hcov1beta1.HyperConverged{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hcoutils.HyperConvergedName,
+				Namespace: testNS,
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithObjects(hc, ingress).WithStatusSubresource(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+
+		Expect(ingressAfter.Status.ComponentRoutes).To(HaveLen(1))
+
+		component := ingressAfter.Status.ComponentRoutes[0]
+		Expect(component.Name).To(Equal(componentName))
+		Expect(component.Namespace).To(Equal(testNS))
+		Expect(component.DefaultHostname).To(Equal(defaultDomain))
+		Expect(component.CurrentHostnames).To(HaveLen(1))
+		Expect(component.CurrentHostnames[0]).To(Equal(modifiedDomain))
+		Eventually(ingressEventCh).Should(Receive())
+
+		Expect(meta.IsStatusConditionFalse(component.Conditions, "Degraded")).To(BeTrueBecause("Degraded condition should be False"))
+
+		Expect(downloadhost.Get().CurrentHost).To(Equal(modifiedDomain))
+	})
+
+	It("should not modify virt-downloads component, if the custom domain is not subdomain, and no secret", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: defaultDomain,
+			DefaultHost: defaultDomain,
+		})
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		hc := &hcov1beta1.HyperConverged{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hcoutils.HyperConvergedName,
+				Namespace: testNS,
+			},
+		}
+
+		const modifiedDomain = configv1.Hostname("my-dl-link.something-else.com")
+		ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{
+			{
+				Hostname:  modifiedDomain,
+				Name:      componentName,
+				Namespace: testNS,
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithObjects(hc, ingress).WithStatusSubresource(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+
+		Expect(ingressAfter.Status.ComponentRoutes).To(HaveLen(1))
+
+		component := ingressAfter.Status.ComponentRoutes[0]
+		Expect(component.Name).To(Equal(componentName))
+		Expect(component.Namespace).To(Equal(testNS))
+		Expect(component.DefaultHostname).To(Equal(defaultDomain))
+		Expect(component.CurrentHostnames).To(HaveLen(1))
+		Expect(component.CurrentHostnames[0]).To(Equal(defaultDomain))
+		Expect(ingressEventCh).To(BeEmpty())
+		Expect(downloadhost.Get().CurrentHost).To(Equal(defaultDomain))
+
+		Expect(meta.IsStatusConditionTrue(component.Conditions, "Degraded")).To(BeTrueBecause("Degraded condition should be True"))
+	})
+
+	It("should grab the key, if defined", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: defaultDomain,
+			DefaultHost: defaultDomain,
+		})
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		hc := &hcov1beta1.HyperConverged{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hcoutils.HyperConvergedName,
+				Namespace: testNS,
+			},
+		}
+
+		const modifiedDomain = configv1.Hostname("my-dl-link.something-else.com")
+		ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{
+			{
+				Hostname:  modifiedDomain,
+				Name:      componentName,
+				Namespace: testNS,
+				ServingCertKeyPairSecret: configv1.SecretNameReference{
+					Name: "my-secret",
+				},
+			},
+		}
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-secret",
+				Namespace: secretNamespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": cert,
+				"tls.key": key,
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithObjects(hc, ingress, secret).WithStatusSubresource(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+
+		Expect(ingressAfter.Status.ComponentRoutes).To(HaveLen(1))
+
+		component := ingressAfter.Status.ComponentRoutes[0]
+		Expect(component.Name).To(Equal(componentName))
+		Expect(component.Namespace).To(Equal(testNS))
+		Expect(component.DefaultHostname).To(Equal(defaultDomain))
+		Expect(component.CurrentHostnames).To(HaveLen(1))
+		Expect(component.CurrentHostnames[0]).To(Equal(modifiedDomain))
+		Expect(ingressEventCh).To(Receive())
+
+		host := downloadhost.Get()
+		Expect(host.DefaultHost).To(Equal(defaultDomain))
+		Expect(host.CurrentHost).To(Equal(modifiedDomain))
+		Expect(host.Cert).To(Equal(string(cert)))
+		Expect(host.Key).To(Equal(string(key)))
+
+		Expect(meta.IsStatusConditionFalse(component.Conditions, "Degraded")).To(BeTrueBecause("Degraded condition should be False"))
+	})
+
+	It("should not modify virt-downloads component, if the secret not found", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: defaultDomain,
+			DefaultHost: defaultDomain,
+		})
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		hc := &hcov1beta1.HyperConverged{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hcoutils.HyperConvergedName,
+				Namespace: testNS,
+			},
+		}
+
+		const modifiedDomain = configv1.Hostname("my-dl-link." + testDomain)
+		ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{
+			{
+				Hostname:  modifiedDomain,
+				Name:      componentName,
+				Namespace: testNS,
+				ServingCertKeyPairSecret: configv1.SecretNameReference{
+					Name: "my-secret",
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithObjects(hc, ingress).WithStatusSubresource(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+
+		Expect(ingressAfter.Status.ComponentRoutes).To(HaveLen(1))
+
+		component := ingressAfter.Status.ComponentRoutes[0]
+		Expect(component.Name).To(Equal(componentName))
+		Expect(component.Namespace).To(Equal(testNS))
+		Expect(component.DefaultHostname).To(Equal(defaultDomain))
+		Expect(component.CurrentHostnames).To(HaveLen(1))
+		Expect(component.CurrentHostnames[0]).To(Equal(defaultDomain))
+		Expect(ingressEventCh).To(BeEmpty())
+		Expect(downloadhost.Get().CurrentHost).To(Equal(defaultDomain))
+
+		Expect(meta.IsStatusConditionTrue(component.Conditions, "Degraded")).To(BeTrueBecause("Degraded condition should be True"))
+	})
+
+	It("should not modify virt-downloads component, if the secret is with a wrong type", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: defaultDomain,
+			DefaultHost: defaultDomain,
+		})
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		hc := &hcov1beta1.HyperConverged{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hcoutils.HyperConvergedName,
+				Namespace: testNS,
+			},
+		}
+
+		const modifiedDomain = configv1.Hostname("my-dl-link." + testDomain)
+		ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{
+			{
+				Hostname:  modifiedDomain,
+				Name:      componentName,
+				Namespace: testNS,
+				ServingCertKeyPairSecret: configv1.SecretNameReference{
+					Name: "my-secret",
+				},
+			},
+		}
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-secret",
+				Namespace: secretNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"tls.crt": cert,
+				"tls.key": key,
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithObjects(hc, ingress, secret).WithStatusSubresource(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+
+		Expect(ingressAfter.Status.ComponentRoutes).To(HaveLen(1))
+
+		component := ingressAfter.Status.ComponentRoutes[0]
+		Expect(component.Name).To(Equal(componentName))
+		Expect(component.Namespace).To(Equal(testNS))
+		Expect(component.DefaultHostname).To(Equal(defaultDomain))
+		Expect(component.CurrentHostnames).To(HaveLen(1))
+		Expect(component.CurrentHostnames[0]).To(Equal(defaultDomain))
+		Expect(ingressEventCh).To(BeEmpty())
+		Expect(downloadhost.Get().CurrentHost).To(Equal(defaultDomain))
+
+		Expect(meta.IsStatusConditionTrue(component.Conditions, "Degraded")).To(BeTrueBecause("Degraded condition should be True"))
+	})
+
+	It("should not modify virt-downloads component, if the secret is wrong", func(ctx context.Context) {
+		ctx = logr.NewContext(ctx, GinkgoLogr)
+		downloadhost.Set(downloadhost.CLIDownloadHost{
+			CurrentHost: defaultDomain,
+			DefaultHost: defaultDomain,
+		})
+		req := reconcile.Request{}
+		ingressEventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+		defer close(ingressEventCh)
+
+		hc := &hcov1beta1.HyperConverged{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hcoutils.HyperConvergedName,
+				Namespace: testNS,
+			},
+		}
+
+		const modifiedDomain = configv1.Hostname("my-dl-link." + testDomain)
+		ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{
+			{
+				Hostname:  modifiedDomain,
+				Name:      componentName,
+				Namespace: testNS,
+				ServingCertKeyPairSecret: configv1.SecretNameReference{
+					Name: "my-secret",
+				},
+			},
+		}
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-secret",
+				Namespace: secretNamespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"non-tls-key": []byte("some value"),
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithObjects(hc, ingress, secret).WithStatusSubresource(ingress).WithScheme(scheme).Build()
+		r := newIngressClusterController(cl, ingressEventCh)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		ingressAfter := &configv1.Ingress{}
+		Expect(r.Get(ctx, client.ObjectKey{Name: "cluster"}, ingressAfter)).To(Succeed())
+
+		Expect(ingressAfter.Status.ComponentRoutes).To(HaveLen(1))
+
+		component := ingressAfter.Status.ComponentRoutes[0]
+		Expect(component.Name).To(Equal(componentName))
+		Expect(component.Namespace).To(Equal(testNS))
+		Expect(component.DefaultHostname).To(Equal(defaultDomain))
+		Expect(component.CurrentHostnames).To(HaveLen(1))
+		Expect(component.CurrentHostnames[0]).To(Equal(defaultDomain))
+		Expect(ingressEventCh).To(BeEmpty())
+		Expect(downloadhost.Get().CurrentHost).To(Equal(defaultDomain))
+
+		Expect(meta.IsStatusConditionTrue(component.Conditions, "Degraded")).To(BeTrueBecause("Degraded condition should be True"))
+	})
+})
+
+func getIngress() *configv1.Ingress {
+	return &configv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: configv1.GroupVersion.String(),
+			Kind:       "Ingress",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.IngressSpec{
+			Domain: testDomain,
+		},
+		Status: configv1.IngressStatus{
+			DefaultPlacement: "Workers",
+		},
+	}
+}
+
+func generateCert() ([]byte, []byte, error) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	publicKey := privKey.PublicKey
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(5 * time.Minute),
+
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &publicKey, privKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certOut := &bytes.Buffer{}
+	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(privKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyOut := &bytes.Buffer{}
+	err = pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return certOut.Bytes(), keyOut.Bytes(), nil
+}

--- a/controllers/ingresscluster/tls.go
+++ b/controllers/ingresscluster/tls.go
@@ -1,0 +1,43 @@
+package ingresscluster
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"time"
+)
+
+func verifyCertificate(customCert []byte) error {
+	block, _ := pem.Decode(customCert)
+	if block == nil {
+		return fmt.Errorf("failed to decode certificate PEM")
+	}
+	certificate, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	if now.After(certificate.NotAfter) {
+		return fmt.Errorf("custom TLS certificate is expired")
+	}
+	if now.Before(certificate.NotBefore) {
+		return fmt.Errorf("custom TLS certificate is not valid yet")
+	}
+	return nil
+}
+
+func verifyPrivateKey(customKey []byte) error {
+	block, _ := pem.Decode(customKey)
+
+	if block == nil {
+		return fmt.Errorf("failed to decode key PEM")
+	}
+	if _, err := x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+		if _, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+			if _, err = x509.ParseECPrivateKey(block.Bytes); err != nil {
+				return fmt.Errorf("block %s is not valid key PEM", block.Type)
+			}
+		}
+	}
+	return nil
+}

--- a/controllers/nodes/nodes_controller.go
+++ b/controllers/nodes/nodes_controller.go
@@ -104,10 +104,7 @@ func (r *ReconcileNodeCounter) Reconcile(ctx context.Context, _ reconcile.Reques
 	}
 
 	hco := &hcov1beta1.HyperConverged{}
-	namespace, err := hcoutil.GetOperatorNamespaceFromEnv()
-	if err != nil {
-		return reconcile.Result{}, err
-	}
+	namespace := hcoutil.GetOperatorNamespaceFromEnv()
 	hcoKey := types.NamespacedName{
 		Name:      hcoutil.HyperConvergedName,
 		Namespace: namespace,

--- a/controllers/observability/observability_controller.go
+++ b/controllers/observability/observability_controller.go
@@ -72,12 +72,9 @@ func NewReconciler(mgr ctrl.Manager, namespace string, ownerDeployment *appsv1.D
 func SetupWithManager(mgr ctrl.Manager, ownerDeployment *appsv1.Deployment) error {
 	log.Info("Setting up controller")
 
-	namespace, err := util.GetOperatorNamespaceFromEnv()
-	if err != nil {
-		return fmt.Errorf("failed to get operator namespace: %v", err)
-	}
+	namespace := util.GetOperatorNamespaceFromEnv()
 
-	err = rules.SetupRules()
+	err := rules.SetupRules()
 	if err != nil {
 		return fmt.Errorf("failed to setup Prometheus rules: %v", err)
 	}

--- a/controllers/operands/cliDownload_test.go
+++ b/controllers/operands/cliDownload_test.go
@@ -18,6 +18,7 @@ import (
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
@@ -333,6 +334,33 @@ var _ = Describe("Cli Downloads Route", func() {
 				}
 			}),
 		)
+
+		Context("Customize Download Link", func() {
+			var origHost downloadhost.CLIDownloadHost
+
+			BeforeEach(func() {
+				origHost = downloadhost.Get()
+				DeferCleanup(func() {
+					downloadhost.Set(origHost)
+				})
+			})
+
+			It("should use modified URL, certificate and keys, if exists", func() {
+
+				downloadhost.Set(downloadhost.CLIDownloadHost{
+					DefaultHost: "default-host.com",
+					CurrentHost: "cli-dl.example.com",
+					Cert:        "crt",
+					Key:         "key",
+				})
+
+				expectedResource := NewCliDownloadsRoute(hco)
+
+				Expect(expectedResource.Spec.Host).To(Equal("cli-dl.example.com"))
+				Expect(expectedResource.Spec.TLS.Certificate).To(Equal("crt"))
+				Expect(expectedResource.Spec.TLS.Key).To(Equal("key"))
+			})
+		})
 
 	})
 })

--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"reflect"
+	"slices"
 
 	"k8s.io/utils/ptr"
 
@@ -22,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/cmd/cmdcommon"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -544,7 +544,7 @@ func (h consoleHandler) ensure(req *common.HcoRequest) *EnsureResult {
 		}
 	}
 
-	if !cmdcommon.StringInSlice(kvUIPluginName, consoleObj.Spec.Plugins) {
+	if !slices.Contains(consoleObj.Spec.Plugins, kvUIPluginName) {
 		req.Logger.Info("Enabling kubevirt plugin in Console")
 		consoleObj.Spec.Plugins = append(consoleObj.Spec.Plugins, kvUIPluginName)
 		err := h.Client.Update(req.Ctx, consoleObj)

--- a/controllers/reqresolver/reqresolver.go
+++ b/controllers/reqresolver/reqresolver.go
@@ -1,0 +1,106 @@
+package reqresolver
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	secondaryCRPrefix = "hco-controlled-cr-"
+	apiServerCRPrefix = "api-server-cr-"
+)
+
+var (
+	randomConstSuffix = ""
+
+	// hyperConvergedNamespacedName is the name/namespace of the HyperConverged resource
+	hyperConvergedNamespacedName types.NamespacedName
+
+	// secondaryCRPlaceholder is a placeholder to be able to discriminate
+	// reconciliation requests triggered by secondary watched resources
+	// use a random generated suffix for security reasons
+	secondaryCRPlaceholder types.NamespacedName
+
+	apiServerCRPlaceholder types.NamespacedName
+)
+
+// ResolveReconcileRequest returns a reconcile.Request to be used throughout the reconciliation cycle,
+// regardless of which resource has triggered it.
+func ResolveReconcileRequest(logger logr.Logger, originalRequest reconcile.Request) (reconcile.Request, bool) {
+	if isTriggeredByHyperConvergedOrUnknown(originalRequest) {
+		logger.Info("Reconciling HyperConverged operator")
+		return originalRequest, true
+	}
+
+	resolvedRequest := getHyperConvergedCRRequest()
+
+	if IsTriggeredByAPIServerCR(originalRequest) {
+		// consider a change in APIServerCr like a change in HCO
+		return resolvedRequest, true
+	}
+
+	logger.Info("The reconciliation got triggered by a secondary CR object")
+	return resolvedRequest, false
+}
+
+func GetHyperConvergedNamespacedName() types.NamespacedName {
+	return hyperConvergedNamespacedName
+}
+
+func getHyperConvergedCRRequest() reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: hyperConvergedNamespacedName,
+	}
+}
+
+func GetSecondaryCRRequest() reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: secondaryCRPlaceholder,
+	}
+}
+
+func GetAPIServerCRRequest() reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: apiServerCRPlaceholder,
+	}
+}
+
+func IsTriggeredByHyperConverged(nsName types.NamespacedName) bool {
+	return nsName == hyperConvergedNamespacedName
+}
+
+func isTriggeredByHyperConvergedOrUnknown(request reconcile.Request) bool {
+	return request.NamespacedName != secondaryCRPlaceholder && request.NamespacedName != apiServerCRPlaceholder
+}
+
+func IsTriggeredByAPIServerCR(request reconcile.Request) bool {
+	return request.NamespacedName == apiServerCRPlaceholder
+}
+
+func GeneratePlaceHolders() {
+	randomConstSuffix = uuid.New().String()
+
+	ns := hcoutil.GetOperatorNamespaceFromEnv()
+	hyperConvergedNamespacedName = types.NamespacedName{
+		Name:      hcoutil.HyperConvergedName,
+		Namespace: ns,
+	}
+
+	secondaryCRPlaceholder = types.NamespacedName{
+		Name:      secondaryCRPrefix + randomConstSuffix,
+		Namespace: ns,
+	}
+
+	apiServerCRPlaceholder = types.NamespacedName{
+		Name:      apiServerCRPrefix + randomConstSuffix,
+		Namespace: ns,
+	}
+}
+
+func init() {
+	GeneratePlaceHolders()
+}

--- a/controllers/reqresolver/reqresolver_test.go
+++ b/controllers/reqresolver/reqresolver_test.go
@@ -1,0 +1,124 @@
+package reqresolver_test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/reqresolver"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	namespace = "test-ns"
+)
+
+func TestReqResolver(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ReqResolver Suite")
+}
+
+var (
+	nsBefore string
+
+	_ = BeforeSuite(func() {
+		nsBefore = hcoutil.GetOperatorNamespaceFromEnv()
+		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, namespace)).To(Succeed())
+		reqresolver.GeneratePlaceHolders()
+	})
+
+	_ = AfterSuite(func() {
+		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, nsBefore)).To(Succeed())
+		reqresolver.GeneratePlaceHolders()
+	})
+)
+
+var _ = Describe("test ResolveReconcileRequest", func() {
+	It("should return original req and true for request triggered by HC", func() {
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: namespace,
+				Name:      hcoutil.HyperConvergedName,
+			},
+		}
+		requestAfter, triggeredByHC := reqresolver.ResolveReconcileRequest(GinkgoLogr, req)
+		Expect(requestAfter).To(Equal(req))
+		Expect(triggeredByHC).To(BeTrue())
+	})
+
+	It("should return original req and true for request triggered by unknown source", func() {
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: namespace,
+				Name:      "unknown",
+			},
+		}
+		requestAfter, triggeredByHC := reqresolver.ResolveReconcileRequest(GinkgoLogr, req)
+		Expect(requestAfter).To(Equal(req))
+		Expect(triggeredByHC).To(BeTrueBecause("should recognized as triggered by the HyperConverged CR"))
+	})
+
+	It("should return HC req and true for request triggered by API-Server", func() {
+		expected := reconcile.Request{
+			NamespacedName: reqresolver.GetHyperConvergedNamespacedName(),
+		}
+		requestAfter, triggeredByHC := reqresolver.ResolveReconcileRequest(GinkgoLogr, reqresolver.GetAPIServerCRRequest())
+		Expect(requestAfter).To(Equal(expected))
+		Expect(triggeredByHC).To(BeTrueBecause("should recognized as triggered by the HyperConverged CR"))
+	})
+
+	It("should return HC req and true for request triggered by Ingress", func() {
+		expected := reconcile.Request{
+			NamespacedName: reqresolver.GetHyperConvergedNamespacedName(),
+		}
+		requestAfter, triggeredByHC := reqresolver.ResolveReconcileRequest(GinkgoLogr, reqresolver.GetIngressCRResource())
+		Expect(requestAfter).To(Equal(expected))
+		Expect(triggeredByHC).To(BeTrueBecause("should recognized as triggered by the HyperConverged CR"))
+	})
+
+	It("should return HC req and false for request triggered by Secondary resource", func() {
+		expected := reconcile.Request{
+			NamespacedName: reqresolver.GetHyperConvergedNamespacedName(),
+		}
+		requestAfter, triggeredByHC := reqresolver.ResolveReconcileRequest(GinkgoLogr, reqresolver.GetSecondaryCRRequest())
+		Expect(requestAfter).To(Equal(expected))
+		Expect(triggeredByHC).To(BeFalseBecause("should recognized as triggered by a secondary resource"))
+	})
+})
+
+var _ = Describe("Check generated requests", func() {
+	It("test GetHyperConvergedNamespacedName", func() {
+		n := reqresolver.GetHyperConvergedNamespacedName()
+		Expect(n).To(Equal(types.NamespacedName{Name: hcoutil.HyperConvergedName, Namespace: namespace}))
+		Expect(reqresolver.IsTriggeredByHyperConverged(n)).To(BeTrueBecause("should recognized as triggered by HyperConverged CR"))
+		Expect(reqresolver.IsTriggeredByAPIServerCR(reconcile.Request{NamespacedName: n})).To(BeFalseBecause("should not be recognized as triggered by APIServer CR"))
+	})
+
+	It("test GetAPIServerCRRequest", func() {
+		req := reqresolver.GetAPIServerCRRequest()
+		Expect(req.NamespacedName.Namespace).To(Equal(namespace))
+		Expect(req.NamespacedName.Name).To(HavePrefix("api-server-cr-"))
+		Expect(reqresolver.IsTriggeredByHyperConverged(req.NamespacedName)).To(BeFalseBecause("should not be recognized as triggered by HyperConverged CR"))
+		Expect(reqresolver.IsTriggeredByAPIServerCR(req)).To(BeTrueBecause("should be recognized as triggered by APIServer CR"))
+	})
+
+	It("test GetSecondaryCRRequest", func() {
+		req := reqresolver.GetSecondaryCRRequest()
+		Expect(req.NamespacedName.Namespace).To(Equal(namespace))
+		Expect(req.NamespacedName.Name).To(HavePrefix("hco-controlled-cr-"))
+		Expect(reqresolver.IsTriggeredByHyperConverged(req.NamespacedName)).To(BeFalseBecause("should not be recognized as triggered by HyperConverged CR"))
+		Expect(reqresolver.IsTriggeredByAPIServerCR(req)).To(BeFalseBecause("should not be recognized as triggered by APIServer CR"))
+	})
+
+	It("test GetIngressCRResource", func() {
+		req := reqresolver.GetIngressCRResource()
+		Expect(req.NamespacedName.Namespace).To(Equal(namespace))
+		Expect(req.NamespacedName.Name).To(HavePrefix("ingress-cr-"))
+		Expect(reqresolver.IsTriggeredByHyperConverged(req.NamespacedName)).To(BeFalseBecause("should not be recognized as triggered by HyperConverged CR"))
+		Expect(reqresolver.IsTriggeredByAPIServerCR(req)).To(BeFalseBecause("should not be recognized as triggered by APIServer CR"))
+	})
+})

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -846,14 +846,8 @@ rules:
   - ""
   resources:
   - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes
+  - secrets
   verbs:
   - get
   - list
@@ -982,11 +976,24 @@ rules:
   resources:
   - clusterversions
   - infrastructures
-  - ingresses
   - networks
   verbs:
   - get
   - list
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
 - apiGroups:
   - config.openshift.io
   resources:
@@ -1032,6 +1039,14 @@ rules:
   - create
   - update
   - delete
+  - patch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - update
   - patch
 - apiGroups:
   - operators.coreos.com

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
@@ -317,14 +317,8 @@ spec:
           - ""
           resources:
           - pods
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
           - nodes
+          - secrets
           verbs:
           - get
           - list
@@ -453,11 +447,24 @@ spec:
           resources:
           - clusterversions
           - infrastructures
-          - ingresses
           - networks
           verbs:
           - get
           - list
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - ingresses/status
+          verbs:
+          - update
         - apiGroups:
           - config.openshift.io
           resources:
@@ -503,6 +510,14 @@ spec:
           - create
           - update
           - delete
+          - patch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+          - update
           - patch
         - apiGroups:
           - operators.coreos.com

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.15.0-unstable
-    createdAt: "2025-02-09 09:42:58"
+    createdAt: "2025-02-16 11:46:33"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -317,14 +317,8 @@ spec:
           - ""
           resources:
           - pods
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
           - nodes
+          - secrets
           verbs:
           - get
           - list
@@ -453,11 +447,24 @@ spec:
           resources:
           - clusterversions
           - infrastructures
-          - ingresses
           - networks
           verbs:
           - get
           - list
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - ingresses/status
+          verbs:
+          - update
         - apiGroups:
           - config.openshift.io
           resources:
@@ -503,6 +510,14 @@ spec:
           - create
           - update
           - delete
+          - patch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+          - update
           - patch
         - apiGroups:
           - operators.coreos.com

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -512,12 +512,7 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		roleWithAllPermissions("", stringListToSlice("services")),
 		{
 			APIGroups: emptyAPIGroup,
-			Resources: stringListToSlice("pods"),
-			Verbs:     stringListToSlice("get", "list", "watch"),
-		},
-		{
-			APIGroups: emptyAPIGroup,
-			Resources: stringListToSlice("nodes"),
+			Resources: stringListToSlice("pods", "nodes", "secrets"),
 			Verbs:     stringListToSlice("get", "list", "watch"),
 		},
 		{
@@ -565,8 +560,18 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		roleWithAllPermissions("console.openshift.io", stringListToSlice("consoleclidownloads", "consolequickstarts")),
 		{
 			APIGroups: stringListToSlice(configOpenshiftIO),
-			Resources: stringListToSlice("clusterversions", "infrastructures", "ingresses", "networks"),
+			Resources: stringListToSlice("clusterversions", "infrastructures", "networks"),
 			Verbs:     stringListToSlice("get", "list"),
+		},
+		{
+			APIGroups: stringListToSlice(configOpenshiftIO),
+			Resources: stringListToSlice("ingresses"),
+			Verbs:     stringListToSlice("get", "list", "watch"),
+		},
+		{
+			APIGroups: stringListToSlice(configOpenshiftIO),
+			Resources: stringListToSlice("ingresses/status"),
+			Verbs:     stringListToSlice("update"),
 		},
 		{
 			APIGroups: stringListToSlice(configOpenshiftIO),
@@ -585,6 +590,11 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		},
 		roleWithAllPermissions("coordination.k8s.io", stringListToSlice("leases")),
 		roleWithAllPermissions("route.openshift.io", stringListToSlice("routes")),
+		{
+			APIGroups: stringListToSlice("route.openshift.io"),
+			Resources: stringListToSlice("routes/custom-host"),
+			Verbs:     stringListToSlice("create", "update", "patch"),
+		},
 		{
 			APIGroups: stringListToSlice("operators.coreos.com"),
 			Resources: stringListToSlice("operatorconditions"),

--- a/pkg/downloadhost/domainname.go
+++ b/pkg/downloadhost/domainname.go
@@ -1,0 +1,43 @@
+package downloadhost
+
+import (
+	"sync"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+const (
+	CLIDownloadsServiceName = "hyperconverged-cluster-cli-download"
+)
+
+type CLIDownloadHost struct {
+	DefaultHost configv1.Hostname
+	CurrentHost configv1.Hostname
+	Cert        string
+	Key         string
+}
+
+var (
+	cliDownloadHost CLIDownloadHost
+	lock            = sync.RWMutex{}
+)
+
+func Set(info CLIDownloadHost) bool {
+	lock.Lock()
+	defer lock.Unlock()
+
+	changed := false
+	if cliDownloadHost != info {
+		changed = true
+		cliDownloadHost = info
+	}
+
+	return changed
+}
+
+func Get() CLIDownloadHost {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	return cliDownloadHost
+}

--- a/pkg/downloadhost/domainname_test.go
+++ b/pkg/downloadhost/domainname_test.go
@@ -1,0 +1,60 @@
+package downloadhost_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "domainname")
+}
+
+var _ = Describe("domainname", func() {
+	var valueBefore downloadhost.CLIDownloadHost
+	BeforeEach(func() {
+		valueBefore = downloadhost.Get()
+	})
+
+	AfterEach(func() {
+		downloadhost.Set(valueBefore)
+	})
+
+	It("should set and get the domain name", func() {
+		info := downloadhost.CLIDownloadHost{
+			DefaultHost: "aaa",
+			CurrentHost: "bbb",
+			Cert:        "ccc",
+			Key:         "ddd",
+		}
+		Expect(downloadhost.Set(info)).To(BeTrue())
+		Expect(downloadhost.Get()).To(Equal(info))
+	})
+
+	It("should return true if the value was changed", func() {
+		infoBefore := downloadhost.CLIDownloadHost{
+			DefaultHost: "aaa",
+			CurrentHost: "bbb",
+			Cert:        "ccc",
+			Key:         "ddd",
+		}
+
+		infoToSet := downloadhost.CLIDownloadHost{
+			DefaultHost: "111",
+			CurrentHost: "222",
+			Cert:        "333",
+			Key:         "444",
+		}
+
+		downloadhost.Set(infoBefore)
+		Expect(downloadhost.Get()).To(Equal(infoBefore))
+		Expect(downloadhost.Set(infoBefore)).To(BeFalse())
+
+		Expect(downloadhost.Set(infoToSet)).To(BeTrue())
+		Expect(downloadhost.Get()).To(Equal(infoToSet))
+	})
+})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -48,12 +48,8 @@ var ErrNoNamespace = fmt.Errorf("namespace not found for current environment")
 // is returned by functions that only work on operators running in cluster mode)
 var ErrRunLocal = fmt.Errorf("operator run mode forced to local")
 
-func GetOperatorNamespaceFromEnv() (string, error) {
-	if namespace, ok := os.LookupEnv(OperatorNamespaceEnv); ok {
-		return namespace, nil
-	}
-
-	return "", fmt.Errorf("%s unset or empty in environment", OperatorNamespaceEnv)
+func GetOperatorNamespaceFromEnv() string {
+	return os.Getenv(OperatorNamespaceEnv)
 }
 
 func CheckPrimaryUDNImageEnvExists() error {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -36,16 +36,8 @@ var _ = Describe("Test general utilities", func() {
 			const expectedNs = "mynamespace"
 			_ = os.Setenv(OperatorNamespaceEnv, expectedNs)
 
-			ns, err := GetOperatorNamespaceFromEnv()
-			Expect(err).ToNot(HaveOccurred())
+			ns := GetOperatorNamespaceFromEnv()
 			Expect(ns).To(Equal(expectedNs))
-		})
-
-		It("should return an error if the OPERATOR_NAMESPACE env var is not set", func() {
-			_ = os.Unsetenv(OperatorNamespaceEnv)
-
-			_, err := GetOperatorNamespaceFromEnv()
-			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/pkg/webhooks/setup.go
+++ b/pkg/webhooks/setup.go
@@ -29,11 +29,7 @@ var (
 )
 
 func SetupWebhookWithManager(ctx context.Context, mgr ctrl.Manager, isOpenshift bool, hcoTLSSecurityProfile *openshiftconfigv1.TLSSecurityProfile) error {
-	operatorNsEnv, nserr := hcoutil.GetOperatorNamespaceFromEnv()
-	if nserr != nil {
-		logger.Error(nserr, "failed to get operator namespace from the environment")
-		return nserr
-	}
+	operatorNsEnv := hcoutil.GetOperatorNamespaceFromEnv()
 
 	decoder := admission.NewDecoder(mgr.GetScheme())
 

--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -3,18 +3,26 @@ package tests_test
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"flag"
+	"fmt"
 	"net/http"
+	"slices"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
+	v1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
@@ -54,18 +62,104 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 		for _, link := range ccd.Spec.Links {
 			// virtctl for Windows for ARM 64 is still not shipped, avoid checking it
 			// TODO: remove this once ready
-			if !(strings.Contains(link.Href, "windows") && strings.Contains(link.Href, "arm64")) {
-				By("Checking links. Link:" + link.Href)
-				client := &http.Client{Transport: &http.Transport{
-					// ssl of the route is irrelevant
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-				}}
-				resp, err := client.Get(link.Href)
-				_ = resp.Body.Close()
-
-				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				ExpectWithOffset(1, resp).To(HaveHTTPStatus(http.StatusOK))
+			if strings.Contains(link.Href, "windows") && strings.Contains(link.Href, "arm64") {
+				continue
 			}
+			By("Checking links. Link:" + link.Href)
+			client := &http.Client{Transport: &http.Transport{
+				// ssl of the route is irrelevant
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}}
+			resp, err := client.Get(link.Href)
+			_ = resp.Body.Close()
+
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, resp).To(HaveHTTPStatus(http.StatusOK))
 		}
+	})
+
+	Context("URL Download customization", func() {
+		var existingRoutes string
+		BeforeEach(func(ctx context.Context) {
+			GinkgoWriter.Println("Reading the Ingress before")
+			ingress := &configv1.Ingress{}
+			Expect(cli.Get(ctx, client.ObjectKey{Name: "cluster"}, ingress)).To(Succeed())
+
+			routeBytes, err := json.Marshal(ingress.Spec.ComponentRoutes)
+			Expect(err).ToNot(HaveOccurred())
+			existingRoutes = string(routeBytes)
+
+			if len(ingress.Spec.ComponentRoutes) > 0 {
+				GinkgoWriter.Println("removing the custom routes before the test")
+				cleanupPatch := []byte(`[{"op": "remove", "path": "/spec/componentRoutes"}]`)
+				Expect(cli.Patch(ctx, ingress, client.RawPatch(types.JSONPatchType, cleanupPatch))).To(Succeed())
+			}
+		})
+
+		AfterEach(func(ctx context.Context) {
+			ingress := &configv1.Ingress{}
+			Expect(cli.Get(ctx, client.ObjectKey{Name: "cluster"}, ingress)).To(Succeed())
+
+			if len(ingress.Spec.ComponentRoutes) > 0 {
+				GinkgoWriter.Println("restoring the custom routes after the test")
+				cleanupPatch := []byte(fmt.Sprintf(`[{"op": "replace", "path": "/spec/componentRoutes", "value": %v}]`, existingRoutes))
+				Expect(cli.Patch(ctx, ingress, client.RawPatch(types.JSONPatchType, cleanupPatch))).To(Succeed())
+			}
+		})
+
+		It("should allow download URL customisation", Label("custom_dl_link"), func(ctx context.Context) {
+			By("make sure the ingress contains the virt-downloads route component")
+			ingress := &configv1.Ingress{}
+			Expect(cli.Get(ctx, client.ObjectKey{Name: "cluster"}, ingress)).To(Succeed())
+
+			Expect(slices.ContainsFunc(ingress.Status.ComponentRoutes, func(route configv1.ComponentRouteStatus) bool {
+				return route.Name == "virt-downloads"
+			})).To(BeTrueBecause("can't find the virt-downloads route in staus of the the cluster Ingress"))
+
+			By("customize the virt-downloads route, to set another host")
+			baseDomain := ingress.Spec.Domain
+			newCLIDLHost := "virt-dl." + baseDomain
+			patch := []byte(fmt.Sprintf(`[{"op": "add", "path": "/spec/componentRoutes", "value": [{"name": "virt-downloads", "hostname": %q, "namespace": %q}]}]`, newCLIDLHost, tests.InstallNamespace))
+			Expect(cli.Patch(ctx, ingress, client.RawPatch(types.JSONPatchType, patch))).To(Succeed())
+
+			customTransport := http.DefaultTransport.(*http.Transport).Clone()
+			customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+			httpClient := &http.Client{Transport: customTransport, Timeout: time.Second * 1}
+
+			ccdKey := client.ObjectKey{Name: "virtctl-clidownloads-kubevirt-hyperconverged"}
+
+			By("checking ConsoleCLIDownload links")
+			Eventually(func(g Gomega, ctx context.Context) {
+				ccd := &consolev1.ConsoleCLIDownload{}
+
+				g.Expect(cli.Get(ctx, ccdKey, ccd)).To(Succeed())
+				g.Expect(ccd.Spec.Links).To(HaveLen(7))
+				for _, link := range ccd.Spec.Links {
+					// virtctl for Windows for ARM 64 is still not shipped, avoid checking it
+					// TODO: remove this once ready
+					if strings.Contains(link.Href, "windows") && strings.Contains(link.Href, "arm64") {
+						continue
+					}
+
+					g.Expect(link.Href).To(ContainSubstring(newCLIDLHost))
+					res, err := httpClient.Head(link.Href)
+					g.Expect(err).NotTo(HaveOccurred(), "HEAD failed for %s", link.Href)
+					g.Expect(res.StatusCode).To(Equal(http.StatusOK), "non OK response for %s", link.Href)
+				}
+			}).WithContext(ctx).
+				WithTimeout(60 * time.Second).
+				WithPolling(time.Second).
+				Should(Succeed())
+
+			routeKey := client.ObjectKey{Name: downloadhost.CLIDownloadsServiceName, Namespace: tests.InstallNamespace}
+			Eventually(func(g Gomega, ctx context.Context) {
+				route := &v1.Route{}
+				g.Expect(cli.Get(ctx, routeKey, route)).To(Succeed())
+				g.Expect(route.Spec.Host).To(Equal(newCLIDLHost))
+			}).WithContext(ctx).
+				WithTimeout(60 * time.Second).
+				WithPolling(time.Second).
+				Should(Succeed())
+		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes, the user must not use the default CLI download links. For example, if the domain is internal, but the download link need to be internal.

openshift allows modifying the openshift CLI download link by adding a component route to the Ingress cluster CR spec.

openshift suggest to add additional component routes by first add them to the ingress status by the operator, and then let the user to add them to the ingress spec if needed. the operator is responsible to modify the route and the download link, if the user modified the url.

This PR adds a new controller to HCO, to watch the ingress, add the required component to the status, and modify the route and the download links, if the user modified the url in the ingress spec.

The user should add a route component named `"virt-downloads"`, with the namesapce where HCO is deployed.

For example:
```yaml
spec:
  componentRoutes:
  - hostname: my-dl-link.apps.nahshon-cluster.cnvqedevops.qe.gcp.devcluster.openshift.com
    name: virt-downloads
    namespace: kubevirt-hyperconverged
```

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-55666
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow customizing the CLI download link
```
