### PR TITLE
New alert: `HCOMultiArchGoldenImagesDisabled`

### DIFF
--- a/api/v1beta1/register.go
+++ b/api/v1beta1/register.go
@@ -9,13 +9,18 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
 
-	hcoutils "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+const (
+	APIVersionBeta    = "v1beta1"
+	CurrentAPIVersion = APIVersionBeta
+	APIVersionGroup   = "hco.kubevirt.io"
+	APIVersion        = APIVersionGroup + "/" + CurrentAPIVersion
 )
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: hcoutils.APIVersionGroup, Version: hcoutils.APIVersionBeta}
+	SchemeGroupVersion = schema.GroupVersion{Group: APIVersionGroup, Version: APIVersionBeta}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -65,6 +65,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/nodes"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/observability"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/authorization"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/collectors"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/metrics"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/upgradepatch"
@@ -256,6 +257,9 @@ func main() {
 	operatormetrics.Register = controllerruntimemetrics.Registry.Register
 	err = metrics.SetupMetrics()
 	cmdHelper.ExitOnError(err, "failed to setup metrics: %v")
+
+	err = collectors.SetupCollectors(mgr.GetClient(), operatorNamespace)
+	cmdHelper.ExitOnError(err, "failed to setup metrics controllers: %v")
 
 	err = passt.CheckPasstImagesEnvExists()
 	cmdHelper.ExitOnError(err, "failed to retrieve passt env vars")

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
@@ -4886,7 +4886,6 @@ spec:
     - apiGroups:
       - hco.kubevirt.io
       apiVersions:
-      - v1alpha1
       - v1beta1
       operations:
       - CREATE
@@ -4932,7 +4931,6 @@ spec:
     - apiGroups:
       - hco.kubevirt.io
       apiVersions:
-      - v1alpha1
       - v1beta1
       operations:
       - CREATE

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.16.0-unstable
-    createdAt: "2025-08-20 12:11:20"
+    createdAt: "2025-08-21 21:11:10"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -4886,7 +4886,6 @@ spec:
     - apiGroups:
       - hco.kubevirt.io
       apiVersions:
-      - v1alpha1
       - v1beta1
       operations:
       - CREATE
@@ -4932,7 +4931,6 @@ spec:
     - apiGroups:
       - hco.kubevirt.io
       apiVersions:
-      - v1alpha1
       - v1beta1
       operations:
       - CREATE

--- a/hack/prom-rule-ci/hyperconverged-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/hyperconverged-prom-rules-tests.yaml
@@ -1072,3 +1072,79 @@ tests:
             kubernetes_operator_component: "hyperconverged-cluster-operator"
             data_import_cron_name: "dict1"
             managed_data_source_name: "ds1"
+
+# Test HCOMultiArchGoldenImagesDisabled
+- interval: 1m
+  input_series:
+    - series: 'kubevirt_hco_multi_arch_boot_images_enabled'
+      # time:      0     1 2 3 4 5 6 7     8     9
+      values: "stale stale 0 0 1 1 0 0 stale stale"
+
+  alert_rule_test:
+    - eval_time: 0m
+      alertname: HCOMultiArchGoldenImagesDisabled
+      exp_alerts: [ ]
+
+    - eval_time: 1m
+      alertname: HCOMultiArchGoldenImagesDisabled
+      exp_alerts: [ ]
+    - eval_time: 2m
+      alertname: HCOMultiArchGoldenImagesDisabled
+      exp_alerts:
+        - exp_annotations:
+            description: "The cluster is multi-arch, but the enableMultiArchBootImageImport feature gate is disabled. This may cause issues with VM booting on nodes with different architectures."
+            summary: "Multi-arch boot images feature is disabled in a multi-arch cluster."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOMultiArchGoldenImagesDisabled"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+    - eval_time: 3m
+      alertname: HCOMultiArchGoldenImagesDisabled
+      exp_alerts:
+        - exp_annotations:
+            description: "The cluster is multi-arch, but the enableMultiArchBootImageImport feature gate is disabled. This may cause issues with VM booting on nodes with different architectures."
+            summary: "Multi-arch boot images feature is disabled in a multi-arch cluster."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOMultiArchGoldenImagesDisabled"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+    - eval_time: 4m
+      alertname: HCOMultiArchGoldenImagesDisabled
+      exp_alerts: [ ]
+    - eval_time: 5m
+      alertname: HCOMultiArchGoldenImagesDisabled
+      exp_alerts: [ ]
+    - eval_time: 6m
+      alertname: HCOMultiArchGoldenImagesDisabled
+      exp_alerts:
+        - exp_annotations:
+            description: "The cluster is multi-arch, but the enableMultiArchBootImageImport feature gate is disabled. This may cause issues with VM booting on nodes with different architectures."
+            summary: "Multi-arch boot images feature is disabled in a multi-arch cluster."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOMultiArchGoldenImagesDisabled"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+    - eval_time: 7m
+      alertname: HCOMultiArchGoldenImagesDisabled
+      exp_alerts:
+        - exp_annotations:
+            description: "The cluster is multi-arch, but the enableMultiArchBootImageImport feature gate is disabled. This may cause issues with VM booting on nodes with different architectures."
+            summary: "Multi-arch boot images feature is disabled in a multi-arch cluster."
+            runbook_url: "https://kubevirt.io/monitoring/runbooks/HCOMultiArchGoldenImagesDisabled"
+          exp_labels:
+            severity: "warning"
+            operator_health_impact: "none"
+            kubernetes_operator_part_of: "kubevirt"
+            kubernetes_operator_component: "hyperconverged-cluster-operator"
+    - eval_time: 8m
+      alertname: HCOMultiArchGoldenImagesDisabled
+      exp_alerts: [ ]
+    - eval_time: 9m
+      alertname: HCOMultiArchGoldenImagesDisabled
+      exp_alerts: [ ]

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -835,7 +835,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 				},
 				Rule: admissionregistrationv1.Rule{
 					APIGroups:   stringListToSlice(util.APIVersionGroup),
-					APIVersions: stringListToSlice(util.APIVersionAlpha, util.APIVersionBeta),
+					APIVersions: stringListToSlice(util.APIVersionBeta),
 					Resources:   stringListToSlice("hyperconvergeds"),
 				},
 			},
