### PR TITLE
Fix issue in upgrade tests

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -41,8 +41,7 @@ jobs:
       - name: set unstable tag
         # This workflow always pushes unstable tags, both from main and release branches.
         run: |
-          echo "IMAGE_TAG=${CSV_VERSION}-unstable" >> $GITHUB_ENV
-          echo "UNSTABLE=UNSTABLE" >> $GITHUB_ENV
+          echo "IMAGE_TAG=$(date -u +%Y%m%d-%H%M%S) >> $GITHUB_ENV
 
       - name: Build and Push Applications Images
         env:
@@ -71,4 +70,10 @@ jobs:
       - name: Build and Push the Index Image
         run: |
           export OPM=$(pwd)/linux-amd64-opm
-          ./hack/build-index-image.sh latest ${{ env.UNSTABLE }}
+          ./hack/build-index-image.sh latest UNSTABLE
+      - name: Re-tag and Push all the Images
+        env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          CSV_VERSION: ${{ env.CSV_VERSION }}
+        run: |
+          IMAGE_TAG="${IMAGE_TAG}" NEW_TAG="${CSV_VERSION}-unstable" make retag-push-all-images

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ OPERATOR_IMAGE     ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-operator
 WEBHOOK_IMAGE      ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-webhook
 FUNC_TEST_IMAGE    ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-functest
 VIRT_ARTIFACTS_SERVER ?= $(REGISTRY_NAMESPACE)/virt-artifacts-server
+BUNDLE_IMAGE       ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-bundle
+INDEX_IMAGE        ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-index
 LDFLAGS            ?= -w -s
 GOLANDCI_LINT_VERSION ?= v1.64.4
 HCO_BUMP_LEVEL ?= minor
@@ -144,6 +146,14 @@ container-push-functest:
 
 container-push-artifacts-server:
 	. "hack/cri-bin.sh" && $$CRI_BIN manifest push $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG)
+
+retag-push-all-images:
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(OPERATOR_IMAGE) MULTIARCH=true CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE) MULTIARCH=true CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE) MULTIARCH=true CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER) MULTIARCH=true CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(BUNDLE_IMAGE) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(INDEX_IMAGE) MULTIARCH=true CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
 
 cluster-up:
 	./cluster/up.sh
@@ -331,4 +341,5 @@ bump-hco:
 		build-push-multi-arch-webhook-image \
 		build-push-multi-arch-functest-image \
 		build-push-multi-arch-artifacts-server \
-		build-push-multi-arch-images
+		build-push-multi-arch-images \
+		retag-push-all-images

--- a/hack/retag-multi-arch-images.sh
+++ b/hack/retag-multi-arch-images.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+ARCHITECTURES="amd64 arm64 s390x"
+
+if [[ -z ${IMAGE_REPO} ]]; then
+  echo "IMAGE_REPO must be defined"
+  exit 1
+fi
+
+NEW_IMAGE_REPO=${NEW_IMAGE_REPO:-${IMAGE_REPO}}
+
+if [[ -z ${CURRENT_TAG} ]]; then
+  echo "CURRENT_TAG must be defined"
+  exit 1
+fi
+
+if [[ -z ${NEW_TAG} ]]; then
+  echo "NEW_TAG must be defined"
+  exit 1
+fi
+
+if [[ "${MULTIARCH}" == "true" ]]; then
+  for arch in ${ARCHITECTURES}; do
+    NEW_IMAGE="${NEW_IMAGE_REPO}:${NEW_TAG}-${arch}"
+    . "hack/cri-bin.sh" && ${CRI_BIN} tag "${IMAGE_REPO}:${CURRENT_TAG}-${arch}" "${NEW_IMAGE}"
+    . "hack/cri-bin.sh" && ${CRI_BIN} push "${NEW_IMAGE}"
+  done
+fi
+
+# retag the manifest
+NEW_IMAGE="${NEW_IMAGE_REPO}:${NEW_TAG}"
+. "hack/cri-bin.sh" && ${CRI_BIN} tag "${IMAGE_REPO}:${CURRENT_TAG}" "${NEW_IMAGE}"
+. "hack/cri-bin.sh" && ${CRI_BIN} push "${NEW_IMAGE}"


### PR DESCRIPTION
**What this PR does / why we need it**:

We have an inherent issue in our upgrade tests. The test is taking the unstable bundles from quay. We build these bundles each time we merge a PR.

All the images in the unstable bundles are listed with their digests, rather than their tag, in order to support disconnected environment.

If this process is failed in the middle, e.g. when the operator image was already built and pushed to quay.io, but the bundle image failed, then the bundle is actually broken: it is an old version of the bundle, pointing to images that are no longer there, because the operator images are was already replaced.

This PR fixes this issue by first pushing the images with a temporary tag, and only if everything went well, retugs the images with the unstable tag.

As a side effect, the old images are not been GCed and we can investigate issues if needed.

Here is how it will look like in quay.io:
![image](https://github.com/user-attachments/assets/91c3066a-0db8-4cc5-a622-68c0f74ad41c)

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
