### PR TITLE
Don't set the deprecated FGs in KV CR

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -201,19 +201,14 @@ var _ = Describe("HyperconvergedController", func() {
 					"CPUManager",
 					"Snapshot",
 					"HotplugVolumes",
-					"GPU",
 					"HostDevices",
 					"WithHostModelCPU",
 					"HypervStrictCheck",
 					"ExpandDisks",
 					"DownwardMetrics",
 					"VMExport",
-					"DisableCustomSELinuxPolicy",
 					"KubevirtSeccompProfile",
 					"VMPersistentState",
-					"VMLiveUpdateFeatures",
-					"VolumesUpdateStrategy",
-					"VolumeMigration",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -81,9 +81,6 @@ const (
 	// Allow attaching a data volume to a running VMI
 	kvHotplugVolumesGate = "HotplugVolumes"
 
-	// Allow assigning GPU and vGPU devices to virtual machines
-	kvGPUGate = "GPU"
-
 	// Allow assigning host devices to virtual machines
 	kvHostDevicesGate = "HostDevices"
 
@@ -93,23 +90,11 @@ const (
 	// Export VMs to outside of the cluster
 	kvVMExportGate = "VMExport"
 
-	// Disable the installation and usage of the custom SELinux policy
-	kvDisableCustomSELinuxPolicyGate = "DisableCustomSELinuxPolicy"
-
 	// Enable the installation of the KubeVirt seccomp profile
 	kvKubevirtSeccompProfile = "KubevirtSeccompProfile"
 
 	// Enable VM state persistence
 	kvVMPersistentState = "VMPersistentState"
-
-	// Enable VM live update, to allow live propagation of VM changes to their VMI
-	kvVMLiveUpdateFeatures = "VMLiveUpdateFeatures"
-
-	// enables to specify the strategy on the volume updates.
-	kvVolumesUpdateStrategyGate = "VolumesUpdateStrategy"
-
-	// enables to migrate the storage. It depends on the VolumesUpdateStrategy feature.
-	kvVolumeMigrationGate = "VolumeMigration"
 )
 
 const (
@@ -123,15 +108,10 @@ var (
 		kvSnapshotGate,
 		kvHotplugVolumesGate,
 		kvExpandDisksGate,
-		kvGPUGate,
 		kvHostDevicesGate,
 		kvVMExportGate,
-		kvDisableCustomSELinuxPolicyGate,
 		kvKubevirtSeccompProfile,
 		kvVMPersistentState,
-		kvVMLiveUpdateFeatures,
-		kvVolumesUpdateStrategyGate,
-		kvVolumeMigrationGate,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of


### PR DESCRIPTION
**What this PR does / why we need it**:

The following FGs are deprecatd in KV, and there is no point to set them
in the KubeVirt CR:
* `GPU` - GA in KV
* `DisableCustomSELinuxPolicy` - GA in KV
* `VolumesUpdateStrategy` - GA in KV v1.3.0
* `VMLiveUpdateFeatures` - GA in KV v1.4.0
* `VolumeMigration` - GA in KV v1.5.0

This PR changes HCO to stop setting these FGs in the KubVirt CR.
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't set the following deprecated FGs in the KubeVirt CR:
GPU
DisableCustomSELinuxPolicy
VolumesUpdateStrategy
VMLiveUpdateFeatures
VolumeMigration
```
