### PR TITLE
Fix issues with build multi-arch images

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -22,6 +22,8 @@ jobs:
       REGISTRY_NAMESPACE: kubevirt
       OPM_VERSION: v1.47.0
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Checkout the latest code
         uses: actions/checkout@v4
         with:
@@ -42,17 +44,12 @@ jobs:
           echo "IMAGE_TAG=${CSV_VERSION}-unstable" >> $GITHUB_ENV
           echo "UNSTABLE=UNSTABLE" >> $GITHUB_ENV
 
-      - name: Build Applications Images
-        env:
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
-        run: |
-          IMAGE_TAG=${IMAGE_TAG} make build-multi-arch-images
-      - name: Push Application Images
+      - name: Build and Push Applications Images
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
           make quay-login
-          IMAGE_TAG=${IMAGE_TAG} make push-multi-arch-images
+          IMAGE_TAG=${IMAGE_TAG} make build-push-multi-arch-images
       - name: Build Digester
         run: |
           (cd tools/digester && go build .)

--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -15,6 +15,8 @@ jobs:
       REGISTRY_NAMESPACE: kubevirt
       OPM_VERSION: v1.47.0
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: resolve the correct branch of the tag
         run: |
           GIT_TAG=${{ github.ref }}
@@ -44,17 +46,12 @@ jobs:
           CSV_VERSION=$(ls -d ${PACKAGE_DIR}/*/ | sort -rV | awk "NR==1" | cut -d '/' -f 5)
           echo "CSV_VERSION=${CSV_VERSION}" >> $GITHUB_ENV
           echo "PACKAGE_DIR=${PACKAGE_DIR}" >> $GITHUB_ENV
-      - name: Build Applications Images
-        env:
-          IMAGE_TAG: ${{ env.CSV_VERSION }}
-        run: |
-          IMAGE_TAG=${CSV_VERSION} make build-multi-arch-images
-      - name: Push Application Images
+      - name: Build and Push Applications Images
         env:
           IMAGE_TAG: ${{ env.CSV_VERSION }}
         run: |
           make quay-login
-          IMAGE_TAG=${IMAGE_TAG} make push-multi-arch-images
+          IMAGE_TAG=${CSV_VERSION} make build-push-multi-arch-images
       - name: Build Digester
         run: |
           (cd tools/digester && go build .)
@@ -93,16 +90,11 @@ jobs:
           echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
           echo "NEW_IMAGE_TAG=${NEW_IMAGE_TAG}" >> $GITHUB_ENV
 
-      - name: Build Applications next version Images
+      - name: Build and Push Applications next version Images
         env:
           NEW_IMAGE_TAG: ${{ env.NEW_IMAGE_TAG }}
         run: |
-          IMAGE_TAG=${NEW_IMAGE_TAG} make build-multi-arch-images
-      - name: Push next version Application Images
-        env:
-          NEW_IMAGE_TAG: ${{ env.NEW_IMAGE_TAG }}
-        run: |
-          IMAGE_TAG=${NEW_IMAGE_TAG} make push-multi-arch-images
+          IMAGE_TAG=${NEW_IMAGE_TAG} make build-push-multi-arch-images
       - name: run manifest for next version
         env:
           PACKAGE_DIR: ${{ env.PACKAGE_DIR }}

--- a/Makefile
+++ b/Makefile
@@ -96,25 +96,19 @@ hack-clean: ## Run ./hack/clean.sh
 
 container-build: container-build-operator container-build-webhook container-build-operator-courier container-build-functest container-build-artifacts-server
 
-build-multi-arch-images: build-multi-arch-operator-image build-multi-arch-webhook-image build-multi-arch-functest-image build-multi-arch-artifacts-server
+build-push-multi-arch-images: build-push-multi-arch-operator-image build-push-multi-arch-webhook-image build-push-multi-arch-functest-image build-push-multi-arch-artifacts-server
 
 container-build-operator:
 	. "hack/cri-bin.sh" && $$CRI_BIN build --platform=linux/$(ARCH) -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
-build-multi-arch-operator-image:
-	IMAGE_NAME=$(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) SHA=SHA DOCKER_FILE=build/Dockerfile ./hack/build-multi-arch-images.sh
-
-push-multi-arch-operator-image:
-	. "hack/cri-bin.sh" && $$CRI_BIN manifest push $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG)
+build-push-multi-arch-operator-image:
+	IMAGE_NAME=$(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) SHA=SHA DOCKER_FILE=build/Dockerfile ./hack/build-push-multi-arch-images.sh
 
 container-build-webhook:
 	. "hack/cri-bin.sh" && $$CRI_BIN build --platform=linux/$(ARCH) -f build/Dockerfile.webhook -t $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
-build-multi-arch-webhook-image:
-	IMAGE_NAME=$(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) SHA=$(SHA) DOCKER_FILE="build/Dockerfile.webhook" ./hack/build-multi-arch-images.sh
-
-push-multi-arch-webhook-image:
-	. "hack/cri-bin.sh" && $$CRI_BIN manifest push $(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG)
+build-push-multi-arch-webhook-image:
+	IMAGE_NAME=$(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE):$(IMAGE_TAG) SHA=$(SHA) DOCKER_FILE="build/Dockerfile.webhook" ./hack/build-push-multi-arch-images.sh
 
 container-build-operator-courier:
 	podman build -f tools/operator-courier/Dockerfile -t hco-courier .
@@ -125,24 +119,16 @@ container-build-validate-bundles:
 container-build-functest:
 	. "hack/cri-bin.sh" && $$CRI_BIN build  --platform=linux/$(ARCH) -f build/Dockerfile.functest -t $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
-build-multi-arch-functest-image:
-	IMAGE_NAME=$(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) SHA=$(SHA) DOCKER_FILE="build/Dockerfile.functest" ./hack/build-multi-arch-images.sh
-
-push-multi-arch-functest-image:
-	. "hack/cri-bin.sh" && $$CRI_BIN manifest push $(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG)
+build-push-multi-arch-functest-image:
+	IMAGE_NAME=$(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE):$(IMAGE_TAG) SHA=$(SHA) DOCKER_FILE="build/Dockerfile.functest" ./hack/build-push-multi-arch-images.sh
 
 container-build-artifacts-server:
 	podman build -f build/Dockerfile.artifacts -t $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
-build-multi-arch-artifacts-server:
-	IMAGE_NAME=$(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG) SHA=$(SHA) DOCKER_FILE="build/Dockerfile.artifacts" ./hack/build-multi-arch-images.sh
-
-push-multi-arch-artifacts-server:
-	. "hack/cri-bin.sh" && $$CRI_BIN manifest push $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG)
+build-push-multi-arch-artifacts-server:
+	IMAGE_NAME=$(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG) SHA=$(SHA) DOCKER_FILE="build/Dockerfile.artifacts" ./hack/build-push-multi-arch-images.sh
 
 container-push: container-push-operator container-push-webhook container-push-functest container-push-artifacts-server
-
-push-multi-arch-images: push-multi-arch-operator-image push-multi-arch-webhook-image push-multi-arch-functest-image push-multi-arch-artifacts-server
 
 quay-login:
 	podman login $(IMAGE_REGISTRY) -u $(QUAY_USERNAME) -p "$(QUAY_PASSWORD)"
@@ -341,13 +327,8 @@ bump-hco:
 		sanity \
 		goimport \
 		bump-hco \
-		build-multi-arch-operator-image \
-		push-multi-arch-operator-image \
-		build-multi-arch-webhook-image \
-		push-multi-arch-webhook-image \
-		build-multi-arch-functest-image \
-		push-multi-arch-functest-image \
-		build-multi-arch-artifacts-server \
-		push-multi-arch-artifacts-server \
-		build-multi-arch-images \
-		push-multi-arch-images
+		build-push-multi-arch-operator-image \
+		build-push-multi-arch-webhook-image \
+		build-push-multi-arch-functest-image \
+		build-push-multi-arch-artifacts-server \
+		build-push-multi-arch-images

--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -60,11 +60,13 @@ export IMAGE_TAG="nb_${build_date}_$(git show -s --format=%h)"
 export IMAGE_PREFIX=kubevirtci
 TEMP_OPERATOR_IMAGE=${IMAGE_PREFIX}/hyperconverged-cluster-operator
 TEMP_WEBHOOK_IMAGE=${IMAGE_PREFIX}/hyperconverged-cluster-webhook
+TEMP_DOWNLOAD_IMAGE=${IMAGE_PREFIX}/virt-artifacts-server
 CSV_OPERATOR_IMAGE=${IMAGE_REGISTRY}/${TEMP_OPERATOR_IMAGE}
 CSV_WEBHOOK_IMAGE=${IMAGE_REGISTRY}/${TEMP_WEBHOOK_IMAGE}
+CSV_DOWNLOAD_IMAGE=${IMAGE_REGISTRY}/${TEMP_DOWNLOAD_IMAGE}
 
 # Build HCO & HCO Webhook
-OPERATOR_IMAGE=${TEMP_OPERATOR_IMAGE} WEBHOOK_IMAGE=${TEMP_WEBHOOK_IMAGE} make container-build-operator container-push-operator container-build-webhook container-push-webhook
+OPERATOR_IMAGE=${TEMP_OPERATOR_IMAGE} WEBHOOK_IMAGE=${TEMP_WEBHOOK_IMAGE} make build-push-multi-arch-operator-image build-push-multi-arch-webhook-image build-push-multi-arch-artifacts-server
 
 # Update image digests
 sed -i "s#quay.io/kubevirt/virt-#${kv_image/-*/-}#" deploy/images.csv
