### PR TITLE
Produce multi-arch images

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -46,13 +46,13 @@ jobs:
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
-          IMAGE_TAG=${IMAGE_TAG} make container-build
+          IMAGE_TAG=${IMAGE_TAG} make build-multi-arch-images
       - name: Push Application Images
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
           make quay-login
-          IMAGE_TAG=${IMAGE_TAG} make container-push
+          IMAGE_TAG=${IMAGE_TAG} make push-multi-arch-images
       - name: Build Digester
         run: |
           (cd tools/digester && go build .)

--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -48,13 +48,13 @@ jobs:
         env:
           IMAGE_TAG: ${{ env.CSV_VERSION }}
         run: |
-          IMAGE_TAG=${CSV_VERSION} make container-build
+          IMAGE_TAG=${CSV_VERSION} make build-multi-arch-images
       - name: Push Application Images
         env:
           IMAGE_TAG: ${{ env.CSV_VERSION }}
         run: |
           make quay-login
-          IMAGE_TAG=${IMAGE_TAG} make container-push
+          IMAGE_TAG=${IMAGE_TAG} make push-multi-arch-images
       - name: Build Digester
         run: |
           (cd tools/digester && go build .)
@@ -97,12 +97,12 @@ jobs:
         env:
           NEW_IMAGE_TAG: ${{ env.NEW_IMAGE_TAG }}
         run: |
-          IMAGE_TAG=${NEW_IMAGE_TAG} make container-build
+          IMAGE_TAG=${NEW_IMAGE_TAG} make build-multi-arch-images
       - name: Push next version Application Images
         env:
           NEW_IMAGE_TAG: ${{ env.NEW_IMAGE_TAG }}
         run: |
-          IMAGE_TAG=${NEW_IMAGE_TAG} make container-push
+          IMAGE_TAG=${NEW_IMAGE_TAG} make push-multi-arch-images
       - name: run manifest for next version
         env:
           PACKAGE_DIR: ${{ env.PACKAGE_DIR }}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,16 @@ VIRT_ARTIFACTS_SERVER ?= $(REGISTRY_NAMESPACE)/virt-artifacts-server
 LDFLAGS            ?= -w -s
 GOLANDCI_LINT_VERSION ?= v1.64.4
 HCO_BUMP_LEVEL ?= minor
+UNAME_ARCH     := $(shell uname -m)
+ifeq ($(UNAME_ARCH),x86_64)
+	TEMP_ARCH = amd64
+else ifeq ($(UNAME_ARCH),aarch64)
+	TEMP_ARCH = arm64
+else
+	TEMP_ARCH := $(UNAME_ARCH)
+endif
 
+ARCH ?= $(TEMP_ARCH)
 
 # Prow doesn't have docker command
 DO=./hack/in-docker.sh
@@ -87,11 +96,25 @@ hack-clean: ## Run ./hack/clean.sh
 
 container-build: container-build-operator container-build-webhook container-build-operator-courier container-build-functest container-build-artifacts-server
 
+build-multi-arch-images: build-multi-arch-operator-image build-multi-arch-webhook-image build-multi-arch-functest-image build-multi-arch-artifacts-server
+
 container-build-operator:
-	. "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	. "hack/cri-bin.sh" && $$CRI_BIN build --platform=linux/$(ARCH) -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+
+build-multi-arch-operator-image:
+	IMAGE_NAME=$(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) SHA=SHA DOCKER_FILE=build/Dockerfile ./hack/build-multi-arch-images.sh
+
+push-multi-arch-operator-image:
+	. "hack/cri-bin.sh" && $$CRI_BIN manifest push $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG)
 
 container-build-webhook:
-	. "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile.webhook -t $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	. "hack/cri-bin.sh" && $$CRI_BIN build --platform=linux/$(ARCH) -f build/Dockerfile.webhook -t $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+
+build-multi-arch-webhook-image:
+	IMAGE_NAME=$(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) SHA=$(SHA) DOCKER_FILE="build/Dockerfile.webhook" ./hack/build-multi-arch-images.sh
+
+push-multi-arch-webhook-image:
+	. "hack/cri-bin.sh" && $$CRI_BIN manifest push $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
 
 container-build-operator-courier:
 	podman build -f tools/operator-courier/Dockerfile -t hco-courier .
@@ -100,12 +123,26 @@ container-build-validate-bundles:
 	podman build -f tools/operator-sdk-validate/Dockerfile -t operator-sdk-validate-hco .
 
 container-build-functest:
-	. "hack/cri-bin.sh" && $$CRI_BIN build -f build/Dockerfile.functest -t $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+	. "hack/cri-bin.sh" && $$CRI_BIN build  --platform=linux/$(ARCH) -f build/Dockerfile.functest -t $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
+
+build-multi-arch-functest-image:
+	IMAGE_NAME=$(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) SHA=$(SHA) DOCKER_FILE="build/Dockerfile.functest" ./hack/build-multi-arch-images.sh
+
+push-multi-arch-functest-image:
+	. "hack/cri-bin.sh" && $$CRI_BIN manifest push $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)
 
 container-build-artifacts-server:
 	podman build -f build/Dockerfile.artifacts -t $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