@@ -887,7 +887,7 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 				},
 				Rule: admissionregistrationv1.Rule{
 					APIGroups:   stringListToSlice(util.APIVersionGroup),
-					APIVersions: stringListToSlice(util.APIVersionAlpha, util.APIVersionBeta),
+					APIVersions: stringListToSlice(util.APIVersionBeta),
 					Resources:   stringListToSlice("hyperconvergeds"),
 				},
 			},

--- a/pkg/monitoring/hyperconverged/collectors/collectors_test.go
+++ b/pkg/monitoring/hyperconverged/collectors/collectors_test.go
@@ -1,0 +1,13 @@
+package collectors
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCollectors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Collectors Suite")
+}

--- a/pkg/monitoring/hyperconverged/collectors/controllers.go
+++ b/pkg/monitoring/hyperconverged/collectors/controllers.go
@@ -1,0 +1,18 @@
+package collectors
+
+import (
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func SetupCollectors(cli client.Client, namespace string) error {
+	err := operatormetrics.RegisterCollector(
+		getMultiArchBootImagesStatusCollector(cli, namespace),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/monitoring/hyperconverged/collectors/operator_collectors.go
+++ b/pkg/monitoring/hyperconverged/collectors/operator_collectors.go
@@ -1,0 +1,81 @@
+package collectors
+
+import (
+	"context"
+
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
+)
+
+const (
+	multiArchBootImagesFeatureEnabled  = float64(1)
+	multiArchBootImagesFeatureDisabled = float64(0)
+)
+
+var (
+	multiArchBootImagesStatus = operatormetrics.NewGauge(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_hco_multi_arch_boot_images_enabled",
+			Help: "indicates if the Multi-Arch Boot Images feature is enabled (1) or not (0)",
+		},
+	)
+
+	logger = logf.Log.WithName("operator-metrics-collector")
+)
+
+func getMultiArchBootImagesStatusCollector(cli client.Client, operatorNamespace string) operatormetrics.Collector {
+	return operatormetrics.Collector{
+		Metrics: []operatormetrics.Metric{
+			multiArchBootImagesStatus,
+		},
+		CollectCallback: getMultiArchBootImagesStatusCallback(cli, operatorNamespace),
+	}
+}
+
+func getMultiArchBootImagesStatusCallback(cli client.Client, operatorNamespace string) func() []operatormetrics.CollectorResult {
+	return func() []operatormetrics.CollectorResult {
+		hc := hcov1beta1.HyperConverged{}
+		key := client.ObjectKey{Name: hcov1beta1.HyperConvergedName, Namespace: operatorNamespace}
+		if err := cli.Get(context.TODO(), key, &hc); err != nil {
+			if !errors.IsNotFound(err) {
+				logger.Info("HyperConverged not found")
+			} else {
+				logger.Error(err, "can't read HyperConverged")
+			}
+			// Don't set the metric if the HyperConverged CR does not exist
+			return []operatormetrics.CollectorResult{}
+		}
+
+		if len(nodeinfo.GetWorkloadsArchitectures()) <= 1 {
+			// Don't set the metric if the cluster is not multi-architecture
+			return []operatormetrics.CollectorResult{}
+		}
+
+		if len(hc.Status.DataImportCronTemplates) == 0 {
+			// Don't set the metric if no common nor custom DataImportCronTemplates found
+			return []operatormetrics.CollectorResult{}
+		}
+
+		// Set the metric based on the FeatureGate value
+		value := multiArchBootImagesFeatureDisabled
+		if ptr.Deref(hc.Spec.FeatureGates.EnableMultiArchBootImageImport, false) {
+			logger.Info("Multi-Arch boot images feature is enabled")
+			value = multiArchBootImagesFeatureEnabled
+		} else {
+			logger.Info("Multi-Arch boot images feature is disabled, but running on a multi-arch cluster with boot images enabled")
+		}
+
+		return []operatormetrics.CollectorResult{
+			{
+				Metric: multiArchBootImagesStatus,
+				Value:  value,
+			},
+		}
+	}
+}

--- a/pkg/monitoring/hyperconverged/collectors/operator_collectors_test.go
+++ b/pkg/monitoring/hyperconverged/collectors/operator_collectors_test.go
@@ -1,0 +1,206 @@
+package collectors
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
+)
+
+var _ = Describe("HyperConverged Collectors", func() {
+	var hco *hcov1beta1.HyperConverged
+
+	BeforeEach(func() {
+		hco = commontestutils.NewHco()
+
+		origNodeInfoFunc := nodeinfo.GetWorkloadsArchitectures
+
+		DeferCleanup(func() {
+			nodeinfo.GetWorkloadsArchitectures = origNodeInfoFunc
+		})
+	})
+
+	Describe("kubevirt_hco_multi_arch_boot_images_enabled", func() {
+		When("cluster is multi architectures", func() {
+			BeforeEach(func() {
+				nodeinfo.GetWorkloadsArchitectures = func() []string {
+					return []string{"arch1", "arch2"}
+				}
+			})
+
+			When("we deploy DICTs", func() {
+				BeforeEach(func() {
+					hco.Status.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplateStatus{
+						{
+							DataImportCronTemplate: hcov1beta1.DataImportCronTemplate{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "image1",
+								},
+							},
+						},
+						{
+							DataImportCronTemplate: hcov1beta1.DataImportCronTemplate{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "image2",
+								},
+							},
+						},
+					}
+				})
+
+				It("should be set and enabled, if multi-arch dict enabled", func() {
+					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+
+					cli := commontestutils.InitClient([]client.Object{hco})
+					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
+					Expect(isSet).To(BeTrue())
+					Expect(isEnabled).To(BeTrue())
+				})
+
+				It("should be set and disabled, if multi-arch dict disabled", func() {
+					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(false)
+
+					cli := commontestutils.InitClient([]client.Object{hco})
+					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
+					Expect(isSet).To(BeTrue())
+					Expect(isEnabled).To(BeFalse())
+				})
+
+				It("should be set and disabled, if multi-arch dict is not set", func() {
+					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = nil
+
+					cli := commontestutils.InitClient([]client.Object{hco})
+					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
+					Expect(isSet).To(BeTrue())
+					Expect(isEnabled).To(BeFalse())
+				})
+			})
+
+			When("we don't deploy DICTS", func() {
+				BeforeEach(func() {
+					hco.Status.DataImportCronTemplates = nil
+				})
+
+				It("should not be set, if multi-arch dict enabled", func() {
+					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+
+					cli := commontestutils.InitClient([]client.Object{hco})
+					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
+					Expect(isSet).To(BeFalse())
+					Expect(isEnabled).To(BeFalse())
+				})
+
+				It("should not be set, if multi-arch dict disabled", func() {
+					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(false)
+
+					cli := commontestutils.InitClient([]client.Object{hco})
+					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
+					Expect(isSet).To(BeFalse())
+					Expect(isEnabled).To(BeFalse())
+				})
+			})
+		})
+
+		When("cluster is with single architecture", func() {
+			BeforeEach(func() {
+				nodeinfo.GetWorkloadsArchitectures = func() []string {
+					return []string{"single-arch"}
+				}
+			})
+
+			When("we deploy DICTs", func() {
+				BeforeEach(func() {
+					hco.Status.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplateStatus{
+						{
+							DataImportCronTemplate: hcov1beta1.DataImportCronTemplate{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "image1",
+								},
+							},
+						},
+						{
+							DataImportCronTemplate: hcov1beta1.DataImportCronTemplate{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "image2",
+								},
+							},
+						},
+					}
+				})
+
+				It("should not be set, if multi-arch dict enabled", func() {
+					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+
+					cli := commontestutils.InitClient([]client.Object{hco})
+					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
+					Expect(isSet).To(BeFalse())
+					Expect(isEnabled).To(BeFalse())
+				})
+
+				It("should not be set, if multi-arch dict disabled", func() {
+					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(false)
+
+					cli := commontestutils.InitClient([]client.Object{hco})
+					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
+
+					Expect(isSet).To(BeFalse())
+					Expect(isEnabled).To(BeFalse())
+				})
+
+				It("should not be set, if multi-arch dict is not set", func() {
+					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = nil
+
+					cli := commontestutils.InitClient([]client.Object{hco})
+					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
+
+					Expect(isSet).To(BeFalse())
+					Expect(isEnabled).To(BeFalse())
+				})
+			})
+
+			When("we don't deploy DICTs", func() {
+				BeforeEach(func() {
+					hco.Status.DataImportCronTemplates = nil
+				})
+
+				It("should not be set, if multi-arch dict enabled", func() {
+					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+
+					cli := commontestutils.InitClient([]client.Object{hco})
+					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
+
+					Expect(isSet).To(BeFalse())
+					Expect(isEnabled).To(BeFalse())
+				})
+
+				It("should not be set, if multi-arch dict disabled", func() {
+					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(false)
+
+					cli := commontestutils.InitClient([]client.Object{hco})
+					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
+
+					Expect(isSet).To(BeFalse())
+					Expect(isEnabled).To(BeFalse())
+				})
+			})
+		})
+	})
+})
+
+func isMultiArchBootImagesFeatureEnabled(cli client.Client) (isSet, isEnabled bool) {
+	callback := getMultiArchBootImagesStatusCallback(cli, commontestutils.Namespace)
+
+	res := callback()
+	if len(res) == 0 {
+		return false, false
+	}
+
+	isEnabled = res[0].Value == multiArchBootImagesFeatureEnabled
+
+	return true, isEnabled
+}

