### PR TITLE
Move the enableApplicationAwareQuota feature gate to new field

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -66,7 +66,7 @@ type HyperConvergedSpec struct {
 
 	// featureGates is a map of feature gate flags. Setting a flag to `true` will enable
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
-	// +kubebuilder:default={"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false, "enableApplicationAwareQuota": false}
+	// +kubebuilder:default={"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false}
 	// +optional
 	FeatureGates HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
@@ -268,6 +268,12 @@ type HyperConvergedSpec struct {
 	// +kubebuilder:default=false
 	// +default=false
 	DeployKubeSecondaryDNS *bool `json:"deployKubeSecondaryDNS,omitempty"`
+
+	// EnableApplicationAwareQuota if true, enables the Application Aware Quota feature
+	// +optional
+	// +kubebuilder:default=false
+	// +default=false
+	EnableApplicationAwareQuota *bool `json:"enableApplicationAwareQuota,omitempty"`
 }
 
 // CertRotateConfigCA contains the tunables for TLS certificates.
@@ -482,10 +488,8 @@ type HyperConvergedFeatureGates struct {
 	// +default=false
 	AlignCPUs *bool `json:"alignCPUs,omitempty"`
 
-	// EnableApplicationAwareQuota if true, enables the Application Aware Quota feature
-	// +optional
-	// +kubebuilder:default=false
-	// +default=false
+	// Deprecated: This field is ignored and will be removed on the next version of the API.
+	// Use spec.enableApplicationAwareQuota instead
 	EnableApplicationAwareQuota *bool `json:"enableApplicationAwareQuota,omitempty"`
 
 	// primaryUserDefinedNetworkBinding deploys the needed configurations for kubevirt users to
@@ -853,7 +857,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}},"featureGates": {"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false, "enableApplicationAwareQuota": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist", "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "enableCommonBootImageImport": true, "deployVmConsoleProxy": false, "deployKubeSecondaryDNS": false}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}},"featureGates": {"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist", "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "enableApplicationAwareQuota": false, "enableCommonBootImageImport": true, "deployVmConsoleProxy": false, "deployKubeSecondaryDNS": false}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -553,6 +553,11 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableApplicationAwareQuota != nil {
+		in, out := &in.EnableApplicationAwareQuota, &out.EnableApplicationAwareQuota
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1beta1/zz_generated.defaults.go
+++ b/api/v1beta1/zz_generated.defaults.go
@@ -56,10 +56,6 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.FeatureGates.AlignCPUs = &ptrVar1
 	}
-	if in.Spec.FeatureGates.EnableApplicationAwareQuota == nil {
-		var ptrVar1 bool = false
-		in.Spec.FeatureGates.EnableApplicationAwareQuota = &ptrVar1
-	}
 	if in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster == nil {
 		var ptrVar1 uint32 = 5
 		in.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster = &ptrVar1
@@ -163,6 +159,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 	if in.Spec.DeployKubeSecondaryDNS == nil {
 		var ptrVar1 bool = false
 		in.Spec.DeployKubeSecondaryDNS = &ptrVar1
+	}
+	if in.Spec.EnableApplicationAwareQuota == nil {
+		var ptrVar1 bool = false
+		in.Spec.EnableApplicationAwareQuota = &ptrVar1
 	}
 }
 

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -328,8 +328,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 					},
 					"enableApplicationAwareQuota": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EnableApplicationAwareQuota if true, enables the Application Aware Quota feature",
-							Default:     false,
+							Description: "Deprecated: This field is ignored and will be removed on the next version of the API. Use spec.enableApplicationAwareQuota instead",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -668,6 +667,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 					"deployKubeSecondaryDNS": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Deploy KubeSecondaryDNS by CNAO",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"enableApplicationAwareQuota": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EnableApplicationAwareQuota if true, enables the Application Aware Quota feature",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",

