### PR TITLE
Add two new alerts for multi-arch annotations

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,8 +6,11 @@ Sum of CPU core requests for all running virt-launcher VMIs across the entire Ku
 ### cnv_abnormal
 Monitors resources for potential problems. Type: Gauge.
 
-### kubevirt_hco_dict_with_no_supported_architectures
-Indicates whether the DataImportCron has supported architectures (0) or it has not (1). Type: Gauge.
+### kubevirt_hco_dataimportcrontemplate_with_architecture_annotation
+Indicates whether the DataImportCronTemplate has the ssp.kubevirt.io/dict.architectures annotation (0) or not (1). Type: Gauge.
+
+### kubevirt_hco_dataimportcrontemplate_with_supported_architectures
+Indicates whether the DataImportCronTemplate has supported architectures (0) or not (1). Type: Gauge.
 
 ### kubevirt_hco_hyperconverged_cr_exists
 Indicates whether the HyperConverged custom resource exists (1) or not (0). Type: Gauge.

--- a/hack/prom-rule-ci/hyperconverged-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/hyperconverged-prom-rules-tests.yaml
@@ -826,3 +826,249 @@ tests:
             operator_health_impact: "warning"
             kubernetes_operator_part_of: "kubevirt"
             kubernetes_operator_component: "hyperconverged-cluster-operator"
