### PR TITLE
Bump golang base images to v1.24

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.6 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.3 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.6 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.3 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.functest.ci
+++ b/build/Dockerfile.functest.ci
@@ -1,5 +1,5 @@
-# registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+# registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.6 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.3 AS builder
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .

--- a/tests/build/Dockerfile
+++ b/tests/build/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "diskspacecheck=0" >> /etc/dnf/dnf.conf && dnf update -y && dnf install
 
 RUN pip3 install j2cli && pip3 install operator-courier
 
-ENV GO_VERSION=1.23.4 \
+ENV GO_VERSION=1.24.3 \
     KUBEBUILDER_VERSION="3.2.0" \
     ARCH="amd64" \
     GOPATH="/go" \


### PR DESCRIPTION
**What this PR does / why we need it**:
This is needed in order to bump the base images in openshift-ci.

Only after this PR and a PR in openshift-ci will be merged, we could bump the go version for the project itself.

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-63406
```

**Release note**:
```release-note
None
```
