### PR TITLE
passt: Deploy NAD on non default ns

### DIFF
--- a/controllers/handlers/passt/nad_test.go
+++ b/controllers/handlers/passt/nad_test.go
@@ -43,6 +43,25 @@ var _ = Describe("Passt NetworkAttachmentDefinition tests", func() {
 			Expect(nad.Spec.Config).To(ContainSubstring(`"name": "primary-udn-kubevirt-binding"`))
 			Expect(nad.Spec.Config).To(ContainSubstring(`"type": "kubevirt-passt-binding"`))
 		})
+
+		Context("OpenShift platform behavior", func() {
+			BeforeEach(func() {
+				getClusterInfo := hcoutil.GetClusterInfo
+
+				hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
+					return &commontestutils.ClusterInfoMock{}
+				}
+
+				DeferCleanup(func() {
+					hcoutil.GetClusterInfo = getClusterInfo
+				})
+			})
+
+			It("should use openshift-cnv namespace on OpenShift", func() {
+				nad := passt.NewPasstBindingCNINetworkAttachmentDefinition(hco)
+				Expect(nad.Namespace).To(Equal("openshift-cnv"))
+			})
+		})
 	})
 
 	Context("NetworkAttachmentDefinition deployment", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On OpenShift deploy NAD on openshift-cnv, instead on default namespace
Because CNO deploys multus with access to openshift-cnv.

It is cleaner.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