--- a/pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go
+++ b/pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go
@@ -7,13 +7,14 @@ import (
 )
 
 const (
-	outOfBandUpdateAlert          = "KubeVirtCRModified"
-	unsafeModificationAlert       = "UnsupportedHCOModification"
-	installationNotCompletedAlert = "HCOInstallationIncomplete"
-	singleStackIPv6Alert          = "SingleStackIPv6Unsupported"
-	MisconfiguredDeschedulerAlert = "HCOMisconfiguredDescheduler"
-	unsupportedArchitecturesAlert = "HCOGoldenImageWithNoSupportedArchitecture"
-	dictWithNoArchAnnotationAlert = "HCOGoldenImageWithNoArchitectureAnnotation"
+	outOfBandUpdateAlert             = "KubeVirtCRModified"
+	unsafeModificationAlert          = "UnsupportedHCOModification"
+	installationNotCompletedAlert    = "HCOInstallationIncomplete"
+	singleStackIPv6Alert             = "SingleStackIPv6Unsupported"
+	MisconfiguredDeschedulerAlert    = "HCOMisconfiguredDescheduler"
+	unsupportedArchitecturesAlert    = "HCOGoldenImageWithNoSupportedArchitecture"
+	dictWithNoArchAnnotationAlert    = "HCOGoldenImageWithNoArchitectureAnnotation"
+	multiArchBootImagesDisabledAlert = "HCOMultiArchGoldenImagesDisabled"
 
 	severityAlertLabelKey     = "severity"
 	healthImpactAlertLabelKey = "operator_health_impact"
@@ -100,6 +101,18 @@ func operatorAlerts() []promv1.Rule {
 			Annotations: map[string]string{
 				"description": "The {{ $labels.data_import_cron_name }} DataImportCronTemplate (for the {{ $labels.managed_data_source_name }} DataSource) does not have the 'ssp.kubevirt.io/dict.architectures' annotation. Using this golden image for VM boot disk, may cause the VM to fail.",
 				"summary":     "DataImportCronTemplate without 'ssp.kubevirt.io/dict.architectures' annotation was detected in the HyperConverged resource.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "none",
+			},
+		},
+		{
+			Alert: multiArchBootImagesDisabledAlert,
+			Expr:  intstr.FromString("kubevirt_hco_multi_arch_boot_images_enabled == 0"),
+			Annotations: map[string]string{
+				"description": "The cluster is multi-arch, but the enableMultiArchBootImageImport feature gate is disabled. This may cause issues with VM booting on nodes with different architectures.",
+				"summary":     "Multi-arch boot images feature is disabled in a multi-arch cluster.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:     "warning",

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -1,5 +1,7 @@
 package util
 
+import "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+
 // pod names
 const (
 	HCOOperatorName  = "hyperconverged-cluster-operator"
@@ -38,11 +40,10 @@ const (
 	AppLabel                           = "app"
 	UndefinedNamespace                 = ""
 	OpenshiftNamespace                 = "openshift"
-	APIVersionAlpha                    = "v1alpha1"
-	APIVersionBeta                     = "v1beta1"
-	CurrentAPIVersion                  = APIVersionBeta
-	APIVersionGroup                    = "hco.kubevirt.io"
-	APIVersion                         = APIVersionGroup + "/" + CurrentAPIVersion
+	APIVersionBeta                     = v1beta1.APIVersionBeta
+	CurrentAPIVersion                  = v1beta1.CurrentAPIVersion
+	APIVersionGroup                    = v1beta1.APIVersionGroup
+	APIVersion                         = v1beta1.APIVersion
 	HyperConvergedKind                 = "HyperConverged"
 	// Recommended labels by Kubernetes. See
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/


### PR DESCRIPTION
**What this PR does / why we need it**:

Added the new `kubevirt_hco_multi_arch_boot_images_enabled` metric. It set if running on a multi-arch cluster, and there are valid DataImportCronTemplates. If the `enableMultiArchBootImageImport` FG is enabled, the metric value will be 1, if not, the value will be 0.

Added the `HCOMultiArchGoldenImagesDisabled` alert. The alert is triggered if the the `enableMultiArchBootImageImport` FG is disabled, while running on a multi-arch cluster (i.e., when the `kubevirt_hco_multi_arch_boot_images_enabled` is with value of 0).

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-63043
https://issues.redhat.com/browse/CNV-64419
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added the new `kubevirt_hco_multi_arch_boot_images_enabled` metric.
Added the `HCOMultiArchGoldenImagesDisabled` alert.
```
