### PR TITLE
[1.14] NodeNetworkInterfaceDown alert fires for disabled NICs

### DIFF
--- a/hack/prom-rule-ci/observability-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/observability-prom-rules-tests.yaml
@@ -73,37 +73,85 @@ tests:
 
   - interval: 1m
     input_series:
-      # Test case 1: IFF_UP is set and IFF_RUNNING is NOT set (should alert)
-      # Flag value = 1 (IFF_UP=1, IFF_RUNNING=0)
+      # Test case 1: IFF_UP is set, IFF_RUNNING and IFF_LOWER_UP are NOT set, interface is up (should alert)
+      # Flag value = 1 (IFF_UP=1, IFF_RUNNING=0, IFF_LOWER_UP=0)
       - series: 'node_network_flags{instance="n1.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n1.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="eth0"}'
         values: "1+0x30"
 
       # Test case 2: IFF_UP is set and IFF_RUNNING is set (should NOT alert)
-      # Flag value = 65 (IFF_UP=1, IFF_RUNNING=64)
+      # Flag value = 65 (IFF_UP=1, IFF_RUNNING=64, IFF_LOWER_UP=0)
       - series: 'node_network_flags{instance="n1.cnv.redhat.com",device="eth1"}'
         values: "65+0x30"
+      - series: 'node_network_up{instance="n1.cnv.redhat.com",device="eth1"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="eth1"}'
+        values: "1+0x30"
 
       # Test case 3: IFF_UP is NOT set and IFF_RUNNING is NOT set (should NOT alert)
-      # Flag value = 0 (IFF_UP=0, IFF_RUNNING=0)
+      # Flag value = 0 (IFF_UP=0, IFF_RUNNING=0, IFF_LOWER_UP=0)
       - series: 'node_network_flags{instance="n1.cnv.redhat.com",device="eth2"}'
         values: "0+0x30"
+      - series: 'node_network_up{instance="n1.cnv.redhat.com",device="eth2"}'
+        values: "0+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="eth2"}'
+        values: "0+0x30"
 
-      # Test case 4: IFF_UP is set and IFF_RUNNING is NOT set but device is in ignored list (should NOT alert)
-      # Flag value = 1 (IFF_UP=1, IFF_RUNNING=0)
+      # Test case 4: IFF_UP is set, IFF_RUNNING and IFF_LOWER_UP are NOT set but device is in ignored list (should NOT alert)
+      # Flag value = 1 (IFF_UP=1, IFF_RUNNING=0, IFF_LOWER_UP=0)
       - series: 'node_network_flags{instance="n1.cnv.redhat.com",device="lo"}'
         values: "1+0x30"
+      - series: 'node_network_up{instance="n1.cnv.redhat.com",device="lo"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="lo"}'
+        values: "1+0x30"
 
-      # Test case 5: Multiple interfaces with different states on same instance
-      # Two interfaces with IFF_UP=1, IFF_RUNNING=0 (should alert with count=2)
+      # Test case 5: IFF_UP is set, IFF_RUNNING and IFF_LOWER_UP are NOT set but node_network_up is 0 (should NOT alert)
+      # Flag value = 1 (IFF_UP=1, IFF_RUNNING=0, IFF_LOWER_UP=0)
+      - series: 'node_network_flags{instance="n1.cnv.redhat.com",device="eth3"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n1.cnv.redhat.com",device="eth3"}'
+        values: "0+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="eth3"}'
+        values: "1+0x30"
+
+      # Test case 5a: IFF_UP is set, IFF_RUNNING is NOT set but IFF_LOWER_UP is set (should NOT alert)
+      # Flag value = 65537 (IFF_UP=1, IFF_RUNNING=0, IFF_LOWER_UP=65536)
+      - series: 'node_network_flags{instance="n1.cnv.redhat.com",device="eth5"}'
+        values: "65537+0x30"
+      - series: 'node_network_up{instance="n1.cnv.redhat.com",device="eth5"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n1.cnv.redhat.com",device="eth5"}'
+        values: "1+0x30"
+
+      # Test case 6: Multiple interfaces with different states on same instance
+      # Two interfaces with IFF_UP=1, IFF_RUNNING=0, IFF_LOWER_UP=0, node_network_up=1 (should alert with count=2)
       - series: 'node_network_flags{instance="n2.cnv.redhat.com",device="eth0"}'
         values: "1+0x30"
