### PR TITLE
Remove old api version from the SSP CRD on upgrade

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1405,6 +1405,37 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(counterValueAfter).To(Equal(counterValueBefore))
 			})
 
+			It("Should remove v1beta1 from SSP CRD on upgrade, if exists", func() {
+				expected.sspCRD.Status.StoredVersions = []string{
+					"v1beta1",
+					"v1beta2",
+				}
+
+				const sspCrd = "ssps.ssp.kubevirt.io"
+				foundResource := &apiextensionsv1.CustomResourceDefinition{}
+				UpdateVersion(&expected.hco.Status, hcoVersionName, "1.13.0")
+
+				cl := expected.initClient()
+
+				r := initReconciler(cl, nil)
+				r.firstLoop = false
+				r.ownVersion = newHCOVersion
+
+				res, err := r.Reconcile(context.TODO(), request)
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: sspCrd, Namespace: ""},
+						foundResource),
+				).To(Succeed())
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Requeue).To(BeTrue())
+
+				Expect(foundResource.Status.StoredVersions).To(HaveLen(1))
+				Expect(foundResource.Status.StoredVersions).ToNot(ContainElement("v1beta1"))
+				Expect(foundResource.Status.StoredVersions).To(ContainElement("v1beta2"))
+			})
+
 			DescribeTable(
 				"be tolerant parsing parse version",
 				func(testHcoVersion string, acceptableVersion bool, errorMessage string) {

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -128,6 +128,7 @@ type BasicExpected struct {
 	virtioWinRole        *rbacv1.Role
 	virtioWinRoleBinding *rbacv1.RoleBinding
 	hcoCRD               *apiextensionsv1.CustomResourceDefinition
+	sspCRD               *apiextensionsv1.CustomResourceDefinition
 	consolePluginDeploy  *appsv1.Deployment
 	consoleProxyDeploy   *appsv1.Deployment
 	consolePluginSvc     *corev1.Service
@@ -155,6 +156,7 @@ func (be BasicExpected) toArray() []client.Object {
 		be.virtioWinRole,
 		be.virtioWinRoleBinding,
 		be.hcoCRD,
+		be.sspCRD,
 		be.consolePluginDeploy,
 		be.consoleProxyDeploy,
 		be.consolePluginSvc,
@@ -308,6 +310,13 @@ func getBasicDeployment() *BasicExpected {
 		},
 	}
 	res.hcoCRD = hcoCrd
+
+	sspCrd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ssps.ssp.kubevirt.io",
+		},
+	}
+	res.sspCRD = sspCrd
 
 	csv := hcoutil.GetClusterInfo().GetCSV()
 	res.csv = csv


### PR DESCRIPTION
Since version 1.10, SSP moved to a new api version - `v1beta2`.
In latest release, SSP completely removed the old API `v1beta1` from their CRD.
This might result in an upgrade issue with OLM, if the cluster has initially started with version 1.9 or below.
This PR removes the old SSP api version v1beta1 from the storedVersions list in the SSP CRD status, to allow a smooth upgrade to 1.14.0.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-57082
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
