### PR TITLE
KubeVirtCRModified e2e: Remove prometheus check for metric value

### DIFF
--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -143,18 +143,6 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 				"expected different counter value; value before: %0.2f; expected value: %0.2f", valueBefore, valueBefore+float64(1),
 			)
 
-		By("checking that the prometheus metric was increased by 1")
-		Eventually(func(ctx context.Context) float64 {
-			return getMetricValue(ctx, promClient, query)
-		}).
-			WithTimeout(60*time.Second).
-			WithPolling(time.Second).
-			WithContext(ctx).
-			Should(
-				Equal(valueBefore+float64(1)),
-				"expected different counter value; value before: %0.2f; expected value: %0.2f", valueBefore, valueBefore+float64(1),
-			)
-
 		By("Checking the alert")
 		Eventually(func(ctx context.Context) *promApiv1.Alert {
 			alerts, err := promClient.Alerts(ctx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In KubeVirtCRModified alert e2e test we check the metric value in hco no need to check also prometheus

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
