### PR TITLE
Bump kubevirtci dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,6 @@ dump-state:
 	./hack/dump-state.sh 
 
 bump-kubevirtci:
-	rm -rf _kubevirtci
 	./hack/bump-kubevirtci.sh
 
 gogenerate:
@@ -337,6 +336,7 @@ bump-hco:
 		sanity \
 		goimport \
 		bump-hco \
+		bump-kubevirtci \
 		build-push-multi-arch-operator-image \
 		build-push-multi-arch-webhook-image \
 		build-push-multi-arch-functest-image \

--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -112,7 +112,7 @@ OLM_VERSION=$(curl https://api.github.com/repos/operator-framework/operator-life
 export KUBEVIRT_PROVIDER=k8s-1.32
 export KUBEVIRT_MEMORY_SIZE=12G
 export KUBEVIRT_NUM_NODES=4
-# export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+# auto updated by hack/bump-kubevirtci.sh
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-"2504171552-a558e3fe"}
 make cluster-up
 

--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -106,22 +106,21 @@ sdk_url=$(curl https://api.github.com/repos/operator-framework/operator-sdk/rele
 wget $sdk_url -O operator-sdk
 chmod +x operator-sdk
 
+OLM_VERSION=$(curl https://api.github.com/repos/operator-framework/operator-lifecycle-manager/releases/latest | jq -r .name)
+
 # start K8s cluster
-export KUBEVIRT_PROVIDER=k8s-1.31
+export KUBEVIRT_PROVIDER=k8s-1.32
 export KUBEVIRT_MEMORY_SIZE=12G
 export KUBEVIRT_NUM_NODES=4
+# export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-"2504171552-a558e3fe"}
 make cluster-up
 
 export KUBECONFIG=$(_kubevirtci/cluster-up/kubeconfig.sh)
-
-# export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
-export KUBEVIRTCI_TAG=2412041602-733e595f
 export KUBECTL=$(pwd)/_kubevirtci/cluster-up/kubectl.sh
 
 # install OLM on the cluster
-# latest OLM, v0.29.0 is broken. Forcing a working OLM version
-# TODO: drop the --version command line parameter when https://github.com/operator-framework/operator-lifecycle-manager/issues/3419 is resolved.
-./operator-sdk olm install --version=v0.28.0
+./operator-sdk olm install --version "${OLM_VERSION}"
 
 # Deploy cert-manager for webhooks
 $KUBECTL apply -f deploy/cert-manager.yaml

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.32'}
-# export LATEST_KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
-# export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-${LATEST_KUBEVIRTCI_TAG}}
+# auto updated by hack/bump-kubevirtci.sh
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-"2504171552-a558e3fe"}
 
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.31'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.32'}
 # export LATEST_KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
 # export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-${LATEST_KUBEVIRTCI_TAG}}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2412041602-733e595f}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-"2504171552-a558e3fe"}
 
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'

--- a/hack/bump-kubevirtci.sh
+++ b/hack/bump-kubevirtci.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ex
+
+KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+
+for file in cluster/kubevirtci.sh automation/nightly/test-nightly-build.sh; do
+  if ! grep '^export KUBEVIRTCI_TAG=' "${file}" | grep "${KUBEVIRTCI_TAG}"; then
+    sed -i -E "s|(^export KUBEVIRTCI_TAG=).*$|\1\${KUBEVIRTCI_TAG:-\"$KUBEVIRTCI_TAG\"}|g" ${file}
+  fi
+done
+


### PR DESCRIPTION
`KUBEVIRT_PROVIDER` ==> k8s-1.32
`KUBEVIRTCI_TAG` ==> 2504171552-a558e3fe

In the nightly build test: `OLM` ==> latest

Add a script to automatically update `KUBEVIRTCI_TAG` to the latest tag.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
