### PR TITLE
Fix a bug when building a multi-ach manifest image

### DIFF
--- a/hack/build-index-image.sh
+++ b/hack/build-index-image.sh
@@ -91,6 +91,9 @@ function create_file_based_catalog() {
     IMAGES="${IMAGES} ${current_image}"
   done
 
+  if podman manifest exists "${INDEX_IMAGE_NAME}"; then
+    podman manifest rm "${INDEX_IMAGE_NAME}"
+  fi
   podman manifest create "${INDEX_IMAGE_NAME}" ${IMAGES}
   podman manifest push "${INDEX_IMAGE_NAME}"
 }

--- a/hack/build-push-multi-arch-images.sh
+++ b/hack/build-push-multi-arch-images.sh
@@ -16,7 +16,10 @@ SHA=$(git describe --no-match  --always --abbrev=40 --dirty)
 
 . ./hack/cri-bin.sh && export CRI_BIN=${CRI_BIN}
 
-${CRI_BIN} manifest create -a "${IMAGE_NAME}"
+if ${CRI_BIN} manifest exists "${IMAGE_NAME}"; then
+  ${CRI_BIN} manifest rm "${IMAGE_NAME}"
+fi
+${CRI_BIN} manifest create "${IMAGE_NAME}"
 for arch in ${ARCHITECTURES}; do
   ${CRI_BIN} build  --platform=linux/${arch} -f ${DOCKER_FILE} -t "${IMAGE_NAME}-${arch}" --build-arg git_sha=${SHA} .
   ./hack/retry.sh 3 10 "${CRI_BIN} push ${IMAGE_NAME}-${arch}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The current implementation when building a multi-arch manifest image, can't be called twice with the same tag (as a regular image).

This PR fixes the issue by removing the local image if already exist, before re-creating it.


**Release note**:
```release-note
None
```
