### PR TITLE
[wasp-agent] Add relevant alert and metric to detect duplicate wasp-agent deployment

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -394,6 +394,10 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 
 	updateStatus(req)
 
+	metrics.SetHCOMetricMemoryOvercommitPercentage(
+		getMemoryOvercommitPercentage(req.Instance.Spec.HigherWorkloadDensity),
+	)
+
 	// in-memory conditions should start off empty. It will only ever hold
 	// negative conditions (!Available, Degraded, Progressing)
 	req.Conditions = common.NewHcoConditions()
@@ -1051,6 +1055,13 @@ func getNumericalHealthStatus(status string) float64 {
 	}
 
 	return healthStatusCodes[status]
+}
+
+func getMemoryOvercommitPercentage(densityConfig *hcov1beta1.HigherWorkloadDensityConfiguration) float64 {
+	if densityConfig == nil {
+		return 0
+	}
+	return float64(densityConfig.MemoryOvercommitPercentage)
 }
 
 func (r *ReconcileHyperConverged) firstLoopInitialization(request *common.HcoRequest) {

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -948,6 +948,25 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.Status.ObservedGeneration).To(BeEquivalentTo(10))
 			})
 
+			It("Should update memory overcommit metrics according to the CR", func() {
+				expected := getBasicDeployment()
+				expected.hco.Spec.HigherWorkloadDensity = &hcov1beta1.HigherWorkloadDensityConfiguration{
+					MemoryOvercommitPercentage: 42,
+				}
+
+				cl := expected.initClient()
+				r := initReconciler(cl, nil)
+
+				// Do the reconcile
+				res, err := r.Reconcile(context.TODO(), request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res).To(Equal(reconcile.Result{}))
+
+				value, err := metrics.GetHCOMetricMemoryOvercommitPercentage()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(int(value)).To(BeEquivalentTo(42))
+
+			})
 		})
 
 		Context("APIServer CR", func() {

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.0/manifests/kubevirt00.crd.yaml
@@ -983,6 +983,7 @@ spec:
                   vmStateStorageClass:
                     description: VMStateStorageClass is the name of the storage class
                       to use for the PVCs created to preserve VM state, like TPM.
+                      The storage class must support RWX in filesystem mode.
                     type: string
                   webhookConfiguration:
                     description: |-

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,6 +15,9 @@ Indicates whether the DataImportCronTemplate has supported architectures (0) or 
 ### kubevirt_hco_hyperconverged_cr_exists
 Indicates whether the HyperConverged custom resource exists (1) or not (0). Type: Gauge.
 
+### kubevirt_hco_memory_overcommit_percentage
+Indicates the cluster-wide configured VM memory overcommit percentage. Type: Gauge.
+
 ### kubevirt_hco_misconfigured_descheduler
 Indicates whether the optional descheduler is not properly configured (1) to work with KubeVirt or not (0). Type: Gauge.
 

--- a/hack/prom-rule-ci/observability-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/observability-prom-rules-tests.yaml
@@ -390,3 +390,30 @@ tests:
               operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cnv-observability"
+
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_hco_memory_overcommit_percentage'
+        values: "80+0x10 101+0x10"
+      - series: 'kube_daemonset_metadata_generation{namespace="wasp",daemonset="wasp-agent"}'
+        values: "0+0x10 1+0x10"
+
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: DuplicateWaspAgentDSDetected
+        exp_alerts: [ ]
+      - eval_time: 9m
+        alertname: DuplicateWaspAgentDSDetected
+        exp_alerts: [ ]
+      - eval_time: 12m
+        alertname: DuplicateWaspAgentDSDetected
+        exp_alerts:
+          - exp_annotations:
+              summary: "Duplicate wasp-agent deployment detected"
+              description: "Two wasp-agent deployments exist in the cluster. Please follow the instructions mentioned in the runbook to remove the duplicate deployment."
+              runbook_url: "https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/DuplicateWaspAgentDSDetected.md"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cnv-observability"

--- a/pkg/monitoring/observability/rules/alerts/alerts.go
+++ b/pkg/monitoring/observability/rules/alerts/alerts.go
@@ -29,7 +29,9 @@ func Register(operatorRegistry *operatorrules.Registry) error {
 		for _, alert := range alertGroup {
 			alert.Labels["kubernetes_operator_part_of"] = "kubevirt"
 			alert.Labels["kubernetes_operator_component"] = "cnv-observability"
-			alert.Annotations["runbook_url"] = fmt.Sprintf(runbookURLTemplate, alert.Alert)
+			if _, ok := alert.Annotations["runbook_url"]; !ok {
+				alert.Annotations["runbook_url"] = fmt.Sprintf(runbookURLTemplate, alert.Alert)
+			}
 		}
 
 	}

--- a/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
+++ b/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
@@ -116,5 +116,22 @@ func clusterAlerts() []promv1.Rule {
 				"operator_health_impact": "none",
 			},
 		},
+		{
+			Alert: "DuplicateWaspAgentDSDetected",
+			Expr: intstr.FromString(
+				`count(kube_daemonset_metadata_generation{namespace="wasp",daemonset="wasp-agent"}) > 0
+					and kubevirt_hco_memory_overcommit_percentage > 100
+			`),
+			For: ptr.To[promv1.Duration]("1m"),
+			Annotations: map[string]string{
+				"summary":     "Duplicate wasp-agent deployment detected",
+				"description": "Two wasp-agent deployments exist in the cluster. Please follow the instructions mentioned in the runbook to remove the duplicate deployment.",
+				"runbook_url": "https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/DuplicateWaspAgentDSDetected.md",
+			},
+			Labels: map[string]string{
+				"severity":               "warning",
+				"operator_health_impact": "none",
+			},
+		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

Runbook PR: https://github.com/openshift/runbooks/pull/318

**What this PR does / why we need it**:
In an upgrade scenario it can happen that duplicate wasp-agent
deployment can appear, since previous wasp-agent deployments
were manual and in a different namespace.
Therefore in order to make sure the user is aware of it we
are adding an alert which will rely on the a metric of memory
overcommit percentage and presence of wasp namespace.


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-57781
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Prometheus alert for detecting duplicate wasp-agent deployment
```
