### PR TITLE
Deploy wasp-agent using HCO

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -260,6 +260,11 @@ func main() {
 	err = passt.CheckPasstImagesEnvExists()
 	cmdHelper.ExitOnError(err, "failed to retrieve passt env vars")
 
+	if ci.IsOpenshift() {
+		err = checkWaspAgentImageEnvExists()
+		cmdHelper.ExitOnError(err, "failed to retrieve wasp agent image env var")
+	}
+
 	logger.Info("Starting the Cmd.")
 	eventEmitter.EmitEvent(nil, corev1.EventTypeNormal, "Init", "Starting the HyperConverged Pod")
 
@@ -320,6 +325,14 @@ func getCacheOption(operatorNamespace string, ci hcoutil.ClusterInfo) cache.Opti
 				Field: namespaceSelector,
 			},
 			&rbacv1.RoleBinding{}: {
+				Label: labelSelector,
+				Field: namespaceSelector,
+			},
+			&rbacv1.ClusterRole{}: {
+				Label: labelSelector,
+				Field: namespaceSelector,
+			},
+			&rbacv1.ClusterRoleBinding{}: {
 				Label: labelSelector,
 				Field: namespaceSelector,
 			},
@@ -443,4 +456,12 @@ func createPriorityClass(ctx context.Context, mgr manager.Manager) error {
 	}
 
 	return err
+}
+
+func checkWaspAgentImageEnvExists() error {
+	if _, exists := os.LookupEnv(hcoutil.WaspAgentImageEnvV); !exists {
+		return fmt.Errorf("%s env var not found", hcoutil.WaspAgentImageEnvV)
+	}
+
+	return nil
 }

--- a/controllers/handlers/wasp-agent/daemonset.go
+++ b/controllers/handlers/wasp-agent/daemonset.go
@@ -1,0 +1,200 @@
+package wasp_agent
+
+import (
+	"maps"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	clusterRoleName             = "wasp-cluster"
+	verbosity                   = "1"
+	AppComponentWaspAgent       = "wasp-agent"
+	waspAgentServiceAccountName = "wasp"
+	waspAgentSCCName            = "wasp"
+	NoOverCommitPercentage      = 100
+)
+
+var (
+	resourceCPU    = resource.MustParse("100m")
+	resourceMemory = resource.MustParse("50M")
+)
+
+func NewWaspAgentDaemonSetHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewConditionalHandler(
+		operands.NewDaemonSetHandler(Client, Scheme, newWaspAgentDaemonSet),
+		shouldDeployWaspAgent,
+		func(hc *hcov1beta1.HyperConverged) client.Object {
+			return NewWaspAgentWithNameOnly(hc)
+		},
+	)
+}
+
+func NewWaspAgentWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      AppComponentWaspAgent,
+			Labels:    operands.GetLabels(hc, AppComponentWaspAgent),
+			Namespace: hc.Namespace,
+		},
+	}
+}
+
+func newWaspAgentDaemonSet(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
+	waspImage, _ := os.LookupEnv(hcoutil.WaspAgentImageEnvV)
+
+	podLabels := operands.GetLabels(hc, AppComponentWaspAgent)
+	podLabels[hcoutil.AllowEgressToDNSAndAPIServerLabel] = "true"
+	podLabels["name"] = AppComponentWaspAgent
+
+	container := corev1.Container{
+		Name:            AppComponentWaspAgent,
+		Image:           waspImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resourceCPU,
+				corev1.ResourceMemory: resourceMemory,
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: ptr.To(true),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "host",
+				MountPath: "/host",
+			},
+			{
+				Name:      "rootfs",
+				MountPath: "/rootfs",
+			},
+		},
+	}
+	container.Env = createDaemonSetEnvVar()
+
+	spec := appsv1.DaemonSetSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"name": AppComponentWaspAgent,
+			},
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: podLabels,
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName:            waspAgentServiceAccountName,
+				HostPID:                       true,
+				HostUsers:                     ptr.To(true),
+				TerminationGracePeriodSeconds: ptr.To[int64](5),
+				Containers:                    []corev1.Container{container},
+				Volumes: []corev1.Volume{
+					{
+						Name: "host",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/",
+							},
+						},
+					},
+					{
+						Name: "rootfs",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/",
+							},
+						},
+					},
+				},
+				PriorityClassName: "system-node-critical",
+			},
+		},
+	}
+
+	ds := NewWaspAgentWithNameOnly(hc)
+	ds.Spec = spec
+
+	if hc.Spec.Infra.NodePlacement != nil {
+		if hc.Spec.Infra.NodePlacement.NodeSelector != nil {
+			ds.Spec.Template.Spec.NodeSelector = maps.Clone(hc.Spec.Infra.NodePlacement.NodeSelector)
+		}
+
+		if hc.Spec.Infra.NodePlacement.Affinity != nil {
+			ds.Spec.Template.Spec.Affinity = hc.Spec.Infra.NodePlacement.Affinity.DeepCopy()
+		}
+
+		if hc.Spec.Infra.NodePlacement.Tolerations != nil {
+			ds.Spec.Template.Spec.Tolerations = make([]corev1.Toleration, len(hc.Spec.Infra.NodePlacement.Tolerations))
+			copy(ds.Spec.Template.Spec.Tolerations, hc.Spec.Infra.NodePlacement.Tolerations)
+		}
+	} else {
+		affinity := getPodAntiAffinity(ds.Labels[hcoutil.AppLabelComponent], nodeinfo.IsInfrastructureHighlyAvailable())
+		ds.Spec.Template.Spec.Affinity = affinity
+	}
+
+	return ds
+}
+
+func createDaemonSetEnvVar() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "VERBOSITY",
+			Value: verbosity,
+		},
+		{
+			Name: "NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+	}
+}
+
+func shouldDeployWaspAgent(hc *hcov1beta1.HyperConverged) bool {
+	overcommitPercentage := hc.Spec.HigherWorkloadDensity.MemoryOvercommitPercentage
+	return overcommitPercentage > NoOverCommitPercentage
+}
+
+func getPodAntiAffinity(componentLabel string, infrastructureHighlyAvailable bool) *corev1.Affinity {
+	if infrastructureHighlyAvailable {
+		return &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+					{
+						Weight: 90,
+						PodAffinityTerm: corev1.PodAffinityTerm{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      hcoutil.AppLabelComponent,
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{componentLabel},
+									},
+								},
+							},
+							TopologyKey: corev1.LabelHostname,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return nil
+}

