### PR TITLE
Adding the ability to control CommonInstancetypesDeploymentGate through hco

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -490,6 +490,13 @@ type HyperConvergedFeatureGates struct {
 	// be able to bind their VM to a UDN network on the VM's primary interface.
 	// Deprecated: this field is ignored and will be removed in the next version of the API.
 	PrimaryUserDefinedNetworkBinding *bool `json:"primaryUserDefinedNetworkBinding,omitempty"`
+
+	// Enable the control of Kubevirt's CR CommonInstancetypesDeploymentGate feature
+	// gate through the HyperConverged CR
+	// +optional
+	// +kubebuilder:default=true
+	// +default=true
+	CommonInstancetypesDeploymentGate *bool `json:"commonInstancetypesDeploymentGate,omitempty"`
 }
 
 // PermittedHostDevices holds information about devices allowed for passthrough

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -145,6 +145,7 @@ const (
 	kvDisableMDevConfig     = "DisableMDEVConfiguration"
 	kvPersistentReservation = "PersistentReservation"
 	kvAlignCPUs             = "AlignCPUs"
+	kvCommonInstancetypesDeploymentGate = "CommonInstancetypesDeploymentGate"
 )
 
 // CPU Plugin default values
@@ -845,7 +846,10 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates) [
 	if featureGates.AlignCPUs != nil && *featureGates.AlignCPUs {
 		fgs = append(fgs, kvAlignCPUs)
 	}
-
+	if featureGates.CommonInstancetypesDeploymentGate != nil && *featureGates.CommonInstancetypesDeploymentGate {
+		fgs = append(fgs, kvCommonInstancetypesDeploymentGate)
+	}
+	
 	return fgs
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Right now the only way to control the creation of the common instance types is through the Kubervirt CR but that CR is being created and managed by the HCO operator through the hco CR.
This PR give us the ability to change the CommonInstancetypesDeploymentGate to false (right now the default is True)

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