-      - series: 'node_network_flags{instance="n2.cnv.redhat.com",device="eth3"}'
+      - series: 'node_network_up{instance="n2.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n2.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_flags{instance="n2.cnv.redhat.com",device="eth4"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n2.cnv.redhat.com",device="eth4"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n2.cnv.redhat.com",device="eth4"}'
         values: "1+0x30"
       # One interface with IFF_UP=1, IFF_RUNNING=64 (should NOT alert)
       - series: 'node_network_flags{instance="n2.cnv.redhat.com",device="eth1"}'
         values: "65+0x30"
+      - series: 'node_network_up{instance="n2.cnv.redhat.com",device="eth1"}'
+        values: "1+0x30"
       # One ignored interface with IFF_UP=1, IFF_RUNNING=0 (should NOT alert)
       - series: 'node_network_flags{instance="n2.cnv.redhat.com",device="veth123"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n2.cnv.redhat.com",device="veth123"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n2.cnv.redhat.com",device="veth123"}'
         values: "1+0x30"
 
     alert_rule_test:
@@ -141,30 +189,55 @@ tests:
     input_series:
       # Test case 6: Interface transitioning between states
       # Flag values:
-      # - 0 minutes to 5 minutes: 65 (IFF_UP=1, IFF_RUNNING=64) - healthy
-      # - 5 minutes to 15 minutes: 1 (IFF_UP=1, IFF_RUNNING=0) - should alert after 5 minutes in this state
-      # - After 15 minutes: 65 (IFF_UP=1, IFF_RUNNING=64) - becomes healthy again
+      # - 0 minutes to 5 minutes: 65 (IFF_UP=1, IFF_RUNNING=64, IFF_LOWER_UP=0) - healthy
+      # - 5 minutes to 15 minutes: 1 (IFF_UP=1, IFF_RUNNING=0, IFF_LOWER_UP=0) - should alert after 5 minutes in this state
+      # - After 15 minutes: 65 (IFF_UP=1, IFF_RUNNING=64, IFF_LOWER_UP=0) - becomes healthy again
       - series: 'node_network_flags{instance="n3.cnv.redhat.com",device="eth0"}'
         values: "65+0x5 1+0x10 65+0x15"
+      - series: 'node_network_up{instance="n3.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n3.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
 
       # Test case 7: Interface with complex flag changes
       # Flag transitions:
-      # - 0 to 8 minutes: 0 (IFF_UP=0, IFF_RUNNING=0) - down but shouldn't alert due to no IFF_UP
-      # - 8 to 25 minutes: 1 (IFF_UP=1, IFF_RUNNING=0) - should alert after 5 minutes in this state
+      # - 0 to 8 minutes: 0 (IFF_UP=0, IFF_RUNNING=0, IFF_LOWER_UP=0) - down but shouldn't alert due to no IFF_UP
+      # - 8 to 25 minutes: 1 (IFF_UP=1, IFF_RUNNING=0, IFF_LOWER_UP=0) - should alert after 5 minutes in this state
       - series: 'node_network_flags{instance="n3.cnv.redhat.com",device="eth1"}'
         values: "0+0x8 1+0x17"
+      - series: 'node_network_up{instance="n3.cnv.redhat.com",device="eth1"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n3.cnv.redhat.com",device="eth1"}'
+        values: "1+0x30"
 
-      # Test case 8: Multiple ignored interfaces with same instance
-      # Flag value = 1 (IFF_UP=1, IFF_RUNNING=0) - would alert if not ignored
+      # Test case 8: Multiple ignored interfaces with same instance (should NOT alert)
+      # All interfaces with problematic flags are in the ignored list
       - series: 'node_network_flags{instance="n4.cnv.redhat.com",device="lo"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n4.cnv.redhat.com",device="lo"}'
         values: "1+0x30"
       - series: 'node_network_flags{instance="n4.cnv.redhat.com",device="br-int"}'
         values: "1+0x30"
-      - series: 'node_network_flags{instance="n4.cnv.redhat.com",device="vethXYZ"}'
+      - series: 'node_network_up{instance="n4.cnv.redhat.com",device="br-int"}'
         values: "1+0x30"
