### PR TITLE
Sanity test: Ignore Coverall Failures

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -47,6 +47,7 @@ jobs:
         run: make prom-rules-verify
 
       - name: Coveralls
+        continue-on-error: true
         uses: coverallsapp/github-action@v2
         with:
           file: coverprofiles/cover.coverprofile


### PR DESCRIPTION
**What this PR does / why we need it**:

The coverall site is many time not stable, and each time it happen, it blocks our CI.

This PR makes sure the sanity test passed even if coverall returns error.

**Release note**:
```release-note
None
```
