### PR TITLE
Fix the nightly test in openshiftci

### DIFF
--- a/deploy/kustomize/deploy_kustomize.sh
+++ b/deploy/kustomize/deploy_kustomize.sh
@@ -13,6 +13,7 @@ QUAY_PASSWORD="${QUAY_PASSWORD:-}"
 CONTENT_ONLY="${CONTENT_ONLY:-false}"
 KVM_EMULATION="${KVM_EMULATION:-false}"
 OC_TOOL="${OC_TOOL:-oc}"
+TIMEOUT="${TIMEOUT:-15m}"
 
 #####################
 
@@ -152,8 +153,8 @@ retry_loop() {
 
   if [[ $success -eq 1 ]]; then
     echo "[INFO] Deployment successful, waiting for HCO Operator to report Ready..."
-    ${OC_TOOL} wait -n ${TARGET_NAMESPACE} hyperconverged kubevirt-hyperconverged --for condition=Available --timeout=15m
-    ${OC_TOOL} wait "$(${OC_TOOL} get pods -n ${TARGET_NAMESPACE} -l name=hyperconverged-cluster-operator -o name)" -n "${TARGET_NAMESPACE}" --for condition=Ready --timeout=15m
+    ${OC_TOOL} wait -n ${TARGET_NAMESPACE} hyperconverged kubevirt-hyperconverged --for condition=Available --timeout=${TIMEOUT}
+    ${OC_TOOL} wait "$(${OC_TOOL} get pods -n ${TARGET_NAMESPACE} -l name=hyperconverged-cluster-operator -o name)" -n "${TARGET_NAMESPACE}" --for condition=Ready --timeout=${TIMEOUT}
   else
     echo "[ERROR] Deployment failed."
     exit 1

--- a/tools/k8s-label-visualizer/conf.json
+++ b/tools/k8s-label-visualizer/conf.json
@@ -17,7 +17,7 @@
     },
     {
       "group": "ssp.kubevirt.io",
-      "version": "v1beta1",
+      "version": "v1beta2",
       "kind": "ssps"
     },
     {

--- a/tools/k8s-label-visualizer/k8s_fetcher.py
+++ b/tools/k8s-label-visualizer/k8s_fetcher.py
@@ -22,6 +22,7 @@ class ObjectFetcher(object):
 
         result = []
         for nt in self.conf.namespaced:
+            print(f"Fetching {nt.group}/{nt.version} {nt.kind} in namespace {ns}")
             response = api.list_namespaced_custom_object(
                 namespace=ns,
                 group=nt.group,
@@ -32,6 +33,7 @@ class ObjectFetcher(object):
             result.extend(response["items"])
 
         for ct in self.conf.cluster:
+            print(f"Fetching cluster scoped {ct.group}/{ct.version} {ct.kind}")
             response = api.list_cluster_custom_object(
                 group=ct.group,
                 version=ct.version,

--- a/tools/k8s-label-visualizer/requirements.txt
+++ b/tools/k8s-label-visualizer/requirements.txt
@@ -2,9 +2,8 @@ cachetools==5.3.3
 certifi==2024.7.4
 chardet==5.2.0
 google-auth==2.29.0
-graphviz==0.20.3
 idna==3.7
-kubernetes==29.0.0
+kubernetes==32.0.0
 marshmallow==3.21.2
 marshmallow-dataclass==8.6.1
 mypy-extensions==1.0.0
@@ -21,3 +20,4 @@ typing-extensions==4.11.0
 typing-inspect==0.9.0
 urllib3==2.2.2
 websocket-client==1.8.0
+graphviz==0.21


### PR DESCRIPTION
**What this PR does / why we need it**:

The nightly test is broken for a long time, since the deprecation of SSP v1beta1.

The script is trying to collect resource from the non-existing CRD version, and fails.

This PR fixes the SSP CRD version to v1beta2, and add some printout and some additional improvements.

**Release note**:
```release-note
None
```
