### PR TITLE
Set multi-acrh related fields in the SSP CR

### DIFF
--- a/controllers/handlers/ssp.go
+++ b/controllers/handlers/ssp.go
@@ -154,6 +154,17 @@ func NewSSP(hc *hcov1beta1.HyperConverged) (*sspv1beta3.SSP, []hcov1beta1.DataIm
 		return nil, nil, err
 	}
 
+	cpArches := nodeinfo.GetControlPlaneArchitectures()
+	wlArches := nodeinfo.GetWorkloadsArchitectures()
+
+	var cluster *sspv1beta3.Cluster
+	if len(cpArches) > 0 || len(wlArches) > 0 {
+		cluster = &sspv1beta3.Cluster{
+			ControlPlaneArchitectures: cpArches,
+			WorkloadArchitectures:     wlArches,
+		}
+	}
+
 	spec := sspv1beta3.SSPSpec{
 		TemplateValidator: &sspv1beta3.TemplateValidator{
 			Replicas: ptr.To(defaultTemplateValidatorReplicas),
@@ -162,6 +173,11 @@ func NewSSP(hc *hcov1beta1.HyperConverged) (*sspv1beta3.SSP, []hcov1beta1.DataIm
 			Namespace:               templatesNamespace,
 			DataImportCronTemplates: hcoDictSliceToSSP(hc, dataImportCronStatuses),
 		},
+
+		Cluster: cluster,
+
+		EnableMultipleArchitectures: hc.Spec.FeatureGates.EnableMultiArchBootImageImport,
+
 		// NodeLabeller field is explicitly initialized to its zero-value,
 		// in order to future-proof from bugs if SSP changes it to pointer-type,
 		// causing nil pointers dereferences at the DeepCopyInto() below.


### PR DESCRIPTION
1. Update the new SSP `Cluster` field with the number of the control-plane nodes, and the number of the workloads nodes.

2. Reflect the HyperConverged `EnableMultiArchBootImageImport` feature gate, in the SSP `EnableMultipleArchitectures` field.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-61344
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set multi-acrh related fields in the SSP CR
```