+build-multi-arch-artifacts-server:
+	IMAGE_NAME=$(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG) SHA=$(SHA) DOCKER_FILE="build/Dockerfile.artifacts" ./hack/build-multi-arch-images.sh
+
+push-multi-arch-artifacts-server:
+	. "hack/cri-bin.sh" && $$CRI_BIN manifest push $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG)
+
 container-push: container-push-operator container-push-webhook container-push-functest container-push-artifacts-server
+
+push-multi-arch-images: push-multi-arch-operator-image push-multi-arch-webhook-image push-multi-arch-functest-image push-multi-arch-artifacts-server
 
 quay-login:
 	podman login $(IMAGE_REGISTRY) -u $(QUAY_USERNAME) -p "$(QUAY_PASSWORD)"
@@ -120,7 +157,7 @@ container-push-functest:
 	. "hack/cri-bin.sh" && $$CRI_BIN push $$CRI_INSECURE $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)
 
 container-push-artifacts-server:
-	podman push $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG)
+	. "hack/cri-bin.sh" && $$CRI_BIN manifest push $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG)
 
 cluster-up:
 	./cluster/up.sh
@@ -303,4 +340,14 @@ bump-hco:
 		lint-monitoring \
 		sanity \
 		goimport \
-		bump-hco
+		bump-hco \
+		build-multi-arch-operator-image \
+		push-multi-arch-operator-image \
+		build-multi-arch-webhook-image \
+		push-multi-arch-webhook-image \
+		build-multi-arch-functest-image \
+		push-multi-arch-functest-image \
+		build-multi-arch-artifacts-server \
+		push-multi-arch-artifacts-server \
+		build-multi-arch-images \
+		push-multi-arch-images

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,11 @@
-FROM docker.io/golang:1.23.4 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.6 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .
-RUN make build-operator build-csv-merger
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-operator build-csv-merger
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 ENV OPERATOR=/usr/local/bin/hyperconverged-cluster-operator \
@@ -29,4 +32,5 @@ ARG git_sha=NONE
 
 LABEL multi.GIT_URL=${git_url} \
       multi.GIT_SHA=${git_sha} \
-      app=hyperconverged-cluster-operator
+      app=hyperconverged-cluster-operator \
+      arch=${ARCH}

--- a/build/Dockerfile.artifacts
+++ b/build/Dockerfile.artifacts
@@ -1,18 +1,9 @@
-FROM registry.access.redhat.com/ubi9/nginx-124
-
-WORKDIR /opt/app-root/src
-
-COPY hack/config /tmp/config
-
-USER 0
-RUN dnf -y install zip file && \
-    sed -i -E '/^ +location.*$/a\        }\n\n        location = /health {\n            access_log off;\n            return 200;' /etc/nginx/nginx.conf && \
-    sed '/^\s*listen\s*\[::\]:8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv4 && \
-    sed '/^\s*listen\s*8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv6
-USER 1001
+FROM --platform=${BUILDPLATFORM} quay.io/centos/centos:stream9 as downloader
 
 ARG download_url=https://github.com/kubevirt/kubevirt/releases/download
 
+COPY hack/config /tmp/config
+RUN dnf -y install zip file
 RUN eval $(cat /tmp/config  |grep KUBEVIRT_VERSION=) && \
     echo "KUBEVIRT_VERSION: $KUBEVIRT_VERSION" && \
     for arch in amd64 arm64 s390x; do \
@@ -40,10 +31,23 @@ RUN eval $(cat /tmp/config  |grep KUBEVIRT_VERSION=) && \
                 printf "\n\n### Downloading ${url}\n"; \
                 curl --fail -L -o virtctl${extension} "${url}" && \
                 file virtctl${extension} && \
-                mkdir -p ./${arch}/${l_os} && ${archive_command} ./${arch}/${l_os}/virtctl${archive_extension} virtctl${extension} && rm virtctl${extension}; \
+                mkdir -p ./bin/${arch}/${l_os} && ${archive_command} ./bin/${arch}/${l_os}/virtctl${archive_extension} virtctl${extension} && rm virtctl${extension}; \
             fi; \
         done; \
     done
+
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/nginx-124
+
+WORKDIR /opt/app-root/src
+
+COPY --from=downloader ./bin/ ./
+
+USER 0
+RUN sed -i -E '/^ +location.*$/a\        }\n\n        location = /health {\n            access_log off;\n            return 200;' /etc/nginx/nginx.conf && \
+    sed '/^\s*listen\s*\[::\]:8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv4 && \
+    sed '/^\s*listen\s*8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv6
+
+USER 1001
 
 ARG git_url=https://github.com/kubevirt/hyperconverged-cluster-operator.git
 ARG git_sha=NONE

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -1,8 +1,11 @@
-FROM docker.io/golang:1.23.4 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.6 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .
-RUN make build-functest
+
+ARG TARGETARCH
+
+RUN ARCH=${TARGETARCH} make build-functest
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
@@ -30,4 +33,5 @@ ARG git_sha=NONE
 
 LABEL multi.GIT_URL=${git_url} \
       multi.GIT_SHA=${git_sha} \
