### PR TITLE
Bump golangci-lint to v1.64.4

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -67,6 +67,6 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.62.2
+          version: v1.64.4
           skip-pkg-cache: true
           args: --timeout=5m --out-${NO_FUTURE}format line-number

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ WEBHOOK_IMAGE      ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-webhook
 FUNC_TEST_IMAGE    ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-functest
 VIRT_ARTIFACTS_SERVER ?= $(REGISTRY_NAMESPACE)/virt-artifacts-server
 LDFLAGS            ?= -w -s
-GOLANDCI_LINT_VERSION ?= v1.57.0
+GOLANDCI_LINT_VERSION ?= v1.64.4
 HCO_BUMP_LEVEL ?= minor
 
 
@@ -37,9 +37,8 @@ goimport:
 
 
 lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANDCI_LINT_VERSION}
+	GOTOOLCHAIN=go1.23.4 go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANDCI_LINT_VERSION}
 	golangci-lint run
-	(cd tests && golangci-lint run)
 
 build: build-operator build-csv-merger build-webhook
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Note: this version can't compiled with go1.23.5, as currently defined in our go.mod file. This is why we specify the go toolchain in the Makefile, and set it to v1.23.4

This PR also remove the running golangci-lint in the tests directory, because it's a left over from the the split of the go.mod in this directory, that was already canceled.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
