### PR TITLE
Adds the --dump-network-policies flag to the CSV generator

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -197,6 +197,7 @@ function create_hpp_csv() {
 function create_aaq_csv() {
   local operatorName="application-aware-quota"
   local dumpCRDsArg="--dump-crds"
+  local dumpNetworkPoliciesArg="--dump-network-policies"
   local operatorArgs=" \
     --csv-version=${CSV_VERSION} \
     --operator-image=${AAQ_OPERATOR_IMAGE} \
@@ -207,7 +208,7 @@ function create_aaq_csv() {
     --pull-policy=IfNotPresent \
   "
 
-  gen_csv ${DEFAULT_CSV_GENERATOR} ${operatorName} "${AAQ_OPERATOR_IMAGE}" ${dumpCRDsArg} ${operatorArgs}
+  gen_csv ${DEFAULT_CSV_GENERATOR} ${operatorName} "${AAQ_OPERATOR_IMAGE}" ${dumpCRDsArg} ${dumpNetworkPoliciesArg} ${operatorArgs}
   echo "${operatorName}"
 }
 


### PR DESCRIPTION
, as introduced in
https://github.com/kubevirt/application-aware-quota/pull/159. This flag enables including NetworkPolicies in the generated CSV to improve overall security.
The policies ensure that AAQ pods can only connect to the API server and DNS, and only receive incoming connections for the webhook and metrics servers.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-60820
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add network Policies to AAQ pods
```
