### PR TITLE
Fix a bug when setting a CPU quantity without a type

### DIFF
--- a/controllers/operands/aaq_test.go
+++ b/controllers/operands/aaq_test.go
@@ -69,7 +69,8 @@ var _ = Describe("AAQ tests", func() {
 
 	Context("test NewAAQ", func() {
 		It("should have all default fields", func() {
-			aaq := NewAAQ(hco)
+			aaq, err := NewAAQ(hco)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(aaq.Name).To(Equal("aaq-" + hco.Name))
 			Expect(aaq.Namespace).To(BeEmpty())
@@ -108,7 +109,8 @@ var _ = Describe("AAQ tests", func() {
 				},
 			}
 
-			aaq := NewAAQ(hco)
+			aaq, err := NewAAQ(hco)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(aaq.Spec.NamespaceSelector).ToNot(BeNil())
 			Expect(aaq.Spec.NamespaceSelector.MatchLabels).To(Equal(labels))
 		})
@@ -118,7 +120,8 @@ var _ = Describe("AAQ tests", func() {
 				VmiCalcConfigName: ptr.To(aaqv1alpha1.VmiPodUsage),
 			}
 
-			aaq := NewAAQ(hco)
+			aaq, err := NewAAQ(hco)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(aaq.Spec.Configuration.VmiCalculatorConfiguration.ConfigName).To(Equal(aaqv1alpha1.VmiPodUsage))
 		})
 
@@ -127,7 +130,8 @@ var _ = Describe("AAQ tests", func() {
 				AllowApplicationAwareClusterResourceQuota: true,
 			}
 
-			aaq := NewAAQ(hco)
+			aaq, err := NewAAQ(hco)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(aaq.Spec.Configuration.AllowApplicationAwareClusterResourceQuota).To(BeTrue())
 		})
 
@@ -135,7 +139,8 @@ var _ = Describe("AAQ tests", func() {
 			hco.Spec.Infra.NodePlacement = &testNodePlacement
 			hco.Spec.Workloads.NodePlacement = &testNodePlacement
 
-			aaq := NewAAQ(hco)
+			aaq, err := NewAAQ(hco)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(aaq.Spec.Infra).To(Equal(testNodePlacement))
 			Expect(aaq.Spec.Workloads).To(Equal(testNodePlacement))
@@ -154,7 +159,8 @@ var _ = Describe("AAQ tests", func() {
 				},
 			}
 
-			aaq := NewAAQ(hco)
+			aaq, err := NewAAQ(hco)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(aaq.Spec.CertConfig.CA).ToNot(BeNil())
 			Expect(aaq.Spec.CertConfig.CA.Duration).ToNot(BeNil())
@@ -187,7 +193,8 @@ var _ = Describe("AAQ tests", func() {
 		})
 
 		It("should delete AAQ if the enableApplicationAwareQuota FG is not set", func() {
-			aaq := NewAAQ(hco)
+			aaq, err := NewAAQ(hco)
+			Expect(err).ToNot(HaveOccurred())
 			cl = commontestutils.InitClient([]client.Object{hco, aaq})
 
 			handler := newAAQHandler(cl, commontestutils.GetScheme())

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -3977,6 +3977,9 @@ Version: 1.2.3`)
 				}
 
 				if isAnnotationPresentOnKV {
+					if existingResource.Annotations == nil {
+						existingResource.Annotations = make(map[string]string)
+					}
 					existingResource.Annotations[kubevirtcorev1.EmulatorThreadCompleteToEvenParity] = ""
 				}
 
@@ -4016,6 +4019,9 @@ Version: 1.2.3`)
 				}
 
 				if isAnnotationPresentOnKV {
+					if existingResource.Annotations == nil {
+						existingResource.Annotations = make(map[string]string)
+					}
 					existingResource.Annotations[kubevirtcorev1.EmulatorThreadCompleteToEvenParity] = ""
 				}
 
@@ -4418,4 +4424,17 @@ Version: 1.2.3`)
 
 	})
 
+	Context("Quantity", func() {
+		It("should add a quantity type if missing", func() {
+			hco := commontestutils.NewHco()
+			hco.Spec.LiveMigrationConfig.BandwidthPerMigration = ptr.To("1.5")
+
+			kv, err := NewKubeVirt(hco)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kv).ToNot(BeNil())
+			Expect(kv.Spec.Configuration.MigrationConfiguration).ToNot(BeNil())
+			Expect(kv.Spec.Configuration.MigrationConfiguration.BandwidthPerMigration).ToNot(BeNil())
+			Expect(kv.Spec.Configuration.MigrationConfiguration.BandwidthPerMigration).To(HaveValue(Equal(resource.MustParse("1500m"))))
+		})
+	})
 })

--- a/pkg/reformatobj/reformatobj.go
+++ b/pkg/reformatobj/reformatobj.go
@@ -1,0 +1,34 @@
+package reformatobj
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ReformatObj reformats client objects to solve the quantity bug.
+// The bug is happening when setting a quantity field without quantity
+// type.
+// for example
+//
+//	limit:
+//	  cpu: "1.5"
+//
+// In this case, the client actually set a formatted value to the resource
+// in K8s cluster, while HCO keep use the original un-typed quantity value.
+// That causes an endless loop of updates, because HCO compares the values
+// and finds out they are different.
+func ReformatObj[T any](obj *T) (*T, error) {
+	bts, err := json.Marshal(obj)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal %T: %w", obj, err)
+	}
+
+	var obj2 T
+	err = json.Unmarshal(bts, &obj2)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal %T: %w", obj, err)
+	}
+
+	return &obj2, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When setting, for example, the
`spec.resourceRequirements.storageWorkloads.limit` field to `"1.5"`, the client set the value in CDI to `"1500m"`. Then HCO will always find this value as not matches to the required value of `"1.5"`, and will constantly try to update CDI.

This PR fixes this issue by turning the required objects to json and back to objects. The json marshaling performs the same change in the object. Now when HCO will compare the required value with the existing one, both will be at the newer format, with the quantity type, and HCO will understand that no change was done, and it will not try to update the CR again.

Also. This PR adds a mutex protection to the cache in the operand handlers.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-58521
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug when setting a CPU quantity without a type
```
