### PR TITLE
Fix bug in bearer tokens

### DIFF
--- a/controllers/alerts/reconciler.go
+++ b/controllers/alerts/reconciler.go
@@ -86,7 +86,7 @@ func getReconcilers(ci hcoutil.ClusterInfo, namespace string, owner metav1.Owner
 		newRoleReconciler(namespace, owner),
 		newRoleBindingReconciler(namespace, owner, ci),
 		newMetricServiceReconciler(namespace, owner),
-		newSecretReconciler(namespace, owner),
+		NewSecretReconciler(namespace, owner, secretName, newSecret),
 		newServiceMonitorReconciler(namespace, owner),
 	}
 

--- a/controllers/webhooks/bearer-token-controller/secret.go
+++ b/controllers/webhooks/bearer-token-controller/secret.go
@@ -3,26 +3,16 @@ package bearer_token_controller
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/authorization"
 )
 
 const (
 	secretName = "hco-webhook-bearer-auth"
 )
 
-var logger = logf.Log.WithName("init-bearer-token")
-
 func newWHSecretReconciler(namespace string, owner metav1.OwnerReference) *alerts.SecretReconciler {
-	token, err := authorization.CreateToken()
-	if err != nil {
-		logger.Error(err, "failed to create bearer token")
-		return nil
-	}
-
-	return alerts.CreateSecretReconciler(newSecret(namespace, owner, token))
+	return alerts.NewSecretReconciler(namespace, owner, secretName, newSecret)
 }
 
 func newSecret(namespace string, owner metav1.OwnerReference, token string) *corev1.Secret {


### PR DESCRIPTION
**What this PR does / why we need it**:

When the bearer token is refreshed, the webhook reconciler removevs its secret, but creates the operator secret, Also, the cached secret is not updated in the secret reconciler. This cause several issues:

* the webhook metrics endpoints becomes non-available, as the secret does not exist
* the webhook overrides the operator secret.
* both webhook and operator can't create the right secret, as the cached secret is with the old token.

This PR addresses all these issues and fixes them.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-68641
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug in bearer tokens
```
