### PR TITLE
Retry push images on the retag script

### DIFF
--- a/hack/architecture.sh
+++ b/hack/architecture.sh
@@ -1,0 +1,1 @@
+ARCHITECTURES="amd64 arm64 s390x"

--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+source ./hack/architecture.sh
+
 set -ex
 
 ##################################################################
@@ -23,8 +26,6 @@ BUNDLE_REGISTRY_IMAGE_NAME=${BUNDLE_REGISTRY_IMAGE_NAME:-hyperconverged-cluster-
 INDEX_REGISTRY_IMAGE_NAME=${INDEX_REGISTRY_IMAGE_NAME:-hyperconverged-cluster-index}
 OPM=${OPM:-opm}
 UNSTABLE=$2
-ARCHITECTURES="amd64 arm64 s390x"
-
 
 function create_index_image() {
   CURRENT_VERSION=$1

--- a/hack/build-push-multi-arch-images.sh
+++ b/hack/build-push-multi-arch-images.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ARCHITECTURES="amd64 arm64 s390x"
+source ./hack/architecture.sh
 
 if [[ -z ${IMAGE_NAME} ]]; then
   echo "IMAGE_NAME must be defined"

--- a/hack/retag-multi-arch-images.sh
+++ b/hack/retag-multi-arch-images.sh
@@ -25,11 +25,11 @@ if [[ "${MULTIARCH}" == "true" ]]; then
   for arch in ${ARCHITECTURES}; do
     NEW_IMAGE="${NEW_IMAGE_REPO}:${NEW_TAG}-${arch}"
     ${CRI_BIN} tag "${IMAGE_REPO}:${CURRENT_TAG}-${arch}" "${NEW_IMAGE}"
-    ${CRI_BIN} push "${NEW_IMAGE}"
+    ./hack/retry.sh 3 10 "${CRI_BIN} push ${NEW_IMAGE}"
   done
 fi
 
 # retag the manifest
 NEW_IMAGE="${NEW_IMAGE_REPO}:${NEW_TAG}"
 ${CRI_BIN} tag "${IMAGE_REPO}:${CURRENT_TAG}" "${NEW_IMAGE}"
-${CRI_BIN} push "${NEW_IMAGE}"
+./hack/retry.sh 3 10 "${CRI_BIN} push ${NEW_IMAGE}"

--- a/hack/retag-multi-arch-images.sh
+++ b/hack/retag-multi-arch-images.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ARCHITECTURES="amd64 arm64 s390x"
+source ./hack/architecture.sh
 
 if [[ -z ${IMAGE_REPO} ]]; then
   echo "IMAGE_REPO must be defined"
@@ -19,15 +19,17 @@ if [[ -z ${NEW_TAG} ]]; then
   exit 1
 fi
 
+. ./hack/cri-bin.sh && export CRI_BIN=${CRI_BIN}
+
 if [[ "${MULTIARCH}" == "true" ]]; then
   for arch in ${ARCHITECTURES}; do
     NEW_IMAGE="${NEW_IMAGE_REPO}:${NEW_TAG}-${arch}"
-    . "hack/cri-bin.sh" && ${CRI_BIN} tag "${IMAGE_REPO}:${CURRENT_TAG}-${arch}" "${NEW_IMAGE}"
-    . "hack/cri-bin.sh" && ${CRI_BIN} push "${NEW_IMAGE}"
+    ${CRI_BIN} tag "${IMAGE_REPO}:${CURRENT_TAG}-${arch}" "${NEW_IMAGE}"
+    ${CRI_BIN} push "${NEW_IMAGE}"
   done
 fi
 
 # retag the manifest
 NEW_IMAGE="${NEW_IMAGE_REPO}:${NEW_TAG}"
-. "hack/cri-bin.sh" && ${CRI_BIN} tag "${IMAGE_REPO}:${CURRENT_TAG}" "${NEW_IMAGE}"
-. "hack/cri-bin.sh" && ${CRI_BIN} push "${NEW_IMAGE}"
+${CRI_BIN} tag "${IMAGE_REPO}:${CURRENT_TAG}" "${NEW_IMAGE}"
+${CRI_BIN} push "${NEW_IMAGE}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up of #3500 

The action may still fail for server error 502, when re-tagging the images

This PR add a retry mechanism also to the `hack/retag-multi-arch-images.sh` script, to fix the issue.

Also, this PR adds a common list of supported architectures, to be used by the scripts, instead of duplicate the list in each script.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
