### PR TITLE
Set default value for KV's defaultRuntimeClass field

### DIFF
--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -495,9 +495,7 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		config.CPUModel = *hc.Spec.DefaultCPUModel
 	}
 
-	if hc.Spec.DefaultRuntimeClass != nil {
-		config.DefaultRuntimeClass = *hc.Spec.DefaultRuntimeClass
-	}
+	config.DefaultRuntimeClass = getKvPriorityClassName(hc)
 
 	if hc.Spec.VMStateStorageClass != nil {
 		config.VMStateStorageClass = *hc.Spec.VMStateStorageClass
@@ -1035,4 +1033,11 @@ func getLabelPatch(dest, src map[string]string) ([]byte, error) {
 	}
 
 	return json.Marshal(patches)
+}
+
+func getKvPriorityClassName(hc *hcov1beta1.HyperConverged) string {
+	if hc.Spec.DefaultRuntimeClass != nil && *hc.Spec.DefaultRuntimeClass != "" {
+		return *hc.Spec.DefaultRuntimeClass
+	}
+	return kvPriorityClass
 }

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -3947,12 +3947,12 @@ Version: 1.2.3`)
 				Expect(kv.Spec.Configuration.DefaultRuntimeClass).To(Equal(runtimeClass))
 			})
 
-			DescribeTable("Should be empty on KubevirtCR if not defined in HCO CR", func(runtimeClass *string) {
+			DescribeTable("Should use the default priority class on the KubeVirt CR if not defined in HCO CR", func(runtimeClass *string) {
 				hco.Spec.DefaultRuntimeClass = runtimeClass
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(kv.Spec.Configuration.DefaultRuntimeClass).To(BeEmpty())
+				Expect(kv.Spec.Configuration.DefaultRuntimeClass).To(Equal(kvPriorityClass))
 			},
 				Entry("nil defaultRuntimeClass", nil),
 				Entry("empty defaultRuntimeClass", ptr.To("")),


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix bug: The default KubeVirt's defaultRuntimeClass should be the priority class managed by HCO. Currently, if this configuration is missing in the HyperConverged CR, HCO does not set the KV field.

This PR fixes the issue, so if the HyperConverged
`spec.defaultRuntimeClass` field is empty, HCO will set the KV field to `kubevirt-cluster-critical`.

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-62721
```

**Release note**:
```release-note
Set default value for KV's defaultRuntimeClass field
```
