### PR TITLE
cluster-alerts: Add alert rule DeprecatedMachineType

### DIFF
--- a/hack/prom-rule-ci/observability-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/observability-prom-rules-tests.yaml
@@ -417,3 +417,29 @@ tests:
               operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cnv-observability"
+
+  # Test for DeprecatedMachineType alert
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vm_info{name="deprecated-vm", namespace="default", machine_type="pc-q35-rhel7.6.0", status_group="running"}'
+        values: '1+0x10'
+      - series: 'kubevirt_node_deprecated_machine_types{machine_type="pc-q35-rhel7.6.0"}'
+        values: '1+0x10'
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: DeprecatedMachineType
+        exp_alerts:
+          - exp_annotations:
+              summary: "Virtual Machine 'deprecated-vm' in namespace 'default' is using a deprecated machine type."
+              description: "Virtual Machine 'deprecated-vm' in namespace 'default' is using machine type 'pc-q35-rhel7.6.0', which is deprecated. Current status: 'running'."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/DeprecatedMachineType"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              namespace: "default"
+              name: "deprecated-vm"
+              machine_type: "pc-q35-rhel7.6.0"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cnv-observability"
+              status_group: "running"

--- a/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
+++ b/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
@@ -133,5 +133,22 @@ func clusterAlerts() []promv1.Rule {
 				"operator_health_impact": "none",
 			},
 		},
+		{
+			Alert: "DeprecatedMachineType",
+			Expr: intstr.FromString(`
+			  kubevirt_vm_info
+			  * on(machine_type) group_left()
+				max(kubevirt_node_deprecated_machine_types) by (machine_type)
+			`),
+			For: ptr.To(promv1.Duration("5m")),
+			Annotations: map[string]string{
+				"summary":     "Virtual Machine '{{ $labels.name }}' in namespace '{{ $labels.namespace }}' is using a deprecated machine type.",
+				"description": "Virtual Machine '{{ $labels.name }}' in namespace '{{ $labels.namespace }}' is using machine type '{{ $labels.machine_type }}', which is deprecated. Current status: '{{ $labels.status_group }}'.",
+			},
+			Labels: map[string]string{
+				"severity":               "warning",
+				"operator_health_impact": "none",
+			},
+		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `DeprecatedMachineType` alert to detect when a VM is using a deprecated machine type.

Rule Expression:
```
kubevirt_vm_info
* on(machine_type) group_left()
  max(kubevirt_node_deprecated_machine_types) by (machine_type)
```

How It Works:
- Uses only `kubevirt_vm_info`, covering both running and stopped VMs.
- Joins each VM's machine type against the cluster's deprecated types.
- Fires when any VM uses a deprecated type.

Alert Details:
- Fires after 5m of continuous match.
- Summary: VM <namespace>/<name> is using a deprecated machine type.
- Description: Includes VM name, namespace, and machine type.
- Severity: warning, operator_health_impact: warning.

Why this is needed:
- Provides early visibility into workloads running on machine types that will be removed in future releases.
- Allows administrators to proactively migrate workloads to supported types before upgrading clusters, reducing the risk of downtime or incompatibility.

**Reviewer Checklist**

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-56660
```

**Release note**:
```release-note
add new alert `DeprecatedMachineType` for detecting vms with deprecated machine types.
```
