### PR TITLE
E2E: extand monitoring test timeout

### DIFF
--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -38,6 +38,11 @@ import (
 
 var runbookClient = http.DefaultClient
 
+const (
+	prometheousTimeout = 5 * time.Minute
+	prometheousPolling = 10 * time.Second
+)
+
 var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring", Serial, Ordered, Label(tests.OpenshiftLabel, "monitoring"), func() {
 	flag.Parse()
 
@@ -149,7 +154,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			Expect(err).ToNot(HaveOccurred())
 			alert := getAlertByName(alerts, "KubeVirtCRModified")
 			return alert
-		}).WithTimeout(60 * time.Second).WithPolling(time.Second).WithContext(ctx).ShouldNot(BeNil())
+		}).WithTimeout(prometheousTimeout).WithPolling(prometheousPolling).WithContext(ctx).ShouldNot(BeNil())
 	})
 
 	It("UnsupportedHCOModification alert should fired when there is an jsonpatch annotation to modify an operand CRs", func(ctx context.Context) {
@@ -166,7 +171,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			Expect(err).ToNot(HaveOccurred())
 			alert := getAlertByName(alerts, "UnsupportedHCOModification")
 			return alert
-		}).WithTimeout(60 * time.Second).WithPolling(time.Second).WithContext(ctx).ShouldNot(BeNil())
+		}).WithTimeout(prometheousTimeout).WithPolling(prometheousPolling).WithContext(ctx).ShouldNot(BeNil())
 	})
 
 	Describe("KubeDescheduler", Serial, Ordered, Label(tests.OpenshiftLabel, "monitoring"), func() {
@@ -254,8 +259,8 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			Eventually(func(ctx context.Context) float64 {
 				return getMetricValue(ctx, promClient, query)
 			}).
-				WithTimeout(60*time.Second).
-				WithPolling(time.Second).
+				WithTimeout(5*time.Minute).
+				WithPolling(10*time.Second).
 				WithContext(ctx).
 				Should(
 					Equal(float64(1)),
@@ -268,7 +273,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 				Expect(err).ToNot(HaveOccurred())
 				alert := getAlertByName(alerts, hcoalerts.MisconfiguredDeschedulerAlert)
 				return alert
-			}).WithTimeout(60 * time.Second).WithPolling(time.Second).WithContext(ctx).ShouldNot(BeNil())
+			}).WithTimeout(prometheousTimeout).WithPolling(prometheousPolling).WithContext(ctx).ShouldNot(BeNil())
 
 			By("Correctly configuring the descheduler for KubeVirt")
 			Expect(cli.Patch(ctx, descheduler, patchConfigure)).To(Succeed())
@@ -290,8 +295,8 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			Eventually(func(ctx context.Context) float64 {
 				return getMetricValue(ctx, promClient, query)
 			}).
-				WithTimeout(60*time.Second).
-				WithPolling(time.Second).
+				WithTimeout(5*time.Minute).
+				WithPolling(10*time.Second).
 				WithContext(ctx).
 				Should(
 					Equal(float64(0)),
@@ -304,7 +309,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 				Expect(err).ToNot(HaveOccurred())
 				alert := getAlertByName(alerts, hcoalerts.MisconfiguredDeschedulerAlert)
 				return alert
-			}).WithTimeout(60 * time.Second).WithPolling(time.Second).WithContext(ctx).Should(BeNil())
+			}).WithTimeout(prometheousTimeout).WithPolling(prometheousPolling).WithContext(ctx).Should(BeNil())
 
 			By("Misconfiguring a second time the descheduler")
 			Expect(cli.Patch(ctx, descheduler, patchMisconfigure)).To(Succeed())
@@ -326,8 +331,8 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			Eventually(func(ctx context.Context) float64 {
 				return getMetricValue(ctx, promClient, query)
 			}).
-				WithTimeout(60*time.Second).
-				WithPolling(time.Second).
+				WithTimeout(5*time.Minute).
+				WithPolling(10*time.Second).
 				WithContext(ctx).
 				Should(
 					Equal(float64(1)),
@@ -340,7 +345,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 				Expect(err).ToNot(HaveOccurred())
 				alert := getAlertByName(alerts, hcoalerts.MisconfiguredDeschedulerAlert)
 				return alert
-			}).WithTimeout(60 * time.Second).WithPolling(time.Second).WithContext(ctx).ShouldNot(BeNil())
+			}).WithTimeout(prometheousTimeout).WithPolling(prometheousPolling).WithContext(ctx).ShouldNot(BeNil())
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The `UnsupportedHCOModification alert` test fails freqantly, when trying to read the expected alert from Prometheous.

This PR is trying to reduce the failures by extanding the timeout from one minutes to five, for all the calls to Prometheous.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
