### PR TITLE
[Release 1.15] Revert moving deployKubeSecondaryDNS FG to a regular field

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -66,7 +66,7 @@ type HyperConvergedSpec struct {
 
 	// featureGates is a map of feature gate flags. Setting a flag to `true` will enable
 	// the feature. Setting `false` or removing the feature gate, disables the feature.
-	// +kubebuilder:default={"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false}
+	// +kubebuilder:default={"downwardMetrics": false, "deployKubeSecondaryDNS": false, "disableMDevConfiguration": false, "persistentReservation": false}
 	// +optional
 	FeatureGates HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
@@ -267,12 +267,6 @@ type HyperConvergedSpec struct {
 	// +default=false
 	DeployVMConsoleProxy *bool `json:"deployVmConsoleProxy,omitempty"`
 
-	// Deploy KubeSecondaryDNS by CNAO
-	// +optional
-	// +kubebuilder:default=false
-	// +default=false
-	DeployKubeSecondaryDNS *bool `json:"deployKubeSecondaryDNS,omitempty"`
-
 	// EnableApplicationAwareQuota if true, enables the Application Aware Quota feature
 	// +optional
 	// +kubebuilder:default=false
@@ -451,8 +445,10 @@ type HyperConvergedFeatureGates struct {
 	// Use spec.deployVmConsoleProxy instead
 	DeployVMConsoleProxy *bool `json:"deployVmConsoleProxy,omitempty"`
 
-	// Deprecated: This field is ignored and will be removed on the next version of the API.
-	// Use spec.deployKubeSecondaryDNS instead
+	// Deploy KubeSecondaryDNS by CNAO
+	// +optional
+	// +kubebuilder:default=false
+	// +default=false
 	DeployKubeSecondaryDNS *bool `json:"deployKubeSecondaryDNS,omitempty"`
 
 	// Deprecated: this field is ignored and will be removed in the next version of the API.
@@ -861,7 +857,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}},"featureGates": {"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist", "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "enableApplicationAwareQuota": false, "enableCommonBootImageImport": true, "deployVmConsoleProxy": false, "deployKubeSecondaryDNS": false}
+	// +kubebuilder:default={"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}},"featureGates": {"downwardMetrics": false, "deployKubeSecondaryDNS": false, "disableMDevConfiguration": false, "persistentReservation": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist", "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "enableApplicationAwareQuota": false, "enableCommonBootImageImport": true, "deployVmConsoleProxy": false}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -553,11 +553,6 @@ func (in *HyperConvergedSpec) DeepCopyInto(out *HyperConvergedSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.DeployKubeSecondaryDNS != nil {
-		in, out := &in.DeployKubeSecondaryDNS, &out.DeployKubeSecondaryDNS
-		*out = new(bool)
-		**out = **in
-	}
 	if in.EnableApplicationAwareQuota != nil {
 		in, out := &in.EnableApplicationAwareQuota, &out.EnableApplicationAwareQuota
 		*out = new(bool)

--- a/api/v1beta1/zz_generated.defaults.go
+++ b/api/v1beta1/zz_generated.defaults.go
@@ -44,6 +44,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.FeatureGates.DownwardMetrics = &ptrVar1
 	}
+	if in.Spec.FeatureGates.DeployKubeSecondaryDNS == nil {
+		var ptrVar1 bool = false
+		in.Spec.FeatureGates.DeployKubeSecondaryDNS = &ptrVar1
+	}
 	if in.Spec.FeatureGates.DisableMDevConfiguration == nil {
 		var ptrVar1 bool = false
 		in.Spec.FeatureGates.DisableMDevConfiguration = &ptrVar1
@@ -155,10 +159,6 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 	if in.Spec.DeployVMConsoleProxy == nil {
 		var ptrVar1 bool = false
 		in.Spec.DeployVMConsoleProxy = &ptrVar1
-	}
-	if in.Spec.DeployKubeSecondaryDNS == nil {
-		var ptrVar1 bool = false
-		in.Spec.DeployKubeSecondaryDNS = &ptrVar1
 	}
 	if in.Spec.EnableApplicationAwareQuota == nil {
 		var ptrVar1 bool = false

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -269,7 +269,8 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedF
 					},
 					"deployKubeSecondaryDNS": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated: This field is ignored and will be removed on the next version of the API. Use spec.deployKubeSecondaryDNS instead",
+							Description: "Deploy KubeSecondaryDNS by CNAO",
+							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -665,14 +666,6 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 					"deployVmConsoleProxy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "deploy VM console proxy resources in SSP operator",
-							Default:     false,
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
-					"deployKubeSecondaryDNS": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Deploy KubeSecondaryDNS by CNAO",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",

--- a/assets/upgradePatches.json
+++ b/assets/upgradePatches.json
@@ -133,24 +133,6 @@
       "semverRange": "<1.15.0",
       "jsonPatch": [
         {
-          "op": "test",
-          "path": "/spec/featureGates/deployKubeSecondaryDNS",
-          "value": true
-        },
-        {
-          "op": "move",
-          "from": "/spec/featureGates/deployKubeSecondaryDNS",
-          "path": "/spec/deployKubeSecondaryDNS"
-        }
-      ],
-      "jsonPatchApplyOptions": {
-        "allowMissingPathOnRemove": true
-      }
-    },
-    {
-      "semverRange": "<1.15.0",
-      "jsonPatch": [
-        {
           "op": "remove",
           "path": "/spec/featureGates/enableCommonBootImageImport"
         },
@@ -161,10 +143,6 @@
         {
           "op": "remove",
           "path": "/spec/featureGates/enableApplicationAwareQuota"
-        },
-        {
-          "op": "remove",
-          "path": "/spec/featureGates/deployKubeSecondaryDNS"
         }
       ],
       "jsonPatchApplyOptions": {

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -56,11 +56,11 @@ spec:
                 server:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
-              deployKubeSecondaryDNS: false
               deployVmConsoleProxy: false
               enableApplicationAwareQuota: false
               enableCommonBootImageImport: true
               featureGates:
+                deployKubeSecondaryDNS: false
                 disableMDevConfiguration: false
                 downwardMetrics: false
                 persistentReservation: false
@@ -1025,10 +1025,6 @@ spec:
                   Default RuntimeClass can be changed when kubevirt is running, existing VMIs are not impacted till
                   the next restart/live-migration when they are eventually going to consume the new default RuntimeClass.
                 type: string
-              deployKubeSecondaryDNS:
-                default: false
-                description: Deploy KubeSecondaryDNS by CNAO
-                type: boolean
               deployVmConsoleProxy:
                 default: false
                 description: deploy VM console proxy resources in SSP operator
@@ -1065,6 +1061,7 @@ spec:
                 type: string
               featureGates:
                 default:
+                  deployKubeSecondaryDNS: false
                   disableMDevConfiguration: false
                   downwardMetrics: false
                   persistentReservation: false
@@ -1084,9 +1081,8 @@ spec:
                       in the next version of the API.'
                     type: boolean
                   deployKubeSecondaryDNS:
-                    description: |-
-                      Deprecated: This field is ignored and will be removed on the next version of the API.
-                      Use spec.deployKubeSecondaryDNS instead
+                    default: false
+                    description: Deploy KubeSecondaryDNS by CNAO
                     type: boolean
                   deployKubevirtIpamController:
                     description: 'Deprecated: this field is ignored and will be removed

--- a/controllers/operands/networkAddons.go
+++ b/controllers/operands/networkAddons.go
@@ -158,7 +158,7 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged, opts ...string) (*networkad
 		return nil, err
 	}
 
-	if hc.Spec.DeployKubeSecondaryDNS != nil && *hc.Spec.DeployKubeSecondaryDNS {
+	if hc.Spec.FeatureGates.DeployKubeSecondaryDNS != nil && *hc.Spec.FeatureGates.DeployKubeSecondaryDNS {
 		baseDomain := util.GetClusterInfo().GetBaseDomain()
 		cnaoSpec.KubeSecondaryDNS = &networkaddonsshared.KubeSecondaryDNS{
 			Domain:       baseDomain,

--- a/controllers/operands/networkAddons_test.go
+++ b/controllers/operands/networkAddons_test.go
@@ -605,7 +605,7 @@ var _ = Describe("CNA Operand", func() {
 
 			const kubeSecondaryDNSNameServerIP = "127.0.0.1"
 			if o.setFeatureGate {
-				hco.Spec.DeployKubeSecondaryDNS = ptr.To(o.featureGateValue)
+				hco.Spec.FeatureGates.DeployKubeSecondaryDNS = ptr.To(o.featureGateValue)
 				hco.Spec.KubeSecondaryDNSNameServerIP = ptr.To(kubeSecondaryDNSNameServerIP)
 			}
 

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -56,11 +56,11 @@ spec:
                 server:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
-              deployKubeSecondaryDNS: false
               deployVmConsoleProxy: false
               enableApplicationAwareQuota: false
               enableCommonBootImageImport: true
               featureGates:
+                deployKubeSecondaryDNS: false
                 disableMDevConfiguration: false
                 downwardMetrics: false
                 persistentReservation: false
@@ -1025,10 +1025,6 @@ spec:
                   Default RuntimeClass can be changed when kubevirt is running, existing VMIs are not impacted till
                   the next restart/live-migration when they are eventually going to consume the new default RuntimeClass.
                 type: string
-              deployKubeSecondaryDNS:
-                default: false
-                description: Deploy KubeSecondaryDNS by CNAO
-                type: boolean
               deployVmConsoleProxy:
                 default: false
                 description: deploy VM console proxy resources in SSP operator
@@ -1065,6 +1061,7 @@ spec:
                 type: string
               featureGates:
                 default:
+                  deployKubeSecondaryDNS: false
                   disableMDevConfiguration: false
                   downwardMetrics: false
                   persistentReservation: false
@@ -1084,9 +1081,8 @@ spec:
                       in the next version of the API.'
                     type: boolean
                   deployKubeSecondaryDNS:
-                    description: |-
-                      Deprecated: This field is ignored and will be removed on the next version of the API.
-                      Use spec.deployKubeSecondaryDNS instead
+                    default: false
+                    description: Deploy KubeSecondaryDNS by CNAO
                     type: boolean
                   deployKubevirtIpamController:
                     description: 'Deprecated: this field is ignored and will be removed

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -11,12 +11,12 @@ spec:
     server:
       duration: 24h0m0s
       renewBefore: 12h0m0s
-  deployKubeSecondaryDNS: false
   deployVmConsoleProxy: false
   enableApplicationAwareQuota: false
   enableCommonBootImageImport: true
   featureGates:
     alignCPUs: false
+    deployKubeSecondaryDNS: false
     disableMDevConfiguration: false
     downwardMetrics: false
     persistentReservation: false

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.15.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.15.0/manifests/hco00.crd.yaml
@@ -56,11 +56,11 @@ spec:
                 server:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
-              deployKubeSecondaryDNS: false
               deployVmConsoleProxy: false
               enableApplicationAwareQuota: false
               enableCommonBootImageImport: true
               featureGates:
+                deployKubeSecondaryDNS: false
                 disableMDevConfiguration: false
                 downwardMetrics: false
                 persistentReservation: false
@@ -1025,10 +1025,6 @@ spec:
                   Default RuntimeClass can be changed when kubevirt is running, existing VMIs are not impacted till
                   the next restart/live-migration when they are eventually going to consume the new default RuntimeClass.
                 type: string
-              deployKubeSecondaryDNS:
-                default: false
-                description: Deploy KubeSecondaryDNS by CNAO
-                type: boolean
               deployVmConsoleProxy:
                 default: false
                 description: deploy VM console proxy resources in SSP operator
@@ -1065,6 +1061,7 @@ spec:
                 type: string
               featureGates:
                 default:
+                  deployKubeSecondaryDNS: false
                   disableMDevConfiguration: false
                   downwardMetrics: false
                   persistentReservation: false
@@ -1084,9 +1081,8 @@ spec:
                       in the next version of the API.'
                     type: boolean
                   deployKubeSecondaryDNS:
-                    description: |-
-                      Deprecated: This field is ignored and will be removed on the next version of the API.
-                      Use spec.deployKubeSecondaryDNS instead
+                    default: false
+                    description: Deploy KubeSecondaryDNS by CNAO
                     type: boolean
                   deployKubevirtIpamController:
                     description: 'Deprecated: this field is ignored and will be removed

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/hco00.crd.yaml
@@ -56,11 +56,11 @@ spec:
                 server:
                   duration: 24h0m0s
                   renewBefore: 12h0m0s
-              deployKubeSecondaryDNS: false
               deployVmConsoleProxy: false
               enableApplicationAwareQuota: false
               enableCommonBootImageImport: true
               featureGates:
+                deployKubeSecondaryDNS: false
                 disableMDevConfiguration: false
                 downwardMetrics: false
                 persistentReservation: false
@@ -1025,10 +1025,6 @@ spec:
                   Default RuntimeClass can be changed when kubevirt is running, existing VMIs are not impacted till
                   the next restart/live-migration when they are eventually going to consume the new default RuntimeClass.
                 type: string
-              deployKubeSecondaryDNS:
-                default: false
-                description: Deploy KubeSecondaryDNS by CNAO
-                type: boolean
               deployVmConsoleProxy:
                 default: false
                 description: deploy VM console proxy resources in SSP operator
@@ -1065,6 +1061,7 @@ spec:
                 type: string
               featureGates:
                 default:
+                  deployKubeSecondaryDNS: false
                   disableMDevConfiguration: false
                   downwardMetrics: false
                   persistentReservation: false
@@ -1084,9 +1081,8 @@ spec:
                       in the next version of the API.'
                     type: boolean
                   deployKubeSecondaryDNS:
-                    description: |-
-                      Deprecated: This field is ignored and will be removed on the next version of the API.
-                      Use spec.deployKubeSecondaryDNS instead
+                    default: false
+                    description: Deploy KubeSecondaryDNS by CNAO
                     type: boolean
                   deployKubevirtIpamController:
                     description: 'Deprecated: this field is ignored and will be removed

--- a/docs/api.md
+++ b/docs/api.md
@@ -120,7 +120,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}},"featureGates": {"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist", "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "enableApplicationAwareQuota": false, "enableCommonBootImageImport": true, "deployVmConsoleProxy": false, "deployKubeSecondaryDNS": false} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}},"featureGates": {"downwardMetrics": false, "deployKubeSecondaryDNS": false, "disableMDevConfiguration": false, "persistentReservation": false}, "liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "resourceRequirements": {"vmiCPUAllocationRatio": 10}, "uninstallStrategy": "BlockUninstallIfWorkloadsExist", "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "enableApplicationAwareQuota": false, "enableCommonBootImageImport": true, "deployVmConsoleProxy": false} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -157,7 +157,7 @@ HyperConvergedFeatureGates is a set of optional feature gates to enable or disab
 | enableCommonBootImageImport | Deprecated: This field is ignored. Use spec.enableCommonBootImageImport instead | *bool |  | false |
 | deployTektonTaskResources | Deprecated: This field is ignored and will be removed on the next version of the API. | *bool |  | false |
 | deployVmConsoleProxy | Deprecated: This field is ignored and will be removed on the next version of the API. Use spec.deployVmConsoleProxy instead | *bool |  | false |
-| deployKubeSecondaryDNS | Deprecated: This field is ignored and will be removed on the next version of the API. Use spec.deployKubeSecondaryDNS instead | *bool |  | false |
+| deployKubeSecondaryDNS | Deploy KubeSecondaryDNS by CNAO | *bool | false | false |
 | deployKubevirtIpamController | Deprecated: this field is ignored and will be removed in the next version of the API. | *bool |  | false |
 | nonRoot | Deprecated: // Deprecated: This field is ignored and will be removed on the next version of the API. | *bool |  | false |
 | disableMDevConfiguration | Disable mediated devices handling on KubeVirt | *bool | false | false |
@@ -202,7 +202,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | tuningPolicy | TuningPolicy allows to configure the mode in which the RateLimits of kubevirt are set. If TuningPolicy is not present the default kubevirt values are used. It can be set to `annotation` for fine-tuning the kubevirt queryPerSeconds (qps) and burst values. Qps and burst values are taken from the annotation hco.kubevirt.io/tuningPolicy | HyperConvergedTuningPolicy |  | false |
 | infra | infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarily directly on each node running VMs/VMIs. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
 | workloads | workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload. | [HyperConvergedConfig](#hyperconvergedconfig) |  | false |
-| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"downwardMetrics": false, "disableMDevConfiguration": false, "persistentReservation": false} | false |
+| featureGates | featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature. | [HyperConvergedFeatureGates](#hyperconvergedfeaturegates) | {"downwardMetrics": false, "deployKubeSecondaryDNS": false, "disableMDevConfiguration": false, "persistentReservation": false} | false |
 | liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false} | false |
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
 | mediatedDevicesConfiguration | MediatedDevicesConfiguration holds information about MDEV types to be defined on nodes, if available | *[MediatedDevicesConfiguration](#mediateddevicesconfiguration) |  | false |
@@ -236,7 +236,6 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | instancetypeConfig | InstancetypeConfig holds the configuration of instance type related functionality within KubeVirt. | *v1.InstancetypeConfiguration |  | false |
 | CommonInstancetypesDeployment | CommonInstancetypesDeployment holds the configuration of common-instancetypes deployment within KubeVirt. | *v1.CommonInstancetypesDeployment |  | false |
 | deployVmConsoleProxy | deploy VM console proxy resources in SSP operator | *bool | false | false |
-| deployKubeSecondaryDNS | Deploy KubeSecondaryDNS by CNAO | *bool | false | false |
 | enableApplicationAwareQuota | EnableApplicationAwareQuota if true, enables the Application Aware Quota feature | *bool | false | false |
 
 [Back to TOC](#table-of-contents)

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -144,6 +144,12 @@ virtual machine.
 ### withHostPassthroughCPU Feature Gate
 This feature gate is deprecated and is ignored.
 
+### deployKubeSecondaryDNS Feature Gate
+Set the `deployKubeSecondaryDNS` feature gate to true to allow deploying KubeSecondaryDNS by CNAO.
+For additional information, see here: [KubeSecondaryDNS](https://github.com/kubevirt/kubesecondarydns)
+
+**Default**: `false`
+
 ### persistentReservation Feature Gate
 Set the `persistentReservation` feature gate to true in order to enable the reservation of a LUN through the SCSI Persistent Reserve commands.
 
@@ -185,6 +191,7 @@ spec:
   workloads: {}
   featureGates:
     alignCPUs: true
+    deployKubeSecondaryDNS: true
 ```
 
 ## Live Migration Configurations
@@ -740,10 +747,7 @@ Set the `spec.deployKubeSecondaryDNS` field gate to `true` to allow deploying Ku
 
 In order to set KSD's NameServerIP, set it on HyperConverged CR under spec.kubeSecondaryDNSNameServerIP field.
 Default: empty string. Value is a string representation of IPv4 (i.e "127.0.0.1").
-
-For additional information, see here: [KubeSecondaryDNS](https://github.com/kubevirt/kubesecondarydns)
-
-**Default**: `false`
+For more info see [deployKubeSecondaryDNS Feature Gate](#deploykubesecondarydns-feature-gate).
 
 ### KubeSecondaryDNS Name Server IP example
 ```yaml
@@ -752,7 +756,6 @@ kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
 spec:
-  deployKubeSecondaryDNS: true
   kubeSecondaryDNSNameServerIP: "127.0.0.1"
 ```
 

--- a/pkg/upgradepatch/hc.cr.json
+++ b/pkg/upgradepatch/hc.cr.json
@@ -10,6 +10,7 @@
     "workloads": {},
     "featureGates": {
       "downwardMetrics": false,
+      "deployKubeSecondaryDNS": false,
       "disableMDevConfiguration": false,
       "persistentReservation": false,
       "alignCPUs": false
@@ -49,7 +50,6 @@
     },
     "enableCommonBootImageImport": true,
     "deployVmConsoleProxy": false,
-    "deployKubeSecondaryDNS": false,
     "enableApplicationAwareQuota": false
   },
   "status": {}

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -497,11 +497,6 @@ func validateOldFGOnCreate(warnings []string, hc *v1beta1.HyperConverged) []stri
 		warnings = append(warnings, fmt.Sprintf(fgMovedWarning, "deployVmConsoleProxy"))
 	}
 
-	//nolint:staticcheck
-	if hc.Spec.FeatureGates.DeployKubeSecondaryDNS != nil {
-		warnings = append(warnings, fmt.Sprintf(fgMovedWarning, "deployKubeSecondaryDNS"))
-	}
-
 	return warnings
 }
 
@@ -519,11 +514,6 @@ func validateOldFGOnUpdate(warnings []string, hc, prevHC *v1beta1.HyperConverged
 	//nolint:staticcheck
 	if oldFGChanged(hc.Spec.FeatureGates.DeployVMConsoleProxy, prevHC.Spec.FeatureGates.DeployVMConsoleProxy) {
 		warnings = append(warnings, fmt.Sprintf(fgMovedWarning, "deployVmConsoleProxy"))
-	}
-
-	//nolint:staticcheck
-	if oldFGChanged(hc.Spec.FeatureGates.DeployKubeSecondaryDNS, prevHC.Spec.FeatureGates.DeployKubeSecondaryDNS) {
-		warnings = append(warnings, fmt.Sprintf(fgMovedWarning, "deployKubeSecondaryDNS"))
 	}
 
 	return warnings

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -517,7 +517,7 @@ var _ = Describe("webhooks validator", func() {
 						EnableManagedTenantQuota:    ptr.To(false),
 						DeployVMConsoleProxy:        ptr.To(false),
 						DeployKubeSecondaryDNS:      ptr.To(false),
-					}, "enableManagedTenantQuota", "nonRoot", "enableApplicationAwareQuota", "enableCommonBootImageImport", "deployVmConsoleProxy", "deployKubeSecondaryDNS"),
+					}, "enableManagedTenantQuota", "nonRoot", "enableApplicationAwareQuota", "enableCommonBootImageImport", "deployVmConsoleProxy"),
 			)
 		})
 	})
@@ -1298,27 +1298,6 @@ var _ = Describe("webhooks validator", func() {
 				Entry("should not trigger warning if deployVmConsoleProxy (false) disappeared", ptr.To(false), nil),
 				Entry("should not trigger warning if deployVmConsoleProxy (true) wasn't changed", ptr.To(true), ptr.To(true)),
 				Entry("should not trigger warning if deployVmConsoleProxy (false) wasn't changed", ptr.To(false), ptr.To(false)),
-			)
-
-			//nolint:staticcheck
-			DescribeTable("should return warning for deployKubeSecondaryDNS on update", func(newFG, oldFG *bool) {
-				newHCO := hco.DeepCopy()
-				hco.Spec.FeatureGates.DeployKubeSecondaryDNS = newFG
-				newHCO.Spec.FeatureGates.DeployKubeSecondaryDNS = oldFG
-
-				err := wh.ValidateUpdate(ctx, dryRun, newHCO, hco)
-
-				Expect(err).To(HaveOccurred())
-				expected := &ValidationWarning{}
-				Expect(errors.As(err, &expected)).To(BeTrue())
-
-				Expect(expected.warnings).To(HaveLen(1))
-				Expect(expected.warnings).To(ContainElements(ContainSubstring("deployKubeSecondaryDNS")))
-			},
-				Entry("should trigger warning if deployKubeSecondaryDNS appeared as true", nil, ptr.To(true)),
-				Entry("should trigger warning if deployKubeSecondaryDNS appeared as false", nil, ptr.To(false)),
-				Entry("should trigger warning if deployKubeSecondaryDNS has changed from true to false", ptr.To(true), ptr.To(false)),
-				Entry("should trigger warning if deployKubeSecondaryDNS has changed from false to true", ptr.To(false), ptr.To(true)),
 			)
 
 			//nolint:staticcheck

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 	Context("feature gate defaults", func() {
 		defaultFeatureGates := v1beta1.HyperConvergedFeatureGates{
 			DownwardMetrics:          ptr.To(false),
+			DeployKubeSecondaryDNS:   ptr.To(false),
 			DisableMDevConfiguration: ptr.To(false),
 			PersistentReservation:    ptr.To(false),
 			AlignCPUs:                ptr.To(false),
@@ -84,6 +85,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
 			Entry("when removing /spec/featureGates/downwardMetrics", "/spec/featureGates/downwardMetrics"),
+			Entry("when removing /spec/featureGates/deployKubeSecondaryDNS", "/spec/featureGates/deployKubeSecondaryDNS"),
 			Entry("when removing /spec/featureGates/persistentReservation", "/spec/featureGates/persistentReservation"),
 			Entry("when removing /spec/featureGates/alignCPUs", "/spec/featureGates/alignCPUs"),
 			Entry("when removing /spec/featureGates", "/spec/featureGates"),


### PR DESCRIPTION
**What this PR does / why we need it**:
The `deployKubeSecondaryDNS` feature gate was move by mitake to be be a regular field. This feature is not globally available yet, and should be protected by a feature gate.

This PR reverts #3372

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-60339
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Revert moving deployKubeSecondaryDNS FG to a regular field
```
