### PR TITLE
re-enable the revive linter rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,11 +11,56 @@ linters:
       force-expect-to: true
     revive:
       rules:
+        - name: bare-return
+          disabled: true
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
         - name: dot-imports
           arguments:
             - allowedPackages:
                 - github.com/onsi/ginkgo/v2
                 - github.com/onsi/gomega
+        - name: empty-block
+        - name: empty-lines
+          disabled: true
+        - name: enforce-slice-style
+          arguments:
+            - "nil"
+          disabled: true
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+          disabled: true
+        - name: filename-format
+          arguments:
+            - "^[_a-z][_a-z0-9]*\\.go$"
+          disabled: true
+        - name: increment-decrement
+        - name: indent-error-flow
+          disabled: true
+        - name: line-length-limit
+          arguments:
+            - 200
+          disabled: true
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-naming
+          disabled: true
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
+          disabled: true
+        - name: useless-break
+        - name: use-any
+          disabled: true
+        - name: var-declaration
+        - name: var-naming
+          disabled: true
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
**What this PR does / why we need it**:
Apparently, when adding a specific rule setting to revive setting, it cancels all the other rules, leaving only the ones under `rervive.rules`.

In PR 2803, we configured revive's dot-import rule, so from then, revive only checks this single rule.

This commit re-enable all the default revive rules, according to https://github.com/mgechev/revive/blob/62f0b012e5f927a733e4ee41c5e27091d8c57c71/revive.toml#L1

Disable any rule that currently introduces new linter warnings. They will be enabled one by one with their finding fixed, in the following commits.

The following rules are removed as they won't implemented:
* enforce-map-style - not agree with the rule logic
* exported - too much work to implement, not worth it
* package-comments - too much work to implement, not worth it

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
