### PR TITLE
Add HighNodeCPUFrequency alert

### DIFF
--- a/hack/prom-rule-ci/observability-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/observability-prom-rules-tests.yaml
@@ -291,3 +291,51 @@ tests:
               kubernetes_operator_component: "cnv-observability"
               job: "kubelet"
               metrics_path: "/metrics"
+
+  - interval: 1m
+    input_series:
+      # Test case 1: CPU frequency is above 80% of max (should alert)
+      # Current frequency: 2800 MHz, Max frequency: 3000 MHz (93.3% > 80%)
+      - series: 'node_cpu_frequency_hertz{instance="n1.cnv.redhat.com",cpu="0"}'
+        values: "2800000000+0x30"
+      - series: 'node_cpu_frequency_max_hertz{instance="n1.cnv.redhat.com",cpu="0"}'
+        values: "3000000000+0x30"
+
+      # Test case 2: CPU frequency is below 80% of max (should NOT alert)
+      # Current frequency: 2000 MHz, Max frequency: 3000 MHz (66.7% < 80%)
+      - series: 'node_cpu_frequency_hertz{instance="n2.cnv.redhat.com",cpu="0"}'
+        values: "2000000000+0x30"
+      - series: 'node_cpu_frequency_max_hertz{instance="n2.cnv.redhat.com",cpu="0"}'
+        values: "3000000000+0x30"
+
+      # Test case 3: Missing max frequency metric (should NOT alert)
+      # Current frequency exists but max frequency doesn't
+      - series: 'node_cpu_frequency_hertz{instance="n3.cnv.redhat.com",cpu="0"}'
+        values: "2800000000+0x30"
+
+      # Test case 4: Missing current frequency metric (should NOT alert)
+      # Max frequency exists but current frequency doesn't
+      - series: 'node_cpu_frequency_max_hertz{instance="n4.cnv.redhat.com",cpu="0"}'
+        values: "3000000000+0x30"
+
+    alert_rule_test:
+      # At 3 minutes, no alerts should fire yet (not enough time elapsed)
+      - eval_time: 3m
+        alertname: HighNodeCPUFrequency
+        exp_alerts: [ ]
+
+      # At 8 minutes, alerts should fire for instances with high CPU frequency
+      - eval_time: 8m
+        alertname: HighNodeCPUFrequency
+        exp_alerts:
+          - exp_annotations:
+              summary: "High CPU frequency detected on node n1.cnv.redhat.com"
+              description: "CPU frequency on node n1.cnv.redhat.com (CPU 0) is 2.8GHz, which is above 80% of the maximum frequency. This may indicate high CPU utilization or thermal throttling."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/HighNodeCPUFrequency"
+            exp_labels:
+              instance: "n1.cnv.redhat.com"
+              cpu: "0"
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cnv-observability"

--- a/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
+++ b/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
@@ -87,5 +87,22 @@ func clusterAlerts() []promv1.Rule {
 				"operator_health_impact": "none",
 			},
 		},
+		{
+			Alert: "HighNodeCPUFrequency",
+			Expr: intstr.FromString(`
+				node_cpu_frequency_hertz > 0
+				and on(instance, cpu)
+				node_cpu_frequency_hertz - on(instance, cpu) group_left() node_cpu_frequency_max_hertz * 0.8 > 0
+			`),
+			For: ptr.To[promv1.Duration]("5m"),
+			Annotations: map[string]string{
+				"summary":     "High CPU frequency detected on node {{ $labels.instance }}",
+				"description": "CPU frequency on node {{ $labels.instance }} (CPU {{ $labels.cpu }}) is {{ $value | humanize }}Hz, which is above 80% of the maximum frequency. This may indicate high CPU utilization or thermal throttling.",
+			},
+			Labels: map[string]string{
+				"severity":               "warning",
+				"operator_health_impact": "none",
+			},
+		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Monitor CPU frequency metrics and alerts when CPU frequency exceeds 80% of the maximum frequency.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-61568
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add HighNodeCPUFrequency alert
```