--- a/controllers/handlers/wasp-agent/daemonset_test.go
+++ b/controllers/handlers/wasp-agent/daemonset_test.go
@@ -1,0 +1,159 @@
+package wasp_agent
+
+import (
+	"context"
+	"maps"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+)
+
+var _ = Describe("Wasp Agent DaemonSet", func() {
+	var (
+		hco *hcov1beta1.HyperConverged
+		req *common.HcoRequest
+		ds  client.Client
+	)
+
+	BeforeEach(func() {
+		hco = commontestutils.NewHco()
+		hco.Annotations = make(map[string]string)
+		req = commontestutils.NewReq(hco)
+	})
+
+	Context("Wasp DaemonSet deployment", func() {
+		It("should not create if overcommit percent is less or equal to 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 100,
+			}
+			ds = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewWaspAgentDaemonSetHandler(ds, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundDs := &appsv1.DaemonSetList{}
+			Expect(ds.List(context.Background(), foundDs)).To(Succeed())
+			Expect(foundDs.Items).To(BeEmpty())
+		})
+		It("should delete DaemonSet when percentage is set to 100 and below", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 100,
+			}
+			scc := newWaspAgentDaemonSet(hco)
+			ds = commontestutils.InitClient([]client.Object{hco, scc})
+
+			handler := NewWaspAgentDaemonSetHandler(ds, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(scc.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
+
+			foundDs := &appsv1.DaemonSetList{}
+			Expect(ds.List(context.Background(), foundDs)).To(Succeed())
+			Expect(foundDs.Items).To(BeEmpty())
+		})
+		It("should create Deamonset when percentage is set to higher than 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			ds = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewWaspAgentDaemonSetHandler(ds, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal("wasp-agent"))
+			Expect(res.Created).To(BeTrue())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundDs := &appsv1.DaemonSetList{}
+			Expect(ds.List(context.Background(), foundDs)).To(Succeed())
+			Expect(foundDs.Items).To(HaveLen(1))
+			Expect(foundDs.Items[0].Name).To(Equal("wasp-agent"))
+		})
+	})
+	Context("Wasp agent DaemonSet update", func() {
+		It("should update DaemonSet fields if not matched to the requirements", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			originalDs := newWaspAgentDaemonSet(hco)
+			modifiedDs := originalDs.DeepCopy()
+			modifiedDs.Spec.Template.Spec.Containers[0].Image = "malicious:tag"
+			modifiedDs.Spec.Template.Spec.HostPID = false
+			modifiedDs.Spec.Template.Spec.Containers[0].SecurityContext.Privileged = ptr.To(false)
+			modifiedDs.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("500m")
+			modifiedDs.Spec.Template.Spec.Volumes = nil
+			ds = commontestutils.InitClient([]client.Object{hco, modifiedDs})
+			handler := NewWaspAgentDaemonSetHandler(ds, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Deleted).To(BeFalse())
+
+			reconciledDs := &appsv1.DaemonSet{}
+			Expect(ds.Get(context.Background(), client.ObjectKey{Name: res.Name, Namespace: hco.Namespace}, reconciledDs)).To(Succeed())
+
+			Expect(reconciledDs.Spec.Template.Spec.Containers[0].Image).
+				To(Equal(originalDs.Spec.Template.Spec.Containers[0].Image))
+			Expect(reconciledDs.Spec.Template.Spec.HostPID).
+				To(Equal(originalDs.Spec.Template.Spec.HostPID))
+			Expect(reconciledDs.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).
+				To(Equal(originalDs.Spec.Template.Spec.Containers[0].SecurityContext.Privileged))
+			Expect(reconciledDs.Spec.Template.Spec.Containers[0].Resources.Requests).
+				To(Equal(originalDs.Spec.Template.Spec.Containers[0].Resources.Requests))
+			Expect(reconciledDs.Spec.Template.Spec.Volumes).
+				To(Equal(originalDs.Spec.Template.Spec.Volumes))
+		})
+
+		It("should reconcile labels if they are missing while preserving user labels", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			ds := newWaspAgentDaemonSet(hco)
+			expectedLabels := maps.Clone(ds.Labels)
+			delete(ds.Labels, "app.kubernetes.io/component")
+			ds.Labels["user-added-label"] = "user-value"
+			cli := commontestutils.InitClient([]client.Object{hco, ds})
+			handler := NewWaspAgentDaemonSetHandler(cli, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundDs := &appsv1.DaemonSet{}
+			Expect(cli.Get(context.Background(), client.ObjectKey{Name: "wasp-agent", Namespace: hco.Namespace}, foundDs)).To(Succeed())
+
+			for key, value := range expectedLabels {
+				Expect(foundDs.Labels).To(HaveKeyWithValue(key, value))
+			}
+			Expect(foundDs.Labels).To(HaveKeyWithValue("user-added-label", "user-value"))
+		})
+	})
+
+})

