### PR TITLE
[monitoring]: fix wasp-agent alert rule

### DIFF
--- a/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
+++ b/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
@@ -120,7 +120,7 @@ func clusterAlerts() []promv1.Rule {
 			Alert: "DuplicateWaspAgentDSDetected",
 			Expr: intstr.FromString(
 				`count(kube_daemonset_metadata_generation{namespace="wasp",daemonset="wasp-agent"}) > 0
-					and kubevirt_hco_memory_overcommit_percentage > 100
+					and on() (kubevirt_hco_memory_overcommit_percentage > 100)
 			`),
 			For: ptr.To[promv1.Duration]("1m"),
 			Annotations: map[string]string{


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

since the metrics that are in use by the rule have different labels the strict matching using and didn't work, so we have to use the on() in order to perform just a logical and.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-57781
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
