### PR TITLE
Remove a redundant check from the HC predicate

### DIFF
--- a/controllers/nodes/predicates.go
+++ b/controllers/nodes/predicates.go
@@ -51,11 +51,6 @@ func (hyperconvergedPredicate) Update(e event.TypedUpdateEvent[*v1beta1.HyperCon
 		return true
 	}
 
-	if !reflect.DeepEqual(e.ObjectNew.Spec.Infra, e.ObjectOld.Spec.Infra) {
-		// If the Infra spec not changed, we want to reconcile
-		return true
-	}
-
 	return false
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up #3594

In the `HyperConverged` predicate in the node controller, we trigger reconcile on `HyperConverged` CR update, if the workloads or the infra field was modified. But we actually don't need to check the infra field, because it does not affect the node counting, but only the workloads field does.

This PR drops the unnecessary check of the infra field.

```release-note
None
```
