### PR TITLE
bump golang to v1.23.5, to fix CVE-2024-21626

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/kubevirt/hyperconverged-cluster-operator
 
 go 1.23.2
 
+toolchain go1.23.5
+
 require (
 	dario.cat/mergo v1.0.1
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-55403
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bump golang to v1.23.5, to fix CVE-2024-21626
```
