### PR TITLE
Adding ClusterRole and ClusterRoleBinding handlers

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -933,7 +933,9 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - roles
+  - clusterroles
   - rolebindings
+  - clusterrolebindings
   verbs:
   - get
   - list

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
@@ -368,7 +368,9 @@ spec:
           - rbac.authorization.k8s.io
           resources:
           - roles
+          - clusterroles
           - rolebindings
+          - clusterrolebindings
           verbs:
           - get
           - list

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.16.0-unstable
-    createdAt: "2025-08-01 07:30:20"
+    createdAt: "2025-08-03 09:57:43"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -368,7 +368,9 @@ spec:
           - rbac.authorization.k8s.io
           resources:
           - roles
+          - clusterroles
           - rolebindings
+          - clusterrolebindings
           verbs:
           - get
           - list

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -554,7 +554,8 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 			Resources: stringListToSlice("deployments", "replicasets", "daemonsets"),
 			Verbs:     stringListToSlice("get", "list", "watch", "create", "update", "delete"),
 		},
-		roleWithAllPermissions("rbac.authorization.k8s.io", stringListToSlice("roles", "rolebindings")),
+		roleWithAllPermissions("rbac.authorization.k8s.io",
+			stringListToSlice("roles", "clusterroles", "rolebindings", "clusterrolebindings")),
 		{
 			APIGroups: stringListToSlice("apiextensions.k8s.io"),
 			Resources: stringListToSlice("customresourcedefinitions"),


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

I've decided to split the work of adding the wasp-agent deployment into few separate PRs.
This PR code prepares the functionality to deploy cluster roles for the wasp-agent SA, 
to that the wasp-agent pods will be able to list and watch all the pods in the cluster.

The handlers are simple, without cache and mutex, because for my case the HCO API won't infuence
the configuration of the Roles, so there is no need to implement the cache and to recalculate the desired configuration
when HCO CR is being changed.

**What this PR does / why we need it**:
enhance the HCO handler functionality so that it will be able to prepare the relevant roles and role-bindings for operands that need cluster-wide access to kube resources.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-57781
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
