### PR TITLE
Add missing mutex lock for aaq.reset()

### DIFF
--- a/controllers/operands/aaq.go
+++ b/controllers/operands/aaq.go
@@ -67,6 +67,9 @@ func (*aaqHooks) checkComponentVersion(cr runtime.Object) bool {
 }
 
 func (h *aaqHooks) reset() {
+	h.Lock()
+	defer h.Unlock()
+
 	h.cache = nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up PR #3379: the cache in the aaqHooks is now protected by a mutex. But we didn't lock the mutex in the reset() method.

This PR adds the missing lock.

**Jira Ticket**:
```jira-ticket
None
```

**Release note**:
```release-note
None
```
