### PR TITLE
Support NetworkPolicies in the bundle image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ LDFLAGS            ?= -w -s
 GOLANDCI_LINT_VERSION ?= v2.0.2
 HCO_BUMP_LEVEL ?= minor
 ASSETS_DIR ?= assets
+DUMP_NETWORK_POLICIES ?= "false"
 UNAME_ARCH     := $(shell uname -m)
 ifeq ($(UNAME_ARCH),x86_64)
 	TEMP_ARCH = amd64
@@ -39,7 +40,7 @@ sanity: generate generate-doc validate-no-offensive-lang goimport lint-metrics l
 	go fmt ./...
 	go mod tidy -v
 	go mod vendor
-	./hack/build-manifests.sh
+	make build-manifests
 	git add -N vendor
 	git difftool -y --trust-exit-code --extcmd=./hack/diff-csv.sh
 
@@ -64,7 +65,7 @@ build-webhook: $(SOURCES) ## Build binary from source
 	go build -ldflags="${LDFLAGS}" -o _out/hyperconverged-cluster-webhook ./cmd/hyperconverged-cluster-webhook
 
 build-manifests:
-	./hack/build-manifests.sh
+	DUMP_NETWORK_POLICIES=$(DUMP_NETWORK_POLICIES) ./hack/build-manifests.sh
 
 build-manifests-prev:
 	RELEASE_DELTA=1 ./hack/build-manifests.sh

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ build-operator: gogenerate $(SOURCES) ## Build binary from source
 	go build -ldflags="${LDFLAGS}" -o _out/hyperconverged-cluster-operator ./cmd/hyperconverged-cluster-operator
 
 build-csv-merger: ## Build binary from source
-	go build -ldflags="${LDFLAGS}" -o _out/csv-merger tools/csv-merger/csv-merger.go
+	go build -ldflags="${LDFLAGS}" -o _out/csv-merger ./tools/csv-merger
 
 build-webhook: $(SOURCES) ## Build binary from source
 	go build -ldflags="${LDFLAGS}" -o _out/hyperconverged-cluster-webhook ./cmd/hyperconverged-cluster-webhook

--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 
+	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
@@ -22,6 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -44,8 +46,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	controllerruntimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
-
-	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
@@ -106,6 +106,7 @@ var (
 		aaqv1alpha1.AddToScheme,
 		deschedulerv1.AddToScheme,
 		netattdefv1.AddToScheme,
+		networkingv1.AddToScheme,
 	}
 )
 
@@ -342,6 +343,10 @@ func getCacheOption(operatorNamespace string, ci hcoutil.ClusterInfo) cache.Opti
 			Label: labelSelector,
 			Field: namespaceSelector,
 		},
+		&networkingv1.NetworkPolicy{}: {
+			Label: labelSelector,
+			Field: namespaceSelector,
+		},
 	}
 
 	cacheOptionsByObjectForDescheduler := map[client.Object]cache.ByObject{
@@ -394,7 +399,6 @@ func getCacheOption(operatorNamespace string, ci hcoutil.ClusterInfo) cache.Opti
 	}
 
 	return cacheOptions