--- a/controllers/handlers/wasp-agent/rbac.go
+++ b/controllers/handlers/wasp-agent/rbac.go
@@ -1,0 +1,104 @@
+package wasp_agent
+
+import (
+	log "github.com/go-logr/logr"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+)
+
+func NewWaspAgentClusterRoleBindingHandler(
+	_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
+	return operands.NewConditionalHandler(
+		operands.NewClusterRoleBindingHandler(Client, Scheme, newWaspAgentClusterRoleBinding(hc)),
+		shouldDeployWaspAgent,
+		func(hc *hcov1beta1.HyperConverged) client.Object {
+			return newWaspAgentClusterRoleBindingWithNameOnly(hc)
+		},
+	), nil
+}
+
+func newWaspAgentClusterRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRoleBinding {
+	crb := newWaspAgentClusterRoleBindingWithNameOnly(hc)
+
+	crb.RoleRef = rbacv1.RoleRef{
+		Kind:     "ClusterRole",
+		Name:     clusterRoleName,
+		APIGroup: "rbac.authorization.k8s.io",
+	}
+
+	crb.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      waspAgentServiceAccountName,
+			Namespace: hc.Namespace,
+		},
+	}
+
+	return crb
+}
+
+func newWaspAgentClusterRoleBindingWithNameOnly(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+			Kind:       "ClusterRoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   clusterRoleName,
+			Labels: operands.GetLabels(hc, AppComponentWaspAgent),
+		},
+	}
+}
+
+func NewWaspAgentClusterRoleHandler(
+	_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
+	return operands.NewConditionalHandler(
+		operands.NewClusterRoleHandler(Client, Scheme, newWaspAgentClusterRole(hc)),
+		shouldDeployWaspAgent,
+		func(hc *hcov1beta1.HyperConverged) client.Object {
+			return newWaspAgentClusterRoleWithNameOnly(hc)
+		},
+	), nil
+}
+
+func newWaspAgentClusterRole(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRole {
+	cr := newWaspAgentClusterRoleWithNameOnly(hc)
+	cr.Rules = getClusterPolicyRules()
+
+	return cr
+}
+
+func newWaspAgentClusterRoleWithNameOnly(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   clusterRoleName,
+			Labels: operands.GetLabels(hc, AppComponentWaspAgent),
+		},
+	}
+}
+
+func getClusterPolicyRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"pods",
+			},
+			Verbs: []string{
+				"watch",
+				"list",
+			},
+		},
+	}
+}

