### PR TITLE
Don't use the default SA in the artifact-server

### DIFF
--- a/deploy/index-image/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
@@ -582,6 +582,8 @@ spec:
           - create
           - delete
         serviceAccountName: hyperconverged-cluster-operator
+      - rules: []
+        serviceAccountName: hyperconverged-cluster-cli-download
       - rules:
         - apiGroups:
           - operator.openshift.io
@@ -3392,6 +3394,7 @@ spec:
                 app.kubernetes.io/version: 1.15.0
                 name: hyperconverged-cluster-cli-download
             spec:
+              automountServiceAccountToken: false
               containers:
               - image: +ARTIFACTS_SERVER_IMAGE_TO_REPLACE+
                 imagePullPolicy: IfNotPresent
@@ -3429,6 +3432,7 @@ spec:
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
+              serviceAccountName: hyperconverged-cluster-cli-download
       - label:
           app.kubernetes.io/component: network
           app.kubernetes.io/managed-by: olm

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt-hyperconverged-operator.v1.15.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.15.0-unstable
-    createdAt: "2025-02-28 11:03:47"
+    createdAt: "2025-03-02 09:35:57"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -582,6 +582,8 @@ spec:
           - create
           - delete
         serviceAccountName: hyperconverged-cluster-operator
+      - rules: []
+        serviceAccountName: hyperconverged-cluster-cli-download
       - rules:
         - apiGroups:
           - operator.openshift.io
@@ -3392,6 +3394,7 @@ spec:
                 app.kubernetes.io/version: 1.15.0
                 name: hyperconverged-cluster-cli-download
             spec:
+              automountServiceAccountToken: false
               containers:
               - image: quay.io/kubevirt/virt-artifacts-server:1.15.0-unstable
                 imagePullPolicy: IfNotPresent
@@ -3429,6 +3432,7 @@ spec:
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
+              serviceAccountName: hyperconverged-cluster-cli-download
       - label:
           app.kubernetes.io/component: network
           app.kubernetes.io/managed-by: olm

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -221,6 +221,7 @@ spec:
         app.kubernetes.io/version: 1.15.0
         name: hyperconverged-cluster-cli-download
     spec:
+      automountServiceAccountToken: false
       containers:
       - image: quay.io/kubevirt/virt-artifacts-server:1.15.0-unstable
         imagePullPolicy: Always
@@ -258,6 +259,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      serviceAccountName: hyperconverged-cluster-cli-download
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -35,6 +35,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    name: hyperconverged-cluster-cli-download
+  name: hyperconverged-cluster-cli-download
+  namespace: kubevirt-hyperconverged
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
     name: hyperconverged-cluster-operator
   name: hyperconverged-cluster-operator
   namespace: kubevirt-hyperconverged

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -136,7 +136,8 @@ func main() {
 	}
 
 	serviceAccounts := map[string]v1.ServiceAccount{
-		"hyperconverged-cluster-operator": components.GetServiceAccount(*operatorNamespace),
+		"hyperconverged-cluster-operator":     components.GetServiceAccount(*operatorNamespace),
+		"hyperconverged-cluster-cli-download": components.GetCLIDownloadServiceAccount(*operatorNamespace),
 	}
 	permissions := make([]rbacv1.Role, 0)
 	roleBindings := make([]rbacv1.RoleBinding, 0)


### PR DESCRIPTION
**What this PR does / why we need it**:
* Create new ServiceAccount for the artifact-server, with no permissions.
* Set the ServiceAccountName to the new SA, in the pod template
* Set the `automountServiceAccountToken` field to false.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-57139
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't use the default SA in the artifact-server
```
