### PR TITLE
Fix non-stand-alone unit tests

### DIFF
--- a/controllers/common/hcoConditions_test.go
+++ b/controllers/common/hcoConditions_test.go
@@ -111,8 +111,12 @@ var _ = Describe("HCO Conditions Tests", func() {
 	})
 
 	Context("Test IsStatusConditionTrue", func() {
-		conds := NewHcoConditions()
-		Expect(conds.IsEmpty()).To(BeTrue())
+		var conds HcoConditions
+
+		BeforeEach(func() {
+			conds = NewHcoConditions()
+			Expect(conds.IsEmpty()).To(BeTrue())
+		})
 
 		It("Should return false when the conditionType is not present", func() {
 			Expect(conds.IsStatusConditionTrue(hcov1beta1.ConditionReconcileComplete)).To(BeFalse())

--- a/controllers/operands/aaq_test.go
+++ b/controllers/operands/aaq_test.go
@@ -348,6 +348,7 @@ var _ = Describe("AAQ tests", func() {
 	Context("check cache", func() {
 		It("should create new cache if it empty", func() {
 			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
+			cl = commontestutils.InitClient([]client.Object{hco})
 			handler := newAAQHandler(cl, commontestutils.GetScheme())
 			op, ok := handler.(*conditionalHandler)
 			Expect(ok).To(BeTrue())

--- a/controllers/operands/cdi_test.go
+++ b/controllers/operands/cdi_test.go
@@ -1261,8 +1261,15 @@ var _ = Describe("CDI Operand", func() {
 		})
 
 		Context("Cache", func() {
-			cl := commontestutils.InitClient([]client.Object{})
-			handler := newCdiHandler(cl, commontestutils.GetScheme())
+			var (
+				cl      client.Client
+				handler *cdiHandler
+			)
+
+			BeforeEach(func() {
+				cl = commontestutils.InitClient([]client.Object{})
+				handler = newCdiHandler(cl, commontestutils.GetScheme())
+			})
 
 			It("should start with empty cache", func() {
 				Expect(handler.hooks.(*cdiHooks).cache).To(BeNil())

--- a/controllers/operands/dashboard.go
+++ b/controllers/operands/dashboard.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"errors"
+	"io"
 	"maps"
 	"os"
 	filepath "path/filepath"
@@ -64,8 +65,7 @@ func processDashboardConfigMapFile(path string, info os.FileInfo, logger log.Log
 			return nil, err
 		}
 
-		cm := &v1.ConfigMap{}
-		err = util.UnmarshalYamlFileToObject(file, cm)
+		cm, err := cmFromFile(file)
 		if err != nil {
 			logger.Error(err, "Can't generate a Configmap object from yaml file", "file name", path)
 		} else {
@@ -73,5 +73,17 @@ func processDashboardConfigMapFile(path string, info os.FileInfo, logger log.Log
 			return newCmHandler(Client, Scheme, cm), nil
 		}
 	}
+
 	return nil, nil
+}
+
+func cmFromFile(reader io.Reader) (*v1.ConfigMap, error) {
+	cm := &v1.ConfigMap{}
+	err := util.UnmarshalYamlFileToObject(reader, cm)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cm, nil
 }

--- a/controllers/operands/imageStream_test.go
+++ b/controllers/operands/imageStream_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
@@ -26,14 +25,19 @@ var _ = Describe("imageStream tests", func() {
 	schemeForTest := commontestutils.GetScheme()
 
 	var (
-		logger            = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("imageStream_test")
 		testFilesLocation = getTestFilesLocation() + "/imageStreams"
 		storeOrigFunc     = getImageStreamFileLocation
 		hco               *hcov1beta1.HyperConverged
 	)
 
+	origLogger := logger
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
+		logger = GinkgoLogr
+
+		DeferCleanup(func() {
+			logger = origLogger
+		})
 	})
 
 	AfterEach(func() {

--- a/controllers/operands/kubevirt_test.go
+++ b/controllers/operands/kubevirt_test.go
@@ -3795,8 +3795,15 @@ Version: 1.2.3`)
 		})
 
 		Context("Cache", func() {
-			cl := commontestutils.InitClient([]client.Object{})
-			handler := newKubevirtHandler(cl, commontestutils.GetScheme())
+			var (
+				cl      client.Client
+				handler *kubevirtHandler
+			)
+
+			BeforeEach(func() {
+				cl = commontestutils.InitClient([]client.Object{})
+				handler = newKubevirtHandler(cl, commontestutils.GetScheme())
+			})
 
 			It("should start with empty cache", func() {
 				Expect(handler.hooks.(*kubevirtHooks).cache).To(BeNil())

--- a/controllers/operands/networkAddons_test.go
+++ b/controllers/operands/networkAddons_test.go
@@ -1006,8 +1006,15 @@ var _ = Describe("CNA Operand", func() {
 		})
 
 		Context("Cache", func() {
-			cl := commontestutils.InitClient([]client.Object{})
-			handler := newCnaHandler(cl, commontestutils.GetScheme())
+			var (
+				cl      client.Client
+				handler *cnaHandler
+			)
+
+			BeforeEach(func() {
+				cl = commontestutils.InitClient([]client.Object{})
+				handler = newCnaHandler(cl, commontestutils.GetScheme())
+			})
 
 			It("should start with empty cache", func() {
 				Expect(handler.hooks.(*cnaHooks).cache).To(BeNil())

--- a/controllers/operands/operandHandler_test.go
+++ b/controllers/operands/operandHandler_test.go
@@ -22,6 +22,14 @@ import (
 )
 
 var _ = Describe("Test operandHandler", func() {
+	origLogger := logger
+	BeforeEach(func() {
+		logger = GinkgoLogr
+		DeferCleanup(func() {
+			logger = origLogger
+		})
+	})
+
 	Context("Test operandHandler", func() {
 		testFileLocation := getTestFilesLocation()
 

--- a/controllers/operands/quickStart.go
+++ b/controllers/operands/quickStart.go
@@ -2,6 +2,7 @@ package operands
 
 import (
 	"errors"
+	"io"
 	"os"
 	filepath "path/filepath"
 	"reflect"
@@ -124,8 +125,7 @@ func processQuickstartFile(path string, info os.FileInfo, logger log.Logger, hc 
 			return nil, err
 		}
 
-		qs := &consolev1.ConsoleQuickStart{}
-		err = util.UnmarshalYamlFileToObject(file, qs)
+		qs, err := quickStartFromFile(file)
 		if err != nil {
 			logger.Error(err, "Can't generate a ConsoleQuickStart object from yaml file", "file name", path)
 		} else {
@@ -135,4 +135,15 @@ func processQuickstartFile(path string, info os.FileInfo, logger log.Logger, hc 
 		}
 	}
 	return nil, nil
+}
+
+func quickStartFromFile(reader io.Reader) (*consolev1.ConsoleQuickStart, error) {
+	qs := &consolev1.ConsoleQuickStart{}
+	err := util.UnmarshalYamlFileToObject(reader, qs)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return qs, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Unit tests must be stand alone, pass when run as a single test and must not be depend on other previous tests.

This is not the case in the `controllers/hyperconverged`, `controllers/operands` and the `controllers/common` packages, where several tests are failing when running individually (e.g. with `FIt`), or when running tests with random order.

This PR moves all the required settings to the top level of the test file, or makes other changes, to make all the test independent.

**Release note**:
```release-note
None
```
