### PR TITLE
Fix issue in AWS lanes

### DIFF
--- a/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:40-x86_64 AS builder
+FROM quay.io/fedora/fedora:42 AS builder
 ARG INITIAL_VERSION=1.15.0
 ARG INITIAL_VERSION_SED="1\.15\.0"
 ARG TARGET_VERSION=100.0.0

--- a/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:40-x86_64 AS builder
+FROM quay.io/fedora/fedora:42 AS builder
 ARG INITIAL_VERSION=1.15.0
 ARG INITIAL_VERSION_SED="1\.15\.0"
 ARG TARGET_VERSION=100.0.0

--- a/hack/consecutive-upgrades-test.sh
+++ b/hack/consecutive-upgrades-test.sh
@@ -172,6 +172,8 @@ function upgrade() {
   Msg "make sure that the VM is still running, after the upgrade"
   ${CMD} get vm -n ${VMS_NAMESPACE} -o yaml testvm
   ${CMD} get vmi -n ${VMS_NAMESPACE} -o yaml testvm
+  ${CMD} get vmim -n ${VMS_NAMESPACE} -o yaml
+
   ${CMD} get vmi -n ${VMS_NAMESPACE} testvm -o jsonpath='{ .status.phase }' | grep 'Running'
   CURRENT_BOOTTIME=$(check_uptime 10 60)
 

--- a/hack/vm.yaml
+++ b/hack/vm.yaml
@@ -11,6 +11,12 @@ spec:
         kubevirt.io/domain: testvm
     spec:
       domain:
+        cpu:
+          features:
+            - name: "gds-no"
+              policy: "disable"
+            - name: "pcommit"
+              policy: "disable"
         devices:
           disks:
             - name: containerdisk


### PR DESCRIPTION
**What this PR does / why we need it**:

If the worker is with ARM architecture, CI failes to build the index image, as it explicitly uses AMD64 base image.

This PR change the base image to be a multi-arch manifest, to allow ARM build.

Also, fix upgrade-issue in AWS:
Many upgrade test are failing in AWS, when the VM launcher image is not replaced after upgrade.

The nodes in AWS does not have the same labels, and KV can't find a node live-migrate the VM.

This commit disables the VM's "gds-no" CPU feature, so the VM should now find avaliable node.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
