### PR TITLE
fix debug's leftovers in publish-community-operators.yaml

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -31,7 +31,7 @@ jobs:
             TARGET_BRANCH=main
           fi
           echo "TARGET_BRANCH=${TARGET_BRANCH}" >> $GITHUB_ENV
-          echo "TAGGED_VERSION=${GIT_TAG}" >> $GITHUB_ENV
+          echo "TAGGED_VERSION=${TAGGED_VERSION}" >> $GITHUB_ENV
       - name: Checkout the latest code of ${{ env.TARGET_BRANCH }} branch
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix error in the .github/workflows/publish-community-operators.yaml, as result of debug leftover.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