--- a/controllers/handlers/wasp-agent/rbac_test.go
+++ b/controllers/handlers/wasp-agent/rbac_test.go
@@ -1,0 +1,269 @@
+package wasp_agent
+
+import (
+	"context"
+	"maps"
+
+	log "github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+var _ = Describe("Wasp agent Cluster Role", func() {
+	var (
+		hco *hcov1beta1.HyperConverged
+		req *common.HcoRequest
+		cl  client.Client
+	)
+
+	BeforeEach(func() {
+		hco = commontestutils.NewHco()
+		hco.Annotations = make(map[string]string)
+		req = commontestutils.NewReq(hco)
+	})
+
+	Context("newWaspAgentClusterRole", func() {
+		It("Should have all the default fields", func() {
+			cr := newWaspAgentClusterRole(hco)
+			Expect(cr.Name).To(Equal("wasp-cluster"))
+			Expect(cr.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
+			Expect(cr.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, "wasp-agent"))
+			Expect(cr.Rules).To(HaveLen(1))
+			Expect(cr.Rules[0].APIGroups).To(HaveLen(1))
+			Expect(cr.Rules[0].APIGroups[0]).To(Equal(""))
+			Expect(cr.Rules[0].Resources).To(HaveLen(1))
+			Expect(cr.Rules[0].Resources[0]).To(Equal("pods"))
+			Expect(cr.Rules[0].Verbs).To(HaveLen(2))
+			Expect(cr.Rules[0].Verbs).To(ContainElements("list", "watch"))
+		})
+	})
+
+	Context("Cluster role deployment", func() {
+		It("should not create if overcommit percent is less or equal to 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 100,
+			}
+			cr := newWaspAgentClusterRole(hco)
+
+			cl = commontestutils.InitClient([]client.Object{hco, cr})
+
+			handler, err := NewWaspAgentClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
+			Expect(err).ToNot(HaveOccurred())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(cr.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
+
+			foundCRs := &rbacv1.ClusterRoleList{}
+			Expect(cl.List(context.Background(), foundCRs)).To(Succeed())
+			Expect(foundCRs.Items).To(BeEmpty())
+		})
+		It("should delete cluster role when percentage is set to 100 and below", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 100,
+			}
+			cr := newWaspAgentClusterRole(hco)
+
+			cl = commontestutils.InitClient([]client.Object{hco, cr})
+
+			handler, err := NewWaspAgentClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
+			Expect(err).ToNot(HaveOccurred())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(cr.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
+
+			foundCRs := &rbacv1.ClusterRoleList{}
+			Expect(cl.List(context.Background(), foundCRs)).To(Succeed())
+			Expect(foundCRs.Items).To(BeEmpty())
+		})
+		It("should create cluster role when percentage is set to higher than 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+
+			handler, err := NewWaspAgentClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
+			Expect(err).ToNot(HaveOccurred())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal("wasp-cluster"))
+			Expect(res.Created).To(BeTrue())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundCRs := &rbacv1.ClusterRoleList{}
+			Expect(cl.List(context.Background(), foundCRs)).To(Succeed())
+			Expect(foundCRs.Items).To(HaveLen(1))
+			Expect(foundCRs.Items[0].Name).To(Equal("wasp-cluster"))
+		})
+	})
+	Context("Wasp agent cluster role update", func() {
+		It("should reconcile labels if they are missing while preserving user labels", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			cr := newWaspAgentClusterRole(hco)
+			expectedLabels := maps.Clone(cr.Labels)
+			delete(cr.Labels, "app.kubernetes.io/component")
+			cr.Labels["user-added-label"] = "user-value"
+			cl = commontestutils.InitClient([]client.Object{hco, cr})
+
+			handler, err := NewWaspAgentClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
+			Expect(err).ToNot(HaveOccurred())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundCr := &rbacv1.ClusterRole{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: "wasp-cluster"}, foundCr)).To(Succeed())
+
+			for key, value := range expectedLabels {
+				Expect(foundCr.Labels).To(HaveKeyWithValue(key, value))
+			}
+			Expect(foundCr.Labels).To(HaveKeyWithValue("user-added-label", "user-value"))
+		})
+	})
+})
+
+var _ = Describe("Wasp agent Cluster Role Binding", func() {
+	var (
+		hco *hcov1beta1.HyperConverged
+		req *common.HcoRequest
+		cl  client.Client
+	)
+
+	BeforeEach(func() {
+		hco = commontestutils.NewHco()
+		hco.Annotations = make(map[string]string)
+		req = commontestutils.NewReq(hco)
+	})
+
+	Context("newWaspAgentClusterRoleBinding", func() {
+		It("Should have all the default fields", func() {
+			crb := newWaspAgentClusterRoleBinding(hco)
+			Expect(crb.Name).To(Equal("wasp-cluster"))
+			Expect(crb.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
+			Expect(crb.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, "wasp-agent"))
+			Expect(crb.RoleRef.Name).To(Equal("wasp-cluster"))
+			Expect(crb.Subjects).To(HaveLen(1))
+			Expect(crb.Subjects[0].Name).To(Equal("wasp"))
+			Expect(crb.Subjects[0].Namespace).To(Equal(hco.Namespace))
+		})
+	})
+	Context("Cluster role binding deployment", func() {
+		It("should not create if overcommit percent is less or equal to 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 100,
+			}
+			crb := newWaspAgentClusterRoleBinding(hco)
+
+			cl = commontestutils.InitClient([]client.Object{hco, crb})
+
+			handler, err := NewWaspAgentClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
+			Expect(err).ToNot(HaveOccurred())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(crb.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
+
+			foundCRBs := &rbacv1.ClusterRoleBindingList{}
+			Expect(cl.List(context.Background(), foundCRBs)).To(Succeed())
+			Expect(foundCRBs.Items).To(BeEmpty())
+		})
+		It("should delete cluster role binding when percentage is set to 100 and below", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 100,
+			}
+			crb := newWaspAgentClusterRoleBinding(hco)
+
+			cl = commontestutils.InitClient([]client.Object{hco, crb})
+
+			handler, err := NewWaspAgentClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
+			Expect(err).ToNot(HaveOccurred())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(crb.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
+
+			foundCRBs := &rbacv1.ClusterRoleBindingList{}
+			Expect(cl.List(context.Background(), foundCRBs)).To(Succeed())
+			Expect(foundCRBs.Items).To(BeEmpty())
+		})
+		It("should create cluster role binding when percentage is set to higher than 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+
+			handler, err := NewWaspAgentClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
+			Expect(err).ToNot(HaveOccurred())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal("wasp-cluster"))
+			Expect(res.Created).To(BeTrue())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundCRBs := &rbacv1.ClusterRoleBindingList{}
+			Expect(cl.List(context.Background(), foundCRBs)).To(Succeed())
+			Expect(foundCRBs.Items).To(HaveLen(1))
+			Expect(foundCRBs.Items[0].Name).To(Equal("wasp-cluster"))
+		})
+	})
+	Context("Wasp agent cluster role binding update", func() {
+		It("should reconcile labels if they are missing while preserving user labels", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			crb := newWaspAgentClusterRoleBinding(hco)
+			expectedLabels := maps.Clone(crb.Labels)
+			delete(crb.Labels, "app.kubernetes.io/component")
+			crb.Labels["user-added-label"] = "user-value"
+			cl = commontestutils.InitClient([]client.Object{hco, crb})
+
+			handler, err := NewWaspAgentClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
+			Expect(err).ToNot(HaveOccurred())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundCrb := &rbacv1.ClusterRoleBinding{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: "wasp-cluster"}, foundCrb)).To(Succeed())
+
+			for key, value := range expectedLabels {
+				Expect(foundCrb.Labels).To(HaveKeyWithValue(key, value))
+			}
+			Expect(foundCrb.Labels).To(HaveKeyWithValue("user-added-label", "user-value"))
+		})
+	})
+})

