### PR TITLE
Add new metric when DICT is w/o supported architecture

### DIFF
--- a/controllers/handlers/golden-images/golden_images_test.go
+++ b/controllers/handlers/golden-images/golden_images_test.go
@@ -716,7 +716,7 @@ var _ = Describe("Test data import cron template", func() {
 				Expect(dictsStatuses[1].Annotations).To(HaveKeyWithValue("testing.kubevirt.io/fake.annotation", "true"))
 				Expect(dictsStatuses[1].Annotations).To(HaveKeyWithValue(MultiArchDICTAnnotation, ""))
 				Expect(dictsStatuses[1].Status.OriginalSupportedArchitectures).To(Equal("arm64"))
-				Expect(meta.IsStatusConditionFalse(dictsStatuses[1].Status.Conditions, dictConditionDeployedType)).To(BeTrue())
+				Expect(meta.IsStatusConditionFalse(dictsStatuses[1].Status.Conditions, DictConditionDeployedType)).To(BeTrue())
 
 				Expect(dictsStatuses[2].Annotations).To(HaveKeyWithValue("testing.kubevirt.io/fake.annotation", "true"))
 				Expect(dictsStatuses[2].Annotations).To(HaveKeyWithValue(MultiArchDICTAnnotation, "amd64,s390x"))
@@ -725,7 +725,7 @@ var _ = Describe("Test data import cron template", func() {
 				Expect(dictsStatuses[3].Annotations).To(HaveKeyWithValue("testing.kubevirt.io/fake.annotation", "true"))
 				Expect(dictsStatuses[3].Annotations).To(HaveKeyWithValue(MultiArchDICTAnnotation, ""))
 				Expect(dictsStatuses[3].Status.OriginalSupportedArchitectures).To(Equal("arm64"))
-				Expect(meta.IsStatusConditionFalse(dictsStatuses[3].Status.Conditions, dictConditionDeployedType)).To(BeTrue())
+				Expect(meta.IsStatusConditionFalse(dictsStatuses[3].Status.Conditions, DictConditionDeployedType)).To(BeTrue())
 
 				sspDicts := HCODictSliceToSSP(hco, dictsStatuses)
 				Expect(sspDicts).To(HaveLen(2))

--- a/controllers/handlers/ssp.go
+++ b/controllers/handlers/ssp.go
@@ -100,6 +100,8 @@ func (h *sspHooks) JustBeforeComplete(req *common.HcoRequest) {
 		req.Instance.Status.DataImportCronTemplates = h.dictStatuses
 		req.StatusDirty = true
 	}
+
+	goldenimages.CheckDataImportCronTemplates(req.Instance)
 }
 
 func NewSSP(hc *hcov1beta1.HyperConverged) (*sspv1beta3.SSP, []hcov1beta1.DataImportCronTemplateStatus, error) {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,6 +6,9 @@ Sum of CPU core requests for all running virt-launcher VMIs across the entire Ku
 ### cnv_abnormal
 Monitors resources for potential problems. Type: Gauge.
 
+### kubevirt_hco_dict_with_no_supported_architectures
+Indicates whether the DataImportCron has supported architectures (0) or it has not (1). Type: Gauge.
+
 ### kubevirt_hco_hyperconverged_cr_exists
 Indicates whether the HyperConverged custom resource exists (1) or not (0). Type: Gauge.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Added new `GaugeVec` metric named
`kubevirt_hco_dict_with_no_supported_architectures`.

When multi-arch boot images is enabled, and a DataImportCronTemplate does not have any supported architecture, HCO set the metric for this DICT to 1.0.

The metric have two labels: `data_import_cron_name` and `data_source_name`.
**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-64420
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add new metric when DICT is w/o supported architecture
```
