### PR TITLE
Add two new labels for NetworkPolicy

### DIFF
--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -123,8 +123,9 @@ var (
 		"Comma separated list of CSVs that can be skipped (read replaced) by this version")
 	olmSkipRange = flag.String("olm-skip-range", "",
 		"Semver range expression for CSVs that can be skipped (read replaced) by this version")
-	mgImage        = flag.String("mg-image", "quay.io/kubevirt/must-gather", "Operator suggested must-gather image")
-	testImagesNVRs = flag.String("test-images-nvrs", "", "Test Images NVRs")
+	mgImage             = flag.String("mg-image", "quay.io/kubevirt/must-gather", "Operator suggested must-gather image")
+	testImagesNVRs      = flag.String("test-images-nvrs", "", "Test Images NVRs")
+	dumpNetworkPolicies = flag.Bool("dump-network-policies", false, "Dump network policy yamls to stdout")
 
 	envVars EnvVarFlags
 )
@@ -424,6 +425,7 @@ func getDeploymentParams() *components.DeploymentOperatorParams {
 		HppoVersion:            *hppoVersion,
 		AaqVersion:             *aaqVersion,
 		Env:                    envVars,
+		AddNetworkPolicyLabels: *dumpNetworkPolicies,
 	}
 }
 

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -116,13 +116,7 @@ func main() {
 	// same service account multiple times.
 	deployments := []appsv1.Deployment{
 		components.GetDeploymentOperator(operatorParams),
-		components.GetDeploymentWebhook(
-			*operatorNamespace,
-			*webhookImage,
-			"IfNotPresent",
-			*hcoKvIoVersion,
-			[]corev1.EnvVar{},
-		),
+		components.GetDeploymentWebhook(operatorParams),
 		components.GetDeploymentCliDownloads(operatorParams),
 	}
 	// hco-operator and hco-webhook


### PR DESCRIPTION
**What this PR does / why we need it**:

Optionally add two new labels to the operator and the webhook pods, in the CSV.

The `hco.kubevirt.io/allow-access-cluster-services` label is used to allow egress to the DNS and the API-Server.

The `hco.kubevirt.io/allow-prometheus-access` label is used to allow ingress to the metrics port of the pod.

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-63367
```

**Release note**:
```release-note
CSV: Add two new labels for NetworkPolicy
```
