### PR TITLE
fix the publish github action

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -129,6 +129,7 @@ jobs:
         env:
           NEW_IMAGE_TAG: ${{ env.NEW_IMAGE_TAG }}
         run: |
+          make quay-login
           IMAGE_TAG=${NEW_IMAGE_TAG} make build-push-multi-arch-images
 
       - name: run manifest for next version


### PR DESCRIPTION
Add missing quay.io login

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
