### PR TITLE
Fix failures in e2e tests, when calling the alert manager

### DIFF
--- a/controllers/observability/observability_controller.go
+++ b/controllers/observability/observability_controller.go
@@ -42,7 +42,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 
 	var errors []error
 
-	if err := r.ensurePodDisruptionBudgetAtLimitIsSilenced(); err != nil {
+	if err := r.ensurePodDisruptionBudgetAtLimitIsSilenced(ctx); err != nil {
 		errors = append(errors, err)
 	}
 

--- a/controllers/observability/pod_disruption_budget_at_limit.go
+++ b/controllers/observability/pod_disruption_budget_at_limit.go
@@ -1,6 +1,7 @@
 package observability
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -19,7 +20,7 @@ const (
 	AlertmanagerSvcHost = "https://alertmanager-main.openshift-monitoring.svc.cluster.local:9094"
 )
 
-func (r *Reconciler) ensurePodDisruptionBudgetAtLimitIsSilenced() error {
+func (r *Reconciler) ensurePodDisruptionBudgetAtLimitIsSilenced(ctx context.Context) error {
 	if r.amApi == nil {
 		var err error
 		r.amApi, err = r.NewAlertmanagerApi()
@@ -28,7 +29,7 @@ func (r *Reconciler) ensurePodDisruptionBudgetAtLimitIsSilenced() error {
 		}
 	}
 
-	amSilences, err := r.amApi.ListSilences()
+	amSilences, err := r.amApi.ListSilences(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list alertmanager silences: %w", err)
 	}
@@ -58,7 +59,7 @@ func (r *Reconciler) ensurePodDisruptionBudgetAtLimitIsSilenced() error {
 		StartsAt: time.Now().Format(time.RFC3339),
 	}
 
-	if err := r.amApi.CreateSilence(silence); err != nil {
+	if err = r.amApi.CreateSilence(ctx, silence); err != nil {
 		return fmt.Errorf("failed to create alertmanager silence: %w", err)
 	}
 	log.Info("Silenced PodDisruptionBudgetAtLimit alerts")

--- a/pkg/alertmanager/silences_test.go
+++ b/pkg/alertmanager/silences_test.go
@@ -1,6 +1,7 @@
 package alertmanager_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -44,8 +45,8 @@ var _ = Describe("Silences", func() {
 		ts.Close()
 	})
 
-	It("should successfully GET /api/v2/silences", func() {
-		silences, err := api.ListSilences()
+	It("should successfully GET /api/v2/silences", func(ctx context.Context) {
+		silences, err := api.ListSilences(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(silences).To(HaveLen(1))
 
@@ -57,13 +58,13 @@ var _ = Describe("Silences", func() {
 		Expect(silences[0].Matchers[0].Value).To(Equal("TestAlert"))
 	})
 
-	It("should successfully POST /api/v2/silences", func() {
-		err := api.CreateSilence(alertmanager.Silence{})
+	It("should successfully POST /api/v2/silences", func(ctx context.Context) {
+		err := api.CreateSilence(ctx, alertmanager.Silence{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should successfully DELETE /api/v2/silences/{id}", func() {
-		err := api.DeleteSilence("bb881d7f-3278-46fd-a638-d42c57f235b6")
+	It("should successfully DELETE /api/v2/silences/{id}", func(ctx context.Context) {
+		err := api.DeleteSilence(ctx, "bb881d7f-3278-46fd-a638-d42c57f235b6")
 		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

The current test logic relays on the existence of a bearer token.

However, In some test environments, the kubeconfig file is client certificate file, rather than a bearer token one.

In this case the test will fail when trying to access send HTTP requests to the alert manager.

This PR allow also using the certificate identification, if the bearer token does not exist.

**Release note**:
```release-note
None
```