--- a/controllers/handlers/wasp-agent/scc.go
+++ b/controllers/handlers/wasp-agent/scc.go
@@ -1,0 +1,73 @@
+package wasp_agent
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+)
+
+func NewWaspAgentSCCHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewConditionalHandler(
+		operands.NewSecurityContextConstraintsHandler(Client, Scheme, newWaspAgentSCC),
+		shouldDeployWaspAgent,
+		func(hc *hcov1beta1.HyperConverged) client.Object {
+			return newWaspAgentSCCWithNameOnly(hc)
+		},
+	)
+}
+
+func newWaspAgentSCC(hc *hcov1beta1.HyperConverged) *securityv1.SecurityContextConstraints {
+	scc := newWaspAgentSCCWithNameOnly(hc)
+
+	scc.AllowPrivilegedContainer = true
+	scc.AllowHostDirVolumePlugin = true
+	scc.AllowHostIPC = true
+	scc.AllowHostNetwork = true
+	scc.AllowHostPID = true
+	scc.AllowHostPorts = true
+	scc.ReadOnlyRootFilesystem = false
+	scc.DefaultAddCapabilities = nil
+	scc.RunAsUser = securityv1.RunAsUserStrategyOptions{
+		Type: securityv1.RunAsUserStrategyRunAsAny,
+	}
+	scc.SupplementalGroups = securityv1.SupplementalGroupsStrategyOptions{
+		Type: securityv1.SupplementalGroupsStrategyRunAsAny,
+	}
+	scc.SELinuxContext = securityv1.SELinuxContextStrategyOptions{
+		Type: securityv1.SELinuxStrategyRunAsAny,
+	}
+	scc.Users = []string{
+		fmt.Sprintf("system:serviceaccount:%s:%s", hc.Namespace, waspAgentServiceAccountName),
+	}
+	scc.Volumes = []securityv1.FSType{
+		securityv1.FSTypeAll,
+	}
+	scc.AllowedCapabilities = []corev1.Capability{
+		"*",
+	}
+	scc.AllowedUnsafeSysctls = []string{
+		"*",
+	}
+	scc.SeccompProfiles = []string{
+		"*",
+	}
+
+	return scc
+}
+
+func newWaspAgentSCCWithNameOnly(hc *hcov1beta1.HyperConverged) *securityv1.SecurityContextConstraints {
+	return &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   waspAgentSCCName,
+			Labels: operands.GetLabels(hc, AppComponentWaspAgent),
+		},
+	}
+}

--- a/controllers/handlers/wasp-agent/scc_test.go
+++ b/controllers/handlers/wasp-agent/scc_test.go
@@ -1,0 +1,178 @@
+package wasp_agent
+
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	securityv1 "github.com/openshift/api/security/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
+	var (
+		hco *hcov1beta1.HyperConverged
+		req *common.HcoRequest
+		cl  client.Client
+	)
+
+	BeforeEach(func() {
+		hco = commontestutils.NewHco()
+		hco.Annotations = make(map[string]string)
+		req = commontestutils.NewReq(hco)
+	})
+
+	Context("newWaspAgentSCC", func() {
+		It("should have all default fields", func() {
+			scc := newWaspAgentSCC(hco)
+			Expect(scc.Name).To(Equal("wasp"))
+			Expect(scc.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
+			Expect(scc.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, "wasp-agent"))
+
+			Expect(scc.AllowPrivilegedContainer).To(BeTrue())
+			Expect(scc.AllowHostDirVolumePlugin).To(BeTrue())
+			Expect(scc.AllowHostIPC).To(BeTrue())
+			Expect(scc.AllowHostNetwork).To(BeTrue())
+			Expect(scc.AllowHostPID).To(BeTrue())
+			Expect(scc.AllowHostPorts).To(BeTrue())
+			Expect(scc.ReadOnlyRootFilesystem).To(BeFalse())
+			Expect(scc.DefaultAddCapabilities).To(BeNil())
+
+			Expect(scc.RunAsUser.Type).To(Equal(securityv1.RunAsUserStrategyRunAsAny))
+			Expect(scc.SupplementalGroups.Type).To(Equal(securityv1.SupplementalGroupsStrategyRunAsAny))
+			Expect(scc.SELinuxContext.Type).To(Equal(securityv1.SELinuxStrategyRunAsAny))
+
+			expectedUser := "system:serviceaccount:" + hco.Namespace + ":wasp"
+			Expect(scc.Users).To(ContainElement(expectedUser))
+
+			Expect(scc.Volumes).To(ContainElement(securityv1.FSTypeAll))
+		})
+	})
+
+	Context("SecurityContextConstraints deployment", func() {
+		It("should not create if overcommit percent is less or equal to 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 100,
+			}
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewWaspAgentSCCHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundSCCs := &securityv1.SecurityContextConstraintsList{}
+			Expect(cl.List(context.Background(), foundSCCs)).To(Succeed())
+			Expect(foundSCCs.Items).To(BeEmpty())
+		})
+
+		It("should delete SecurityContextConstraints when percentage is set to 100 and below", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 100,
+			}
+			scc := newWaspAgentSCC(hco)
+			cl = commontestutils.InitClient([]client.Object{hco, scc})
+
+			handler := NewWaspAgentSCCHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(scc.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
+
+			foundSCCs := &securityv1.SecurityContextConstraintsList{}
+			Expect(cl.List(context.Background(), foundSCCs)).To(Succeed())
+			Expect(foundSCCs.Items).To(BeEmpty())
+		})
+
+		It("should create SecurityContextConstraints when percentage is set to higher than 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewWaspAgentSCCHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal("wasp"))
+			Expect(res.Created).To(BeTrue())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundSCCs := &securityv1.SecurityContextConstraintsList{}
+			Expect(cl.List(context.Background(), foundSCCs)).To(Succeed())
+			Expect(foundSCCs.Items).To(HaveLen(1))
+			Expect(foundSCCs.Items[0].Name).To(Equal("wasp"))
+		})
+	})
+
+	Context("SecurityContextConstraints update", func() {
+		It("should update SecurityContextConstraints fields if not matched to the requirements", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			scc := newWaspAgentSCC(hco)
+			scc.AllowPrivilegedContainer = false
+			scc.AllowHostNetwork = false
+			scc.Users = []string{"wrong-user"}
+
+			cl = commontestutils.InitClient([]client.Object{hco, scc})
+
+			handler := NewWaspAgentSCCHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundSCC := &securityv1.SecurityContextConstraints{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: "wasp"}, foundSCC)).To(Succeed())
+			Expect(foundSCC.AllowPrivilegedContainer).To(BeTrue())
+			Expect(foundSCC.AllowHostNetwork).To(BeTrue())
+			Expect(foundSCC.Users).To(ContainElement(fmt.Sprintf("system:serviceaccount:%s:wasp", hco.Namespace)))
+		})
+
+		It("should reconcile labels if they are missing while preserving user labels", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			scc := newWaspAgentSCC(hco)
+			expectedLabels := maps.Clone(scc.Labels)
+			delete(scc.Labels, "app.kubernetes.io/component")
+			scc.Labels["user-added-label"] = "user-value"
+			cl = commontestutils.InitClient([]client.Object{hco, scc})
+			handler := NewWaspAgentSCCHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundSCC := &securityv1.SecurityContextConstraints{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: "wasp"}, foundSCC)).To(Succeed())
+
+			for key, value := range expectedLabels {
+				Expect(foundSCC.Labels).To(HaveKeyWithValue(key, value))
+			}
+			Expect(foundSCC.Labels).To(HaveKeyWithValue("user-added-label", "user-value"))
+		})
+	})
+})