-
 }
 
 func getManagerOptions(operatorNamespace string, needLeaderElection bool, ci hcoutil.ClusterInfo, scheme *apiruntime.Scheme) manager.Options {

--- a/controllers/alerts/constants.go
+++ b/controllers/alerts/constants.go
@@ -1,0 +1,17 @@
+package alerts
+
+import hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+
+const (
+	operatorName                 = "hyperconverged-cluster-operator"
+	defaultMonitoringNamespace   = "monitoring"
+	openshiftMonitoringNamespace = "openshift-monitoring"
+)
+
+func getMonitoringNamespace(ci hcoutil.ClusterInfo) string {
+	if ci.IsOpenshift() {
+		return openshiftMonitoringNamespace
+	}
+
+	return defaultMonitoringNamespace
+}

--- a/controllers/alerts/metrics_test.go
+++ b/controllers/alerts/metrics_test.go
@@ -14,7 +14,9 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -106,6 +108,56 @@ var _ = Describe("alert tests", func() {
 			Expect(hco.Status.RelatedObjects).To(HaveLen(6))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
+		})
+
+		It("should not create network policy if the pod is without the np labels", func() {
+			cl := commontestutils.InitClient([]client.Object{ns})
+			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
+
+			Expect(r.Reconcile(req, false)).To(Succeed())
+
+			np := &networkingv1.NetworkPolicy{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: policyName}, np)).To(MatchError(k8serrors.IsNotFound, "should return NotFound error"))
+		})
+
+		It("should create network policy if the pod is with the np labels", func() {
+			pod := ci.GetPod()
+			if pod.Labels == nil {
+				pod.Labels = make(map[string]string)
+			}
+			pod.Labels[hcoutil.AllowEgressToDNSAndAPIServerLabel] = "true"
+			pod.Labels[hcoutil.AllowIngressToMetricsEndpointLabel] = "true"
+
+			DeferCleanup(func() {
+				delete(pod.Labels, hcoutil.AllowEgressToDNSAndAPIServerLabel)
+				delete(pod.Labels, hcoutil.AllowIngressToMetricsEndpointLabel)
+			})
+
+			cl := commontestutils.InitClient([]client.Object{ns})
+			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
+
+			Expect(r.Reconcile(req, false)).To(Succeed())
+
+			np := &networkingv1.NetworkPolicy{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: policyName}, np)).To(Succeed())
+
+			hco := commontestutils.NewHco()
+			req = commontestutils.NewReq(hco)
+			Expect(r.UpdateRelatedObjects(req)).To(Succeed())
+			Expect(req.StatusDirty).To(BeTrue())
+			Expect(hco.Status.RelatedObjects).To(HaveLen(7))
+
+			Expect(np.Spec.Egress).To(HaveLen(1))
+			Expect(np.Spec.Egress[0].To).To(HaveLen(1))
+			Expect(np.Spec.Egress[0].To[0].NamespaceSelector).ToNot(BeNil())
+			Expect(np.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels).To(HaveKeyWithValue("kubernetes.io/metadata.name", "openshift-monitoring"))
+
+			expectedEventsWithNP := append(expectedEvents, commontestutils.MockEvent{
+				EventType: corev1.EventTypeNormal,
+				Reason:    "Created",
+				Msg:       "Created NetworkPolicy " + policyName,
+			})
+			Expect(ee.CheckEvents(expectedEventsWithNP)).To(BeTrue())
 		})
 
 		It("should fail on error", func() {

--- a/controllers/alerts/network_policy.go
+++ b/controllers/alerts/network_policy.go
@@ -1,0 +1,108 @@
+package alerts
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	policyName = "hco-allow-egress-to-alert-manager"
+)
+
+type AlertManagerNetworkPolicyReconciler struct {
+	thePolicy *networkingv1.NetworkPolicy
+}
+
+// newAlertRuleReconciler creates new AlertRuleReconciler instance and returns a pointer to it.
+func newAlertManagerNetworkPolicyReconciler(namespace string, owner metav1.OwnerReference, ci hcoutil.ClusterInfo) *AlertManagerNetworkPolicyReconciler {
+	return &AlertManagerNetworkPolicyReconciler{
+		thePolicy: newAlertManagerNetworkPolicy(namespace, owner, ci),
+	}
+}
+
+func newAlertManagerNetworkPolicy(namespace string, owner metav1.OwnerReference, ci hcoutil.ClusterInfo) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            policyName,
+			Namespace:       namespace,
+			Labels:          hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring),
+			OwnerReferences: []metav1.OwnerReference{*owner.DeepCopy()},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": operatorName,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeEgress,
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": getMonitoringNamespace(ci),
+								},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"alertmanager":                "main",
+									"app.kubernetes.io/component": "alert-router",
+									"app.kubernetes.io/instance":  "main",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *AlertManagerNetworkPolicyReconciler) Kind() string {
+	return "NetworkPolicy"
+}
+
+func (r *AlertManagerNetworkPolicyReconciler) ResourceName() string {
+	return policyName
+}
+
+func (r *AlertManagerNetworkPolicyReconciler) GetFullResource() client.Object {
+	return r.thePolicy.DeepCopy()
+}
+
+func (r *AlertManagerNetworkPolicyReconciler) EmptyObject() client.Object {
+	return &networkingv1.NetworkPolicy{}
+}
+
+func (r *AlertManagerNetworkPolicyReconciler) UpdateExistingResource(ctx context.Context, cl client.Client, existing client.Object, logger logr.Logger) (client.Object, bool, error) {
+	needUpdate := false
+	np := existing.(*networkingv1.NetworkPolicy)
+	if !reflect.DeepEqual(r.thePolicy.Spec, np.Spec) {
+		needUpdate = true
+		r.thePolicy.Spec.DeepCopyInto(&np.Spec)
+	}
+
+	needUpdate = updateCommonDetails(&r.thePolicy.ObjectMeta, &np.ObjectMeta) || needUpdate
+
+	if needUpdate {
+		logger.Info("updating the PrometheusRule")
+		err := cl.Update(ctx, np)
+		if err != nil {
+			logger.Error(err, "failed to update the PrometheusRule")
+			return nil, false, err
+		}
+		logger.Info("successfully updated the PrometheusRule")
+	}
+
+	return np, needUpdate, nil
+}