-      # One non-ignored interface that's healthy (IFF_UP=1, IFF_RUNNING=64)
+      - series: 'node_network_flags{instance="n4.cnv.redhat.com",device="veth123"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n4.cnv.redhat.com",device="veth123"}'
+        values: "1+0x30"
+      # Test additional ignore patterns
+      - series: 'node_network_flags{instance="n4.cnv.redhat.com",device="ovs-system"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n4.cnv.redhat.com",device="ovs-system"}'
+        values: "1+0x30"
+      - series: 'node_network_flags{instance="n4.cnv.redhat.com",device="genev_sys_6081"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n4.cnv.redhat.com",device="genev_sys_6081"}'
+        values: "1+0x30"
+      # One non-ignored interface that's healthy (should NOT contribute to alert)
       - series: 'node_network_flags{instance="n4.cnv.redhat.com",device="eth0"}'
         values: "65+0x30"
+      - series: 'node_network_up{instance="n4.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
 
     alert_rule_test:
       # At 8 minutes, no alert should fire (eth0 on n3 has only been down for 3 minutes)
@@ -221,3 +294,36 @@ tests:
       - eval_time: 10m
         alertname: NodeNetworkInterfaceDown
         exp_alerts: [ ]
+
+  - interval: 1m
+    input_series:
+      # Test case 9: Admin up, not running, carrier=1 (should alert)
+      - series: 'node_network_flags{instance="n5.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n5.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n5.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+
+      # Test case 9a: Admin up, not running, carrier=0 - disabled NIC (should NOT alert)
+      - series: 'node_network_flags{instance="n6.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_up{instance="n6.cnv.redhat.com",device="eth0"}'
+        values: "1+0x30"
+      - series: 'node_network_carrier{instance="n6.cnv.redhat.com",device="eth0"}'
+        values: "0+0x30"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NodeNetworkInterfaceDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "Network interfaces are down"
+              description: "1 network devices have been down on instance n5.cnv.redhat.com for more than 5 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NodeNetworkInterfaceDown"
+            exp_labels:
+              instance: "n5.cnv.redhat.com"
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cnv-observability"

--- a/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
+++ b/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
@@ -9,6 +9,14 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// Network interface flag bitmasks for Linux interface flags
+// See: https://github.com/torvalds/linux/blob/master/include/uapi/linux/if.h
+const (
+	IFF_UP       = 1
+	IFF_RUNNING  = 64
+	IFF_LOWER_UP = 65536
+)
+
 var ignoredInterfacesForNetworkDown = []string{
 	"lo",          // loopback interface
 	"tunbr",       // tunnel bridge
@@ -49,12 +57,18 @@ func clusterAlerts() []promv1.Rule {
 		{
 			Alert: "NodeNetworkInterfaceDown",
 			Expr: intstr.FromString(fmt.Sprintf(`count by (instance) (
-					(node_network_flags %% 2) >= 1												# IFF_UP is set
+					(node_network_flags %% %d) >= %d											# IFF_UP is set
 					and
-					(node_network_flags %% 128) < 64											# IFF_RUNNING is NOT set
+					(node_network_flags %% %d) < %d											# IFF_RUNNING is NOT set
 					and
-					on(device) (node_network_flags unless node_network_flags{device=~"%s"})		# Excluding ignored interfaces
-				) > 0`, strings.Join(ignoredInterfacesForNetworkDown, "|"))),
+					(node_network_flags %% %d) < %d										    # IFF_LOWER_UP is NOT set
+					and
+					on(instance,device) node_network_up == 1									        # Interface is up
+					and
+					on(instance,device) node_network_carrier == 1                                    # Interface carrier is up
+					and
+					on(instance,device) (node_network_flags unless node_network_flags{device=~"%s"})     # Excluding ignored interfaces
+				) > 0`, (IFF_UP << 1), IFF_UP, (IFF_RUNNING << 1), IFF_RUNNING, (IFF_LOWER_UP << 1), IFF_LOWER_UP, strings.Join(ignoredInterfacesForNetworkDown, "|"))),
 			For: ptr.To[promv1.Duration]("5m"),
 			Annotations: map[string]string{
 				"summary":     "Network interfaces are down",


### PR DESCRIPTION
This pr it backport for https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3539, https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3736

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
jira-ticket: https://issues.redhat.com/browse/CNV-68866

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