--- a/controllers/handlers/wasp-agent/service_account.go
+++ b/controllers/handlers/wasp-agent/service_account.go
@@ -1,0 +1,32 @@
+package wasp_agent
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+)
+
+func NewWaspAgentServiceAccountHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewConditionalHandler(
+		operands.NewServiceAccountHandler(Client, Scheme, newWaspAgentServiceAccount),
+		shouldDeployWaspAgent,
+		func(hc *hcov1beta1.HyperConverged) client.Object {
+			return newWaspAgentServiceAccount(hc)
+		},
+	)
+}
+
+func newWaspAgentServiceAccount(hc *hcov1beta1.HyperConverged) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      waspAgentServiceAccountName,
+			Namespace: hc.Namespace,
+			Labels:    operands.GetLabels(hc, AppComponentWaspAgent),
+		},
+	}
+}

--- a/controllers/handlers/wasp-agent/service_account_test.go
+++ b/controllers/handlers/wasp-agent/service_account_test.go
@@ -1,0 +1,134 @@
+package wasp_agent
+
+import (
+	"context"
+	"maps"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+var _ = Describe("Wasp Agent Service Account", func() {
+	var (
+		hco *hcov1beta1.HyperConverged
+		req *common.HcoRequest
+		cl  client.Client
+	)
+
+	BeforeEach(func() {
+		hco = commontestutils.NewHco()
+		hco.Annotations = make(map[string]string)
+		req = commontestutils.NewReq(hco)
+	})
+
+	Context("newWaspAgentServiceAccount", func() {
+		It("should have all default values", func() {
+			sa := newWaspAgentServiceAccount(hco)
+			Expect(sa.Name).To(Equal("wasp"))
+			Expect(sa.Namespace).To(BeEquivalentTo(hco.Namespace))
+			Expect(sa.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
+			Expect(sa.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, "wasp-agent"))
+		})
+	})
+
+	Context("Wasp agent service account deployment", func() {
+		It("should not create if overcommit percent is less or equal to 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 100,
+			}
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewWaspAgentServiceAccountHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundSAs := &corev1.ServiceAccountList{}
+			Expect(cl.List(context.Background(), foundSAs)).To(Succeed())
+			Expect(foundSAs.Items).To(BeEmpty())
+
+		})
+
+		It("should delete service account when percentage is set to 100 and below", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 100,
+			}
+			sa := newWaspAgentServiceAccount(hco)
+
+			cl = commontestutils.InitClient([]client.Object{hco, sa})
+
+			handler := NewWaspAgentServiceAccountHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(sa.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
+
+			foundSAs := &corev1.ServiceAccountList{}
+			Expect(cl.List(context.Background(), foundSAs)).To(Succeed())
+			Expect(foundSAs.Items).To(BeEmpty())
+
+		})
+
+		It("should create service account when percentage is set to higher than 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+
+			handler := NewWaspAgentServiceAccountHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal("wasp"))
+			Expect(res.Created).To(BeTrue())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundSAs := &corev1.ServiceAccountList{}
+			Expect(cl.List(context.Background(), foundSAs)).To(Succeed())
+			Expect(foundSAs.Items).To(HaveLen(1))
+			Expect(foundSAs.Items[0].Name).To(Equal("wasp"))
+		})
+	})
+	Context("Wasp agent service account update", func() {
+		It("should reconcile labels if they are missing while preserving user labels", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			sa := newWaspAgentServiceAccount(hco)
+			expectedLabels := maps.Clone(sa.Labels)
+			delete(sa.Labels, "app.kubernetes.io/component")
+			sa.Labels["user-added-label"] = "user-value"
+			cl = commontestutils.InitClient([]client.Object{hco, sa})
+			handler := NewWaspAgentServiceAccountHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundDs := &corev1.ServiceAccount{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: "wasp", Namespace: hco.Namespace}, foundDs)).To(Succeed())
+
+			for key, value := range expectedLabels {
+				Expect(foundDs.Labels).To(HaveKeyWithValue(key, value))
+			}
+			Expect(foundDs.Labels).To(HaveKeyWithValue("user-added-label", "user-value"))
+		})
+	})
+})