--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -116,6 +116,24 @@
       "jsonPatch": [
         {
           "op": "test",
+          "path": "/spec/featureGates/enableApplicationAwareQuota",
+          "value": true
+        },
+        {
+          "op": "move",
+          "from": "/spec/featureGates/enableApplicationAwareQuota",
+          "path": "/spec/enableApplicationAwareQuota"
+        }
+      ],
+      "jsonPatchApplyOptions": {
+        "allowMissingPathOnRemove": true
+      }
+    },
+    {
+      "semverRange": "<1.15.0",
+      "jsonPatch": [
+        {
+          "op": "test",
           "path": "/spec/featureGates/deployKubeSecondaryDNS",
           "value": true
         },
@@ -139,6 +157,10 @@
         {
           "op": "remove",
           "path": "/spec/featureGates/deployVmConsoleProxy"
+        },
+        {
+          "op": "remove",
+          "path": "/spec/featureGates/enableApplicationAwareQuota"
         },
         {
           "op": "remove",

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -58,11 +58,11 @@ spec:
                   renewBefore: 12h0m0s
               deployKubeSecondaryDNS: false
               deployVmConsoleProxy: false
+              enableApplicationAwareQuota: false
               enableCommonBootImageImport: true
               featureGates:
                 disableMDevConfiguration: false
                 downwardMetrics: false
-                enableApplicationAwareQuota: false
                 persistentReservation: false
               liveMigrationConfig:
                 allowAutoConverge: false
@@ -1023,6 +1023,11 @@ spec:
                 default: false
                 description: deploy VM console proxy resources in SSP operator
                 type: boolean
+              enableApplicationAwareQuota:
+                default: false
+                description: EnableApplicationAwareQuota if true, enables the Application
+                  Aware Quota feature
+                type: boolean
               enableCommonBootImageImport:
                 default: true
                 description: |-
@@ -1052,7 +1057,6 @@ spec:
                 default:
                   disableMDevConfiguration: false
                   downwardMetrics: false
-                  enableApplicationAwareQuota: false
                   persistentReservation: false
                 description: |-
                   featureGates is a map of feature gate flags. Setting a flag to `true` will enable
@@ -1097,9 +1101,9 @@ spec:
                       guests.
                     type: boolean
                   enableApplicationAwareQuota:
-                    default: false
-                    description: EnableApplicationAwareQuota if true, enables the
-                      Application Aware Quota feature
+                    description: |-
+                      Deprecated: This field is ignored and will be removed on the next version of the API.
+                      Use spec.enableApplicationAwareQuota instead
                     type: boolean
                   enableCommonBootImageImport:
                     description: 'Deprecated: This field is ignored. Use spec.enableCommonBootImageImport

--- a/controllers/operands/aaq.go
+++ b/controllers/operands/aaq.go
@@ -28,7 +28,7 @@ func newAAQHandler(Client client.Client, Scheme *runtime.Scheme) Operand {
 			hooks:  &aaqHooks{},
 		},
 		shouldDeploy: func(hc *hcov1beta1.HyperConverged) bool {
-			return hc.Spec.FeatureGates.EnableApplicationAwareQuota != nil && *hc.Spec.FeatureGates.EnableApplicationAwareQuota
+			return hc.Spec.EnableApplicationAwareQuota != nil && *hc.Spec.EnableApplicationAwareQuota
 		},
 		getCRWithName: func(hc *hcov1beta1.HyperConverged) client.Object {
 			return NewAAQWithNameOnly(hc)

--- a/controllers/operands/aaq_test.go
+++ b/controllers/operands/aaq_test.go
@@ -213,7 +213,7 @@ var _ = Describe("AAQ tests", func() {
 		})
 
 		It("should create AAQ if the enableApplicationAwareQuota FG is true", func() {
-			hco.Spec.FeatureGates.EnableApplicationAwareQuota = ptr.To(true)
+			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
 			cl = commontestutils.InitClient([]client.Object{hco})
 
 			handler := newAAQHandler(cl, commontestutils.GetScheme())
@@ -241,7 +241,7 @@ var _ = Describe("AAQ tests", func() {
 
 		It("should update AAQ fields, if not matched to the requirements", func() {
 			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
-			hco.Spec.FeatureGates.EnableApplicationAwareQuota = ptr.To(true)
+			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
 			aaq := NewAAQWithNameOnly(hco)
 			aaq.Spec.Infra = testNodePlacement
 			aaq.Spec.PriorityClass = ptr.To[aaqv1alpha1.AAQPriorityClass]("wrongPC")
@@ -292,7 +292,7 @@ var _ = Describe("AAQ tests", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
-			hco.Spec.FeatureGates.EnableApplicationAwareQuota = ptr.To(true)
+			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
 			outdatedResource := NewAAQWithNameOnly(hco)
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
@@ -325,7 +325,7 @@ var _ = Describe("AAQ tests", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
 			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
-			hco.Spec.FeatureGates.EnableApplicationAwareQuota = ptr.To(true)
+			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
 			outdatedResource := NewAAQWithNameOnly(hco)
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
@@ -356,7 +356,7 @@ var _ = Describe("AAQ tests", func() {
 
 	Context("check cache", func() {
 		It("should create new cache if it empty", func() {
-			hco.Spec.FeatureGates.EnableApplicationAwareQuota = ptr.To(true)
+			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
 			handler := newAAQHandler(cl, commontestutils.GetScheme())
 			op, ok := handler.(*conditionalHandler)
 			Expect(ok).To(BeTrue())

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -58,11 +58,11 @@ spec:
                   renewBefore: 12h0m0s
               deployKubeSecondaryDNS: false
               deployVmConsoleProxy: false
+              enableApplicationAwareQuota: false
               enableCommonBootImageImport: true
               featureGates:
                 disableMDevConfiguration: false
                 downwardMetrics: false
-                enableApplicationAwareQuota: false
                 persistentReservation: false
               liveMigrationConfig:
                 allowAutoConverge: false
@@ -1023,6 +1023,11 @@ spec:
                 default: false
                 description: deploy VM console proxy resources in SSP operator
                 type: boolean
+              enableApplicationAwareQuota:
+                default: false
+                description: EnableApplicationAwareQuota if true, enables the Application
+                  Aware Quota feature
+                type: boolean
               enableCommonBootImageImport:
                 default: true
                 description: |-
@@ -1052,7 +1057,6 @@ spec:
                 default:
                   disableMDevConfiguration: false
                   downwardMetrics: false
-                  enableApplicationAwareQuota: false
                   persistentReservation: false
                 description: |-
                   featureGates is a map of feature gate flags. Setting a flag to `true` will enable
@@ -1097,9 +1101,9 @@ spec:
                       guests.
                     type: boolean
                   enableApplicationAwareQuota:
-                    default: false
-                    description: EnableApplicationAwareQuota if true, enables the
-                      Application Aware Quota feature
+                    description: |-
+                      Deprecated: This field is ignored and will be removed on the next version of the API.
+                      Use spec.enableApplicationAwareQuota instead
                     type: boolean
                   enableCommonBootImageImport:
                     description: 'Deprecated: This field is ignored. Use spec.enableCommonBootImageImport

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -13,12 +13,12 @@ spec:
       renewBefore: 12h0m0s
   deployKubeSecondaryDNS: false
   deployVmConsoleProxy: false
+  enableApplicationAwareQuota: false
   enableCommonBootImageImport: true
   featureGates:
     alignCPUs: false
     disableMDevConfiguration: false
     downwardMetrics: false
-    enableApplicationAwareQuota: false
     persistentReservation: false
   higherWorkloadDensity:
     memoryOvercommitPercentage: 100

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.15.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.15.0/manifests/hco00.crd.yaml
@@ -58,11 +58,11 @@ spec:
                   renewBefore: 12h0m0s
               deployKubeSecondaryDNS: false
               deployVmConsoleProxy: false
+              enableApplicationAwareQuota: false
               enableCommonBootImageImport: true
               featureGates:
                 disableMDevConfiguration: false
                 downwardMetrics: false
-                enableApplicationAwareQuota: false
                 persistentReservation: false
               liveMigrationConfig:
                 allowAutoConverge: false
@@ -1023,6 +1023,11 @@ spec:
                 default: false
                 description: deploy VM console proxy resources in SSP operator
                 type: boolean
+              enableApplicationAwareQuota:
+                default: false
+                description: EnableApplicationAwareQuota if true, enables the Application
+                  Aware Quota feature
+                type: boolean
               enableCommonBootImageImport:
                 default: true
                 description: |-
@@ -1052,7 +1057,6 @@ spec:
                 default:
                   disableMDevConfiguration: false
                   downwardMetrics: false
-                  enableApplicationAwareQuota: false
                   persistentReservation: false
                 description: |-
                   featureGates is a map of feature gate flags. Setting a flag to `true` will enable
@@ -1097,9 +1101,9 @@ spec:
                       guests.
                     type: boolean
                   enableApplicationAwareQuota:
-                    default: false
-                    description: EnableApplicationAwareQuota if true, enables the
-                      Application Aware Quota feature
+                    description: |-
+                      Deprecated: This field is ignored and will be removed on the next version of the API.
+                      Use spec.enableApplicationAwareQuota instead
                     type: boolean
                   enableCommonBootImageImport:
                     description: 'Deprecated: This field is ignored. Use spec.enableCommonBootImageImport

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/hco00.crd.yaml
@@ -58,11 +58,11 @@ spec:
                   renewBefore: 12h0m0s
               deployKubeSecondaryDNS: false
               deployVmConsoleProxy: false
+              enableApplicationAwareQuota: false
               enableCommonBootImageImport: true
               featureGates:
                 disableMDevConfiguration: false
                 downwardMetrics: false
-                enableApplicationAwareQuota: false
                 persistentReservation: false
               liveMigrationConfig:
                 allowAutoConverge: false
@@ -1023,6 +1023,11 @@ spec:
                 default: false
                 description: deploy VM console proxy resources in SSP operator
                 type: boolean
+              enableApplicationAwareQuota:
+                default: false
+                description: EnableApplicationAwareQuota if true, enables the Application
+                  Aware Quota feature
+                type: boolean
               enableCommonBootImageImport:
                 default: true
                 description: |-
@@ -1052,7 +1057,6 @@ spec:
                 default:
                   disableMDevConfiguration: false
                   downwardMetrics: false
-                  enableApplicationAwareQuota: false
                   persistentReservation: false
                 description: |-
                   featureGates is a map of feature gate flags. Setting a flag to `true` will enable
@@ -1097,9 +1101,9 @@ spec:
                       guests.
                     type: boolean
                   enableApplicationAwareQuota:
-                    default: false
-                    description: EnableApplicationAwareQuota if true, enables the
-                      Application Aware Quota feature
+                    description: |-
+                      Deprecated: This field is ignored and will be removed on the next version of the API.
+                      Use spec.enableApplicationAwareQuota instead
                     type: boolean
                   enableCommonBootImageImport:
                     description: 'Deprecated: This field is ignored. Use spec.enableCommonBootImageImport

--- a/docs/api.md
+++ b/docs/api.md
@@ -120,7 +120,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}},"featureGates": {"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false, "enableApplicationAwareQuota": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist", "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "enableCommonBootImageImport": true, "deployVmConsoleProxy": false, "deployKubeSecondaryDNS": false} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}},"featureGates": {"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist", "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "enableApplicationAwareQuota": false, "enableCommonBootImageImport": true, "deployVmConsoleProxy": false, "deployKubeSecondaryDNS": false} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -165,7 +165,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | enableManagedTenantQuota | Deprecated: This field is ignored and will be removed on the next version of the API. | *bool |  | false |
 | autoResourceLimits | Deprecated: this field is ignored and will be removed in the next version of the API. | *bool |  | false |
 | alignCPUs | Enable KubeVirt to request up to two additional dedicated CPUs in order to complete the total CPU count to an even parity when using emulator thread isolation. Note: this feature is in Developer Preview. | *bool | false | false |
-| enableApplicationAwareQuota | EnableApplicationAwareQuota if true, enables the Application Aware Quota feature | *bool | false | false |
+| enableApplicationAwareQuota | Deprecated: This field is ignored and will be removed on the next version of the API. Use spec.enableApplicationAwareQuota instead | *bool |  | false |
 | primaryUserDefinedNetworkBinding | primaryUserDefinedNetworkBinding deploys the needed configurations for kubevirt users to be able to bind their VM to a UDN network on the VM's primary interface. Deprecated: this field is ignored and will be removed in the next version of the API. | *bool |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -202,7 +202,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | tuningPolicy | TuningPolicy allows to configure the mode in which the RateLimits of kubevirt are set. If TuningPolicy is not present the default kubevirt values are used. It can be set to `annotation` for fine-tuning the kubevirt queryPerSeconds (qps) and burst values. Qps and burst values are taken from the annotation hco.kubevirt.io/tuningPolicy | HyperConvergedTuningPolicy |  | false |
 | infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarily directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
 | workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
-| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false, "enableApplicationAwareQuota": false} | false |
+| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false} | false |
 | liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false} | false |
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
 | mediatedDevicesConfiguration | MediatedDevicesConfiguration holds information about MDEV types to be defined on nodes, if available | *[MediatedDevicesConfiguration](#mediateddevicesconfiguration) |  | false |
@@ -236,6 +236,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | instancetypeConfig | InstancetypeConfig holds the configuration of instance type related functionality within KubeVirt. | *v1.InstancetypeConfiguration |  | false |
 | deployVmConsoleProxy | deploy VM console proxy resources in SSP operator | *bool | false | false |
 | deployKubeSecondaryDNS | Deploy KubeSecondaryDNS by CNAO | *bool | false | false |
+| enableApplicationAwareQuota | EnableApplicationAwareQuota if true, enables the Application Aware Quota feature | *bool | false | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -173,13 +173,6 @@ to an even parity when using emulator thread isolation.
 
 **Default**: `false`
 
-### enableApplicationAwareQuota Feature Gate
-Set the `enableApplicationAwareQuota` feature gate to `true` to enable the [Application Aware Quota](https://github.com/kubevirt/application-aware-quota) feature 
-
-See [below](#configure-application-aware-quota-aaq) for Application Aware Quota configurations.
-
-**Default**: `false`
-
 ### Feature Gates Example
 
 ```yaml
@@ -1127,7 +1120,7 @@ With the `Custom` profile, the cipher list should be expressed according to Open
 On plain k8s, where APIServer CR is not available, the default value will be `Intermediate`.
 
 ## Configure Application Aware Quota (AAQ)
-To enable the AAQ feature, set the `spec.featureGates.enableApplicationAwareQuota` field to `true`. See [featureGates](#enableapplicationawarequota-feature-gate) above.
+To enable the AAQ feature, set the `spec.enableApplicationAwareQuota` field to `true`.
 
 To configure AAQ, set the fields of the `applicationAwareConfig` object in the HyperConverged resource's spec. The 
 `applicationAwareConfig` object contains several fields:
@@ -1154,6 +1147,7 @@ Pods that set `.spec.nodeName` are not allowed to use in any namespace that AAQ 
 ### Example
 ```yaml
 spec:
+  enableApplicationAwareQuota: true
   applicationAwareConfig:
     vmiCalcConfigName: "VmiPodUsage"
     namespaceSelector:
@@ -1166,6 +1160,7 @@ spec:
 It is also possible to target every namespace by defining an empty (non-nil) namespaceSelector as follows:
 ```yaml
 spec:
+  enableApplicationAwareQuota: true
   applicationAwareConfig:
     namespaceSelector: {}
 ```

--- a/pkg/upgradepatch/hc.cr.json
+++ b/pkg/upgradepatch/hc.cr.json
@@ -12,8 +12,7 @@
       "downwardMetrics": false,
       "disableMDevConfiguration": false,
       "persistentReservation": false,
-      "alignCPUs": false,
-      "enableApplicationAwareQuota": false
+      "alignCPUs": false
     },
     "liveMigrationConfig": {
       "parallelMigrationsPerCluster": 5,
@@ -50,7 +49,8 @@
     },
     "enableCommonBootImageImport": true,
     "deployVmConsoleProxy": false,
-    "deployKubeSecondaryDNS": false
+    "deployKubeSecondaryDNS": false,
+    "enableApplicationAwareQuota": false
   },
   "status": {}
 }

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -483,6 +483,11 @@ func (wh *WebhookHandler) validateDeprecatedFeatureGates(hc *v1beta1.HyperConver
 
 func validateOldFGOnCreate(warnings []string, hc *v1beta1.HyperConverged) []string {
 	//nolint:staticcheck
+	if hc.Spec.FeatureGates.EnableApplicationAwareQuota != nil {
+		warnings = append(warnings, fmt.Sprintf(fgMovedWarning, "enableApplicationAwareQuota"))
+	}
+
+	//nolint:staticcheck
 	if hc.Spec.FeatureGates.EnableCommonBootImageImport != nil {
 		warnings = append(warnings, fmt.Sprintf(fgMovedWarning, "enableCommonBootImageImport"))
 	}
@@ -501,6 +506,11 @@ func validateOldFGOnCreate(warnings []string, hc *v1beta1.HyperConverged) []stri
 }
 
 func validateOldFGOnUpdate(warnings []string, hc, prevHC *v1beta1.HyperConverged) []string {
+	//nolint:staticcheck
+	if oldFGChanged(hc.Spec.FeatureGates.EnableApplicationAwareQuota, prevHC.Spec.FeatureGates.EnableApplicationAwareQuota) {
+		warnings = append(warnings, fmt.Sprintf(fgMovedWarning, "enableApplicationAwareQuota"))
+	}
+
 	//nolint:staticcheck
 	if oldFGChanged(hc.Spec.FeatureGates.EnableCommonBootImageImport, prevHC.Spec.FeatureGates.EnableCommonBootImageImport) {
 		warnings = append(warnings, fmt.Sprintf(fgMovedWarning, "enableCommonBootImageImport"))

--- a/tests/func-tests/aaq_test.go
+++ b/tests/func-tests/aaq_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	setAAQFGPatchTemplate = `[{"op": "replace", "path": "/spec/featureGates/enableApplicationAwareQuota", "value": %t}]`
+	setAAQFGPatchTemplate = `[{"op": "replace", "path": "/spec/enableApplicationAwareQuota", "value": %t}]`
 )
 
 var _ = Describe("Test AAQ", Label("AAQ"), Serial, Ordered, func() {

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -66,11 +66,10 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 	Context("feature gate defaults", func() {
 		defaultFeatureGates := v1beta1.HyperConvergedFeatureGates{
-			DownwardMetrics:             ptr.To(false),
-			DisableMDevConfiguration:    ptr.To(false),
-			PersistentReservation:       ptr.To(false),
-			AlignCPUs:                   ptr.To(false),
-			EnableApplicationAwareQuota: ptr.To(false),
+			DownwardMetrics:          ptr.To(false),
+			DisableMDevConfiguration: ptr.To(false),
+			PersistentReservation:    ptr.To(false),
+			AlignCPUs:                ptr.To(false),
 		}
 
 		DescribeTable("Check that featureGates defaults are behaving as expected", func(ctx context.Context, path string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This field is actually an enabler and not a feature gate. Calling it "feature gate" made confusions, so this PR deprecates it, and creates the new `spec.enableApplicationAwareQuota` field instead.

The old FG is now ignored.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-51995
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecate the enableApplicationAwareQuota feature gate
Create the new spec.enableApplicationAwareQuota field
```
