### PR TITLE
Add PersistentVolumeFillingUp alert

### DIFF
--- a/hack/prom-rule-ci/observability-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/observability-prom-rules-tests.yaml
@@ -221,3 +221,73 @@ tests:
       - eval_time: 10m
         alertname: NodeNetworkInterfaceDown
         exp_alerts: [ ]
+
+  - interval: 1m
+    input_series:
+      # PVC 1: Should trigger alert - less than 10% space available and will fill up in 4 days
+      - series: 'kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics",persistentvolumeclaim="pvc-1",namespace="test-ns-1"}'
+        values: "10000+0x5 9500+0x5 9000+0x5 8500+0x5 8000+0x30"
+      - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics",persistentvolumeclaim="pvc-1",namespace="test-ns-1"}'
+        values: "100000+0x30"
+      - series: 'kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics",persistentvolumeclaim="pvc-1",namespace="test-ns-1"}'
+        values: "90000+0x5 90500+0x5 91000+0x5 91500+0x5 92000+0x30"
+
+      # PVC 2: Should NOT trigger alert - more than 10% space available
+      - series: 'kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics",persistentvolumeclaim="pvc-2",namespace="test-ns-2"}'
+        values: "30000+0x30"
+      - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics",persistentvolumeclaim="pvc-2",namespace="test-ns-2"}'
+        values: "100000+0x30"
+      - series: 'kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics",persistentvolumeclaim="pvc-2",namespace="test-ns-2"}'
+        values: "70000+0x30"
+
+      # PVC 3: Would trigger alert but has ReadOnlyMany access mode - should NOT alert
+      - series: 'kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics",persistentvolumeclaim="pvc-3",namespace="test-ns-3"}'
+        values: "5000+0x5 4500+0x5 4000+0x5 3500+0x5 3000+0x5 2500+0x5"
+      - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics",persistentvolumeclaim="pvc-3",namespace="test-ns-3"}'
+        values: "100000+0x30"
+      - series: 'kubelet_volume_stats_used_bytes{job="kubelet",metrics_path="/metrics",persistentvolumeclaim="pvc-3",namespace="test-ns-3"}'
+        values: "95000+0x5 95500+0x5 96000+0x5 96500+0x5 97000+0x5 97500+0x5"
+      - series: 'kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany",persistentvolumeclaim="pvc-3",namespace="test-ns-3"}'
+        values: "1+0x30"
+
+    alert_rule_test:
+      # At 5m, no alerts should be firing yet (not enough time elapsed)
+      - eval_time: 5m
+        alertname: PersistentVolumeFillingUp
+        exp_alerts: [ ]
+
+      # At 12m, PVC-1 should be alerting
+      - eval_time: 12m
+        alertname: PersistentVolumeFillingUp
+        exp_alerts:
+          - exp_annotations:
+              summary: "PersistentVolume is filling up"
+              description: "Based on recent sampling, the PersistentVolume claimed by pvc-1 in Namespace test-ns-1 is expected to fill up within four days. Currently 9% is available."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/PersistentVolumeFillingUp"
+            exp_labels:
+              persistentvolumeclaim: "pvc-1"
+              namespace: "test-ns-1"
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cnv-observability"
+              job: "kubelet"
+              metrics_path: "/metrics"
+
+      # At 28m, PVC-1 should still be alerting
+      - eval_time: 28m
+        alertname: PersistentVolumeFillingUp
+        exp_alerts:
+          - exp_annotations:
+              summary: "PersistentVolume is filling up"
+              description: "Based on recent sampling, the PersistentVolume claimed by pvc-1 in Namespace test-ns-1 is expected to fill up within four days. Currently 8% is available."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/PersistentVolumeFillingUp"
+            exp_labels:
+              persistentvolumeclaim: "pvc-1"
+              namespace: "test-ns-1"
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cnv-observability"
+              job: "kubelet"
+              metrics_path: "/metrics"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add PersistentVolumeFillingUp alert to warn users when a volume is expected to fill up within four days based current usage and on Prometheus sampling prediction.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-50892
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add PersistentVolumeFillingUp alert
```
