### PR TITLE
Rename the `deployPasstNetworkBinding` annotation

### DIFF
--- a/controllers/common/consts.go
+++ b/controllers/common/consts.go
@@ -1,5 +1,7 @@
 package common
 
+import "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+
 const (
 	ReconcileCompleted        = "ReconcileCompleted"
 	ReconcileCompletedMessage = "Reconcile completed successfully"
@@ -10,5 +12,5 @@ const (
 	JSONPatchCNAOAnnotationName = "networkaddonsconfigs.kubevirt.io/jsonpatch"
 	JSONPatchSSPAnnotationName  = "ssp.kubevirt.io/jsonpatch"
 	// Tuning Policy annotation name
-	TuningPolicyAnnotationName = "hco.kubevirt.io/tuningPolicy"
+	TuningPolicyAnnotationName = util.HCOAnnotationPrefix + "tuningPolicy"
 )

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -3561,7 +3561,7 @@ Version: 1.2.3`)
 					hco.Spec.TuningPolicy = hcov1beta1.HyperConvergedAnnotationTuningPolicy
 					hco.Annotations = make(map[string]string, 1)
 					//burst is missing
-					hco.Annotations["hco.kubevirt.io/tuningPolicy"] = `{"qps": 100}`
+					hco.Annotations[common.TuningPolicyAnnotationName] = `{"qps": 100}`
 
 					kv, err := NewKubeVirt(hco)
 					Expect(err).To(MatchError("burst parameter not found in annotation"))
@@ -3573,7 +3573,7 @@ Version: 1.2.3`)
 					hco.Spec.TuningPolicy = hcov1beta1.HyperConvergedAnnotationTuningPolicy
 					hco.Annotations = make(map[string]string, 1)
 					// qps field is missing a "
-					hco.Annotations["hco.kubevirt.io/tuningPolicy"] = `{"qps: 100, "burst": 200}`
+					hco.Annotations[common.TuningPolicyAnnotationName] = `{"qps: 100, "burst": 200}`
 
 					kv, err := NewKubeVirt(hco)
 
@@ -3584,7 +3584,7 @@ Version: 1.2.3`)
 				It("Should create the fields and populate them when requested", func() {
 					hco.Spec.TuningPolicy = hcov1beta1.HyperConvergedAnnotationTuningPolicy
 					hco.Annotations = make(map[string]string, 1)
-					hco.Annotations["hco.kubevirt.io/tuningPolicy"] = `{"qps": 100, "burst": 200}`
+					hco.Annotations[common.TuningPolicyAnnotationName] = `{"qps": 100, "burst": 200}`
 
 					kv, err := NewKubeVirt(hco)
 
@@ -3607,7 +3607,7 @@ Version: 1.2.3`)
 				It("Should return error if the json annotation tuningPolicy is present", func() {
 					hco.Spec.TuningPolicy = hcov1beta1.HyperConvergedHighBurstProfile
 					hco.Annotations = make(map[string]string, 1)
-					hco.Annotations["hco.kubevirt.io/tuningPolicy"] = `{"qps": 100, "burst": 200}`
+					hco.Annotations[common.TuningPolicyAnnotationName] = `{"qps": 100, "burst": 200}`
 
 					kv, err := NewKubeVirt(hco)
 

--- a/controllers/handlers/passt/passt.go
+++ b/controllers/handlers/passt/passt.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	DeployPasstNetworkBindingAnnotation = "deployPasstNetworkBinding"
+	DeployPasstNetworkBindingAnnotation = hcoutil.HCOAnnotationPrefix + "deployPasstNetworkBinding"
 
 	BindingName = "passt"
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -179,9 +179,9 @@ to an even parity when using emulator thread isolation.
 
 **Default**: `false`
 
-### deployPasstNetworkBinding annotation
-Set the `deployPasstNetworkBinding=true` HCO CR annotation to deploy the needed configurations for kubevirt users, so they
-can bind their VM using a Passt Network binding.
+### The hco.kubevirt.io/deployPasstNetworkBinding annotation
+Set the `hco.kubevirt.io/deployPasstNetworkBinding` HyperConverged CR annotation to `true`, to deploy the needed
+configurations for kubevirt users, so they can bind their VM using a Passt Network binding.
 
 **Note**: this feature is in Developer Preview.
 

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -81,10 +81,12 @@ const (
 
 	DataImportCronEnabledAnnotation = "dataimportcrontemplate.kubevirt.io/enable"
 
+	HCOAnnotationPrefix = "hco.kubevirt.io/"
+
 	// AllowEgressToDNSAndAPIServerLabel if this label is set, the network policy will allow egress to DNS and API server
-	AllowEgressToDNSAndAPIServerLabel = "hco.kubevirt.io/allow-access-cluster-services"
+	AllowEgressToDNSAndAPIServerLabel = HCOAnnotationPrefix + "allow-access-cluster-services"
 	// AllowIngressToMetricsEndpointLabel if this label is set, the network policy will allow ingress to the metrics endpoint
-	AllowIngressToMetricsEndpointLabel = "hco.kubevirt.io/allow-prometheus-access"
+	AllowIngressToMetricsEndpointLabel = HCOAnnotationPrefix + "allow-prometheus-access"
 )
 
 type AppComponent string


### PR DESCRIPTION
**What this PR does / why we need it**:

The current name is not standard, because it lack the application specific prefix, as required by
[kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set):
> "Automated system components which add annotations to end-user objects, must specify a prefix".

This PR changes the current annotation name to `hco.kubevirt.io/deployPasstNetworkBinding`.

**Jira Ticket**:
```jira-ticket
None
```

**Release note**:
```release-note
Rename the `deployPasstNetworkBinding` annotation to `hco.kubevirt.io/deployPasstNetworkBinding`
```
