### PR TITLE
Set the KV `MultiArchitecture` FG

### DIFF
--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -151,6 +151,7 @@ const (
 	kvAlignCPUs                  = "AlignCPUs"
 	kvPasstIPStackMigration      = "PasstIPStackMigration"
 	kvDecentralizedLiveMigration = "DecentralizedLiveMigration"
+	kvMultiArchitecture          = "MultiArchitecture"
 )
 
 // CPU Plugin default values
@@ -863,6 +864,10 @@ func getFeatureGateChecks(featureGates *hcov1beta1.HyperConvergedFeatureGates, a
 
 	if ptr.Deref(featureGates.DecentralizedLiveMigration, false) {
 		fgs = append(fgs, kvDecentralizedLiveMigration)
+	}
+
+	if ptr.Deref(featureGates.EnableMultiArchBootImageImport, false) {
+		fgs = append(fgs, kvMultiArchitecture)
 	}
 
 	if annotations[passt.DeployPasstNetworkBindingAnnotation] == "true" {

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -2063,6 +2063,31 @@ Version: 1.2.3`)
 							Expect(kv.Annotations).ToNot(HaveKey(kubevirtcorev1.EmulatorThreadCompleteToEvenParity))
 						},
 					),
+					// MultiArchitecture
+					Entry("should add the MultiArchitecture feature gate if enableMultiArchBootImageImport is true in HyperConverged CR",
+						func(hc *hcov1beta1.HyperConverged) {
+							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+								EnableMultiArchBootImageImport: ptr.To(true),
+							}
+						},
+						ContainElement(kvMultiArchitecture),
+					),
+					Entry("should not add the MultiArchitecture feature gate if EnableMultiArchBootImageImport is false in HyperConverged CR",
+						func(hc *hcov1beta1.HyperConverged) {
+							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+								EnableMultiArchBootImageImport: ptr.To(false),
+							}
+						},
+						Not(ContainElement(kvMultiArchitecture)),
+					),
+					Entry("should not add the MultiArchitecture feature gate if EnableMultiArchBootImageImport is not set in HyperConverged CR",
+						func(hc *hcov1beta1.HyperConverged) {
+							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
+								AlignCPUs: nil,
+							}
+						},
+						Not(ContainElement(kvMultiArchitecture)),
+					),
 					// PasstIPStackMigration
 					Entry("should add the Passt Network Binding to Kubevirt CR if PasstNetworkBinding is true in HyperConverged CR",
 						func(hc *hcov1beta1.HyperConverged) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When the HyperConverged's `enableMultiArchBootImageImport` FG is true, enable the KubeVirt's `MultiArchitecture` feature gate, to allow the setting of the VM's `spec.architecure` fieeld. Without this setting, KubeVirt validation will reject the setting of this field.


| **Note**: The KubeVirt's `MultiArchitecture` feature gate is tracked in this VEP: https://github.com/kubevirt/enhancements/issues/84 |
|---|

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-67215
```

**Release note**:
```release-note
None
```
