### PR TITLE
Fix the upgrade test

### DIFF
--- a/hack/check-uptime.sh
+++ b/hack/check-uptime.sh
@@ -5,7 +5,7 @@ function check_uptime() {
   timeout=$2
 
   for _ in $(seq 1 $retries); do
-    BOOTTIME=$(~/virtctl ssh -i ./hack/test_ssh -n ${VMS_NAMESPACE} testvm --username=cirros --local-ssh=true --local-ssh-opts "-o UserKnownHostsFile=/dev/null" --local-ssh-opts "-o StrictHostKeyChecking=no" -c "echo BOOTTIME=\$((\$(date +%s) - \$(awk '{print int(\$1)}' /proc/uptime)))" 2>>/dev/null | grep "^BOOTTIME" | cut -d= -f2 | tr -dc '[:digit:]')
+    BOOTTIME=$(~/virtctl ssh -i ./hack/test_ssh -n ${VMS_NAMESPACE} vmi/testvm --username=cirros --local-ssh=true --local-ssh-opts "-o UserKnownHostsFile=/dev/null" --local-ssh-opts "-o StrictHostKeyChecking=no" -c "echo BOOTTIME=\$((\$(date +%s) - \$(awk '{print int(\$1)}' /proc/uptime)))" 2>>/dev/null | grep "^BOOTTIME" | cut -d= -f2 | tr -dc '[:digit:]')
     if [ -n "${BOOTTIME}" ]
       then
         echo "${BOOTTIME}"


### PR DESCRIPTION
**What this PR does / why we need it**:

In upgrade test, we are trying to run a command inside a VMI, using `virtctl ssh` this is now failing after bumping virtctl to 1.6.x, because there is a breaking change in `virtctl` that is no longer accept the vmi name, but also requires the type (`vmi/vmi-name`, intead of just `vmi-name`).

This PR fixes the issue by adding the missing type to the virtctl ssh command.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
```release-note
None
```
