### PR TITLE
NodeNetworkInterfaceDown alert fires for disabled NICs

### DIFF
--- a/hack/prom-rule-ci/observability-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/observability-prom-rules-tests.yaml
@@ -79,12 +79,16 @@ tests:
         values: "1+0x30"
       - series: 'node_network_up{instance="n1.cnv.redhat.com",device="eth0"}'
         values: "1+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
 
       # Test case 2: IFF_UP is set and IFF_RUNNING is set (should NOT alert)
       # Flag value = 65 (IFF_UP=1, IFF_RUNNING=64, IFF_LOWER_UP=0)
       - series: 'node_network_flags{instance="n1.cnv.redhat.com",device="eth1"}'
         values: "65+0x30"
       - series: 'node_network_up{instance="n1.cnv.redhat.com",device="eth1"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="eth1"}'
         values: "1+0x30"
 
       # Test case 3: IFF_UP is NOT set and IFF_RUNNING is NOT set (should NOT alert)
@@ -93,12 +97,16 @@ tests:
         values: "0+0x30"
       - series: 'node_network_up{instance="n1.cnv.redhat.com",device="eth2"}'
         values: "0+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="eth2"}'
+        values: "0+0x30"
 
       # Test case 4: IFF_UP is set, IFF_RUNNING and IFF_LOWER_UP are NOT set but device is in ignored list (should NOT alert)
       # Flag value = 1 (IFF_UP=1, IFF_RUNNING=0, IFF_LOWER_UP=0)
       - series: 'node_network_flags{instance="n1.cnv.redhat.com",device="lo"}'
         values: "1+0x30"
       - series: 'node_network_up{instance="n1.cnv.redhat.com",device="lo"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="lo"}'
         values: "1+0x30"
 
       # Test case 5: IFF_UP is set, IFF_RUNNING and IFF_LOWER_UP are NOT set but node_network_up is 0 (should NOT alert)
@@ -107,12 +115,16 @@ tests:
         values: "1+0x30"
       - series: 'node_network_up{instance="n1.cnv.redhat.com",device="eth3"}'
         values: "0+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="eth3"}'
+        values: "1+0x30"
 
       # Test case 5a: IFF_UP is set, IFF_RUNNING is NOT set but IFF_LOWER_UP is set (should NOT alert)
       # Flag value = 65537 (IFF_UP=1, IFF_RUNNING=0, IFF_LOWER_UP=65536)
       - series: 'node_network_flags{instance="n1.cnv.redhat.com",device="eth5"}'
         values: "65537+0x30"
       - series: 'node_network_up{instance="n1.cnv.redhat.com",device="eth5"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="eth5"}'
         values: "1+0x30"
 
       # Test case 6: Multiple interfaces with different states on same instance
@@ -121,9 +133,13 @@ tests:
         values: "1+0x30"
       - series: 'node_network_up{instance="n2.cnv.redhat.com",device="eth0"}'
         values: "1+0x30"
+      - series: 'node_network_carrier{instance="n2.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
       - series: 'node_network_flags{instance="n2.cnv.redhat.com",device="eth4"}'
         values: "1+0x30"
       - series: 'node_network_up{instance="n2.cnv.redhat.com",device="eth4"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n2.cnv.redhat.com",device="eth4"}'
         values: "1+0x30"
       # One interface with IFF_UP=1, IFF_RUNNING=64 (should NOT alert)
       - series: 'node_network_flags{instance="n2.cnv.redhat.com",device="eth1"}'
@@ -134,6 +150,8 @@ tests:
       - series: 'node_network_flags{instance="n2.cnv.redhat.com",device="veth123"}'
         values: "1+0x30"
       - series: 'node_network_up{instance="n2.cnv.redhat.com",device="veth123"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n2.cnv.redhat.com",device="veth123"}'
         values: "1+0x30"
 
     alert_rule_test:
@@ -178,6 +196,8 @@ tests:
         values: "65+0x5 1+0x10 65+0x15"
       - series: 'node_network_up{instance="n3.cnv.redhat.com",device="eth0"}'
         values: "1+0x30"
+      - series: 'node_network_carrier{instance="n3.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
 
       # Test case 7: Interface with complex flag changes
       # Flag transitions:
@@ -186,6 +206,8 @@ tests:
       - series: 'node_network_flags{instance="n3.cnv.redhat.com",device="eth1"}'
         values: "0+0x8 1+0x17"
       - series: 'node_network_up{instance="n3.cnv.redhat.com",device="eth1"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n3.cnv.redhat.com",device="eth1"}'
         values: "1+0x30"
 
       # Test case 8: Multiple ignored interfaces with same instance (should NOT alert)
@@ -272,6 +294,39 @@ tests:
       - eval_time: 10m
         alertname: NodeNetworkInterfaceDown
         exp_alerts: [ ]
+
+  - interval: 1m
+    input_series:
+      # Test case 9: Admin up, not running, carrier=1 (should alert)
+      - series: 'node_network_flags{instance="n5.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n5.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n5.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+
+      # Test case 9a: Admin up, not running, carrier=0 - disabled NIC (should NOT alert)
+      - series: 'node_network_flags{instance="n6.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n6.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n6.cnv.redhat.com",device="eth0"}'
+        values: "0+0x30"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NodeNetworkInterfaceDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "Network interfaces are down"
+              description: "1 network devices have been down on instance n5.cnv.redhat.com for more than 5 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NodeNetworkInterfaceDown"
+            exp_labels:
+              instance: "n5.cnv.redhat.com"
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cnv-observability"
 
   - interval: 1m
     input_series:

--- a/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
+++ b/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
@@ -63,9 +63,11 @@ func clusterAlerts() []promv1.Rule {
 					and
 					(node_network_flags %% %d) < %d										    # IFF_LOWER_UP is NOT set
 					and
-					on(device) node_network_up == 1											    # Interface is up
+					on(instance,device) node_network_up == 1									        # Interface is up
 					and
-					on(device) (node_network_flags unless node_network_flags{device=~"%s"})     # Excluding ignored interfaces
+					on(instance,device) node_network_carrier == 1                                    # Interface carrier is up
+					and
+					on(instance,device) (node_network_flags unless node_network_flags{device=~"%s"})     # Excluding ignored interfaces
 				) > 0`, (IFF_UP << 1), IFF_UP, (IFF_RUNNING << 1), IFF_RUNNING, (IFF_LOWER_UP << 1), IFF_LOWER_UP, strings.Join(ignoredInterfacesForNetworkDown, "|"))),
 			For: ptr.To[promv1.Duration]("5m"),
 			Annotations: map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This pr stopped the alert from firing on unplugged/disabled NICs by requiring “link present” (carrier=1), which means only fire if the link is up but the interface still isn’t working.
*this pr will need a backport up to 4.18


**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
jira-ticket: https://issues.redhat.com/browse/CNV-67512
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
