### PR TITLE
Fix another issues in multi-arch images

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -18,9 +18,12 @@ function dump() {
 
 # Get golang
 $CRI_BIN login --username "$(cat "${QUAY_USER}")" --password-stdin quay.io < "${QUAY_PASSWORD}"
-wget -q https://dl.google.com/go/go1.22.6.linux-amd64.tar.gz
+wget -q https://dl.google.com/go/go1.23.5.linux-amd64.tar.gz
 tar -C /usr/local -xf go*.tar.gz
 export PATH=/usr/local/go/bin:$PATH
+
+# add qemu-user-static
+$CRI_BIN run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
 
 # get latest KubeVirt commit
 latest_kubevirt=$(curl -sL https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest)

--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -84,8 +84,10 @@ function create_file_based_catalog() {
 
   IMAGES=
   for arch in ${ARCHITECTURES}; do
-    podman build --platform="linux/${arch}" -t "${INDEX_IMAGE_NAME}-${arch}" -f fbc-catalog.Dockerfile
-    IMAGES="${IMAGES} ${INDEX_IMAGE_NAME}-${arch}"
+    current_image="${INDEX_IMAGE_NAME}-${arch}"
+    podman build --platform="linux/${arch}" -t "${current_image}" -f fbc-catalog.Dockerfile
+    podman push "${current_image}"
+    IMAGES="${IMAGES} ${current_image}"
   done
 
   podman manifest create "${INDEX_IMAGE_NAME}" ${IMAGES}


### PR DESCRIPTION
Follow-up of PR #3308 - need to push the images before creating the manifest, also for the index image.

Also, fix nightly test by installing qemu-user-static, to allow running binaries of one arch, in image build of another arch.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
