### PR TITLE
KubeVirt default FG: Remove graduated network FGs

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -211,7 +211,6 @@ var _ = Describe("HyperconvergedController", func() {
 					"DisableCustomSELinuxPolicy",
 					"KubevirtSeccompProfile",
 					"VMPersistentState",
-					"NetworkBindingPlugins",
 					"VMLiveUpdateFeatures",
 					"DynamicPodInterfaceNaming",
 					"VolumesUpdateStrategy",

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -212,7 +212,6 @@ var _ = Describe("HyperconvergedController", func() {
 					"KubevirtSeccompProfile",
 					"VMPersistentState",
 					"VMLiveUpdateFeatures",
-					"DynamicPodInterfaceNaming",
 					"VolumesUpdateStrategy",
 					"VolumeMigration",
 				}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -105,9 +105,6 @@ const (
 	// Enable VM live update, to allow live propagation of VM changes to their VMI
 	kvVMLiveUpdateFeatures = "VMLiveUpdateFeatures"
 
-	// kvDynamicPodInterfaceNaming enables a mechanism to dynamically determine the primary pod interface for KubeVirt virtual machines.
-	kvDynamicPodInterfaceNamingGate = "DynamicPodInterfaceNaming"
-
 	// enables to specify the strategy on the volume updates.
 	kvVolumesUpdateStrategyGate = "VolumesUpdateStrategy"
 
@@ -133,7 +130,6 @@ var (
 		kvKubevirtSeccompProfile,
 		kvVMPersistentState,
 		kvVMLiveUpdateFeatures,
-		kvDynamicPodInterfaceNamingGate,
 		kvVolumesUpdateStrategyGate,
 		kvVolumeMigrationGate,
 	}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -102,9 +102,6 @@ const (
 	// Enable VM state persistence
 	kvVMPersistentState = "VMPersistentState"
 
-	// Enable using a plugin to bind the pod and the VM network
-	kvHNetworkBindingPluginsGate = "NetworkBindingPlugins"
-
 	// Enable VM live update, to allow live propagation of VM changes to their VMI
 	kvVMLiveUpdateFeatures = "VMLiveUpdateFeatures"
 
@@ -135,7 +132,6 @@ var (
 		kvDisableCustomSELinuxPolicyGate,
 		kvKubevirtSeccompProfile,
 		kvVMPersistentState,
-		kvHNetworkBindingPluginsGate,
 		kvVMLiveUpdateFeatures,
 		kvDynamicPodInterfaceNamingGate,
 		kvVolumesUpdateStrategyGate,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The network binding plugins and dynamic pod interface naming features were declared GA in
KubeVirt v1.5 [1][2].
There is no longer a need to set these FGs.

[1] kubevirt/kubevirt#13314
[2] kubevirt/kubevirt#13243

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt default FG: Remove graduated network FGs
```
