### PR TITLE
Add network policies for the UI pods

### DIFF
--- a/controllers/alerts/metrics_test.go
+++ b/controllers/alerts/metrics_test.go
@@ -121,16 +121,15 @@ var _ = Describe("alert tests", func() {
 		})
 
 		It("should create network policy if the pod is with the np labels", func() {
-			pod := ci.GetPod()
-			if pod.Labels == nil {
-				pod.Labels = make(map[string]string)
+
+			origFunc := common.ShouldDeployNetworkPolicy
+
+			common.ShouldDeployNetworkPolicy = func() bool {
+				return true
 			}
-			pod.Labels[hcoutil.AllowEgressToDNSAndAPIServerLabel] = "true"
-			pod.Labels[hcoutil.AllowIngressToMetricsEndpointLabel] = "true"
 
 			DeferCleanup(func() {
-				delete(pod.Labels, hcoutil.AllowEgressToDNSAndAPIServerLabel)
-				delete(pod.Labels, hcoutil.AllowIngressToMetricsEndpointLabel)
+				common.ShouldDeployNetworkPolicy = origFunc
 			})
 
 			cl := commontestutils.InitClient([]client.Object{ns})

--- a/controllers/alerts/reconciler.go
+++ b/controllers/alerts/reconciler.go
@@ -82,7 +82,7 @@ func getReconcilers(ci hcoutil.ClusterInfo, namespace string, owner metav1.Owner
 		newServiceMonitorReconciler(namespace, owner),
 	}
 
-	if shouldDeployNetworkPolicy(ci) {
+	if common.ShouldDeployNetworkPolicy() {
 		reconcilers = append(reconcilers, newAlertManagerNetworkPolicyReconciler(namespace, owner, ci))
 	}
 
@@ -222,15 +222,4 @@ func updateCommonDetails(required, existing *metav1.ObjectMeta) bool {
 	}
 
 	return true
-}
-
-func shouldDeployNetworkPolicy(ci hcoutil.ClusterInfo) bool {
-	selfPod := ci.GetPod()
-	if selfPod == nil {
-		return false
-	}
-	_, lbl1 := selfPod.Labels[hcoutil.AllowEgressToDNSAndAPIServerLabel]
-	_, lbl2 := selfPod.Labels[hcoutil.AllowIngressToMetricsEndpointLabel]
-
-	return lbl1 || lbl2
 }

--- a/controllers/common/network_policy.go
+++ b/controllers/common/network_policy.go
@@ -1,0 +1,13 @@
+package common
+
+import (
+	"os"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+var deployNetworkPolicy = os.Getenv(hcoutil.DeployNetworkPoliciesEnvV) == "true"
+
+var ShouldDeployNetworkPolicy = func() bool {
+	return deployNetworkPolicy
+}

--- a/controllers/operands/network_policy.go
+++ b/controllers/operands/network_policy.go
@@ -1,0 +1,67 @@
+package operands
+
+import (
+	"errors"
+	"reflect"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+func NewNetworkPolicyHandler(Client client.Client, Scheme *runtime.Scheme, required *networkingv1.NetworkPolicy) *GenericOperand {
+	return NewGenericOperand(Client, Scheme, "NetworkPolicy", newNetworkPolicyHook(required), false)
+}
+
+type networkPolicyHook struct {
+	required *networkingv1.NetworkPolicy
+}
+
+func newNetworkPolicyHook(required *networkingv1.NetworkPolicy) *networkPolicyHook {
+	return &networkPolicyHook{
+		required: required,
+	}
+}
+
+func (nph *networkPolicyHook) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+	return nph.required.DeepCopy(), nil
+}
+
+func (nph *networkPolicyHook) GetEmptyCr() client.Object {
+	return &networkingv1.NetworkPolicy{}
+}
+
+func (nph *networkPolicyHook) UpdateCR(req *common.HcoRequest, cli client.Client, exists, required runtime.Object) (bool, bool, error) {
+	np, ok1 := required.(*networkingv1.NetworkPolicy)
+	found, ok2 := exists.(*networkingv1.NetworkPolicy)
+	if !ok1 || !ok2 {
+		return false, false, errors.New("can't convert to NetworkPolicy")
+	}
+
+	if !reflect.DeepEqual(found.Spec, np.Spec) || !hcoutil.CompareLabels(np, found) {
+		overwritten := false
+
+		if req.HCOTriggered {
+			req.Logger.Info("Updating existing NetworkPolicy's Spec to new opinionated values")
+		} else {
+			req.Logger.Info("Reconciling an externally updated NetworkPolicy's Spec to its opinionated values")
+			overwritten = true
+		}
+
+		hcoutil.MergeLabels(&np.ObjectMeta, &found.ObjectMeta)
+		np.Spec.DeepCopyInto(&found.Spec)
+
+		err := cli.Update(req.Ctx, found)
+		if err != nil {
+			return false, false, err
+		}
+		return true, overwritten, nil
+	}
+	return false, false, nil
+}
+
+func (nph *networkPolicyHook) JustBeforeComplete(_ *common.HcoRequest) { /* no implementation */ }

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -311,6 +311,13 @@ func buildEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
 		})
 	}
 
+	if params.AddNetworkPolicyLabels {
+		envs = append(envs, corev1.EnvVar{
+			Name:  util.DeployNetworkPoliciesEnvV,
+			Value: "true",
+		})
+	}
+
 	return envs
 }
 

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -20,6 +20,7 @@ const (
 	PasstImageEnvV                     = "PASST_SIDECAR_IMAGE"
 	PasstCNIImageEnvV                  = "PASST_CNI_IMAGE"
 	WaspAgentImageEnvV                 = "WASP_AGENT_IMAGE"
+	DeployNetworkPoliciesEnvV          = "DEPLOY_NETWORK_POLICIES"
 	HcoValidatingWebhook               = "validate-hco.kubevirt.io"
 	HcoMutatingWebhookNS               = "mutate-ns-hco.kubevirt.io"
 	PrometheusRuleCRDName              = "prometheusrules.monitoring.coreos.com"

--- a/pkg/webhooks/setup_test.go
+++ b/pkg/webhooks/setup_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/client-go/kubernetes/scheme"
-
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"k8s.io/client-go/rest"
@@ -66,10 +64,9 @@ var _ = Describe("Hyperconverged API: Webhook", func() {
 
 			resources := []client.Object{}
 			cl := commontestutils.InitClient(resources)
-			s := scheme.Scheme
 
 			ws := webhook.NewServer(webhook.Options{})
-			mgr, err := commontestutils.NewManagerMock(&rest.Config{}, manager.Options{WebhookServer: ws, Scheme: s}, cl, logger)
+			mgr, err := commontestutils.NewManagerMock(&rest.Config{}, manager.Options{WebhookServer: ws, Scheme: cl.Scheme()}, cl, logger)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(SetupWebhookWithManager(context.TODO(), mgr, true, nil)).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:

First, change the logic of when to deploy network policies, by the new environment variable `DEPLOY_NETWORK_POLICIES`. Add it to the HCO pod in the CSV, if the `--dump-network-policies` flag is set.

Then, if the `DEPLOY_NETWORK_POLICIES` environment variable is set to "true", deploy and reconcile two network policies. One for the API-Server proxy pods, and one for the console plugin pods.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-63379
https://issues.redhat.com/browse/CNV-63378
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add network policies for the UI pods
```
