### PR TITLE
[upgrade test] set common CPU Model for aws and azure

### DIFF
--- a/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/index-image/Dockerfile.bundle.ci-index-image-upgrade
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:40-x86_64 AS builder
+FROM quay.io/fedora/fedora:42 AS builder
 ARG INITIAL_VERSION=1.15.0
 ARG INITIAL_VERSION_SED="1\.15\.0"
 ARG TARGET_VERSION=100.0.0

--- a/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
+++ b/deploy/olm-catalog/Dockerfile.bundle.ci-index-image-upgrade
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:40-x86_64 AS builder
+FROM quay.io/fedora/fedora:42 AS builder
 ARG INITIAL_VERSION=1.15.0
 ARG INITIAL_VERSION_SED="1\.15\.0"
 ARG TARGET_VERSION=100.0.0

--- a/hack/consecutive-upgrades-test.sh
+++ b/hack/consecutive-upgrades-test.sh
@@ -217,6 +217,9 @@ END
 
 CSV=$( ${CMD} get csv -o name -n ${HCO_NAMESPACE} | grep "kubevirt-hyperconverged-operator")
 
+# Patch the default CPU model to ensure a successful live migration
+${CMD} patch hco kubevirt-hyperconverged -n ${HCO_NAMESPACE} --type=json -p='[{"op": "add", "path": "/spec/defaultCPUModel", "value": "Westmere"}]'
+
 Msg "operator conditions before upgrade"
 source ./hack/check_operator_condition.sh
 KUBECTL_BINARY=${CMD} INSTALLED_NAMESPACE=${HCO_NAMESPACE} printOperatorCondition "${INITIAL_VERSION}"
@@ -236,6 +239,8 @@ upgrade $MID_VERSION $TARGET_VERSION $OO_LAST_BUNDLE
 
 
 Msg "make sure that we don't have outdated VMs"
+
+${CMD} get vmim -n ${VMS_NAMESPACE} -o yaml
 
 INFRASTRUCTURETOPOLOGY=$(${CMD} get infrastructure.config.openshift.io cluster -o json | jq -j '.status.infrastructureTopology')
 UPDATE_METHODS=$(${CMD} get hco ${HCO_RESOURCE_NAME} -n ${HCO_NAMESPACE} -o jsonpath='{.spec .workloadUpdateStrategy .workloadUpdateMethods}')


### PR DESCRIPTION
When performing a live migration, virt-controller picks a target node that has all of the cpu features as the source node. if the cluster nodes have different CPU features, the VMIM will be stuck at Pending. setting defaultCPUModel for AWS and Azure to ensure all of the cpu features in all nodes are aligned and live migration will be done.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
