### PR TITLE
cluser-sync: Fix 2nd cluster-sync

### DIFF
--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -53,6 +53,9 @@ source hack/common.sh
 
 # Remove cert-manager
 "${CMD}" delete -f _out/cert-manager.yaml --ignore-not-found || true
+"${CMD}" delete validatingwebhookconfigurations cert-manager-webhook --ignore-not-found || true
+"${CMD}" delete mutatingwebhookconfigurations cert-manager-webhook --ignore-not-found || true
+"${CMD}" delete secrets -n kubevirt-hyperconverged -l controller.cert-manager.io/fao=true --ignore-not-found || true
 
 # Delete namespace at the end
 # "${CMD}" delete ns kubevirt-hyperconverged --ignore-not-found || true

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -135,6 +135,16 @@ fi
 # manifest-templator does not add them into operator.yaml at the moment. 
 # when a new webhook (deployed by OLM in production) is introduced, 
 # it must be added into webhooks.yaml as well.
+
+echo "Waiting for cert-manager webhook CA bundle..."
+hack/retry.sh 60 1 \
+    "${CMD} get validatingwebhookconfigurations cert-manager-webhook -o jsonpath='{.webhooks[0].clientConfig.caBundle}' | base64 -d | openssl x509 -noout 2>/dev/null" \
+    "echo 'Warning: cert-manager webhook CA bundle still not valid after 60 attempts'"
+
+if [ $? -eq 0 ]; then
+    echo "cert-manager webhook CA bundle is valid!"
+fi
+
 echo "Creating resources for webhooks"
 "${CMD}" apply $LABEL_SELECTOR_ARG -f _out/webhooks.yaml
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Due to issue with cert-manager not cleaned / rotate certs well, the 2nd cluster-sync would fail, fix it by cleaning the dangling objects, and waiting the CA bundle to be valid before continuing deployment (takes around 47 seconds).

Time can be saved if the cert-manager is deployed parallel to build, giving it time to create CA bundle.

Note: it doesn't consume additional time on first cluster-sync, as we reach it with the CA bundle ready, and it directly continues.

```
+ ./cluster/kubectl.sh apply -l 'name!=ssp-operator,name!=hyperconverged-cluster-cli-download' -f _out/webhooks.yaml
selecting docker as container runtime
validatingwebhookconfiguration.admissionregistration.k8s.io/validate-hco.kubevirt.io created
validatingwebhookconfiguration.admissionregistration.k8s.io/nodemaintenance-validation.kubevirt.io created
validatingwebhookconfiguration.admissionregistration.k8s.io/hostpathprovisioner.kubevirt.io created
mutatingwebhookconfiguration.admissionregistration.k8s.io/mutate-hco.kubevirt.io created
Error from server (InternalError): error when creating "_out/webhooks.yaml": Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=30s": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
