### PR TITLE
Split the CRD overlap validation from csv-merger to a new tool

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -354,6 +354,8 @@ ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
   --kubevirt-consoleproxy-image-name="${KUBEVIRT_CONSOLE_PROXY_IMAGE}" \
   --cli-downloads-image-name="${HCO_DOWNLOADS_IMAGE}" > "${CSV_DIR}/${OPERATOR_NAME}.v${CSV_VERSION}.${CSV_EXT}"
 
+(cd ${PROJECT_ROOT}/tools/csv-merger/ && go clean)
+
 rendered_csv="$(cat "${CSV_DIR}/${OPERATOR_NAME}.v${CSV_VERSION}.${CSV_EXT}")"
 rendered_keywords="$(echo "$rendered_csv" |grep 'keywords' -A 3)"
 # assert that --csv-overrides work
@@ -369,8 +371,7 @@ cp -f ${TEMPDIR}/*.${CRD_EXT} ${CSV_DIR}
 (cd ${CSV_DIR} && $CRI_BIN run --rm -v "$(pwd)":/yaml quay.io/pusher/yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable}}" /yaml)
 
 # Check there are not API Groups overlap between different CNV operators
-${PROJECT_ROOT}/tools/csv-merger/csv-merger --crds-dir=${CRD_DIR}
-(cd ${PROJECT_ROOT}/tools/csv-merger/ && go clean)
+go run ${PROJECT_ROOT}/tools/crd-overlap-validator --crds-dir=${CRD_DIR}
 
 if [[ "$1" == "UNIQUE"  ]]; then
   # Add the current CSV_TIMESTAMP to the currentCSV in the packages file

--- a/tools/crd-overlap-validator/crd_overlap_validator.go
+++ b/tools/crd-overlap-validator/crd_overlap_validator.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func main() {
+	crdDir := flag.String("crds-dir", "", "the directory containing the CRDs for apigroup validation. The validation will be performed if and only if the value is non-empty.")
+
+	flag.Parse()
+
+	if *crdDir == "" {
+		fmt.Println("No CRD directory provided. Skipping API group overlap validation.")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	err := validateNoAPIOverlap(*crdDir)
+	if err != nil {
+		fmt.Fprint(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Println("Validation succeeded: no overlapping API Groups found between different CRDs.")
+}
+
+func IOReadDir(root string) ([]string, error) {
+	var files []string
+	fileInfo, err := os.ReadDir(root)
+	if err != nil {
+		return files, err
+	}
+
+	for _, file := range fileInfo {
+		files = append(files, filepath.Join(root, file.Name()))
+	}
+	return files, nil
+}
+
+func validateNoAPIOverlap(crdDir string) error {
+	crdFiles, err := IOReadDir(crdDir)
+	if err != nil {
+		return err
+	}
+
+	// crdMap is populated with operator names as keys and a slice of associated api groups as values.
+	crdMap, err := getCrdMap(crdFiles)
+	if err != nil {
+		return fmt.Errorf("failed to get CRD map: %v", err)
+	}
+
+	overlapsMap := detectAPIOverlap(crdMap)
+
+	return checkAPIOverlapMap(overlapsMap)
+}
+
+func checkAPIOverlapMap(overlapsMap map[string]sets.Set[string]) error {
+	// if at least one overlap found - emit an error.
+	if len(overlapsMap) != 0 {
+		var sb strings.Builder
+		// WriteString always returns error=nil. no point to check it.
+		_, _ = sb.WriteString("ERROR: Overlapping API Groups were found between different operators.\n")
+		for apiGroup := range overlapsMap {
+			_, _ = sb.WriteString(fmt.Sprintf("The API Group %s is being used by these operators: %s\n", apiGroup, strings.Join(overlapsMap[apiGroup].UnsortedList(), ", ")))
+		}
+		return errors.New(sb.String())
+	}
+	return nil
+}
+
+func detectAPIOverlap(crdMap map[string][]string) map[string]sets.Set[string] {
+	// overlapsMap is populated with collisions found - API Groups as keys,
+	// and slice containing operators using them, as values.
+	overlapsMap := make(map[string]sets.Set[string])
+	for operator, groups := range crdMap {
+		for _, apiGroup := range groups {
+			compareMapWithEntry(crdMap, operator, apiGroup, overlapsMap)
+		}
+	}
+	return overlapsMap
+}
+
+func compareMapWithEntry(crdMap map[string][]string, operator string, apigroup string, overlapsMap map[string]sets.Set[string]) {
+	for comparedOperator := range crdMap {
+		if operator == comparedOperator { // don't check self
+			continue
+		}
+
+		if slices.Contains(crdMap[comparedOperator], apigroup) {
+			if overlapsMap[apigroup] == nil {
+				overlapsMap[apigroup] = sets.New[string](operator, comparedOperator)
+			} else {
+				overlapsMap[apigroup].Insert(operator)
+				overlapsMap[apigroup].Insert(comparedOperator)
+			}
+		}
+	}
+}
+
+func getCrdMap(crdFiles []string) (map[string][]string, error) {
+	crdMap := make(map[string][]string)
+
+	for _, crdFilePath := range crdFiles {
+		content, err := os.ReadFile(crdFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CRD file %s: %v", crdFilePath, err)
+		}
+
+		crdFileName := filepath.Base(crdFilePath)
+		reg := regexp.MustCompile(`(\D+)`)
+		operator := reg.FindString(crdFileName)
+
+		var crd apiextensions.CustomResourceDefinition
+		err = yaml.Unmarshal(content, &crd)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse CRD file %s: %v", crdFilePath, err)
+		}
+
+		if !slices.Contains(crdMap[operator], crd.Spec.Group) {
+			crdMap[operator] = append(crdMap[operator], crd.Spec.Group)
+		}
+	}
+
+	return crdMap, nil
+}

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -24,11 +24,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"os"
-	"path/filepath"
-	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -38,8 +35,6 @@ import (
 	"github.com/ghodss/yaml"
 	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -114,7 +109,6 @@ var (
 	relatedImagesList = flag.String("related-images-list", "",
 		"Comma separated list of all the images referred in the CSV (just the image pull URLs or eventually a set of 'image|name' collations)")
 	ignoreComponentsRelatedImages = flag.Bool("ignore-component-related-image", false, "Ignore relatedImages from components CSVs")
-	crdDir                        = flag.String("crds-dir", "", "the directory containing the CRDs for apigroup validation. The validation will be performed if and only if the value is non-empty.")
 	hcoKvIoVersion                = flag.String("hco-kv-io-version", "", "KubeVirt version")
 	kubevirtVersion               = flag.String("kubevirt-version", "", "Kubevirt operator version")
 	kvVirtLauncherOSVersion       = flag.String("virt-launcher-os-version", "", "Virt launcher OS version")
@@ -135,100 +129,6 @@ var (
 	envVars EnvVarFlags
 )
 
-func IOReadDir(root string) ([]string, error) {
-	var files []string
-	fileInfo, err := os.ReadDir(root)
-	if err != nil {
-		return files, err
-	}
-
-	for _, file := range fileInfo {
-		files = append(files, filepath.Join(root, file.Name()))
-	}
-	return files, nil
-}
-
-func validateNoAPIOverlap(crdDir string) error {
-	crdFiles, err := IOReadDir(crdDir)
-	if err != nil {
-		return err
-	}
-
-	// crdMap is populated with operator names as keys and a slice of associated api groups as values.
-	crdMap := getCrdMap(crdFiles)
-
-	overlapsMap := detectAPIOverlap(crdMap)
-
-	return checkAPIOverlapMap(overlapsMap)
-}
-
-func checkAPIOverlapMap(overlapsMap map[string]sets.Set[string]) error {
-	// if at least one overlap found - emit an error.
-	if len(overlapsMap) != 0 {
-		var sb strings.Builder
-		// WriteString always returns error=nil. no point to check it.
-		_, _ = sb.WriteString("ERROR: Overlapping API Groups were found between different operators.\n")
-		for apiGroup := range overlapsMap {
-			_, _ = sb.WriteString(fmt.Sprintf("The API Group %s is being used by these operators: %s\n", apiGroup, strings.Join(overlapsMap[apiGroup].UnsortedList(), ", ")))
-		}
-		return errors.New(sb.String())
-	}
-	return nil
-}
-
-func detectAPIOverlap(crdMap map[string][]string) map[string]sets.Set[string] {
-	// overlapsMap is populated with collisions found - API Groups as keys,
-	// and slice containing operators using them, as values.
-	overlapsMap := make(map[string]sets.Set[string])
-	for operator, groups := range crdMap {
-		for _, apiGroup := range groups {
-			compareMapWithEntry(crdMap, operator, apiGroup, overlapsMap)
-		}
-	}
-	return overlapsMap
-}
-
-func compareMapWithEntry(crdMap map[string][]string, operator string, apigroup string, overlapsMap map[string]sets.Set[string]) {
-	for comparedOperator := range crdMap {
-		if operator == comparedOperator { // don't check self
-			continue
-		}
-
-		if slices.Contains(crdMap[comparedOperator], apigroup) {
-			overlapsMap[apigroup].Insert(operator)
-			overlapsMap[apigroup].Insert(comparedOperator)
-		}
-	}
-}
-
-func getCrdMap(crdFiles []string) map[string][]string {
-	crdMap := make(map[string][]string)
-
-	for _, crdFilePath := range crdFiles {
-		file, err := os.Open(crdFilePath)
-		panicOnError(err)
-
-		content, err := io.ReadAll(file)
-		panicOnError(err)
-
-		err = file.Close()
-		panicOnError(err)
-
-		crdFileName := filepath.Base(crdFilePath)
-		reg := regexp.MustCompile(`([^\d]+)`)
-		operator := reg.FindString(crdFileName)
-
-		var crd apiextensions.CustomResourceDefinition
-		err = yaml.Unmarshal(content, &crd)
-		panicOnError(err)
-
-		if !slices.Contains(crdMap[operator], crd.Spec.Group) {
-			crdMap[operator] = append(crdMap[operator], crd.Spec.Group)
-		}
-	}
-	return crdMap
-}
-
 func main() {
 	flag.Var(&envVars, "env-var", "HCO environment variable (key=value), may be used multiple times")
 
@@ -236,11 +136,6 @@ func main() {
 
 	if webhookImage == nil || *webhookImage == "" {
 		*webhookImage = *operatorImage
-	}
-
-	if *crdDir != "" {
-		panicOnError(validateNoAPIOverlap(*crdDir))
-		os.Exit(0)
 	}
 
 	if *enableUniqueSemver && *olmSkipRange != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

The CRD overlap validation is used only in build-manifest, and not in any other place. It should not be part of the csv-merger, and not part of the operator image.

This PR take this functionality out of the csv-merger, and introduces the new crd-overlap-validator tool, to be used from the build-manifests script.

**Release note**:
```release-note
None
```
