### PR TITLE
[1.14] Fix monitoring linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ lint-metrics:
 	./hack/prom_metric_linter.sh --operator-name="kubevirt" --sub-operator-name="hco"
 
 lint-monitoring:
-	go install github.com/kubevirt/monitoring/monitoringlinter/cmd/monitoringlinter@e2be790
+	go install github.com/kubevirt/monitoring/monitoringlinter/cmd/monitoringlinter@v0.0.10
 	monitoringlinter ./...
 
 bump-hco:


### PR DESCRIPTION
Fixes #3695

bump the monitoring linter version

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
