### PR TITLE
Fix HCOOperatorConditionsUnhealthy alert evaluation

### DIFF
--- a/hack/prom-rule-ci/hyperconverged-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/hyperconverged-prom-rules-tests.yaml
@@ -774,22 +774,28 @@ tests:
 # Test HCOOperatorConditionsUnhealthy
 - interval: 1m
   input_series:
-    - series: 'kubevirt_hco_system_health_status'
-    - values: "stale stale 2 stale"
-
-    - series: 'kubevirt_hco_system_health_status'
-      values: "stale stale 2 stale 1 stale"
+  - series: 'kubevirt_hco_system_health_status'
+    # time:   0     1 2-12  13  14-25 26
+    values: "stale 0 2+0x10 1 1+0x11 0"
 
   alert_rule_test:
+    # No metric, no alert
     - eval_time: 1m
       alertname: HCOOperatorConditionsUnhealthy
       exp_alerts: [ ]
 
-    - eval_time: 1m
+    # Critical state for less than 10 minutes, no alert yet
+    - eval_time: 5m
       alertname: HCOOperatorConditionsUnhealthy
       exp_alerts: [ ]
 
-    - eval_time: 2m
+    # Critical state for less than 10 minutes, no alert yet
+    - eval_time: 10m
+      alertname: HCOOperatorConditionsUnhealthy
+      exp_alerts: [ ]
+
+    # Critical state for more than 10 minutes, alert should fire
+    - eval_time: 12m
       alertname: HCOOperatorConditionsUnhealthy
       exp_alerts:
         - exp_annotations:
@@ -802,7 +808,13 @@ tests:
             kubernetes_operator_part_of: "kubevirt"
             kubernetes_operator_component: "hyperconverged-cluster-operator"
 
-    - eval_time: 4m
+    # Warning state for less than 10 minutes, no alert yet
+    - eval_time: 18m
+      alertname: HCOOperatorConditionsUnhealthy
+      exp_alerts: [ ]
+
+    # Warning state for more than 10 minutes, alert should fire
+    - eval_time: 25m
       alertname: HCOOperatorConditionsUnhealthy
       exp_alerts:
         - exp_annotations:

--- a/pkg/monitoring/hyperconverged/rules/alerts/health_alerts.go
+++ b/pkg/monitoring/hyperconverged/rules/alerts/health_alerts.go
@@ -5,6 +5,7 @@ import (
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/metrics"
 )
@@ -14,6 +15,7 @@ func healthAlerts() []promv1.Rule {
 		{
 			Alert: "HCOOperatorConditionsUnhealthy",
 			Expr:  intstr.FromString(fmt.Sprintf("kubevirt_hco_system_health_status == %f", metrics.SystemHealthStatusError)),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				"description": "HCO and its secondary resources are in a critical state due to system error.",
 				"summary":     "HCO and its secondary resources are in a critical state.",
@@ -26,6 +28,7 @@ func healthAlerts() []promv1.Rule {
 		{
 			Alert: "HCOOperatorConditionsUnhealthy",
 			Expr:  intstr.FromString(fmt.Sprintf("kubevirt_hco_system_health_status == %f", metrics.SystemHealthStatusWarning)),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				"description": "HCO and its secondary resources are in a warning state due to system warning.",
 				"summary":     "HCO and its secondary resources are in a warning state.",


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR updated the HCOOperatorConditionsUnhealthy alert to fire after it sees the issue persists
for longer than 10 minutes.
It should only alert is issue persists.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-62847
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update the HCOOperatorConditionsUnhealthy alert to fire only after 10 minutes
```