+
+# Test HCOGoldenImageWithNoSupportedArchitecture
+- interval: 1m
+  input_series:
+    - series: 'kubevirt_hco_dataimportcrontemplate_with_supported_architectures{data_import_cron_name="dict1", managed_data_source_name="ds1"}'
+      # time:      0     1 2     3 4 5 6     7     8
+      values: "stale stale 0     0 0 0 stale 1     0"
+    - series: 'kubevirt_hco_dataimportcrontemplate_with_supported_architectures{data_import_cron_name="dict2", managed_data_source_name="ds2"}'
+      # time:      0     1     2 3 4 5 6     7     8
+      values: "stale stale stale 0 0 0 0     stale 1"
+
+  alert_rule_test:
+    # No metric, no alert
+    - eval_time: 1m
+      alertname: HCOGoldenImageWithNoSupportedArchitecture
+      exp_alerts: [ ]
+
+    # dict1 metric value of 1 must trigger an alert
+    - eval_time: 2m
+      alertname: HCOGoldenImageWithNoSupportedArchitecture
+      exp_alerts:
+        - exp_annotations:
+            description: "The cluster has no nodes with architecture that matches any of the architectures of the dict1 DataImportCronTemplate (for the ds1 DataSource). This golden image will not be available for use in the cluster."
+            summary: "DataImportCronTemplate with no supported architecture was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoSupportedArchitecture"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict1"
+            managed_data_source_name: "ds1"
+
+    # dict1 and dict2 metric values of 1 must trigger alerts
+    - eval_time: 3m
+      alertname: HCOGoldenImageWithNoSupportedArchitecture
+      exp_alerts:
+        - exp_annotations:
+            description: "The cluster has no nodes with architecture that matches any of the architectures of the dict1 DataImportCronTemplate (for the ds1 DataSource). This golden image will not be available for use in the cluster."
+            summary: "DataImportCronTemplate with no supported architecture was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoSupportedArchitecture"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict1"
+            managed_data_source_name: "ds1"
+        - exp_annotations:
+            description: "The cluster has no nodes with architecture that matches any of the architectures of the dict2 DataImportCronTemplate (for the ds2 DataSource). This golden image will not be available for use in the cluster."
+            summary: "DataImportCronTemplate with no supported architecture was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoSupportedArchitecture"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict2"
+            managed_data_source_name: "ds2"
+
+    # dict1 and dict2 metric values of 1 must trigger alerts
+    - eval_time: 4m
+      alertname: HCOGoldenImageWithNoSupportedArchitecture
+      exp_alerts:
+        - exp_annotations:
+            description: "The cluster has no nodes with architecture that matches any of the architectures of the dict1 DataImportCronTemplate (for the ds1 DataSource). This golden image will not be available for use in the cluster."
+            summary: "DataImportCronTemplate with no supported architecture was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoSupportedArchitecture"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict1"
+            managed_data_source_name: "ds1"
+        - exp_annotations:
+            description: "The cluster has no nodes with architecture that matches any of the architectures of the dict2 DataImportCronTemplate (for the ds2 DataSource). This golden image will not be available for use in the cluster."
+            summary: "DataImportCronTemplate with no supported architecture was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoSupportedArchitecture"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict2"
+            managed_data_source_name: "ds2"
+
+    # dict2 metric value of 1 must trigger an alert
+    - eval_time: 6m
+      alertname: HCOGoldenImageWithNoSupportedArchitecture
+      exp_alerts:
+        - exp_annotations:
+            description: "The cluster has no nodes with architecture that matches any of the architectures of the dict2 DataImportCronTemplate (for the ds2 DataSource). This golden image will not be available for use in the cluster."
+            summary: "DataImportCronTemplate with no supported architecture was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoSupportedArchitecture"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict2"
+            managed_data_source_name: "ds2"
+
+    # No metric, no alert
+    - eval_time: 7m
+      alertname: HCOGoldenImageWithNoSupportedArchitecture
+      exp_alerts: [ ]
+
+    # dict1 metric value of 1 must trigger an alert
+    - eval_time: 8m
+      alertname: HCOGoldenImageWithNoSupportedArchitecture
+      exp_alerts:
+        - exp_annotations:
+            description: "The cluster has no nodes with architecture that matches any of the architectures of the dict1 DataImportCronTemplate (for the ds1 DataSource). This golden image will not be available for use in the cluster."
+            summary: "DataImportCronTemplate with no supported architecture was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoSupportedArchitecture"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict1"
+            managed_data_source_name: "ds1"
+
+# Test HCOGoldenImageWithNoArchitectureAnnotation
+- interval: 1m
+  input_series:
+    - series: 'kubevirt_hco_dataimportcrontemplate_with_architecture_annotation{data_import_cron_name="dict1", managed_data_source_name="ds1"}'
+      # time:      0     1 2     3 4 5 6     7     8
+      values: "stale stale 0     0 0 0 stale 1     0"
+    - series: 'kubevirt_hco_dataimportcrontemplate_with_architecture_annotation{data_import_cron_name="dict2", managed_data_source_name="ds2"}'
+      # time:      0     1     2 3 4 5 6     7     8
+      values: "stale stale stale 0 0 0 0     stale 1"
+
+  alert_rule_test:
+    # No metric, no alert
+    - eval_time: 1m
+      alertname: HCOGoldenImageWithNoArchitectureAnnotation
+      exp_alerts: [ ]
+
+    # dict1 metric value of 1 must trigger an alert
+    - eval_time: 2m
+      alertname: HCOGoldenImageWithNoArchitectureAnnotation
+      exp_alerts:
+        - exp_annotations:
+            description: "The dict1 DataImportCronTemplate (for the ds1 DataSource) does not have the 'ssp.kubevirt.io/dict.architectures' annotation. Using this golden image for VM boot disk, may cause the VM to fail."
+            summary: "DataImportCronTemplate without 'ssp.kubevirt.io/dict.architectures' annotation was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoArchitectureAnnotation"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict1"
+            managed_data_source_name: "ds1"
+
+    # dict1 and dict2 metric values of 1 must trigger alerts
+    - eval_time: 3m
+      alertname: HCOGoldenImageWithNoArchitectureAnnotation
+      exp_alerts:
+        - exp_annotations:
+            description: "The dict1 DataImportCronTemplate (for the ds1 DataSource) does not have the 'ssp.kubevirt.io/dict.architectures' annotation. Using this golden image for VM boot disk, may cause the VM to fail."
+            summary: "DataImportCronTemplate without 'ssp.kubevirt.io/dict.architectures' annotation was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoArchitectureAnnotation"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict1"
+            managed_data_source_name: "ds1"
+        - exp_annotations:
+            description: "The dict2 DataImportCronTemplate (for the ds2 DataSource) does not have the 'ssp.kubevirt.io/dict.architectures' annotation. Using this golden image for VM boot disk, may cause the VM to fail."
+            summary: "DataImportCronTemplate without 'ssp.kubevirt.io/dict.architectures' annotation was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoArchitectureAnnotation"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict2"
+            managed_data_source_name: "ds2"
+
+    # dict1 and dict2 metric values of 1 must trigger alerts
+    - eval_time: 4m
+      alertname: HCOGoldenImageWithNoArchitectureAnnotation
+      exp_alerts:
+        - exp_annotations:
+            description: "The dict1 DataImportCronTemplate (for the ds1 DataSource) does not have the 'ssp.kubevirt.io/dict.architectures' annotation. Using this golden image for VM boot disk, may cause the VM to fail."
+            summary: "DataImportCronTemplate without 'ssp.kubevirt.io/dict.architectures' annotation was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoArchitectureAnnotation"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict1"
+            managed_data_source_name: "ds1"
+        - exp_annotations:
+            description: "The dict2 DataImportCronTemplate (for the ds2 DataSource) does not have the 'ssp.kubevirt.io/dict.architectures' annotation. Using this golden image for VM boot disk, may cause the VM to fail."
+            summary: "DataImportCronTemplate without 'ssp.kubevirt.io/dict.architectures' annotation was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoArchitectureAnnotation"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict2"
+            managed_data_source_name: "ds2"
+
+    # dict2 metric value of 1 must trigger an alert
+    - eval_time: 6m
+      alertname: HCOGoldenImageWithNoArchitectureAnnotation
+      exp_alerts:
+        - exp_annotations:
+            description: "The dict2 DataImportCronTemplate (for the ds2 DataSource) does not have the 'ssp.kubevirt.io/dict.architectures' annotation. Using this golden image for VM boot disk, may cause the VM to fail."
+            summary: "DataImportCronTemplate without 'ssp.kubevirt.io/dict.architectures' annotation was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoArchitectureAnnotation"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict2"
+            managed_data_source_name: "ds2"
+
+    # No metric, no alert
+    - eval_time: 7m
+      alertname: HCOGoldenImageWithNoArchitectureAnnotation
+      exp_alerts: [ ]
+
+    # dict1 metric value of 1 must trigger an alert
+    - eval_time: 8m
+      alertname: HCOGoldenImageWithNoArchitectureAnnotation
+      exp_alerts:
+        - exp_annotations:
+            description: "The dict1 DataImportCronTemplate (for the ds1 DataSource) does not have the 'ssp.kubevirt.io/dict.architectures' annotation. Using this golden image for VM boot disk, may cause the VM to fail."
+            summary: "DataImportCronTemplate without 'ssp.kubevirt.io/dict.architectures' annotation was detected in the HyperConverged resource."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoArchitectureAnnotation"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+            data_import_cron_name: "dict1"
+            managed_data_source_name: "ds1"

