### PR TITLE
Enable CDI WebhookPvcRendering feature gate by default

### DIFF
--- a/controllers/operands/cdi.go
+++ b/controllers/operands/cdi.go
@@ -21,7 +21,9 @@ import (
 const (
 	honorWaitForFirstConsumerGate = "HonorWaitForFirstConsumer"
 	dataVolumeClaimAdoptionGate   = "DataVolumeClaimAdoption"
-	cdiConfigAuthorityAnnotation  = "cdi.kubevirt.io/configAuthority"
+	webhookPvcRenderingGate       = "WebhookPvcRendering"
+
+	cdiConfigAuthorityAnnotation = "cdi.kubevirt.io/configAuthority"
 )
 
 type cdiHandler genericOperand
@@ -100,7 +102,7 @@ func (*cdiHooks) updateCr(req *common.HcoRequest, Client client.Client, exists r
 func (*cdiHooks) justBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 func getDefaultFeatureGates() []string {
-	return []string{honorWaitForFirstConsumerGate, dataVolumeClaimAdoptionGate}
+	return []string{honorWaitForFirstConsumerGate, dataVolumeClaimAdoptionGate, webhookPvcRenderingGate}
 }
 
 func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, error) {

--- a/controllers/operands/cdi_test.go
+++ b/controllers/operands/cdi_test.go
@@ -34,6 +34,8 @@ var _ = Describe("CDI Operand", func() {
 			req *common.HcoRequest
 		)
 
+		defaultFeatureGates := []string{honorWaitForFirstConsumerGate, dataVolumeClaimAdoptionGate, webhookPvcRenderingGate}
+
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
@@ -876,12 +878,12 @@ var _ = Describe("CDI Operand", func() {
 			Expect(foundResource.Spec.Config.ScratchSpaceStorageClass).To(BeNil())
 			Expect(foundResource.Spec.Config.PodResourceRequirements).To(BeNil())
 			Expect(foundResource.Spec.Config.FilesystemOverhead).To(BeNil())
-			Expect(foundResource.Spec.Config.FeatureGates).To(HaveLen(2))
-			Expect(foundResource.Spec.Config.FeatureGates).To(ContainElements(honorWaitForFirstConsumerGate, dataVolumeClaimAdoptionGate))
+			Expect(foundResource.Spec.Config.FeatureGates).To(HaveLen(len(defaultFeatureGates)))
+			Expect(foundResource.Spec.Config.FeatureGates).To(ContainElements(defaultFeatureGates))
 			Expect(*foundResource.Spec.UninstallStrategy).To(Equal(cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist))
 		})
 
-		It("should add HonorWaitForFirstConsumer and DataVolumeClaimAdoption feature gates if Spec.Config if empty", func() {
+		It("should add HonorWaitForFirstConsumer, DataVolumeClaimAdoption and WebhookPvcRendering feature gates if Spec.Config if empty", func() {
 			expectedResource, err := NewCDI(hco)
 			Expect(err).ToNot(HaveOccurred())
 			expectedResource.Spec.Config = nil
@@ -904,8 +906,8 @@ var _ = Describe("CDI Operand", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 			Expect(foundResource.Spec.Config).ToNot(BeNil())
-			Expect(foundResource.Spec.Config.FeatureGates).To(HaveLen(2))
-			Expect(foundResource.Spec.Config.FeatureGates).To(ContainElements(honorWaitForFirstConsumerGate, dataVolumeClaimAdoptionGate))
+			Expect(foundResource.Spec.Config.FeatureGates).To(HaveLen(len(defaultFeatureGates)))
+			Expect(foundResource.Spec.Config.FeatureGates).To(ContainElements(defaultFeatureGates))
 			Expect(*foundResource.Spec.UninstallStrategy).To(Equal(cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist))
 		})
 
@@ -1099,7 +1101,7 @@ var _ = Describe("CDI Operand", func() {
 
 				cdi, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cdi.Spec.Config.FeatureGates).To(HaveLen(3))
+				Expect(cdi.Spec.Config.FeatureGates).To(HaveLen(len(defaultFeatureGates) + 1))
 				Expect(cdi.Spec.Config.FeatureGates).To(ContainElement("fg1"))
 				Expect(cdi.Spec.Config.FilesystemOverhead).ToNot(BeNil())
 				Expect(cdi.Spec.Config.FilesystemOverhead.Global).To(BeEquivalentTo("50"))
@@ -1149,7 +1151,7 @@ var _ = Describe("CDI Operand", func() {
 						cdi),
 				).ToNot(HaveOccurred())
 
-				Expect(cdi.Spec.Config.FeatureGates).To(HaveLen(3))
+				Expect(cdi.Spec.Config.FeatureGates).To(HaveLen(len(defaultFeatureGates) + 1))
 				Expect(cdi.Spec.Config.FeatureGates).To(ContainElement("fg1"))
 				Expect(cdi.Spec.Config.FilesystemOverhead).ToNot(BeNil())
 				Expect(cdi.Spec.Config.FilesystemOverhead.Global).To(BeEquivalentTo("50"))


### PR DESCRIPTION
**What this PR does / why we need it**:
The feature is available since CDI v1.59, and we enable it by default to allow [increasing PVC size](https://github.com/kubevirt/containerized-data-importer/pull/3711) to the minimum supported by its provisioner, and mainly in order to support it in kubevirt for [backend storage](https://github.com/kubevirt/kubevirt/pull/14637). We need it backported to 1.14 & 1.15. It is enabled in [CDI](https://github.com/kubevirt/containerized-data-importer/pull/3736) as well. We will GA it and remove this and the other FGs in CDI main branch as a follow-up PR.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
```release-note
Enable CDI WebhookPvcRendering feature gate by default
```