### PR TITLE
Fix flaky test

### DIFF
--- a/tests/func-tests/debugFuncs_test.go
+++ b/tests/func-tests/debugFuncs_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+)
+
+// printHyperConverged returns a function to print the HyperConverged CR in JSOn format. It is a lazy initialization,
+// so it won't be called unless there is a failure and the output is needed.
+func marshalHyperConverged(hc *v1beta1.HyperConverged) string {
+	ginkgo.GinkgoHelper()
+
+	if hc == nil {
+		return "<nil>"
+	}
+
+	hc.ManagedFields = nil // remove noise
+
+	hcYAML, err := yaml.Marshal(hc)
+	Expect(err).NotTo(HaveOccurred())
+
+	return string(hcYAML)
+}
+
+// PrintHyperConverged returns a function to print the HyperConverged CR in JSOn format. It is a lazy initialization,
+// so it won't be called unless there is a failure and the output is needed.
+func PrintHyperConverged(hc *v1beta1.HyperConverged) func() string {
+	return func() string {
+		hcYAML := marshalHyperConverged(hc)
+		return fmt.Sprintf("Current HyperConverged CR:\n%s\n", hcYAML)
+	}
+}
+
+// PrintHyperConvergedBecause returns a function to print the HyperConverged CR in JSOn format. It is a lazy initialization,
+// so it won't be called unless there is a failure and the output is needed.
+func PrintHyperConvergedBecause(hc *v1beta1.HyperConverged, format string, args ...any) func() string {
+	return func() string {
+		format += "; current HyperConverged CR:\n%s\n"
+		hcYAML := marshalHyperConverged(hc)
+		args = append(args, hcYAML)
+
+		return fmt.Sprintf(format, args...)
+	}
+}
+
+// PrintOrigAndCurrentHyperConvergeds returns a function to print two phases of the HyperConverged CR in JSOn
+// format: one before the test. and one as it is now. It is a lazy initialization, so it won't be called unless there is
+// a failure and the output is needed.
+func PrintOrigAndCurrentHyperConvergeds(orig, modified *v1beta1.HyperConverged) func() string {
+	return func() string {
+		origHCStr := marshalHyperConverged(orig)
+		modifiedHCStr := marshalHyperConverged(modified)
+
+		return fmt.Sprintf("Original HC CR:\n%s\nModified HC CR:\n%s\n", origHCStr, modifiedHCStr)
+	}
+}
+
+// PrintOrigAndCurrentHyperConvergedsBecause returns a function to print two phases of the HyperConverged CR in JSOn
+// format: one before the test. and one as it is now. It is a lazy initialization, so it won't be called unless there is
+// a failure and the output is needed.
+func PrintOrigAndCurrentHyperConvergedsBecause(orig, modified *v1beta1.HyperConverged, format string, args ...any) func() string {
+	return func() string {
+		origHCStr := marshalHyperConverged(orig)
+		modifiedHCStr := marshalHyperConverged(modified)
+
+		format += "; original HC CR:\n%s\nModified HC CR:\n%s\n"
+
+		args = append(args, origHCStr, modifiedHCStr)
+		return fmt.Sprintf(format, args...)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The `golden image test test multi-arch should have the architectures in a customized common DICT the SSP CR` functional test is flaky.

This PR fixes it by adding some more accurate waiting between tests
Also added some debug printout methods.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