--- a/controllers/handlers/wasp-agent/wasp_agent_suite_test.go
+++ b/controllers/handlers/wasp-agent/wasp_agent_suite_test.go
@@ -1,0 +1,13 @@
+package wasp_agent
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWaspAgent(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Wasp Agent Suite")
+}

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -171,6 +171,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo, in
 		&appsv1.DaemonSet{},
 		&rbacv1.Role{},
 		&rbacv1.RoleBinding{},
+		&rbacv1.ClusterRole{},
+		&rbacv1.ClusterRoleBinding{},
 	}
 	if ci.IsMonitoringAvailable() {
 		secondaryResources = append(secondaryResources, []client.Object{

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/passt"
+	waspagent "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/wasp-agent"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/metrics"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -66,6 +67,9 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 			operands.NewServiceHandler(client, scheme, handlers.NewCliDownloadsService),
 			passt.NewPasstServiceAccountHandler(client, scheme),
 			passt.NewPasstSecurityContextConstraintsHandler(client, scheme),
+			waspagent.NewWaspAgentServiceAccountHandler(client, scheme),
+			waspagent.NewWaspAgentSCCHandler(client, scheme),
+			waspagent.NewWaspAgentDaemonSetHandler(client, scheme),
 		}...)
 	}
 
@@ -107,6 +111,8 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 		handlers.NewVirtioWinCmHandler,
 		handlers.NewVirtioWinCmReaderRoleHandler,
 		handlers.NewVirtioWinCmReaderRoleBindingHandler,
