### PR TITLE
Enable SecureExecution feature gate by default

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -220,6 +220,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"KubevirtSeccompProfile",
 					"VMPersistentState",
 					"InstancetypeReferencePolicy",
+					"SecureExecution",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}

--- a/controllers/operands/kubevirt.go
+++ b/controllers/operands/kubevirt.go
@@ -95,6 +95,9 @@ const (
 
 	// enables the instance type reference policy feature
 	kvInstancetypeReferencePolicy = "InstancetypeReferencePolicy"
+
+	// Allow running IBM Z Secure Execution VMs
+	kvSecureExecution = "SecureExecution"
 )
 
 const (
@@ -113,6 +116,7 @@ var (
 		kvKubevirtSeccompProfile,
 		kvVMPersistentState,
 		kvInstancetypeReferencePolicy,
+		kvSecureExecution,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Enable the `SecureExecution` feature gate in kubevirt. This allows Clusters to use Secure Execution VMs on IBM Z

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable SecureExecution Feature for s390x
```
