### PR TITLE
Use the official coveralls github action

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -44,10 +44,12 @@ jobs:
       - name: Prometheus alerts tests
         run: make prom-rules-verify
 
-      - uses: shogo82148/actions-goveralls@v1
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
         with:
-          path-to-profile: coverprofiles/cover.coverprofile
-        continue-on-error: true
+          file: coverprofiles/cover.coverprofile
+          flag-name: Unit
+          format: golang
 
       - name: Verify the current manifests pass validation
         run: make container-build-validate-bundles


### PR DESCRIPTION
**What this PR does / why we need it**:
Until now, we're using the shogo82148/actions-goveralls github action to send the coverage information to coverall.io.

It's appears that there is an official github action for that, and we want to use it to be in sync with coveralls.io, and get better support.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