+		waspagent.NewWaspAgentClusterRoleHandler,
+		waspagent.NewWaspAgentClusterRoleBindingHandler,
 	}
 
 	if ci.IsConsolePluginImageProvided() {

--- a/controllers/operands/rbac.go
+++ b/controllers/operands/rbac.go
@@ -61,18 +61,17 @@ func (h *roleHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exist
 func (*roleHooks) JustBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 // ********* Cluster Role Handler *****************************
-type newClusterRoleFunc func(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRole
 
-func NewClusterRoleHandler(Client client.Client, Scheme *runtime.Scheme, required newClusterRoleFunc) *GenericOperand {
-	return NewGenericOperand(Client, Scheme, "ClusterRole", &clusterRoleHooks{newCrFunc: required}, false)
+func NewClusterRoleHandler(Client client.Client, Scheme *runtime.Scheme, required *rbacv1.ClusterRole) *GenericOperand {
+	return NewGenericOperand(Client, Scheme, "ClusterRole", &clusterRoleHooks{required: required}, false)
 }
 
 type clusterRoleHooks struct {
-	newCrFunc newClusterRoleFunc
+	required *rbacv1.ClusterRole
 }
 
 func (h *clusterRoleHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
-	return h.newCrFunc(hc), nil
+	return h.required, nil
 }
 
 func (h *clusterRoleHooks) GetEmptyCr() client.Object { return &rbacv1.ClusterRole{} }
@@ -165,18 +164,17 @@ func (h roleBindingHooks) UpdateCR(req *common.HcoRequest, Client client.Client,
 func (roleBindingHooks) JustBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }
 
 // ********* Cluster Role Binding Handler *****************************
-type newClusterRoleBindingFunc func(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRoleBinding
 
-func NewClusterRoleBindingHandler(Client client.Client, Scheme *runtime.Scheme, required newClusterRoleBindingFunc) *GenericOperand {
-	return NewGenericOperand(Client, Scheme, "ClusterRoleBinding", &clusterRoleBindingHooks{newCrFunc: required}, false)
+func NewClusterRoleBindingHandler(Client client.Client, Scheme *runtime.Scheme, required *rbacv1.ClusterRoleBinding) *GenericOperand {
+	return NewGenericOperand(Client, Scheme, "ClusterRoleBinding", &clusterRoleBindingHooks{required: required}, false)
 }
 
 type clusterRoleBindingHooks struct {
-	newCrFunc newClusterRoleBindingFunc
+	required *rbacv1.ClusterRoleBinding
 }
 
 func (h clusterRoleBindingHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
-	return h.newCrFunc(hc), nil
+	return h.required, nil
 }
 
 func (h clusterRoleBindingHooks) GetEmptyCr() client.Object { return &rbacv1.ClusterRoleBinding{} }

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.16.0-unstable
-    createdAt: "2025-08-05 14:47:05"
+    createdAt: "2025-08-09 14:47:02"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"

--- a/tests/func-tests/wasp_agent_test.go
+++ b/tests/func-tests/wasp_agent_test.go
@@ -1,0 +1,149 @@
+package tests_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	securityv1 "github.com/openshift/api/security/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
+)
+
+const (
+	waspAgentComponentLabel     = "app.kubernetes.io/component=wasp-agent"
+	dsName                      = "wasp-agent"
+	saName                      = "wasp"
+	sccName                     = "wasp"
+	clusterRoleName             = "wasp-cluster"
+	clusterRoleBindingName      = "wasp-cluster"
+	setMemoryOvercommitTemplate = `[{"op": "replace", "path": "/spec/higherWorkloadDensity/memoryOvercommitPercentage", "value": %d}]`
+	overcommitPercent           = 150
+)
+
+var _ = Describe("Test wasp-agent", Label(tests.OpenshiftLabel, "wasp-agent"), Serial, Ordered, func() {
+	tests.FlagParse()
+
+	var (
+		cli                       client.Client
+		originalOvercommitPercent int
+	)
+
+	BeforeAll(func(ctx context.Context) {
+		cli = tests.GetControllerRuntimeClient()
+		tests.FailIfNotOpenShift(ctx, cli, "wasp-agent")
+		originalHco := tests.GetHCO(ctx, cli)
+		if originalHco.Spec.HigherWorkloadDensity != nil {
+			originalOvercommitPercent = originalHco.Spec.HigherWorkloadDensity.MemoryOvercommitPercentage
+		}
+
+	})
+
+	AfterAll(func(ctx context.Context) {
+		if originalOvercommitPercent != overcommitPercent {
+			setMemoryOvercommitPercentage(ctx, cli, originalOvercommitPercent)
+		}
+	})
+
+	BeforeEach(func() {
+		Expect(securityv1.AddToScheme(cli.Scheme())).To(Succeed())
+	})
+
+	When("Higher density is set beyond 100 percent", func() {
+		It("should deploy wasp-agent components", func(ctx context.Context) {
+			setMemoryOvercommitPercentage(ctx, cli, overcommitPercent)
+
+			By("check the wasp-agent Daemonset")
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				ds, err := getDs(ctx, cli)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(ds.Status.DesiredNumberScheduled).ToNot(BeZero())
+				return ds.Status.DesiredNumberScheduled == ds.Status.CurrentNumberScheduled
+			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(BeTrue())
+
+			By("check the wasp-agent SA")
+			Eventually(func(g Gomega, ctx context.Context) {
+				sa := &v1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      saName,
+						Namespace: tests.InstallNamespace,
+					},
+				}
+				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(sa), sa)).To(Succeed())
+			}).WithTimeout(1 * time.Minute).
+				WithPolling(100 * time.Millisecond).
+				WithContext(ctx).
+				Should(Succeed())
+
+			By("check the wasp-agent cluster role")
+			Eventually(func(g Gomega, ctx context.Context) {
+				role := &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterRoleName,
+					},
+				}
+				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(role), role)).To(Succeed())
+			}).WithTimeout(1 * time.Minute).
+				WithPolling(100 * time.Millisecond).
+				WithContext(ctx).
+				Should(Succeed())
+
+			By("check the wasp-agent cluster role binding")
+			Eventually(func(g Gomega, ctx context.Context) {
+				binding := &rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterRoleBindingName,
+					},
+				}
+				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(binding), binding)).To(Succeed())
+			}).WithTimeout(1 * time.Minute).
+				WithPolling(100 * time.Millisecond).
+				WithContext(ctx).
+				Should(Succeed())
+
+			By("check the wasp-agent SecurityContextConstraints")
+			Eventually(func(g Gomega, ctx context.Context) {
+				scc := &securityv1.SecurityContextConstraints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: sccName,
+					},
+				}
+				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(scc), scc)).To(Succeed())
+			}).WithTimeout(1 * time.Minute).
+				WithPolling(100 * time.Millisecond).
+				WithContext(ctx).
+				Should(Succeed())
+		})
+	})
+})
+
+func setMemoryOvercommitPercentage(ctx context.Context, cli client.Client, percentage int) {
+	patchBytes := []byte(fmt.Sprintf(setMemoryOvercommitTemplate, percentage))
+
+	Eventually(tests.PatchHCO).
+		WithArguments(ctx, cli, patchBytes).
+		WithTimeout(10 * time.Second).
+		WithPolling(100 * time.Millisecond).
+		WithContext(ctx).
+		WithOffset(2).
+		Should(Succeed())
+}
+
+func getDs(ctx context.Context, cli client.Client) (*appsv1.DaemonSet, error) {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName,
+			Namespace: tests.InstallNamespace,
+		},
+	}
+
+	err := cli.Get(ctx, client.ObjectKeyFromObject(ds), ds)
+	return ds, err
+}


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
wasp-agent is a node-local agent that is responsible to mimic
the kubernetes swap feature in out-of-tree manner. It will be used
until we will develop an operational approach to use kuberentes swap

wasp-agent is composed of the following components
- Daemonset that deploys the node-local agent on the worker nodes
- Service account
- Cluster role and cluster role binding
- Security Context Constraints

wasp-agent deployment is conditional, the deployment is being
triggered as far as the memory overcommit percentage is higher
than 100%. In that case in order to make the memory overcommit safer
wasp-agent allows memory tiering with swap so that workload idle
memory would be able to swap instead of OOMKilled.

wasp-agent needs access to pods in all namespaces, therefore
it is required to use the cluster role.

since wasp-agent mimics the kubelet functionality, it is required
to use the privileged SCC in order to be able to function properly on
the node (configuring the cgroups, talk to CRI-O, etc.)

wasp-agent needs to watch all the running pods in the cluster,
therefore it uses the allow-access-cluster-services network
policy in order to communicate with the API server.

wasp-agent currently supported only on OpenShift.


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-57781
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deploy wasp-agent using HCO
```