--- a/controllers/alerts/rbac.go
+++ b/controllers/alerts/rbac.go
@@ -13,10 +13,7 @@ import (
 )
 
 const (
-	operatorName                 = "hyperconverged-cluster-operator"
-	roleName                     = operatorName + "-metrics"
-	defaultMonitoringNamespace   = "monitoring"
-	openshiftMonitoringNamespace = "openshift-monitoring"
+	roleName = operatorName + "-metrics"
 )
 
 // RoleReconciler maintains an RBAC Role to allow Prometheus operator to read from HCO metric
@@ -188,12 +185,4 @@ func newRoleBinding(owner metav1.OwnerReference, namespace string, ci hcoutil.Cl
 			},
 		},
 	}
-}
-
-func getMonitoringNamespace(ci hcoutil.ClusterInfo) string {
-	if ci.IsOpenshift() {
-		return openshiftMonitoringNamespace
-	}
-
-	return defaultMonitoringNamespace
 }

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -22,6 +22,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -175,6 +176,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo, in
 		secondaryResources = append(secondaryResources, []client.Object{
 			&monitoringv1.ServiceMonitor{},
 			&monitoringv1.PrometheusRule{},
+			&networkingv1.NetworkPolicy{},
 		}...)
 	}
 	if ci.IsOpenshift() {

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1180,6 +1180,17 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
@@ -615,6 +615,17 @@ spec:
           - create
           - update
           - delete
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
         serviceAccountName: hyperconverged-cluster-operator
       - rules: []
         serviceAccountName: hyperconverged-cluster-cli-download

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.16.0-unstable
-    createdAt: "2025-07-23 12:31:59"
+    createdAt: "2025-07-23 21:48:04"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -608,6 +608,17 @@ spec:
           - security.openshift.io
           resources:
           - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
           verbs:
           - get
           - list

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -13,6 +13,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -655,6 +656,11 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		{
 			APIGroups: stringListToSlice("security.openshift.io"),
 			Resources: stringListToSlice("securitycontextconstraints"),
+			Verbs:     stringListToSlice("get", "list", "watch", "create", "update", "delete"),
+		},
+		{
+			APIGroups: stringListToSlice(networkingv1.GroupName),
+			Resources: stringListToSlice("networkpolicies"),
 			Verbs:     stringListToSlice("get", "list", "watch", "create", "update", "delete"),
 		},
 	}

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -51,10 +51,6 @@ const (
 
 	kubevirtProjectName = "KubeVirt project"
 	rbacVersionV1       = "rbac.authorization.k8s.io/v1"
-
-	// labels to apply network policies:
-	allowEgressToDNSAndAPIServerLabel  = "hco.kubevirt.io/allow-access-cluster-services"
-	allowIngressToMetricsEndpointLabel = "hco.kubevirt.io/allow-prometheus-access"
 )
 
 var deploymentType = metav1.TypeMeta{
@@ -379,8 +375,8 @@ func getLabels(name, hcoKvIoVersion string) map[string]string {
 func getLabelsWithNetworkPolicies(deploymentName string, params *DeploymentOperatorParams) map[string]string {
 	labels := getLabels(deploymentName, params.HcoKvIoVersion)
 	if params.AddNetworkPolicyLabels {
-		labels[allowEgressToDNSAndAPIServerLabel] = "true"
-		labels[allowIngressToMetricsEndpointLabel] = "true"
+		labels[util.AllowEgressToDNSAndAPIServerLabel] = "true"
+		labels[util.AllowIngressToMetricsEndpointLabel] = "true"
 	}
 
 	return labels

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -80,6 +80,11 @@ const (
 	DeschedulerNamespace = "openshift-kube-descheduler-operator"
 
 	DataImportCronEnabledAnnotation = "dataimportcrontemplate.kubevirt.io/enable"
+
+	// AllowEgressToDNSAndAPIServerLabel if this label is set, the network policy will allow egress to DNS and API server
+	AllowEgressToDNSAndAPIServerLabel = "hco.kubevirt.io/allow-access-cluster-services"
+	// AllowIngressToMetricsEndpointLabel if this label is set, the network policy will allow ingress to the metrics endpoint
+	AllowIngressToMetricsEndpointLabel = "hco.kubevirt.io/allow-prometheus-access"
 )
 
 type AppComponent string

--- a/pkg/util/own_resources.go
+++ b/pkg/util/own_resources.go
@@ -26,7 +26,7 @@ func (or *OwnResources) GetPod() *corev1.Pod {
 	if or == nil {
 		return nil
 	}
-	return or.pod
+	return or.pod.DeepCopy()
 }
 
 // GetDeployment returns the deployment that controls the running pod, or nil if not exists

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -151,6 +151,12 @@ func main() {
 		panicOnError(util.MarshallObject(components.GetOperatorCRD(*apiSources), os.Stdout))
 	case CSVMode:
 		getHcoCsv()
+		if *dumpNetworkPolicies {
+			if err := generateNetworkPolicies(); err != nil {
+				fmt.Fprintf(os.Stderr, "error generating network policies: %v\n", err)
+				os.Exit(1)
+			}
+		}
 
 	default:
 		panic("Unsupported output mode: " + *outputMode)

--- a/tools/csv-merger/network-policies-template.tmpl
+++ b/tools/csv-merger/network-policies-template.tmpl
@@ -1,0 +1,96 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hco-allow-egress-to-dns
+  namespace: {{ .Namespace }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: hco.kubevirt.io/allow-access-cluster-services
+        operator: Exists
+  policyTypes:
+    - Egress
+  egress:
+{{- range .DNSSelectors }}
+    - ports:
+        - protocol: TCP
+          port: {{.DNSPort}}
+        - protocol: UDP
+          port: {{.DNSPort}}
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{.DNSNamespaceSelector}}
+          podSelector:
+            matchLabels:
+              {{.DNSPodSelectorLabel}}: {{.DNSPodSelectorVal}}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hco-allow-egress-to-api-server
+  namespace: {{ .Namespace }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: hco.kubevirt.io/allow-access-cluster-services
+        operator: Exists
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hco-allow-ingress-to-metrics-endpoint
+  namespace: {{ .Namespace }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: hco.kubevirt.io/allow-prometheus-access
+        operator: Exists
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hco-allow-ingress-to-webhook
+  namespace: {{ .Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      name: hyperconverged-cluster-webhook
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .WebhookPort }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hco-allow-ingress-to-cli-dl
+  namespace: {{ .Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      name: hyperconverged-cluster-cli-download
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .CLIDownloadsPort }}

--- a/tools/csv-merger/network_policy_gen.go
+++ b/tools/csv-merger/network_policy_gen.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	_ "embed"
+	"flag"
+	"os"
+	"text/template"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	k8sDNSNamespaceSelector = "kube-system"
+	k8sDNSPodSelectorLabel  = "k8s-app"
+	k8sDNSPodSelectorVal    = "kube-dns"
+	k8sDNSPort              = uint32(53)
+
+	openshiftDNSNamespaceSelector = "openshift-dns"
+	openshiftDNSPodSelectorLabel  = "dns.operator.openshift.io/daemonset-dns"
+	openshiftDNSPodSelectorVal    = "default"
+	openshiftDNSPort              = uint32(5353)
+)
+
+//go:embed network-policies-template.tmpl
+var networkPoliciesTemplateFile string
+
+type networkPoliciesParams struct {
+	Namespace        string
+	DNSSelectors     []DNSSelector
+	WebhookPort      int32
+	CLIDownloadsPort int32
+}
+
+type DNSSelector struct {
+	DNSNamespaceSelector string
+	DNSPodSelectorLabel  string
+	DNSPodSelectorVal    string
+	DNSPort              uint32
+}
+
+var (
+	networkPoliciesTemplate = template.Must(template.New("network-policies").Parse(networkPoliciesTemplateFile))
+
+	// deployK8sDNSNetworkPolicy is a flag to control whether the k8s DNS network policy should be deployed.
+	// By default, the bundle image that includes the network policy yaml files is going to be deployed on openshift.
+	// But it is also possible to deploy the bundle image on k8s clusters, in which case the k8s DNS network policy
+	// should be deployed.
+	// When building for both openshift and k8s, this flag should be set to true, in order to add also the k8s DNS
+	// network policy rule to the bundle image, in addition to the openshift rule.
+	deployK8sDNSNetworkPolicy = flag.Bool("deploy-k8s-dns-networkpolicy", false, "Deploy the k8s DNS network policy; only applied if output-mode is 'CSV' and --dump-network-policies is set")
+
+	params = networkPoliciesParams{
+		WebhookPort:      hcoutil.WebhookPort,
+		CLIDownloadsPort: hcoutil.CliDownloadsServerPort,
+		DNSSelectors: []DNSSelector{
+			{
+				DNSNamespaceSelector: openshiftDNSNamespaceSelector,
+				DNSPodSelectorLabel:  openshiftDNSPodSelectorLabel,
+				DNSPodSelectorVal:    openshiftDNSPodSelectorVal,
+				DNSPort:              openshiftDNSPort,
+			},
+		},
+	}
+)
+
+func generateNetworkPolicies() error {
+	if *deployK8sDNSNetworkPolicy {
+		params.DNSSelectors = append(params.DNSSelectors, DNSSelector{
+			DNSNamespaceSelector: k8sDNSNamespaceSelector,
+			DNSPodSelectorLabel:  k8sDNSPodSelectorLabel,
+			DNSPodSelectorVal:    k8sDNSPodSelectorVal,
+			DNSPort:              k8sDNSPort,
+		})
+	}
+
+	return networkPoliciesTemplate.Execute(os.Stdout, params)
+}

--- a/tools/manifest-splitter/.gitignore
+++ b/tools/manifest-splitter/.gitignore
@@ -1,0 +1,1 @@
+manifest-splitter

--- a/tools/manifest-splitter/file_handler.go
+++ b/tools/manifest-splitter/file_handler.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/ghodss/yaml"
+)
+
+type fileHandler struct {
+	buff          *bytes.Buffer
+	fileTypeIsSet bool
+	operatorName  string
+	fileName      string
+	outputDir     string
+	isNewFile     bool
+	fileTypeName  string
+}
+
+func newFileHandler(operatorName string, outputDir string) *fileHandler {
+	return &fileHandler{
+		operatorName: operatorName,
+		buff:         bytes.NewBuffer([]byte("---\n")),
+		outputDir:    outputDir,
+		isNewFile:    true,
+	}
+}
+
+func (fh *fileHandler) getFileName() string {
+	return fh.fileName
+}
+
+func (fh *fileHandler) writeLine(l string) {
+	fh.buff.WriteString(l)
+	fh.buff.WriteByte('\n')
+	fh.isNewFile = false
+}
+
+var (
+	unknownFileType = indexedFileType{name: "unknown"}
+	crdFileType     = indexedFileType{name: "crd"}
+)
+
+func (fh *fileHandler) writeToFile() error {
+	var fileName string
+
+	switch fh.fileTypeName {
+	case "":
+		fileName = fh.operatorName + unknownFileType.getFileNameSuffix()
+	case "customresourcedefinition":
+		fileName = fh.operatorName + crdFileType.getFileNameSuffix()
+
+	case "clusterserviceversion":
+		fileName = fh.operatorName + csvExtension
+	default:
+		object := map[string]any{}
+		if err := yaml.Unmarshal(fh.buff.Bytes(), &object); err != nil {
+			return err
+		}
+
+		name := object["metadata"].(map[string]any)["name"]
+		fileName = fmt.Sprintf("%s.%s.%s.yaml", fh.operatorName, fh.fileTypeName, name)
+
+	}
+
+	fh.fileName = path.Join(outputDir, fileName)
+
+	file, err := os.OpenFile(fh.getFileName(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.Write(fh.buff.Bytes())
+
+	return err
+}
+
+func (fh *fileHandler) setFileType(ft string) {
+	fh.fileTypeName = ft
+	fh.fileTypeIsSet = true
+}
+
+func (fh *fileHandler) isEmpty() bool {
+	return fh.isNewFile
+}

--- a/tools/manifest-splitter/file_type.go
+++ b/tools/manifest-splitter/file_type.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+)
+
+type indexedFileType struct {
+	name     string
+	numFiles int
+}
+
+func (ft *indexedFileType) getFileNameSuffix() string {
+	n := fmt.Sprintf("%02d.%s.yaml", ft.numFiles, ft.name)
+	ft.numFiles++
+	return n
+}

--- a/tools/manifest-splitter/manifest_splitter.go
+++ b/tools/manifest-splitter/manifest_splitter.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	kindLinePrefix = "kind: "
+
+	yamlSeparator = "---"
+)
+
+var (
+	operatorName  string
+	manifestsFile string
+	outputDir     string
+	csvExtension  string
+)
+
+func main() {
+	var manifests io.Reader = os.Stdin
+	if manifestsFile != "" {
+		fin, err := os.Open(manifestsFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to open %s; %v", manifestsFile, err)
+			os.Exit(1)
+		}
+
+		defer fin.Close()
+
+		manifests = fin
+	}
+
+	err := splitFile(manifests, operatorName, outputDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
+
+func init() {
+	flag.StringVar(&operatorName, "operator-name", "", "The name of the operator to use; mandatory")
+	flag.StringVar(&manifestsFile, "manifests-file", "", "The path to the manifests file; optional; if not provided, reads from stdin")
+	flag.StringVar(&outputDir, "output-dir", ".", "The directory to write the split manifests to; default: the working directory")
+	flag.StringVar(&csvExtension, "csv-extension", ".clusterserviceversion.yaml", "The file extension to use for CSV files; default: '.clusterserviceversion.yaml'")
+	flag.Parse()
+
+	if operatorName == "" {
+		fmt.Fprintln(os.Stderr, "Please provide the operator name using the operator-name flag")
+		flag.Usage()
+		os.Exit(1)
+	}
+}
+
+func splitFile(fin io.Reader, operatorName, outputDir string) error {
+	scanner := bufio.NewScanner(fin)
+	fh := newFileHandler(operatorName, outputDir)
+
+	for scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("unexpected error while processing input; %v", err)
+		}
+
+		line := scanner.Text()
+
+		if line == yamlSeparator {
+			if !fh.isEmpty() {
+				if err := tryWriteFile(fh); err != nil {
+					return err
+				}
+
+				fh = newFileHandler(operatorName, outputDir)
+			}
+			continue
+		}
+
+		fh.writeLine(line)
+
+		if strings.HasPrefix(line, kindLinePrefix) {
+			if fh.fileTypeIsSet {
+				return fmt.Errorf(`wrong manifest: multiple "kind" lines of %q`, line)
+			}
+			fh.setFileType(strings.ToLower(strings.TrimPrefix(line, kindLinePrefix)))
+		}
+	}
+
+	if !fh.isEmpty() {
+		if err := tryWriteFile(fh); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func tryWriteFile(fh *fileHandler) error {
+	if err := fh.writeToFile(); err != nil {
+		return fmt.Errorf("failed to write to file %s; %v", fh.getFileName(), err)
+	}
+
+	if !fh.fileTypeIsSet {
+		fmt.Fprintln(os.Stderr, "Found a non-kubernetes file. It will be saved as", fh.getFileName())
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add the `manifest-splitter` tool, to allow multiple types of K8s manifests in other operators csv-gen
* Use the new `manifest-splitter` tool in the build-manifests script, so the other operator would able to generate NetworkPolicy manifests, to get into the bundle image.
* Add the new `network-policy-gen` tool to generate a set of network policies for HCO and other components.
**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-63363
https://issues.redhat.com/browse/CNV-63366
https://issues.redhat.com/browse/CNV-63382
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow adding network policies to the bundle image
```
