### PR TITLE
[release-1.14] Update assignee list of the bump bot action

### DIFF
--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -94,6 +94,6 @@ jobs:
             ```release-note
             Bump ${{ env.UPDATED_COMPONENT }} to ${{ env.UPDATED_VERSION }}
             ```
-          assignees: tiraboschi,orenc1,nunnatsa,machadovilaca,dharmit
-          reviewers: tiraboschi,orenc1,nunnatsa,machadovilaca,dharmit
+          assignees: orenc1,nunnatsa,machadovilaca,avlitman
+          reviewers: orenc1,nunnatsa,machadovilaca,avlitman
           branch: bump_${{ env.UPDATED_COMPONENT }}_${{ env.UPDATED_VERSION }}_${{ matrix.branches.branch }}


### PR DESCRIPTION
As currently the github action can't open a PR on this branch due to this error:
```
Error: Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the kubevirt/hyperconverged-cluster-operator repository.
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