@@ -76,9 +78,10 @@ export HCO_VERSION="${IMAGE_TAG}"
 
 HCO_OPERATOR_IMAGE_DIGEST=$(tools/digester/digester --image ${CSV_OPERATOR_IMAGE}:${IMAGE_TAG})
 HCO_WEBHOOK_IMAGE_DIGEST=$(tools/digester/digester --image ${CSV_WEBHOOK_IMAGE}:${IMAGE_TAG})
+HCO_DOWNLOAD_IMAGE_DIGEST=$(tools/digester/digester --image ${CSV_DOWNLOAD_IMAGE}:${IMAGE_TAG})
 
 # Build the CSV
-HCO_OPERATOR_IMAGE=${HCO_OPERATOR_IMAGE_DIGEST} HCO_WEBHOOK_IMAGE=${HCO_WEBHOOK_IMAGE_DIGEST} ./hack/build-manifests.sh
+HCO_OPERATOR_IMAGE=${HCO_OPERATOR_IMAGE_DIGEST} HCO_WEBHOOK_IMAGE=${HCO_WEBHOOK_IMAGE_DIGEST} HCO_DOWNLOADS_IMAGE=${HCO_DOWNLOAD_IMAGE_DIGEST} ./hack/build-manifests.sh
 
 # Download OPM
 OPM_VERSION=v1.47.0

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,7 +7,9 @@ ARG TARGETARCH
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-operator build-csv-merger
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/ubi-minimal
+ARG TARGETPLATFORM
+
 ENV OPERATOR=/usr/local/bin/hyperconverged-cluster-operator \
     CSV_MERGER=/usr/local/bin/csv-merger \
     USER_UID=1001 \
