### PR TITLE
[release-1.13] Remove old api version from the SSP CRD on upgrade

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -513,6 +513,12 @@ func (r *ReconcileHyperConverged) handleUpgrade(req *common.HcoRequest, init boo
 		return &reconcile.Result{Requeue: true}, err
 	}
 
+	const sspCrd = "ssps.ssp.kubevirt.io"
+	const sspApiVersionToRemove = "v1beta1"
+	if err = r.removeOldApifromCrd(req, sspCrd, sspApiVersionToRemove); err != nil {
+		return &reconcile.Result{Requeue: false}, err
+	}
+
 	if modified {
 		r.updateConditions(req)
 		return &reconcile.Result{Requeue: true}, nil
@@ -1204,6 +1210,33 @@ func (r *ReconcileHyperConverged) migrateBeforeUpgrade(req *common.HcoRequest) (
 	removeOldQuickStartGuides(req, r.client, r.operandHandler.GetQuickStartNames())
 
 	return upgradePatched, nil
+}
+
+func (r *ReconcileHyperConverged) removeOldApifromCrd(req *common.HcoRequest, crdName, removedApiVersion string) error {
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err := r.client.Get(req.Ctx, types.NamespacedName{Name: crdName}, &crd); err != nil {
+		req.Logger.Error(err, fmt.Sprintf("unable to get %s CRD", crdName))
+		return err
+	}
+
+	versionIndex := slices.Index(crd.Status.StoredVersions, removedApiVersion)
+	if versionIndex == -1 {
+		return nil
+	}
+
+	patchBytes := []byte(fmt.Sprintf(`[
+					{"op":"test", "path":"/status/storedVersions/%[1]d", "value": "%[2]s"},
+					{"op":"remove", "path":"/status/storedVersions/%[1]d"}]`,
+		versionIndex, removedApiVersion))
+	patch := client.RawPatch(types.JSONPatchType, patchBytes)
+
+	if err := r.client.Status().Patch(req.Ctx, &crd, patch); err != nil {
+		req.Logger.Error(err, fmt.Sprintf("failed to remove %v from status of CRD %v", removedApiVersion, crdName))
+		return err
+	}
+
+	req.Logger.Info(fmt.Sprintf("%s has been removed from the CRD %v stored versions", removedApiVersion, crdName))
+	return nil
 }
 
 func (r *ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (bool, error) {

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -128,6 +128,7 @@ type BasicExpected struct {
 	virtioWinRole        *rbacv1.Role
 	virtioWinRoleBinding *rbacv1.RoleBinding
 	hcoCRD               *apiextensionsv1.CustomResourceDefinition
+	sspCRD               *apiextensionsv1.CustomResourceDefinition
 	consolePluginDeploy  *appsv1.Deployment
 	consoleProxyDeploy   *appsv1.Deployment
 	consolePluginSvc     *corev1.Service
@@ -155,6 +156,7 @@ func (be BasicExpected) toArray() []client.Object {
 		be.virtioWinRole,
 		be.virtioWinRoleBinding,
 		be.hcoCRD,
+		be.sspCRD,
 		be.consolePluginDeploy,
 		be.consoleProxyDeploy,
 		be.consolePluginSvc,
@@ -308,6 +310,13 @@ func getBasicDeployment() *BasicExpected {
 		},
 	}
 	res.hcoCRD = hcoCrd
+
+	sspCrd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ssps.ssp.kubevirt.io",
+		},
+	}
+	res.sspCRD = sspCrd
 
 	csv := hcoutil.GetClusterInfo().GetCSV()
 	res.csv = csv


### PR DESCRIPTION
Since version 1.10, SSP moved to a new api version - v1beta2. In latest release, SSP completely removed the old API v1beta1 from their CRD. This might result in an upgrade issue with OLM, if the cluster has initially started with version 1.9 or below. This PR removes the old SSP api version v1beta1 from the storedVersions list in the SSP CRD status, to allow a smooth upgrade to 1.14.0.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-57082
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
