### PR TITLE
Revert: default Eviction Strategy to None on ARM64 clusters

### DIFF
--- a/pkg/webhooks/mutator/hyperConvergedMutator.go
+++ b/pkg/webhooks/mutator/hyperConvergedMutator.go
@@ -7,7 +7,6 @@ import (
 
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -54,7 +53,7 @@ const (
 	dictAnnotationPathTemplate = annotationPathTemplate + "/cdi.kubevirt.io~1storage.bind.immediate.requested"
 )
 
-func (hcm *HyperConvergedMutator) mutateHyperConverged(ctx context.Context, req admission.Request) admission.Response {
+func (hcm *HyperConvergedMutator) mutateHyperConverged(_ context.Context, req admission.Request) admission.Response {
 	hc := &hcov1beta1.HyperConverged{}
 	err := hcm.decoder.Decode(req, hc)
 	if err != nil {
@@ -79,7 +78,7 @@ func (hcm *HyperConvergedMutator) mutateHyperConverged(ctx context.Context, req 
 		}
 	}
 
-	patches = mutateEvictionStrategy(ctx, hcm.cli, hc, patches)
+	patches = mutateEvictionStrategy(hc, patches)
 
 	if hc.Spec.MediatedDevicesConfiguration != nil {
 		if len(hc.Spec.MediatedDevicesConfiguration.MediatedDevicesTypes) > 0 && len(hc.Spec.MediatedDevicesConfiguration.MediatedDeviceTypes) == 0 { //nolint SA1019
@@ -107,36 +106,20 @@ func (hcm *HyperConvergedMutator) mutateHyperConverged(ctx context.Context, req 
 	return admission.Allowed("")
 }
 
-func mutateEvictionStrategy(ctx context.Context, cli client.Client, hc *hcov1beta1.HyperConverged, patches []jsonpatch.JsonPatchOperation) []jsonpatch.JsonPatchOperation {
+func mutateEvictionStrategy(hc *hcov1beta1.HyperConverged, patches []jsonpatch.JsonPatchOperation) []jsonpatch.JsonPatchOperation {
 	if hc.Status.InfrastructureHighlyAvailable == nil || hc.Spec.EvictionStrategy != nil { // New HyperConverged CR
 		return patches
 	}
 
-	workerNodes := &corev1.NodeList{}
-	err := cli.List(ctx, workerNodes, client.MatchingLabels{"node-role.kubernetes.io/worker": ""})
-	if err != nil {
-		hcMutatorLogger.Error(err, "Failed to list worker nodes")
-		return patches
-	}
-
-	allArm64 := true
-	for _, node := range workerNodes.Items {
-		arch, found := node.Labels["kubernetes.io/arch"]
-		if !found || arch != "arm64" {
-			allArm64 = false
-			break
-		}
-	}
-
-	evictionStrategy := kubevirtcorev1.EvictionStrategyNone
-	if !allArm64 && hc.Status.InfrastructureHighlyAvailable != nil && *hc.Status.InfrastructureHighlyAvailable {
-		evictionStrategy = kubevirtcorev1.EvictionStrategyLiveMigrate
+	var value = kubevirtcorev1.EvictionStrategyNone
+	if *hc.Status.InfrastructureHighlyAvailable {
+		value = kubevirtcorev1.EvictionStrategyLiveMigrate
 	}
 
 	patches = append(patches, jsonpatch.JsonPatchOperation{
 		Operation: "replace",
 		Path:      "/spec/evictionStrategy",
-		Value:     evictionStrategy,
+		Value:     value,
 	})
 
 	return patches

--- a/pkg/webhooks/mutator/hyperConvergedMutator_test.go
+++ b/pkg/webhooks/mutator/hyperConvergedMutator_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gomodules.xyz/jsonpatch/v2"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -261,13 +260,10 @@ var _ = Describe("test HyperConverged mutator", func() {
 
 		Context("Check defaults for cluster level EvictionStrategy", func() {
 
-			DescribeTable("check EvictionStrategy default", func(SNO bool, strategy *kubevirtcorev1.EvictionStrategy, patches []jsonpatch.JsonPatchOperation, workerNodeArches []string) {
+			DescribeTable("check EvictionStrategy default", func(SNO bool, strategy *kubevirtcorev1.EvictionStrategy, patches []jsonpatch.JsonPatchOperation) {
 				cr.Status.InfrastructureHighlyAvailable = ptr.To(!SNO)
 
 				cr.Spec.EvictionStrategy = strategy
-
-				cli = commontestutils.InitClient(createFakeNodes(workerNodeArches))
-				mutator = initHCMutator(s, cli)
 
 				req := admission.Request{AdmissionRequest: newCreateRequest(cr, hcoV1beta1Codec)}
 
@@ -279,96 +275,50 @@ var _ = Describe("test HyperConverged mutator", func() {
 				Entry("should set EvictionStrategyNone if not set and on SNO",
 					true,
 					nil,
-					[]jsonpatch.JsonPatchOperation{{
+					[]jsonpatch.JsonPatchOperation{jsonpatch.JsonPatchOperation{
 						Operation: "replace",
 						Path:      "/spec/evictionStrategy",
 						Value:     kubevirtcorev1.EvictionStrategyNone,
 					}},
-					[]string{"amd64"},
 				),
 				Entry("should not override EvictionStrategy if set and on SNO - 1",
 					true,
 					ptr.To(kubevirtcorev1.EvictionStrategyNone),
 					nil,
-					[]string{"amd64"},
 				),
 				Entry("should not override EvictionStrategy if set and on SNO - 2",
 					true,
 					ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrate),
 					nil,
-					[]string{"amd64"},
 				),
 				Entry("should not override EvictionStrategy if set and on SNO - 3",
 					true,
 					ptr.To(kubevirtcorev1.EvictionStrategyExternal),
 					nil,
-					[]string{"amd64"},
 				),
 				Entry("should set EvictionStrategyLiveMigrate if not set and not on SNO",
 					false,
 					nil,
-					[]jsonpatch.JsonPatchOperation{{
+					[]jsonpatch.JsonPatchOperation{jsonpatch.JsonPatchOperation{
 						Operation: "replace",
 						Path:      "/spec/evictionStrategy",
 						Value:     kubevirtcorev1.EvictionStrategyLiveMigrate,
 					}},
-					[]string{"amd64", "amd64"},
 				),
 				Entry("should not override EvictionStrategy if set and not on SNO - 1",
 					false,
 					ptr.To(kubevirtcorev1.EvictionStrategyNone),
 					nil,
-					[]string{"amd64", "amd64"},
 				),
 				Entry("should not override EvictionStrategy if set and not on SNO - 2",
 					false,
 					ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrate),
 					nil,
-					[]string{"amd64", "amd64"},
 				),
 				Entry("should not override EvictionStrategy if set and not on SNO - 3",
 					false,
 					ptr.To(kubevirtcorev1.EvictionStrategyExternal),
 					nil,
-					[]string{"amd64", "amd64"},
-				),
-				Entry("should set EvictionStrategyNone if not set and all ARM64 nodes",
-					false,
-					nil,
-					[]jsonpatch.JsonPatchOperation{{
-						Operation: "replace",
-						Path:      "/spec/evictionStrategy",
-						Value:     kubevirtcorev1.EvictionStrategyNone,
-					}},
-					[]string{"arm64", "arm64"},
-				),
-				Entry("should not override EvictionStrategy if set and all ARM64 nodes",
-					false,
-					ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrate),
-					nil,
-					[]string{"arm64", "arm64"},
-				),
-				Entry("should not override EvictionStrategy if set and all ARM64 nodes",
-					false,
-					ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrate),
-					nil,
-					[]string{"arm64", "arm64"},
-				),
-				Entry("should set LiveMigrate if not set, not SNO, mixed ARM64/AMD64",
-					false,
-					nil,
-					[]jsonpatch.JsonPatchOperation{{
-						Operation: "replace",
-						Path:      "/spec/evictionStrategy",
-						Value:     kubevirtcorev1.EvictionStrategyLiveMigrate,
-					}},
-					[]string{"arm64", "amd64"},
-				),
-				Entry("should not override if set, not SNO, mixed ARM64/AMD64",
-					false,
-					ptr.To(kubevirtcorev1.EvictionStrategyNone),
-					nil,
-					[]string{"arm64", "amd64"},
 				),
 			)
 		})
@@ -504,21 +454,4 @@ func initHCMutator(s *runtime.Scheme, testClient client.Client) *HyperConvergedM
 	mutator := NewHyperConvergedMutator(testClient, decoder)
 
 	return mutator
-}
-
-func createFakeNodes(architectures []string) []client.Object {
-	var nodes []client.Object
-	for i, arch := range architectures {
-		node := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("node-%d", i),
-				Labels: map[string]string{
-					"node-role.kubernetes.io/worker": "",
-					"kubernetes.io/arch":             arch,
-				},
-			},
-		}
-		nodes = append(nodes, node)
-	}
-	return nodes
 }


### PR DESCRIPTION
This reverts commit a878f63e65ea046a3d07dbdf58f88bdcd02b55ee.

It's been decided to keep the `EvictionStrategy` default to `LiveMigrate` for now, as long as we document that it's not fully supported for arm clusters at the moment.

**Release note**:
```release-note
None
```
