### PR TITLE
Fix kubevirt_hco_system_health_status

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -1036,6 +1036,11 @@ func isSystemHealthStatusError(conditions common.HcoConditions) bool {
 }
 
 func isSystemHealthStatusWarning(conditions common.HcoConditions) bool {
+	// Treat upgrade progression as non-warning: ignore Progressing=true when reason is HCOUpgrading
+	if cond, found := conditions.GetCondition(hcov1beta1.ConditionProgressing); found && cond.Status == metav1.ConditionTrue && cond.Reason == "HCOUpgrading" {
+		return !conditions.IsStatusConditionTrue(hcov1beta1.ConditionReconcileComplete)
+	}
+
 	return !conditions.IsStatusConditionTrue(hcov1beta1.ConditionReconcileComplete) || conditions.IsStatusConditionTrue(hcov1beta1.ConditionProgressing)
 }
 

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1650,6 +1650,9 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(cond.Reason).To(Equal("HCOUpgrading"))
 					Expect(cond.Message).To(Equal("HCO is now upgrading to version " + newHCOVersion))
 
+					// system health should remain healthy during upgrade progression
+					verifySystemHealthStatusHealthy(foundResource)
+
 					// check that the upgrade is not done if the not all the versions are match.
 					// Conditions are valid
 					makeComponentReady()
@@ -1668,6 +1671,9 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 					Expect(cond.Reason).To(Equal("HCOUpgrading"))
 					Expect(cond.Message).To(Equal("HCO is now upgrading to version " + newHCOVersion))
+
+					// system health should remain healthy during upgrade progression
+					verifySystemHealthStatusHealthy(foundResource)
 
 					// now, complete the upgrade
 					updateComponentVersion()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix kubevirt_hco_system_health_status.
System health should remain healthy during
upgrade progression.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-67426
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug in kubevirt_hco_system_health_status now reported as healthy also during upgrade.
```
