### PR TITLE
Add `openshift.io/required-scc` annotation to pods

### DIFF
--- a/controllers/operands/kubevirtConsolePlugin.go
+++ b/controllers/operands/kubevirtConsolePlugin.go
@@ -146,6 +146,9 @@ func getKvUIDeployment(hc *hcov1beta1.HyperConverged, deploymentName string, ima
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					Annotations: map[string]string{
+						"openshift.io/required-scc": "restricted-v2",
+					},
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "default",

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
@@ -22,6 +22,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    openshift.io/required-scc: restricted-v2
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
     operatorframework.io/suggested-namespace: kubevirt-hyperconverged
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.15.0-unstable
-    createdAt: "2025-02-02 18:10:08"
+    createdAt: "2025-02-03 08:41:15"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -22,6 +22,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    openshift.io/required-scc: restricted-v2
     operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
     operatorframework.io/suggested-namespace: kubevirt-hyperconverged
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -910,6 +910,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 				"features.operators.openshift.io/token-auth-aws":   "false",
 				"features.operators.openshift.io/token-auth-azure": "false",
 				"features.operators.openshift.io/token-auth-gcp":   "false",
+				"openshift.io/required-scc":                        "restricted-v2",
 			},
 		},
 		Spec: csvv1alpha1.ClusterServiceVersionSpec{


### PR DESCRIPTION
The OpenShift API dictates that a workload should require an SCC by using the  annotation:
https://docs.openshift.com/container-platform/4.17/authentication/managing-security-context-constraints.html#security-context-constraints-requiring_configuring-internal-oauth

`required-scc` prevents customers (or other extension provided) SCCs from being auto-selected by pods. The auto selection can fail in multiple ways: not enough permissions, changes of UID. When combined with pod security admission (on in new clusters in 4.19), this can result in SCCs being selected based on RBAC permissions that violate PSA and results in pods not running.

This PR adds the `openshift.io/required-scc` annotation on all HCO-controlled pods:

- hco-operator
- hco-webhook
- hyperconverged-cluster-cli-download
- kubevirt-console-plugin
- kubevirt-apiserver-proxy
- aaq-operator
- cdi-operator
- cluster-network-addons-operator
- hostpath-provisioner-operator
- ssp-operator
- virt-operator


Signed-off-by: Oren Cohen <ocohen@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-53303
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add openshift.io/required-scc annotation to HCO pods
```
