### PR TITLE
Update the assignees list in a github action

### DIFF
--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -163,6 +163,6 @@ jobs:
             ```release-note
             Prepare version ${{ env.NEW_VERSION }}
             ```
-          assignees: tiraboschi,orenc1,nunnatsa,machadovilaca,dharmit
-          reviewers: tiraboschi,orenc1,nunnatsa,machadovilaca,dharmit
+          assignees: orenc1,nunnatsa,machadovilaca,avlitman
+          reviewers: orenc1,nunnatsa,machadovilaca,avlitman
           branch: prepare_version_${{ env.NEW_VERSION }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The publish-community-operators creates a PR with the wrong list of assignees. This PR updates the list to the right user names.

**Release note**:
```release-note
None
```