-      app=hyperconverged-cluster-functest
+      app=hyperconverged-cluster-functest \
+      arch=${ARCH}

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -1,8 +1,12 @@
-FROM docker.io/golang:1.23.4 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.6 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .
-RUN make build-webhook
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-webhook
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 ENV WEBHOOK=/usr/local/bin/hyperconverged-cluster-webhook \
@@ -27,4 +31,5 @@ ARG git_sha=NONE
 
 LABEL multi.GIT_URL=${git_url} \
       multi.GIT_SHA=${git_sha} \
-      app=hyperconverged-cluster-webhook
+      app=hyperconverged-cluster-webhook \
+      arch=${TARGETARCH}

--- a/hack/build-multi-arch-images.sh
+++ b/hack/build-multi-arch-images.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+ARCHITECTURES="amd64 arm64 s390x"
+
+if [[ -z ${IMAGE_NAME} ]]; then
+  echo "IMAGE_NAME must be defined"
+  exit 1
+fi
+
+if [[ -z ${DOCKER_FILE} ]]; then
+  echo "DOCKER_FILE must be defined"
+  exit 1
+fi
+
+SHA=$(git describe --no-match  --always --abbrev=40 --dirty)
+
+IMAGES=
+for arch in ${ARCHITECTURES}; do
+  . "hack/cri-bin.sh" && ${CRI_BIN} build  --platform=linux/${arch} -f ${DOCKER_FILE} -t "${IMAGE_NAME}-${arch}" --build-arg git_sha=${SHA} .
+  IMAGES="${IMAGES} ${IMAGE_NAME}-${arch}"
+done
+
+. "hack/cri-bin.sh" && ${CRI_BIN} manifest create "${IMAGE_NAME}" ${IMAGES}

--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -16,11 +16,16 @@ if [ "${JOB_TYPE}" == "travis" ]; then
     go test ${PKG_PACKAGE_PATH}webhooks/...
     go test -v -outputdir=./coverprofiles -coverprofile=cover.coverprofile ${PKG_PACKAGE_PATH}... ${CONTROLLERS_PACKAGE_PATH}...
 else
+    set +u
     test_path="./tests/func-tests"
     GOFLAGS='' go install github.com/onsi/ginkgo/v2/ginkgo@$(grep github.com/onsi/ginkgo go.mod | cut -d " " -f2)
     go mod tidy
     go mod vendor
     test_out_path=${test_path}/_out
     mkdir -p ${test_out_path}
+
+    if [[ -n ${ARCH} ]]; then
+      export GOARCH="${ARCH}"
+    fi
     ginkgo build -o ${test_out_path} ${test_path}
 fi

--- a/hack/in-docker.sh
+++ b/hack/in-docker.sh
@@ -9,8 +9,9 @@ HCO_DIR="$(readlink -f $(dirname $0)/../)"
 WORK_DIR="/go/src/github.com/kubevirt/hyperconverged-cluster-operator"
 REGISTRY=${REGISTRY:-quay.io/kubevirtci}
 REPOSITORY=${REPOSITORY:-hco-test-build}
-TAG=${TAG:-v20220510-9ff67b2}
+TAG=${TAG:-v20250102-3529abc}
 BUILD_TAG="${REGISTRY}/${REPOSITORY}:${TAG}"
+ARCH=${ARCH:amd64}
 
 # Execute the build
 [ -t 1 ] && USE_TTY="-it"
@@ -20,5 +21,6 @@ $CRI_BIN run ${USE_TTY} \
     -e RUN_UID=$(id -u) \
     -e RUN_GID=$(id -g) \
     -e GOCACHE=/gocache \
+    -e ARCH=${ARCH} \
     -w ${WORK_DIR} \
     ${BUILD_TAG} "$1"

--- a/tests/func-tests/main_test.go
+++ b/tests/func-tests/main_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 )
 
 func TestTests(t *testing.T) {
+	GinkgoWriter.Printf("Start running the HCO functional tests; go version: %s; platform: %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "HyperConverged cluster E2E Test suite")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When building images, either on release or the unstable images after PR merge, the images will be now a multi-arch manifests, for amd64, arm64 and s390x architectures.

The relevant images are the operator, webhook, tests, artifacts-download and the index image.

Note, the bundle image is data-only image, built from scratch, so we don't need it to be multi-arch.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-55711
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Images are now multi-arch manifests, supporting arm64, amd64 and a390x
```
