### PR TITLE
Move the nightly build images to quay.io/kubevirt

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -79,8 +79,8 @@ go test ./pkg/... ./controllers/...
 # set envs
 build_date="$(date +%Y%m%d)"
 export IMAGE_REGISTRY=quay.io
-export IMAGE_TAG="nb_${build_date}_$(git show -s --format=%h)"
-export REGISTRY_NAMESPACE=kubevirtci
+export IMAGE_TAG="${build_date}_$(git show -s --format=%h)"
+export REGISTRY_NAMESPACE=kubevirt
 
 # Build HCO & HCO Webhook
 make build-push-multi-arch-operator-image build-push-multi-arch-webhook-image build-push-multi-arch-artifacts-server


### PR DESCRIPTION
**What this PR does / why we need it**:

To align with KubeVirt and CDI nightly builds, move the nightly built images from quay.io/kubevirtci registry, to quay.io/kubevirt, and remove the "nb_" prefix from the image tag.

**Release note**:
```release-note
Move the nightly build images to the quay.io/kubevirt registry
```