@@ -33,4 +35,4 @@ ARG git_sha=NONE
 LABEL multi.GIT_URL=${git_url} \
       multi.GIT_SHA=${git_sha} \
       app=hyperconverged-cluster-operator \
-      arch=${ARCH}
+      golang.build.platform=${TARGETPLATFORM}

--- a/build/Dockerfile.artifacts
+++ b/build/Dockerfile.artifacts
@@ -37,6 +37,7 @@ RUN eval $(cat /tmp/config  |grep KUBEVIRT_VERSION=) && \
     done
 
 FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/nginx-124
+ARG TARGETPLATFORM
 
 WORKDIR /opt/app-root/src
 

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -7,7 +7,8 @@ ARG TARGETARCH
 
 RUN ARCH=${TARGETARCH} make build-functest
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/ubi-minimal
+ARG TARGETPLATFORM
 
 ENV USER_UID=1001 \
     TEST_OUT_PATH=/test
@@ -34,4 +35,4 @@ ARG git_sha=NONE
 LABEL multi.GIT_URL=${git_url} \
       multi.GIT_SHA=${git_sha} \
       app=hyperconverged-cluster-functest \
-      arch=${ARCH}
+      golang.build.platform=${TARGETPLATFORM}

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -8,7 +8,9 @@ ARG TARGETARCH
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-webhook
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/ubi-minimal
+ARG TARGETPLATFORM
+
 ENV WEBHOOK=/usr/local/bin/hyperconverged-cluster-webhook \
     USER_UID=1001 \
     USER_NAME=hyperconverged-cluster-webhook \
@@ -32,4 +34,4 @@ ARG git_sha=NONE
 LABEL multi.GIT_URL=${git_url} \
       multi.GIT_SHA=${git_sha} \
       app=hyperconverged-cluster-webhook \
-      arch=${TARGETARCH}
+      golang.build.platform=${TARGETPLATFORM}

--- a/hack/build-push-multi-arch-images.sh
+++ b/hack/build-push-multi-arch-images.sh
@@ -17,7 +17,9 @@ SHA=$(git describe --no-match  --always --abbrev=40 --dirty)
 IMAGES=
 for arch in ${ARCHITECTURES}; do
   . "hack/cri-bin.sh" && ${CRI_BIN} build  --platform=linux/${arch} -f ${DOCKER_FILE} -t "${IMAGE_NAME}-${arch}" --build-arg git_sha=${SHA} .
+  . "hack/cri-bin.sh" && ${CRI_BIN} push "${IMAGE_NAME}-${arch}"
   IMAGES="${IMAGES} ${IMAGE_NAME}-${arch}"
 done
 
 . "hack/cri-bin.sh" && ${CRI_BIN} manifest create "${IMAGE_NAME}" ${IMAGES}
+. "hack/cri-bin.sh" && ${CRI_BIN} manifest push "${IMAGE_NAME}"


### PR DESCRIPTION
**What this PR does / why we need it**:
When building image with different architecture than the build machine architecture, any binary that runs as part of the build will fail (even just creating a user).

Another issue is that github action uses ubuntu, that its podman version is 4.x, and cannot build manifest from local images, as possible in podman 5.x.

docker/podman needs qemu installed on the build machine, to allow running binaries in diffferent architecture as part of the image build process.

This PR installs qemu in the relevant  github actions, and pushes the images before building the manifest, to match the podman 4.x patter.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-55711
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