--- a/pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go
+++ b/pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go
@@ -12,8 +12,11 @@ const (
 	installationNotCompletedAlert = "HCOInstallationIncomplete"
 	singleStackIPv6Alert          = "SingleStackIPv6Unsupported"
 	MisconfiguredDeschedulerAlert = "HCOMisconfiguredDescheduler"
-	severityAlertLabelKey         = "severity"
-	healthImpactAlertLabelKey     = "operator_health_impact"
+	unsupportedArchitecturesAlert = "HCOGoldenImageWithNoSupportedArchitecture"
+	dictWithNoArchAnnotationAlert = "HCOGoldenImageWithNoArchitectureAnnotation"
+
+	severityAlertLabelKey     = "severity"
+	healthImpactAlertLabelKey = "operator_health_impact"
 )
 
 func operatorAlerts() []promv1.Rule {
@@ -77,6 +80,30 @@ func operatorAlerts() []promv1.Rule {
 			Labels: map[string]string{
 				severityAlertLabelKey:     "critical",
 				healthImpactAlertLabelKey: "critical",
+			},
+		},
+		{
+			Alert: unsupportedArchitecturesAlert,
+			Expr:  intstr.FromString("kubevirt_hco_dataimportcrontemplate_with_supported_architectures == 0"),
+			Annotations: map[string]string{
+				"description": "The cluster has no nodes with architecture that matches any of the architectures of the {{ $labels.data_import_cron_name }} DataImportCronTemplate (for the {{ $labels.managed_data_source_name }} DataSource). This golden image will not be available for use in the cluster.",
+				"summary":     "DataImportCronTemplate with no supported architecture was detected in the HyperConverged resource.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "none",
+			},
+		},
+		{
+			Alert: dictWithNoArchAnnotationAlert,
+			Expr:  intstr.FromString("kubevirt_hco_dataimportcrontemplate_with_architecture_annotation == 0"),
+			Annotations: map[string]string{
+				"description": "The {{ $labels.data_import_cron_name }} DataImportCronTemplate (for the {{ $labels.managed_data_source_name }} DataSource) does not have the 'ssp.kubevirt.io/dict.architectures' annotation. Using this golden image for VM boot disk, may cause the VM to fail.",
+				"summary":     "DataImportCronTemplate without 'ssp.kubevirt.io/dict.architectures' annotation was detected in the HyperConverged resource.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "none",
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

`HCOGoldenImageWithNoSupportedArchitecture`:
This alert is triggered in case where the multi-arch boot images feature is enabled, and there is a DataImportCronTemplate with no supported architectures in the cluster.

Runbook: https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoSupportedArchitecture

`HCOGoldenImageWithNoArchitectureAnnotation`:
This alert is triggered in case where the multi-arch boot images feature is enabled, and there is a DataImportCronTemplate without the `ssp.kubevirt.io/dict.architectures` annotation.

Runbook: https://kubevirt.io/monitoring/runbooks/HCOGoldenImageWithNoArchitectureAnnotation

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-63044
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the new HCOGoldenImageWithNoSupportedArchitecture alert
Add the new HCOGoldenImageWithNoArchitectureAnnotation alert
```
