### PR TITLE
[CHORE] Drop workaround for TLSv1.3 ciphers

### DIFF
--- a/cmd/cmdcommon/cmdcommon.go
+++ b/cmd/cmdcommon/cmdcommon.go
@@ -179,31 +179,13 @@ func getOperatorNamespaceFromEnv() (string, error) {
 }
 
 func MutateTLSConfig(cfg *tls.Config) {
-	var ciphersTLS13 = map[string]uint16{
-		"TLS_AES_128_GCM_SHA256":       tls.TLS_AES_128_GCM_SHA256,
-		"TLS_AES_256_GCM_SHA384":       tls.TLS_AES_256_GCM_SHA384,
-		"TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
-	}
-
 	// This callback executes on each client call returning a new config to be used
 	// please be aware that the APIServer is using http keepalive so this is going to
 	// be executed only after a while for fresh connections and not on existing ones
 	cfg.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
 		cipherNames, minTypedTLSVersion := validator.SelectCipherSuitesAndMinTLSVersion()
 
-		// TODO: workaround: TLSv1.3 ciphers are now enabled on openshift/library-go
-		// but on the other side crypto.CipherSuitesOrDie is still failing with an
-		// explict error when it encounters the name of a TLSv1.3 cipher.
-		// Remove the workaround once we can consume https://github.com/openshift/library-go/pull/1956
-		cipherNamesIANAC := crypto.OpenSSLToIANACipherSuites(cipherNames)
-		cipherNamesFilteredNoTLS13 := []string{}
-		for _, cipherName := range cipherNamesIANAC {
-			if _, ok := ciphersTLS13[cipherName]; !ok {
-				cipherNamesFilteredNoTLS13 = append(cipherNamesFilteredNoTLS13, cipherName)
-			}
-		}
-
-		cfg.CipherSuites = crypto.CipherSuitesOrDie(crypto.OpenSSLToIANACipherSuites(cipherNamesFilteredNoTLS13))
+		cfg.CipherSuites = crypto.CipherSuitesOrDie(crypto.OpenSSLToIANACipherSuites(cipherNames))
 		cfg.MinVersion = crypto.TLSVersionOrDie(string(minTypedTLSVersion))
 		return cfg, nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20190517100836-d5b34b957e91+incompatible
 	github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20250410114548-481d56a6c34e
 	github.com/openshift/custom-resource-status v1.1.2
-	github.com/openshift/library-go v0.0.0-20250402180609-ce2ba53fb2a4
+	github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a
 	github.com/operator-framework/api v0.32.0
 	github.com/operator-framework/operator-lib v0.19.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.83.0

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,8 @@ github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20250410114548-481
 github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20250410114548-481d56a6c34e/go.mod h1:wl2qvwuZU+YWNingOkAzabrH5BJwd4OhUH5FAtOG00U=
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
-github.com/openshift/library-go v0.0.0-20250402180609-ce2ba53fb2a4 h1:MDnTCGqFUULZ4+0fr0sQYlB80yTun8nEZ062azvFSCk=
-github.com/openshift/library-go v0.0.0-20250402180609-ce2ba53fb2a4/go.mod h1:DAa3BGl0CFtkfJn/g5rU8kDDTErfMVA/QlFm4cvU+MI=
+github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a h1:wZ0M/4DgILzW+8NKcARzBSG7w/BlSjtjQlBUj/VCk+0=
+github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/operator-framework/api v0.32.0 h1:LZSZr7at3NrjsjwQVNsYD+04o5wMq75jrR0dMYiIIH8=
 github.com/operator-framework/api v0.32.0/go.mod h1:OGJo6HUYxoQwpGaLr0lPJzSek51RiXajJSSa8Jzjvp8=
 github.com/operator-framework/operator-lib v0.19.0 h1:az6ogYj21rtU0SF9uYctRLyKp2dtlqTsmpfehFy6Ce8=

--- a/hack/check_tlsprofile.sh
+++ b/hack/check_tlsprofile.sh
@@ -84,28 +84,28 @@ fi
 sleep 2
 run_nmap old.txt
 clean_nmap_output old.txt
-diff old.txt "hack/tlsprofiles/old.expected${FIPS}"
+diff -w old.txt "hack/tlsprofiles/old.expected${FIPS}"
 
 # nothing should happen in dry-run mode
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco --dry-run=client -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {modern: {}, type: \"Modern\"} }]'"
 sleep 2
 run_nmap old.txt
 clean_nmap_output old.txt
-diff old.txt "hack/tlsprofiles/old.expected${FIPS}"
+diff -w old.txt "hack/tlsprofiles/old.expected${FIPS}"
 check_ssp_up
 
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {intermediate: {}, type: \"Intermediate\"} }]'"
 sleep 2
 run_nmap intermediate.txt
 clean_nmap_output intermediate.txt
-diff intermediate.txt "hack/tlsprofiles/intermediate.expected${FIPS}"
+diff -w intermediate.txt "hack/tlsprofiles/intermediate.expected${FIPS}"
 check_ssp_up
 
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {modern: {}, type: \"Modern\"} }]'"
 sleep 2
 run_nmap modern.txt
 clean_nmap_output modern.txt
-diff modern.txt "hack/tlsprofiles/modern.expected${FIPS}"
+diff -w modern.txt "hack/tlsprofiles/modern.expected${FIPS}"
 check_ssp_up
 
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {custom: {minTLSVersion: \"VersionTLS12\", ciphers: [\"ECDHE-ECDSA-CHACHA20-POLY1305\", \"ECDHE-ECDSA-AES256-GCM-SHA384\", \"AES256-GCM-SHA384\", \"AES128-SHA256\"]}, type: \"Custom\"} }]'  2>&1 | grep 'missing an HTTP/2-required'"
@@ -114,14 +114,14 @@ check_ssp_up
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {custom: {minTLSVersion: \"VersionTLS12\", ciphers: [\"ECDHE-RSA-AES128-GCM-SHA256\", \"ECDHE-ECDSA-CHACHA20-POLY1305\", \"ECDHE-ECDSA-AES256-GCM-SHA384\", \"AES256-GCM-SHA384\", \"AES128-SHA256\"]}, type: \"Custom\"} }]'"
 run_nmap custom.txt
 clean_nmap_output custom.txt
-diff custom.txt "hack/tlsprofiles/custom.expected${FIPS}"
+diff -w custom.txt "hack/tlsprofiles/custom.expected${FIPS}"
 check_ssp_up
 
 ./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"remove\", \"path\": /spec/tlsSecurityProfile }]'"
 sleep 2
 run_nmap default.txt
 clean_nmap_output default.txt
-diff default.txt "hack/tlsprofiles/intermediate.expected${FIPS}"
+diff -w default.txt "hack/tlsprofiles/intermediate.expected${FIPS}"
 
 if [ -n "$PF_PID" ]; then
   echo "Terminating port forwarding"

--- a/hack/tlsprofiles/custom.expected
+++ b/hack/tlsprofiles/custom.expected
@@ -4,16 +4,9 @@ PORT     STATE SERVICE
 |   TLSv1.2: 
 |     ciphers: 
 |       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
-|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
 |       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
-|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
-|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
-|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (secp256r1) - A
-|     compressors: 
+|       TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 2048) - A
+|     compressors:
 |       NULL
 |     cipher preference: server
 |   TLSv1.3: 

--- a/hack/tlsprofiles/custom.expected.fips
+++ b/hack/tlsprofiles/custom.expected.fips
@@ -3,10 +3,6 @@ PORT     STATE SERVICE
 | ssl-enum-ciphers: 
 |   TLSv1.2: 
 |     ciphers: 
-|       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA (secp256r1) - A
-|       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 (secp256r1) - A
-|       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
-|       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (secp256r1) - A
 |       TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
 |       TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
 |     compressors: 

--- a/hack/tlsprofiles/intermediate.expected
+++ b/hack/tlsprofiles/intermediate.expected
@@ -4,18 +4,11 @@ PORT     STATE SERVICE
 |   TLSv1.2: 
 |     ciphers: 
 |       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
 |       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
-|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
-|       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
-|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
-|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
-|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (secp256r1) - A
+|       TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
 |     compressors: 
 |       NULL
-|     cipher preference: server
+|     cipher preference: client
 |   TLSv1.3: 
 |     ciphers: 
 |       TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A

--- a/hack/tlsprofiles/intermediate.expected.fips
+++ b/hack/tlsprofiles/intermediate.expected.fips
@@ -3,10 +3,7 @@ PORT     STATE SERVICE
 | ssl-enum-ciphers: 
 |   TLSv1.2: 
 |     ciphers: 
-|       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA (secp256r1) - A
-|       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 (secp256r1) - A
 |       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
-|       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (secp256r1) - A
 |       TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
 |       TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
 |     compressors: 

--- a/hack/tlsprofiles/old.expected
+++ b/hack/tlsprofiles/old.expected
@@ -7,19 +7,25 @@ PORT     STATE SERVICE
 |       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
 |       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
 |       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
-|     compressors: 
+|       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 2048) - C
+|     compressors:
 |       NULL
 |     cipher preference: server
-|   TLSv1.1: 
+|     warnings:
+|       64-bit block cipher 3DES vulnerable to SWEET32 attack
+|   TLSv1.1:
 |     ciphers: 
 |       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
 |       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
 |       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
 |       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
-|     compressors: 
+|       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 2048) - C
+|     compressors:
 |       NULL
 |     cipher preference: server
-|   TLSv1.2: 
+|     warnings:
+|       64-bit block cipher 3DES vulnerable to SWEET32 attack
+|   TLSv1.2:
 |     ciphers: 
 |       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
 |       TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
@@ -30,14 +36,18 @@ PORT     STATE SERVICE
 |       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
 |       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
 |       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
+|       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 2048) - C
 |       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (secp256r1) - A
-|     compressors: 
+|       TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 2048) - A
+|     compressors:
 |       NULL
 |     cipher preference: server
-|   TLSv1.3: 
+|     warnings:
+|       64-bit block cipher 3DES vulnerable to SWEET32 attack
+|   TLSv1.3:
 |     ciphers: 
 |       TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
 |       TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
 |       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
 |     cipher preference: server
-|_  least strength: A
+|_  least strength: C

--- a/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
@@ -110,15 +110,6 @@ func DefaultTLSVersion() uint16 {
 	return tls.VersionTLS12
 }
 
-// ciphersTLS13 copies golang 1.13 implementation, where TLS1.3 suites are not
-// configurable (cipherSuites field is ignored for TLS1.3 flows and all of the
-// below three - and none other - are used)
-var ciphersTLS13 = map[string]uint16{
-	"TLS_AES_128_GCM_SHA256":       tls.TLS_AES_128_GCM_SHA256,
-	"TLS_AES_256_GCM_SHA384":       tls.TLS_AES_256_GCM_SHA384,
-	"TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
-}
-
 var ciphers = map[string]uint16{
 	"TLS_RSA_WITH_RC4_128_SHA":                      tls.TLS_RSA_WITH_RC4_128_SHA,
 	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":                 tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
@@ -144,6 +135,9 @@ var ciphers = map[string]uint16{
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":        tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
 	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_AES_128_GCM_SHA256":                        tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":                        tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256":                  tls.TLS_CHACHA20_POLY1305_SHA256,
 }
 
 // openSSLToIANACiphersMap maps OpenSSL cipher suite names to IANA names
@@ -223,10 +217,6 @@ func CipherSuite(cipherName string) (uint16, error) {
 		return cipher, nil
 	}
 
-	if _, ok := ciphersTLS13[cipherName]; ok {
-		return 0, fmt.Errorf("all golang TLSv1.3 ciphers are always used for TLSv1.3 flows")
-	}
-
 	return 0, fmt.Errorf("unknown cipher name %q", cipherName)
 }
 
@@ -281,6 +271,9 @@ func DefaultCiphers() []uint16 {
 		// tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,       // forbidden by http/2, disabled to mitigate SWEET32 attack
 		tls.TLS_RSA_WITH_AES_128_CBC_SHA, // forbidden by http/2
 		tls.TLS_RSA_WITH_AES_256_CBC_SHA, // forbidden by http/2
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
 	}
 }
 
@@ -636,7 +629,7 @@ func MakeSelfSignedCAConfig(name string, lifetime time.Duration) (*TLSCertificat
 func MakeSelfSignedCAConfigForSubject(subject pkix.Name, lifetime time.Duration) (*TLSCertificateConfig, error) {
 	if lifetime <= 0 {
 		lifetime = DefaultCACertificateLifetimeDuration
-		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %d years!\n", subject.CommonName, lifetime)
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
 	}
 
 	if lifetime > DefaultCACertificateLifetimeDuration {
@@ -1025,7 +1018,7 @@ func newSigningCertificateTemplateForDuration(subject pkix.Name, caLifetime time
 func newServerCertificateTemplate(subject pkix.Name, hosts []string, lifetime time.Duration, currentTime func() time.Time, authorityKeyId, subjectKeyId []byte) *x509.Certificate {
 	if lifetime <= 0 {
 		lifetime = DefaultCertificateLifetimeDuration
-		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %d years!\n", subject.CommonName, lifetime)
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
 	}
 
 	if lifetime > DefaultCertificateLifetimeDuration {
@@ -1112,7 +1105,7 @@ func CertsFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {
 func NewClientCertificateTemplate(subject pkix.Name, lifetime time.Duration, currentTime func() time.Time) *x509.Certificate {
 	if lifetime <= 0 {
 		lifetime = DefaultCertificateLifetimeDuration
-		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %d years!\n", subject.CommonName, lifetime)
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
 	}
 
 	if lifetime > DefaultCertificateLifetimeDuration {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -302,8 +302,8 @@ github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
 github.com/openshift/custom-resource-status/objectreferences/v1
-# github.com/openshift/library-go v0.0.0-20250402180609-ce2ba53fb2a4
-## explicit; go 1.23.0
+# github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a
+## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/crypto
 # github.com/operator-framework/api v0.32.0
 ## explicit; go 1.24.3


### PR DESCRIPTION
**What this PR does / why we need it**:
github.com/openshift/library-go/pull/1956 got
merged so we can drop the workaround for TLSv1.3
ciphers.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [X] PR Message
- [X] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [X] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Properly support TLSv1.3 ciphers
```
