### PR TITLE
Fix the unit test command in the nightly build

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -74,7 +74,7 @@ go mod edit -replace github.com/kubevirt/cluster-network-addons-operator=./cnao
 go mod tidy
 go mod vendor
 
-go test ./pkg/... ./controller/...
+go test ./pkg/... ./controllers/...
 
 # set envs
 build_date="$(date +%Y%m%d)"


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
