### PR TITLE
Secure the metrics endpoint with https

### DIFF
--- a/cmd/cmdcommon/cmdcommon.go
+++ b/cmd/cmdcommon/cmdcommon.go
@@ -2,6 +2,7 @@ package cmdcommon
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"slices"
 
 	"github.com/go-logr/logr"
+	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/spf13/pflag"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -18,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/webhooks/validator"
 )
 
 // list of namespace allowed for HCO installations (for tests)
@@ -100,7 +103,7 @@ func (h HcCmdHelper) RegisterPPROFServer(mgr manager.Manager) error {
 	}))
 }
 
-func (h HcCmdHelper) ExitOnError(err error, message string, keysAndValues ...interface{}) {
+func (h HcCmdHelper) ExitOnError(err error, message string, keysAndValues ...any) {
 	if err != nil {
 		h.Logger.Error(err, message, keysAndValues...)
 		os.Exit(1)
@@ -173,4 +176,35 @@ func getOperatorNamespaceFromEnv() (string, error) {
 	}
 
 	return namespace, nil
+}
+
+func MutateTLSConfig(cfg *tls.Config) {
+	var ciphersTLS13 = map[string]uint16{
+		"TLS_AES_128_GCM_SHA256":       tls.TLS_AES_128_GCM_SHA256,
+		"TLS_AES_256_GCM_SHA384":       tls.TLS_AES_256_GCM_SHA384,
+		"TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
+
+	// This callback executes on each client call returning a new config to be used
+	// please be aware that the APIServer is using http keepalive so this is going to
+	// be executed only after a while for fresh connections and not on existing ones
+	cfg.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+		cipherNames, minTypedTLSVersion := validator.SelectCipherSuitesAndMinTLSVersion()
+
+		// TODO: workaround: TLSv1.3 ciphers are now enabled on openshift/library-go
+		// but on the other side crypto.CipherSuitesOrDie is still failing with an
+		// explict error when it encounters the name of a TLSv1.3 cipher.
+		// Remove the workaround once we can consume https://github.com/openshift/library-go/pull/1956
+		cipherNamesIANAC := crypto.OpenSSLToIANACipherSuites(cipherNames)
+		cipherNamesFilteredNoTLS13 := []string{}
+		for _, cipherName := range cipherNamesIANAC {
+			if _, ok := ciphersTLS13[cipherName]; !ok {
+				cipherNamesFilteredNoTLS13 = append(cipherNamesFilteredNoTLS13, cipherName)
+			}
+		}
+
+		cfg.CipherSuites = crypto.CipherSuitesOrDie(crypto.OpenSSLToIANACipherSuites(cipherNamesFilteredNoTLS13))
+		cfg.MinVersion = crypto.TLSVersionOrDie(string(minTypedTLSVersion))
+		return cfg, nil
+	}
 }

--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"maps"
 	"os"
@@ -66,7 +67,10 @@ import (
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-const openshiftMonitoringNamespace = "openshift-monitoring"
+const (
+	openshiftMonitoringNamespace = "openshift-monitoring"
+	operatorCertDirEnv           = "OPERATOR_CERT_DIR"
+)
 
 // Change below variables to serve metrics on different host or port.
 var (
@@ -366,8 +370,10 @@ func getCacheOption(operatorNamespace string, ci hcoutil.ClusterInfo) cache.Opti
 func getManagerOptions(operatorNamespace string, needLeaderElection bool, ci hcoutil.ClusterInfo, scheme *apiruntime.Scheme) manager.Options {
 	return manager.Options{
 		Metrics: server.Options{
+			SecureServing:  true,
 			BindAddress:    fmt.Sprintf("%s:%d", hcoutil.MetricsHost, hcoutil.MetricsPort),
 			FilterProvider: authorization.HttpWithBearerToken,
+			TLSOpts:        []func(*tls.Config){cmdcommon.MutateTLSConfig},
 		},
 		HealthProbeBindAddress: fmt.Sprintf("%s:%d", hcoutil.HealthProbeHost, hcoutil.HealthProbePort),
 		ReadinessEndpointName:  hcoutil.ReadinessEndpointName,

--- a/cmd/hyperconverged-cluster-webhook/main.go
+++ b/cmd/hyperconverged-cluster-webhook/main.go
@@ -1,30 +1,17 @@
 package main
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
-
-	"github.com/openshift/library-go/pkg/crypto"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
-	webhookscontrollers "github.com/kubevirt/hyperconverged-cluster-operator/controllers/webhooks"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/authorization"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/webhooks/validator"
-
-	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
-
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
+	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,15 +20,21 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/api"
-	"github.com/kubevirt/hyperconverged-cluster-operator/cmd/cmdcommon"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/webhooks"
+	webhookscontrollers "github.com/kubevirt/hyperconverged-cluster-operator/controllers/webhooks"
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/api"
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/cmd/cmdcommon"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/authorization"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/webhooks"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -93,8 +86,13 @@ func main() {
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: server.Options{
+			SecureServing:  true,
+			CertDir:        webhooks.GetWebhookCertDir(),
+			CertName:       hcoutil.WebhookCertName,
+			KeyName:        hcoutil.WebhookKeyName,
 			BindAddress:    fmt.Sprintf("%s:%d", hcoutil.MetricsHost, hcoutil.MetricsPort),
 			FilterProvider: authorization.HttpWithBearerToken,
+			TLSOpts:        []func(*tls.Config){cmdcommon.MutateTLSConfig},
 		},
 		HealthProbeBindAddress: fmt.Sprintf("%s:%d", hcoutil.HealthProbeHost, hcoutil.HealthProbePort),
 		ReadinessEndpointName:  hcoutil.ReadinessEndpointName,
@@ -106,7 +104,7 @@ func main() {
 			CertName: hcoutil.WebhookCertName,
 			KeyName:  hcoutil.WebhookKeyName,
 			Port:     hcoutil.WebhookPort,
-			TLSOpts:  []func(*tls.Config){MutateTLSConfig},
+			TLSOpts:  []func(*tls.Config){cmdcommon.MutateTLSConfig},
 		}),
 	})
 	cmdHelper.ExitOnError(err, "failed to create manager")
@@ -126,7 +124,8 @@ func main() {
 
 	// Detect OpenShift version
 	ci := hcoutil.GetClusterInfo()
-	ctx := context.TODO()
+	ctx := signals.SetupSignalHandler()
+
 	err = ci.Init(ctx, apiClient, logger)
 	cmdHelper.ExitOnError(err, "Cannot detect cluster type")
 
@@ -175,40 +174,9 @@ func main() {
 	logger.Info("Starting the Cmd.")
 	eventEmitter.EmitEvent(nil, corev1.EventTypeNormal, "Init", "Starting the HyperConverged webhook Pod")
 	// Start the Cmd
-	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+	if err = mgr.Start(ctx); err != nil {
 		logger.Error(err, "Manager exited non-zero")
 		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "UnexpectedError", "HyperConverged crashed; "+err.Error())
 		os.Exit(1)
-	}
-}
-
-func MutateTLSConfig(cfg *tls.Config) {
-	var ciphersTLS13 = map[string]uint16{
-		"TLS_AES_128_GCM_SHA256":       tls.TLS_AES_128_GCM_SHA256,
-		"TLS_AES_256_GCM_SHA384":       tls.TLS_AES_256_GCM_SHA384,
-		"TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
-	}
-
-	// This callback executes on each client call returning a new config to be used
-	// please be aware that the APIServer is using http keepalive so this is going to
-	// be executed only after a while for fresh connections and not on existing ones
-	cfg.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
-		cipherNames, minTypedTLSVersion := validator.SelectCipherSuitesAndMinTLSVersion()
-
-		// TODO: workaround: TLSv1.3 ciphers are now enabled on openshift/library-go
-		// but on the other side crypto.CipherSuitesOrDie is still failing with an
-		// explict error when it encounters the name of a TLSv1.3 cipher.
-		// Remove the workaround once we can consume https://github.com/openshift/library-go/pull/1956
-		cipherNamesIANAC := crypto.OpenSSLToIANACipherSuites(cipherNames)
-		cipherNamesFilteredNoTLS13 := []string{}
-		for _, cipherName := range cipherNamesIANAC {
-			if _, ok := ciphersTLS13[cipherName]; !ok {
-				cipherNamesFilteredNoTLS13 = append(cipherNamesFilteredNoTLS13, cipherName)
-			}
-		}
-
-		cfg.CipherSuites = crypto.CipherSuitesOrDie(crypto.OpenSSLToIANACipherSuites(cipherNamesFilteredNoTLS13))
-		cfg.MinVersion = crypto.TLSVersionOrDie(string(minTypedTLSVersion))
-		return cfg, nil
 	}
 }

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
@@ -3078,7 +3078,7 @@ spec:
                   periodSeconds: 5
                 name: hyperconverged-cluster-operator
                 ports:
-                - containerPort: 8383
+                - containerPort: 8443
                   name: metrics
                   protocol: TCP
                 readinessProbe:
@@ -3158,7 +3158,10 @@ spec:
                   periodSeconds: 5
                 name: hyperconverged-cluster-webhook
                 ports:
-                - containerPort: 8383
+                - containerPort: 4343
+                  name: webhook
+                  protocol: TCP
+                - containerPort: 8443
                   name: metrics
                   protocol: TCP
                 readinessProbe:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.16.0-unstable
-    createdAt: "2025-07-13 15:19:20"
+    createdAt: "2025-07-14 08:50:29"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -3078,7 +3078,7 @@ spec:
                   periodSeconds: 5
                 name: hyperconverged-cluster-operator
                 ports:
-                - containerPort: 8383
+                - containerPort: 8443
                   name: metrics
                   protocol: TCP
                 readinessProbe:
@@ -3158,7 +3158,10 @@ spec:
                   periodSeconds: 5
                 name: hyperconverged-cluster-webhook
                 ports:
-                - containerPort: 8383
+                - containerPort: 4343
+                  name: webhook
+                  protocol: TCP
+                - containerPort: 8443
                   name: metrics
                   protocol: TCP
                 readinessProbe:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -82,7 +82,7 @@ spec:
           periodSeconds: 5
         name: hyperconverged-cluster-operator
         ports:
-        - containerPort: 8383
+        - containerPort: 8443
           name: metrics
           protocol: TCP
         readinessProbe:
@@ -164,7 +164,10 @@ spec:
           periodSeconds: 5
         name: hyperconverged-cluster-webhook
         ports:
-        - containerPort: 8383
+        - containerPort: 4343
+          name: webhook
+          protocol: TCP
+        - containerPort: 8443
           name: metrics
           protocol: TCP
         readinessProbe:

--- a/deploy/webhooks.yaml
+++ b/deploy/webhooks.yaml
@@ -8,6 +8,19 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  name: hyperconverged-cluster-operator-service-cert
+  labels:
+    name: hyperconverged-cluster-operator
+spec:
+  secretName: hyperconverged-cluster-operator-service-cert
+  dnsNames:
+  - hyperconverged-cluster-operator-service.kubevirt-hyperconverged.svc
+  issuerRef:
+    name: selfsigned
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
   name: hyperconverged-cluster-webhook-service-cert
   labels:
     name: hyperconverged-cluster-webhook

--- a/pkg/authorization/http.go
+++ b/pkg/authorization/http.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
-func HttpWithBearerToken(config *rest.Config, httpClient *http.Client) (server.Filter, error) {
+func HttpWithBearerToken(_ *rest.Config, _ *http.Client) (server.Filter, error) {
 	return func(log logr.Logger, handler http.Handler) (http.Handler, error) {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			authValue := req.Header.Get("Authorization")

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -472,6 +472,7 @@ func GetDeploymentSpecWebhook(params *DeploymentOperatorParams) appsv1.Deploymen
 						SecurityContext:          GetStdContainerSecurityContext(),
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Ports: []corev1.ContainerPort{
+							getWebhookPort(),
 							getMetricsPort(),
 						},
 					},
@@ -1185,6 +1186,14 @@ func getMetricsPort() corev1.ContainerPort {
 	return corev1.ContainerPort{
 		Name:          util.MetricsPortName,
 		ContainerPort: util.MetricsPort,
+		Protocol:      corev1.ProtocolTCP,
+	}
+}
+
+func getWebhookPort() corev1.ContainerPort {
+	return corev1.ContainerPort{
+		Name:          util.WebhookPortName,
+		ContainerPort: util.WebhookPort,
 		Protocol:      corev1.ProtocolTCP,
 	}
 }

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -52,7 +52,7 @@ const (
 	// HyperConvergedName is the name of the HyperConverged resource that will be reconciled
 	HyperConvergedName           = "kubevirt-hyperconverged"
 	MetricsHost                  = "0.0.0.0"
-	MetricsPort            int32 = 8383
+	MetricsPort            int32 = 8443
 	MetricsPortName              = "metrics"
 	HealthProbeHost              = "0.0.0.0"
 	HealthProbePort        int32 = 6060
@@ -62,6 +62,7 @@ const (
 	HCOMutatingWebhookPath       = "/mutate-hco-kubevirt-io-v1beta1-hyperconverged"
 	HCONSWebhookPath             = "/mutate-ns-hco-kubevirt-io"
 	WebhookPort                  = 4343
+	WebhookPortName              = "webhook"
 
 	WebhookCertName       = "apiserver.crt"
 	WebhookKeyName        = "apiserver.key"

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -28,19 +28,17 @@ import (
 	"strconv"
 	"strings"
 
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-
 	"github.com/ghodss/yaml"
-
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
-	"github.com/kubevirt/hyperconverged-cluster-operator/tools/util"
-
 	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	"github.com/kubevirt/hyperconverged-cluster-operator/tools/util"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
While working on network policies, it appears that network policies do not work with named ports (e.g. "metrics"), but need the port number of the pod.

The majority of the pods in KubeVirt project, uses port 8443, so we must align with them to be able to use the same network policies.

But moving to port 8443 also requires using https instead of http.

This PR changes the protocol of the metrics endpoint to https, and the port to 8443, both in the operator and the webhook.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-65166
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change the metrics ports in the operator and the webhook pods to 8443, and change the protocol to https
```
