### PR TITLE
Fix issues with ingress-controller

### DIFF
--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -107,14 +107,14 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 			}
 		})
 
-		It("should allow download URL customisation", Label("custom_dl_link"), func(ctx context.Context) {
+		It("should allow download URL customization", Label("custom_dl_link"), func(ctx context.Context) {
 			By("make sure the ingress contains the virt-downloads route component")
 			ingress := &configv1.Ingress{}
 			Expect(cli.Get(ctx, client.ObjectKey{Name: "cluster"}, ingress)).To(Succeed())
 
 			Expect(slices.ContainsFunc(ingress.Status.ComponentRoutes, func(route configv1.ComponentRouteStatus) bool {
 				return route.Name == "virt-downloads"
-			})).To(BeTrueBecause("can't find the virt-downloads route in staus of the the cluster Ingress"))
+			})).To(BeTrueBecause("can't find the virt-downloads route in status of the the cluster Ingress"))
 
 			By("customize the virt-downloads route, to set another host")
 			baseDomain := ingress.Spec.Domain


### PR DESCRIPTION
This PR fixes two bugs at the `ingress-cluster-controller` of HCO:
1. If the reconciliation completed before `HyperConverged` CR is created, and then the CR is created, the ingress-controller reconciliation is not triggered and thus the `virt-downloads` ComponentRoute is not added to the `ingresses.config.openshift.io` CR. This causes a test failure of `should allow download URL customization`. The fix is to add a watch of this controller for the HyperConverged CR, on creation and deletion.
2. When the HyperConverged CR is deleted, the virt-downloads ComponentRoute is deleted from the `ingresses.config.openshift.io` status, and then the ingress-controller tries to update conditions on non-existent entry, resulting in panic in the reconciliation loop. The fix is to not set conditions if the CR was deleted.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-62752
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
