### PR TITLE
[release-1.15] Fix the Webhook's metrics endpoint

### DIFF
--- a/cmd/cmdcommon/cmdcommon.go
+++ b/cmd/cmdcommon/cmdcommon.go
@@ -2,6 +2,7 @@ package cmdcommon
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"slices"
 
 	"github.com/go-logr/logr"
+	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/spf13/pflag"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -18,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/webhooks/validator"
 )
 
 // list of namespace allowed for HCO installations (for tests)
@@ -100,7 +103,7 @@ func (h HcCmdHelper) RegisterPPROFServer(mgr manager.Manager) error {
 	}))
 }
 
-func (h HcCmdHelper) ExitOnError(err error, message string, keysAndValues ...interface{}) {
+func (h HcCmdHelper) ExitOnError(err error, message string, keysAndValues ...any) {
 	if err != nil {
 		h.Logger.Error(err, message, keysAndValues...)
 		os.Exit(1)
@@ -173,4 +176,17 @@ func getOperatorNamespaceFromEnv() (string, error) {
 	}
 
 	return namespace, nil
+}
+
+func MutateTLSConfig(cfg *tls.Config) {
+	// This callback executes on each client call returning a new config to be used
+	// please be aware that the APIServer is using http keepalive so this is going to
+	// be executed only after a while for fresh connections and not on existing ones
+	cfg.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+		cipherNames, minTypedTLSVersion := validator.SelectCipherSuitesAndMinTLSVersion()
+
+		cfg.CipherSuites = crypto.CipherSuitesOrDie(crypto.OpenSSLToIANACipherSuites(cipherNames))
+		cfg.MinVersion = crypto.TLSVersionOrDie(string(minTypedTLSVersion))
+		return cfg, nil
+	}
 }

--- a/cmd/hyperconverged-cluster-webhook/main.go
+++ b/cmd/hyperconverged-cluster-webhook/main.go
@@ -7,41 +7,42 @@ import (
 	"os"
 	"path/filepath"
 
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
-
-	"github.com/openshift/library-go/pkg/crypto"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
-	webhookscontrollers "github.com/kubevirt/hyperconverged-cluster-operator/controllers/webhooks"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/authorization"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/webhooks/validator"
-
-	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
-
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
+	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/api"
-	"github.com/kubevirt/hyperconverged-cluster-operator/cmd/cmdcommon"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/webhooks"
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	sspv1beta2 "kubevirt.io/ssp-operator/api/v1beta2"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/api"
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/cmd/cmdcommon"
+	whapiservercontrollers "github.com/kubevirt/hyperconverged-cluster-operator/controllers/webhooks/apiserver-controller"
+	bearertokencontroller "github.com/kubevirt/hyperconverged-cluster-operator/controllers/webhooks/bearer-token-controller"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/authorization"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/webhooks"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -60,6 +61,8 @@ var (
 		kubevirtcorev1.AddToScheme,
 		openshiftconfigv1.Install,
 		csvv1alpha1.AddToScheme,
+		apiextensionsv1.AddToScheme,
+		monitoringv1.AddToScheme,
 	}
 )
 
@@ -90,45 +93,55 @@ func main() {
 	scheme := apiruntime.NewScheme()
 	cmdHelper.AddToScheme(scheme, resourcesSchemeFuncs)
 
+	// apiclient.New() returns a client without cache.
+	// cache is not initialized before mgr.Start()
+	// we need this because we need to interact with OperatorCondition
+	apiClient, err := client.New(cfg, client.Options{
+		Scheme: scheme,
+	})
+	cmdHelper.ExitOnError(err, "Cannot create a new API client")
+
+	ci := hcoutil.GetClusterInfo()
+	ctx := context.Background()
+	err = ci.Init(ctx, apiClient, logger)
+	cmdHelper.ExitOnError(err, "Cannot detect cluster type")
+
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: server.Options{
+			SecureServing:  true,
+			CertDir:        webhooks.GetWebhookCertDir(),
+			CertName:       hcoutil.WebhookCertName,
+			KeyName:        hcoutil.WebhookKeyName,
 			BindAddress:    fmt.Sprintf("%s:%d", hcoutil.MetricsHost, hcoutil.MetricsPort),
 			FilterProvider: authorization.HttpWithBearerToken,
+			TLSOpts:        []func(*tls.Config){cmdcommon.MutateTLSConfig},
 		},
-		HealthProbeBindAddress: fmt.Sprintf("%s:%d", hcoutil.HealthProbeHost, hcoutil.HealthProbePort),
-		ReadinessEndpointName:  hcoutil.ReadinessEndpointName,
-		LivenessEndpointName:   hcoutil.LivenessEndpointName,
-		LeaderElection:         false,
-		Scheme:                 scheme,
+		HealthProbeBindAddress:     fmt.Sprintf("%s:%d", hcoutil.HealthProbeHost, hcoutil.HealthProbePort),
+		ReadinessEndpointName:      hcoutil.ReadinessEndpointName,
+		LivenessEndpointName:       hcoutil.LivenessEndpointName,
+		LeaderElection:             !ci.IsRunningLocally(),
+		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+		LeaderElectionID:           "hyperconverged-cluster-webhook-lock",
+		Scheme:                     scheme,
+
 		WebhookServer: webhook.NewServer(webhook.Options{
 			CertDir:  webhooks.GetWebhookCertDir(),
 			CertName: hcoutil.WebhookCertName,
 			KeyName:  hcoutil.WebhookKeyName,
 			Port:     hcoutil.WebhookPort,
-			TLSOpts:  []func(*tls.Config){MutateTLSConfig},
+			TLSOpts:  []func(*tls.Config){cmdcommon.MutateTLSConfig},
 		}),
+		Cache: getCacheOption(operatorNamespace, hcoutil.GetClusterInfo()),
 	})
 	cmdHelper.ExitOnError(err, "failed to create manager")
-
-	// apiclient.New() returns a client without cache.
-	// cache is not initialized before mgr.Start()
-	// we need this because we need to interact with OperatorCondition
-	apiClient, err := client.New(mgr.GetConfig(), client.Options{
-		Scheme: mgr.GetScheme(),
-	})
-	cmdHelper.ExitOnError(err, "Cannot create a new API client")
 
 	// register pprof instrumentation if HCO_PPROF_ADDR is set
 	cmdHelper.ExitOnError(cmdHelper.RegisterPPROFServer(mgr), "can't register pprof server")
 
 	logger.Info("Registering Components.")
 
-	// Detect OpenShift version
-	ci := hcoutil.GetClusterInfo()
-	ctx := context.TODO()
-	err = ci.Init(ctx, apiClient, logger)
-	cmdHelper.ExitOnError(err, "Cannot detect cluster type")
+	ctx = signals.SetupSignalHandler()
 
 	eventEmitter := hcoutil.GetEventEmitter()
 	eventEmitter.Init(ci.GetPod(), ci.GetCSV(), mgr.GetEventRecorderFor(hcoutil.HyperConvergedName))
@@ -138,18 +151,6 @@ func main() {
 
 	err = mgr.AddReadyzCheck("ready", healthz.Ping)
 	cmdHelper.ExitOnError(err, "unable to add ready check")
-
-	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
-	// necessary to configure Prometheus to scrape metrics from this operator.
-
-	// apiclient.New() returns a client without cache.
-	// cache is not initialized before mgr.Start()
-	// we need this because we need to read the HCO CR, if there,
-	// to fetch the configured TLSSecurityProfile
-	apiClient, apiCerr := client.New(mgr.GetConfig(), client.Options{
-		Scheme: mgr.GetScheme(),
-	})
-	cmdHelper.ExitOnError(apiCerr, "Cannot create a new API client")
 
 	hcoCR := &hcov1beta1.HyperConverged{}
 	hcoCR.Name = hcoutil.HyperConvergedName
@@ -163,8 +164,13 @@ func main() {
 		hcoTLSSecurityProfile = hcoCR.Spec.TLSSecurityProfile
 	}
 
-	err = webhookscontrollers.RegisterReconciler(mgr, ci)
+	logger.Info("Registering the APIServer reconciler")
+	err = whapiservercontrollers.RegisterReconciler(mgr, ci)
 	cmdHelper.ExitOnError(err, "Cannot register APIServer reconciler")
+
+	logger.Info("Registering the Bearer Token reconciler")
+	err = bearertokencontroller.RegisterReconciler(mgr, ci, eventEmitter)
+	cmdHelper.ExitOnError(err, "Cannot register the Bearer Token reconciler")
 
 	if err = webhooks.SetupWebhookWithManager(ctx, mgr, ci.IsOpenshift(), hcoTLSSecurityProfile); err != nil {
 		logger.Error(err, "unable to create webhook", "webhook", "HyperConverged")
@@ -175,40 +181,41 @@ func main() {
 	logger.Info("Starting the Cmd.")
 	eventEmitter.EmitEvent(nil, corev1.EventTypeNormal, "Init", "Starting the HyperConverged webhook Pod")
 	// Start the Cmd
-	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+	if err = mgr.Start(ctx); err != nil {
 		logger.Error(err, "Manager exited non-zero")
 		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "UnexpectedError", "HyperConverged crashed; "+err.Error())
 		os.Exit(1)
 	}
 }
 
-func MutateTLSConfig(cfg *tls.Config) {
-	var ciphersTLS13 = map[string]uint16{
-		"TLS_AES_128_GCM_SHA256":       tls.TLS_AES_128_GCM_SHA256,
-		"TLS_AES_256_GCM_SHA384":       tls.TLS_AES_256_GCM_SHA384,
-		"TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
+func getCacheOption(operatorNamespace string, ci hcoutil.ClusterInfo) cache.Options {
+	if !ci.IsMonitoringAvailable() {
+		return cache.Options{}
 	}
 
-	// This callback executes on each client call returning a new config to be used
-	// please be aware that the APIServer is using http keepalive so this is going to
-	// be executed only after a while for fresh connections and not on existing ones
-	cfg.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
-		cipherNames, minTypedTLSVersion := validator.SelectCipherSuitesAndMinTLSVersion()
+	namespaceSelector := fields.Set{"metadata.namespace": operatorNamespace}.AsSelector()
+	labelSelector := labels.Set{hcoutil.AppLabel: hcoutil.HCOWebhookName}.AsSelector()
 
-		// TODO: workaround: TLSv1.3 ciphers are now enabled on openshift/library-go
-		// but on the other side crypto.CipherSuitesOrDie is still failing with an
-		// explict error when it encounters the name of a TLSv1.3 cipher.
-		// Remove the workaround once we can consume https://github.com/openshift/library-go/pull/1956
-		cipherNamesIANAC := crypto.OpenSSLToIANACipherSuites(cipherNames)
-		cipherNamesFilteredNoTLS13 := []string{}
-		for _, cipherName := range cipherNamesIANAC {
-			if _, ok := ciphersTLS13[cipherName]; !ok {
-				cipherNamesFilteredNoTLS13 = append(cipherNamesFilteredNoTLS13, cipherName)
-			}
-		}
-
-		cfg.CipherSuites = crypto.CipherSuitesOrDie(crypto.OpenSSLToIANACipherSuites(cipherNamesFilteredNoTLS13))
-		cfg.MinVersion = crypto.TLSVersionOrDie(string(minTypedTLSVersion))
-		return cfg, nil
+	cacheOptions := cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&appsv1.Deployment{}: {
+				Label: labels.Set{"name": hcoutil.HCOWebhookName}.AsSelector(),
+				Field: namespaceSelector,
+			},
+			&corev1.Service{}: {
+				Label: labelSelector,
+				Field: namespaceSelector,
+			},
+			&corev1.Secret{}: {
+				Label: labelSelector,
+				Field: namespaceSelector,
+			},
+			&monitoringv1.ServiceMonitor{}: {
+				Label: labelSelector,
+				Field: namespaceSelector,
+			},
+		},
 	}
+
+	return cacheOptions
 }

--- a/controllers/alerts/constants.go
+++ b/controllers/alerts/constants.go
@@ -1,0 +1,16 @@
+package alerts
+
+import hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+
+const (
+	defaultMonitoringNamespace   = "monitoring"
+	openshiftMonitoringNamespace = "openshift-monitoring"
+)
+
+func getMonitoringNamespace(ci hcoutil.ClusterInfo) string {
+	if ci.IsOpenshift() {
+		return openshiftMonitoringNamespace
+	}
+
+	return defaultMonitoringNamespace
+}

--- a/controllers/alerts/metrics_test.go
+++ b/controllers/alerts/metrics_test.go
@@ -42,6 +42,9 @@ var _ = Describe("alert tests", func() {
 	)
 
 	BeforeEach(func() {
+		origNS, nsVarExists := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
+		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
 		ee.Reset()
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -50,6 +53,14 @@ var _ = Describe("alert tests", func() {
 		}
 
 		req = commontestutils.NewReq(nil)
+
+		DeferCleanup(func() {
+			if nsVarExists {
+				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+			} else {
+				Expect(os.Unsetenv(hcoutil.OperatorNamespaceEnv)).To(Succeed())
+			}
+		})
 	})
 
 	Context("test reconciler", func() {
@@ -1008,7 +1019,7 @@ var _ = Describe("alert tests", func() {
 			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).To(Succeed())
 			Expect(svc.Spec.Ports).To(HaveLen(1))
 			Expect(svc.Spec.Ports[0].Port).To(Equal(hcoutil.MetricsPort))
-			Expect(svc.Spec.Ports[0].Name).To(Equal(operatorPortName))
+			Expect(svc.Spec.Ports[0].Name).To(Equal(OperatorPortName))
 			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
 			Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.IntOrString{Type: intstr.Int, IntVal: hcoutil.MetricsPort}))
 
@@ -1030,7 +1041,7 @@ var _ = Describe("alert tests", func() {
 			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, svc)).To(Succeed())
 			Expect(svc.Spec.Ports).To(HaveLen(1))
 			Expect(svc.Spec.Ports[0].Port).To(Equal(hcoutil.MetricsPort))
-			Expect(svc.Spec.Ports[0].Name).To(Equal(operatorPortName))
+			Expect(svc.Spec.Ports[0].Name).To(Equal(OperatorPortName))
 			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
 			Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.IntOrString{Type: intstr.Int, IntVal: hcoutil.MetricsPort}))
 
@@ -1202,7 +1213,7 @@ var _ = Describe("alert tests", func() {
 			sm := &monitoringv1.ServiceMonitor{}
 			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).To(Succeed())
 			Expect(sm.Spec.Selector).To(Equal(metav1.LabelSelector{MatchLabels: hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)}))
-			Expect(sm.Spec.Endpoints[0].Port).To(Equal(operatorPortName))
+			Expect(sm.Spec.Endpoints[0].Port).To(Equal(OperatorPortName))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
 			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).To(BeEquivalentTo(currentMetric))
@@ -1221,7 +1232,7 @@ var _ = Describe("alert tests", func() {
 			sm := &monitoringv1.ServiceMonitor{}
 			Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: r.namespace, Name: serviceName}, sm)).To(Succeed())
 			Expect(sm.Spec.Selector).To(Equal(metav1.LabelSelector{MatchLabels: hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentMonitoring)}))
-			Expect(sm.Spec.Endpoints[0].Port).To(Equal(operatorPortName))
+			Expect(sm.Spec.Endpoints[0].Port).To(Equal(OperatorPortName))
 
 			Expect(ee.CheckEvents(expectedEvents)).To(BeTrue())
 			Expect(metrics.GetOverwrittenModificationsCount("ServiceMonitor", serviceName)).To(BeEquivalentTo(currentMetric))

--- a/controllers/alerts/namespace.go
+++ b/controllers/alerts/namespace.go
@@ -11,6 +11,8 @@ import (
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
+type reconcileNamespaceFunc func(context.Context, client.Client, string, logr.Logger) error
+
 func reconcileNamespace(ctx context.Context, cl client.Client, namespace string, logger logr.Logger) error {
 	ns := &corev1.Namespace{}
 
@@ -31,7 +33,7 @@ func reconcileNamespace(ctx context.Context, cl client.Client, namespace string,
 	if ns.Labels == nil {
 		ns.Labels = make(map[string]string)
 	}
-	if val, hasKey := ns.Labels[hcoutil.PrometheusNSLabel]; !hasKey || val != "true" {
+	if ns.Labels[hcoutil.PrometheusNSLabel] != "true" {
 		ns.Labels[hcoutil.PrometheusNSLabel] = "true"
 		needUpdate = true
 	}

--- a/controllers/alerts/rbac.go
+++ b/controllers/alerts/rbac.go
@@ -13,10 +13,7 @@ import (
 )
 
 const (
-	operatorName                 = "hyperconverged-cluster-operator"
-	roleName                     = operatorName + "-metrics"
-	defaultMonitoringNamespace   = "monitoring"
-	openshiftMonitoringNamespace = "openshift-monitoring"
+	roleName = hcoutil.HCOOperatorName + "-metrics"
 )
 
 // RoleReconciler maintains an RBAC Role to allow Prometheus operator to read from HCO metric
@@ -188,12 +185,4 @@ func newRoleBinding(owner metav1.OwnerReference, namespace string, ci hcoutil.Cl
 			},
 		},
 	}
-}
-
-func getMonitoringNamespace(ci hcoutil.ClusterInfo) string {
-	if ci.IsOpenshift() {
-		return openshiftMonitoringNamespace
-	}
-
-	return defaultMonitoringNamespace
 }

--- a/controllers/alerts/secret.go
+++ b/controllers/alerts/secret.go
@@ -2,6 +2,7 @@ package alerts
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -17,35 +18,58 @@ const (
 	secretName = "hco-bearer-auth"
 )
 
-type secretReconciler struct {
-	theSecret *corev1.Secret
+type CreateSecretFunc func(namespace string, owner metav1.OwnerReference, token string) *corev1.Secret
+type SecretReconciler struct {
+	theSecret    *corev1.Secret
+	lock         *sync.RWMutex
+	createSecret CreateSecretFunc
+	secretName   string
 }
 
-func newSecretReconciler(namespace string, owner metav1.OwnerReference) *secretReconciler {
+func NewSecretReconciler(namespace string, owner metav1.OwnerReference, secretName string, createSecret CreateSecretFunc) *SecretReconciler {
 	token, err := authorization.CreateToken()
 	if err != nil {
 		logger.Error(err, "failed to create bearer token")
 		return nil
 	}
 
-	return &secretReconciler{
-		theSecret: NewSecret(namespace, owner, token),
+	return &SecretReconciler{
+		theSecret:    createSecret(namespace, owner, token),
+		lock:         &sync.RWMutex{},
+		createSecret: createSecret,
+		secretName:   secretName,
 	}
 }
 
-func (r *secretReconciler) Kind() string {
+func (r *SecretReconciler) Kind() string {
 	return "Secret"
 }
 
-func (r *secretReconciler) ResourceName() string {
-	return secretName
+func (r *SecretReconciler) ResourceName() string {
+	return r.secretName
 }
 
-func (r *secretReconciler) GetFullResource() client.Object {
+func (r *SecretReconciler) GetFullResource() client.Object {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
 	return r.theSecret.DeepCopy()
 }
 
-func (r *secretReconciler) EmptyObject() client.Object {
+func (r *SecretReconciler) refreshToken() error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	token, err := authorization.CreateToken()
+	if err != nil {
+		return err
+	}
+
+	r.theSecret = r.createSecret(r.theSecret.Namespace, r.theSecret.OwnerReferences[0], token)
+	return nil
+}
+
+func (r *SecretReconciler) EmptyObject() client.Object {
 	return &corev1.Secret{}
 }
 
@@ -53,7 +77,7 @@ func (r *secretReconciler) EmptyObject() client.Object {
 // If it does, it returns nil. If the secret exists but the token is incorrect, it deletes the old secret
 // and creates a new one with the updated token. If the secret does not exist, it creates a new one.
 // It deletes the old secret to force Prometheus to reload the configuration.
-func (r *secretReconciler) UpdateExistingResource(ctx context.Context, cl client.Client, resource client.Object, logger logr.Logger) (client.Object, bool, error) {
+func (r *SecretReconciler) UpdateExistingResource(ctx context.Context, cl client.Client, resource client.Object, logger logr.Logger) (client.Object, bool, error) {
 	found := resource.(*corev1.Secret)
 
 	token, err := authorization.CreateToken()
@@ -66,24 +90,29 @@ func (r *secretReconciler) UpdateExistingResource(ctx context.Context, cl client
 		return nil, false, nil
 	}
 
-	// If the the token is incorrect, delete the old secret and create a new one
-	if err := cl.Delete(ctx, found); err != nil {
+	// If the token is incorrect, delete the old secret and create a new one
+	if err = cl.Delete(ctx, found); err != nil {
 		if !errors.IsNotFound(err) {
 			logger.Error(err, "failed to delete old secret")
 			return nil, false, err
 		}
 	}
 
-	newSecret := NewSecret(r.theSecret.Namespace, r.theSecret.OwnerReferences[0], token)
-	if err := cl.Create(ctx, newSecret); err != nil {
+	if err = r.refreshToken(); err != nil {
+		logger.Error(err, "failed to refresh token")
+		return nil, false, err
+	}
+
+	sec := r.GetFullResource()
+	if err = cl.Create(ctx, sec); err != nil {
 		logger.Error(err, "failed to create new secret")
 		return nil, false, err
 	}
 
-	return newSecret, true, nil
+	return sec, true, nil
 }
 
-func NewSecret(namespace string, owner metav1.OwnerReference, token string) *corev1.Secret {
+func newSecret(namespace string, owner metav1.OwnerReference, token string) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",

--- a/controllers/alerts/serviceMonitor.go
+++ b/controllers/alerts/serviceMonitor.go
@@ -8,36 +8,41 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-type serviceMonitorReconciler struct {
+type ServiceMonitorReconciler struct {
 	theServiceMonitor *monitoringv1.ServiceMonitor
 }
 
-func newServiceMonitorReconciler(namespace string, owner metav1.OwnerReference) *serviceMonitorReconciler {
-	return &serviceMonitorReconciler{theServiceMonitor: NewServiceMonitor(namespace, owner)}
+func CreateServiceMonitorReconciler(serviceMonitor *monitoringv1.ServiceMonitor) *ServiceMonitorReconciler {
+	return &ServiceMonitorReconciler{theServiceMonitor: serviceMonitor}
 }
 
-func (r serviceMonitorReconciler) Kind() string {
+func newServiceMonitorReconciler(namespace string, owner metav1.OwnerReference) *ServiceMonitorReconciler {
+	return CreateServiceMonitorReconciler(NewServiceMonitor(namespace, owner))
+}
+
+func (r ServiceMonitorReconciler) Kind() string {
 	return monitoringv1.ServiceMonitorsKind
 }
 
-func (r serviceMonitorReconciler) ResourceName() string {
-	return serviceName
+func (r ServiceMonitorReconciler) ResourceName() string {
+	return r.theServiceMonitor.Name
 }
 
-func (r serviceMonitorReconciler) GetFullResource() client.Object {
+func (r ServiceMonitorReconciler) GetFullResource() client.Object {
 	return r.theServiceMonitor.DeepCopy()
 }
 
-func (r serviceMonitorReconciler) EmptyObject() client.Object {
+func (r ServiceMonitorReconciler) EmptyObject() client.Object {
 	return &monitoringv1.ServiceMonitor{}
 }
 
-func (r serviceMonitorReconciler) UpdateExistingResource(ctx context.Context, cl client.Client, resource client.Object, logger logr.Logger) (client.Object, bool, error) {
+func (r ServiceMonitorReconciler) UpdateExistingResource(ctx context.Context, cl client.Client, resource client.Object, logger logr.Logger) (client.Object, bool, error) {
 	found := resource.(*monitoringv1.ServiceMonitor)
 	modified := false
 	if !reflect.DeepEqual(found.Spec, r.theServiceMonitor.Spec) {
@@ -64,17 +69,25 @@ func NewServiceMonitor(namespace string, owner metav1.OwnerReference) *monitorin
 		Selector: metav1.LabelSelector{
 			MatchLabels: labels,
 		},
-		Endpoints: []monitoringv1.Endpoint{{
-			Port: operatorPortName,
-			Authorization: &monitoringv1.SafeAuthorization{
-				Credentials: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: secretName,
+		Endpoints: []monitoringv1.Endpoint{
+			{
+				Port:   OperatorPortName,
+				Scheme: "https",
+				Authorization: &monitoringv1.SafeAuthorization{
+					Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretName,
+						},
+						Key: "token",
 					},
-					Key: "token",
+				},
+				TLSConfig: &monitoringv1.TLSConfig{
+					SafeTLSConfig: monitoringv1.SafeTLSConfig{
+						InsecureSkipVerify: ptr.To(true),
+					},
 				},
 			},
-		}},
+		},
 	}
 
 	return &monitoringv1.ServiceMonitor{

--- a/controllers/operands/serviceHandler.go
+++ b/controllers/operands/serviceHandler.go
@@ -17,10 +17,11 @@ type genericServiceHandler genericOperand
 
 func newServiceHandler(Client client.Client, Scheme *runtime.Scheme, newCrFunc newSvcFunc) *genericServiceHandler {
 	h := &genericServiceHandler{
-		Client: Client,
-		Scheme: Scheme,
-		crType: "Service",
-		hooks:  &serviceHooks{newCrFunc: newCrFunc},
+		Client:                 Client,
+		Scheme:                 Scheme,
+		crType:                 "Service",
+		hooks:                  &serviceHooks{newCrFunc: newCrFunc},
+		setControllerReference: true,
 	}
 
 	return h

--- a/controllers/webhooks/apiserver-controller/controller.go
+++ b/controllers/webhooks/apiserver-controller/controller.go
@@ -1,4 +1,4 @@
-package webhooks
+package apiserver_controller
 
 import (
 	"context"

--- a/controllers/webhooks/apiserver-controller/controller_test.go
+++ b/controllers/webhooks/apiserver-controller/controller_test.go
@@ -1,4 +1,4 @@
-package webhooks
+package apiserver_controller
 
 import (
 	"context"

--- a/controllers/webhooks/apiserver-controller/webhooks_suite_test.go
+++ b/controllers/webhooks/apiserver-controller/webhooks_suite_test.go
@@ -1,4 +1,4 @@
-package webhooks
+package apiserver_controller
 
 import (
 	"testing"

--- a/controllers/webhooks/bearer-token-controller/bearer_token_controller.go
+++ b/controllers/webhooks/bearer-token-controller/bearer_token_controller.go
@@ -1,0 +1,146 @@
+package bearer_token_controller
+
+// the bearer_token_controller package contains the ReconcileWHBearerToken struct
+// which is used to reconcile bearer tokens in the context the HyperConverged cluster webhook.
+// The webhook provides a bearer token secret, to be used by Prometheus to scrape metrics from the
+// HyperConverged cluster webhook pod.
+//
+// The reconciler makes sure the bearer token secret is created and updated as needed, as well as a
+// Service and a ServiceMonitor resources that points to the webhook pod and uses the bearer token
+// secret for authentication.
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	requeueDurationForNextRequest = time.Minute * 5
+	requeueDurationForError       = time.Millisecond * 100
+)
+
+var (
+	log = logf.Log.WithName("bearer-token-controller")
+)
+
+// RegisterReconciler creates a new WH Bearer Token Reconciler and registers it into manager.
+func RegisterReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo, ee hcoutil.EventEmitter) error {
+	if ci.IsMonitoringAvailable() {
+		return add(mgr, newReconciler(mgr, ci, ee))
+	}
+
+	mgr.GetLogger().Info("The cluster does not have monitoring installed. Skipping the registration of the Bearer Token reconciler")
+	return nil
+}
+
+type ReconcileWHBearerToken struct {
+	metricReconciler *alerts.MonitoringReconciler
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo, ee hcoutil.EventEmitter) reconcile.Reconciler {
+	metricsReconciler := alerts.CreateMonitoringReconciler(ci, mgr.GetClient(), ee, mgr.GetScheme(), false, getReconcilers)
+
+	r := &ReconcileWHBearerToken{
+		metricReconciler: metricsReconciler,
+	}
+
+	return r
+}
+
+// Add creates a new ReconcileWHBearerToken and adds it to the manager.
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("wb-bearer-token-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	srcs := []source.Source{
+		source.Kind[*appsv1.Deployment](
+			mgr.GetCache(), &appsv1.Deployment{},
+			&handler.TypedEnqueueRequestForObject[*appsv1.Deployment]{},
+			newPredicate[*appsv1.Deployment](),
+		),
+		source.Kind[*corev1.Service](
+			mgr.GetCache(), &corev1.Service{},
+			&handler.TypedEnqueueRequestForObject[*corev1.Service]{},
+			newPredicate[*corev1.Service](),
+		),
+		source.Kind[*promv1.ServiceMonitor](
+			mgr.GetCache(), &promv1.ServiceMonitor{},
+			&handler.TypedEnqueueRequestForObject[*promv1.ServiceMonitor]{},
+			newPredicate[*promv1.ServiceMonitor](),
+		),
+		source.Kind[*promv1.ServiceMonitor](
+			mgr.GetCache(), &promv1.ServiceMonitor{},
+			&handler.TypedEnqueueRequestForObject[*promv1.ServiceMonitor]{},
+			newPredicate[*promv1.ServiceMonitor](),
+		),
+	}
+
+	for _, src := range srcs {
+		err = c.Watch(src)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *ReconcileWHBearerToken) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := getLogger(ctx, request)
+
+	reqLogger.Info("Reconciling WH Bearer Token")
+	req := common.NewHcoRequest(ctx, request, reqLogger, false, true)
+
+	if err := r.metricReconciler.Reconcile(req, true); err != nil {
+		return reconcile.Result{RequeueAfter: requeueDurationForError}, err
+	}
+
+	return reconcile.Result{RequeueAfter: requeueDurationForNextRequest}, nil // this will cause the reconciler to run every 5 minutes
+}
+
+func getReconcilers(_ hcoutil.ClusterInfo, namespace string, owner metav1.OwnerReference) []alerts.MetricReconciler {
+	reconcilers := []alerts.MetricReconciler{
+		newWHMetricServiceReconciler(namespace, owner),
+		newWHSecretReconciler(namespace, owner),
+		newWHServiceMonitorReconciler(namespace, owner),
+	}
+
+	return reconcilers
+}
+
+func newPredicate[T client.Object]() predicate.TypedPredicate[T] {
+	return predicate.Or[T](
+		predicate.TypedGenerationChangedPredicate[T]{},
+		predicate.TypedLabelChangedPredicate[T]{},
+	)
+}
+
+func getLogger(ctx context.Context, request reconcile.Request) logr.Logger {
+	l, err := logr.FromContext(ctx)
+	if err != nil {
+		return log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	}
+
+	return l
+}

--- a/controllers/webhooks/bearer-token-controller/controller_test.go
+++ b/controllers/webhooks/bearer-token-controller/controller_test.go
@@ -1,0 +1,157 @@
+package bearer_token_controller
+
+import (
+	"context"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+type monitoringOff struct {
+	commontestutils.ClusterInfoMock
+}
+
+func (monitoringOff) IsMonitoringAvailable() bool { return false }
+
+var _ = Describe("Controller setup and reconcile", func() {
+	var (
+		ci hcoutil.ClusterInfo
+		ee hcoutil.EventEmitter
+	)
+	BeforeEach(func() {
+		ci = commontestutils.ClusterInfoMock{}
+		ee = commontestutils.NewEventEmitterMock()
+	})
+
+	Describe("RegisterReconciler", func() {
+		It("registers when monitoring is available", func() {
+			cl := commontestutils.InitClient([]client.Object{})
+			mgrIntf, err := commontestutils.NewManagerMock(&rest.Config{}, manager.Options{Scheme: commontestutils.GetScheme()}, cl, commontestutils.TestLogger)
+			Expect(err).ToNot(HaveOccurred())
+			mgr := mgrIntf.(*commontestutils.ManagerMock)
+
+			Expect(RegisterReconciler(mgr, ci, ee)).To(Succeed())
+			Expect(mgr.GetRunnables()).To(HaveLen(1))
+		})
+
+		It("skips registration when monitoring is not available", func() {
+			cl := commontestutils.InitClient([]client.Object{})
+			mgrIntf, err := commontestutils.NewManagerMock(&rest.Config{}, manager.Options{Scheme: commontestutils.GetScheme()}, cl, commontestutils.TestLogger)
+			Expect(err).ToNot(HaveOccurred())
+			mgr := mgrIntf.(*commontestutils.ManagerMock)
+
+			Expect(RegisterReconciler(mgr, monitoringOff{}, ee)).To(Succeed())
+			Expect(mgr.GetRunnables()).To(BeEmpty())
+		})
+	})
+
+	Describe("Reconcile", func() {
+		var (
+			nsName  = "wb-bearer-token-test-ns"
+			ns      *corev1.Namespace
+			cl      *commontestutils.HcoTestClient
+			mgrIntf manager.Manager
+			r       reconcile.Reconciler
+			request reconcile.Request
+		)
+
+		BeforeEach(func() {
+			origNS, hadEnvVar := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, nsName)).To(Succeed())
+
+			ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+			cl = commontestutils.InitClient([]client.Object{ns})
+			var err error
+			mgrIntf, err = commontestutils.NewManagerMock(&rest.Config{}, manager.Options{Scheme: commontestutils.GetScheme()}, cl, commontestutils.TestLogger)
+			Expect(err).ToNot(HaveOccurred())
+			r = newReconciler(mgrIntf, commontestutils.ClusterInfoMock{}, commontestutils.NewEventEmitterMock())
+			request = reconcile.Request{NamespacedName: k8stypes.NamespacedName{Name: "irrelevant", Namespace: nsName}}
+
+			DeferCleanup(func() {
+				if hadEnvVar {
+					_ = os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)
+				} else {
+					_ = os.Unsetenv(hcoutil.OperatorNamespaceEnv)
+				}
+			})
+		})
+
+		It("creates Service, Secret, and ServiceMonitor and requeues in 5 minutes", func(ctx context.Context) {
+			res, err := r.Reconcile(ctx, request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.RequeueAfter).To(Equal(5 * time.Minute))
+
+			// Service
+			svc := &corev1.Service{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: serviceName}, svc)).To(Succeed())
+			Expect(svc.Spec.Ports).ToNot(BeEmpty())
+			Expect(svc.Labels).ToNot(BeEmpty())
+
+			// Secret
+			sec := &corev1.Secret{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: secretName}, sec)).To(Succeed())
+			Expect(sec.StringData).To(HaveKey("token"))
+
+			sm := &monitoringv1.ServiceMonitor{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: serviceName}, sm)).To(Succeed())
+		})
+
+		It("propagates error from underlying metric reconciler and requeues quickly", func(ctx context.Context) {
+			// cause a create-error for Service to bubble up
+			cl.InitiateCreateErrors(func(obj client.Object) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Service" {
+					return context.DeadlineExceeded
+				}
+				return nil
+			})
+
+			r = newReconciler(mgrIntf, ci, ee)
+			res, err := r.Reconcile(ctx, request)
+			Expect(err).To(MatchError(context.DeadlineExceeded))
+			Expect(res.RequeueAfter).To(Equal(100 * time.Millisecond))
+		})
+
+		It("should recreate Secret if token is changed", func(ctx context.Context) {
+			res, err := r.Reconcile(ctx, request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.RequeueAfter).To(Equal(5 * time.Minute))
+
+			// Secret
+			sec := &corev1.Secret{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: secretName}, sec)).To(Succeed())
+			Expect(sec.StringData).To(HaveKey("token"))
+
+			origToken := sec.StringData["token"]
+			sec.StringData["token"] = "some-wrong-token"
+			Expect(cl.Update(ctx, sec)).To(Succeed())
+
+			newSec := &corev1.Secret{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: secretName}, newSec)).To(Succeed())
+			Expect(newSec.StringData).To(HaveKey("token"))
+			Expect(newSec.StringData["token"]).To(Equal("some-wrong-token"))
+
+			// Reconcile should delete the old secret and create a new one
+			res, err = r.Reconcile(ctx, request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.RequeueAfter).To(Equal(5 * time.Minute))
+
+			newSec = &corev1.Secret{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: secretName}, newSec)).To(Succeed())
+			Expect(newSec.StringData).To(HaveKey("token"))
+			Expect(newSec.StringData["token"]).To(Equal(origToken))
+		})
+	})
+})

--- a/controllers/webhooks/bearer-token-controller/labels.go
+++ b/controllers/webhooks/bearer-token-controller/labels.go
@@ -1,0 +1,15 @@
+package bearer_token_controller
+
+import (
+	"maps"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+var (
+	labels = hcoutil.GetLabels(hcoutil.HCOWebhookName, hcoutil.AppComponentMonitoring)
+)
+
+func getLabels() map[string]string {
+	return maps.Clone(labels)
+}

--- a/controllers/webhooks/bearer-token-controller/secret.go
+++ b/controllers/webhooks/bearer-token-controller/secret.go
@@ -1,0 +1,34 @@
+package bearer_token_controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts"
+)
+
+const (
+	secretName = "hco-webhook-bearer-auth"
+)
+
+func newWHSecretReconciler(namespace string, owner metav1.OwnerReference) *alerts.SecretReconciler {
+	return alerts.NewSecretReconciler(namespace, owner, secretName, newSecret)
+}
+
+func newSecret(namespace string, owner metav1.OwnerReference, token string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            secretName,
+			Namespace:       namespace,
+			Labels:          getLabels(),
+			OwnerReferences: []metav1.OwnerReference{owner},
+		},
+		StringData: map[string]string{
+			"token": token,
+		},
+	}
+}

--- a/controllers/webhooks/bearer-token-controller/secret_test.go
+++ b/controllers/webhooks/bearer-token-controller/secret_test.go
@@ -1,0 +1,21 @@
+package bearer_token_controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+)
+
+var _ = Describe("newSecret", func() {
+	It("should builds the expected Secret object", func() {
+		owner := metav1.OwnerReference{Name: "o"}
+		sec := newSecret(commontestutils.Namespace, owner, "token content")
+		Expect(sec.Name).To(Equal(secretName))
+		Expect(sec.Namespace).To(Equal(commontestutils.Namespace))
+		Expect(sec.Labels).To(Equal(getLabels()))
+		Expect(sec.StringData).To(HaveKeyWithValue("token", "token content"))
+		Expect(sec.OwnerReferences).To(ContainElement(owner))
+	})
+})

--- a/controllers/webhooks/bearer-token-controller/service.go
+++ b/controllers/webhooks/bearer-token-controller/service.go
@@ -1,0 +1,60 @@
+package bearer_token_controller
+
+import (
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	metricsSuffix = "-operator-metrics"
+	serviceName   = hcoutil.HCOWebhookName + metricsSuffix
+)
+
+func newWHMetricServiceReconciler(namespace string, owner metav1.OwnerReference) *alerts.MetricServiceReconciler {
+	return alerts.CreateMetricServiceReconciler(NewMetricsService(namespace, owner))
+}
+
+func NewMetricsService(namespace string, owner metav1.OwnerReference) *corev1.Service {
+	servicePorts := []corev1.ServicePort{
+		{
+			Port:     hcoutil.MetricsPort,
+			Name:     alerts.OperatorPortName,
+			Protocol: corev1.ProtocolTCP,
+			TargetPort: intstr.IntOrString{
+				Type: intstr.Int, IntVal: hcoutil.MetricsPort,
+			},
+		},
+	}
+
+	webhookName := hcoutil.HCOWebhookName
+	val, ok := os.LookupEnv(alerts.OperatorNameEnv)
+	if ok && val != "" {
+		webhookName = val
+	}
+	labelSelect := map[string]string{"name": webhookName}
+
+	spec := corev1.ServiceSpec{
+		Ports:    servicePorts,
+		Selector: labelSelect,
+	}
+
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            serviceName,
+			Labels:          getLabels(),
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{owner},
+		},
+		Spec: spec,
+	}
+}

--- a/controllers/webhooks/bearer-token-controller/serviceMonitor.go
+++ b/controllers/webhooks/bearer-token-controller/serviceMonitor.go
@@ -1,0 +1,56 @@
+package bearer_token_controller
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts"
+)
+
+func newWHServiceMonitorReconciler(namespace string, owner metav1.OwnerReference) *alerts.ServiceMonitorReconciler {
+	return alerts.CreateServiceMonitorReconciler(newServiceMonitor(namespace, owner))
+}
+
+func newServiceMonitor(namespace string, owner metav1.OwnerReference) *monitoringv1.ServiceMonitor {
+	smLabels := getLabels()
+	spec := monitoringv1.ServiceMonitorSpec{
+		Selector: metav1.LabelSelector{
+			MatchLabels: smLabels,
+		},
+		Endpoints: []monitoringv1.Endpoint{
+			{
+				Port:   alerts.OperatorPortName,
+				Scheme: "https",
+				Authorization: &monitoringv1.SafeAuthorization{
+					Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretName,
+						},
+						Key: "token",
+					},
+				},
+				TLSConfig: &monitoringv1.TLSConfig{
+					SafeTLSConfig: monitoringv1.SafeTLSConfig{
+						InsecureSkipVerify: ptr.To(true),
+					},
+				},
+			},
+		},
+	}
+
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: monitoringv1.SchemeGroupVersion.String(),
+			Kind:       monitoringv1.ServiceMonitorsKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            serviceName,
+			Labels:          smLabels,
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{owner},
+		},
+		Spec: spec,
+	}
+}

--- a/controllers/webhooks/bearer-token-controller/serviceMonitor_test.go
+++ b/controllers/webhooks/bearer-token-controller/serviceMonitor_test.go
@@ -1,0 +1,28 @@
+package bearer_token_controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+)
+
+var _ = Describe("NewServiceMonitor", func() {
+	It("should configures selector, endpoint, auth, and TLS", func() {
+		owner := metav1.OwnerReference{Name: "o"}
+		sm := newServiceMonitor(commontestutils.Namespace, owner)
+
+		Expect(sm.Spec.Selector.MatchLabels).To(Equal(getLabels()))
+		Expect(sm.Spec.Endpoints).To(HaveLen(1))
+		ep := sm.Spec.Endpoints[0]
+		Expect(ep.Port).To(Equal(alerts.OperatorPortName))
+		Expect(ep.Scheme).To(Equal("https"))
+		Expect(ep.Authorization).ToNot(BeNil())
+		Expect(ep.Authorization.Credentials).ToNot(BeNil())
+		Expect(ep.Authorization.Credentials.Name).To(Equal(secretName))
+		Expect(ep.Authorization.Credentials.Key).To(Equal("token"))
+		Expect(*ep.TLSConfig.InsecureSkipVerify).To(BeTrue())
+	})
+})

--- a/controllers/webhooks/bearer-token-controller/service_test.go
+++ b/controllers/webhooks/bearer-token-controller/service_test.go
@@ -1,0 +1,48 @@
+package bearer_token_controller
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+var _ = Describe("NewMetricsService", func() {
+	It("uses default selector name when env var is not set", func() {
+		owner := metav1.OwnerReference{Name: "o"}
+		svc := NewMetricsService(commontestutils.Namespace, owner)
+		Expect(svc.Spec.Selector).To(HaveKeyWithValue("name", hcoutil.HCOWebhookName))
+		Expect(svc.Spec.Ports).To(HaveLen(1))
+		Expect(svc.Spec.Ports[0].Port).To(Equal(hcoutil.MetricsPort))
+		Expect(svc.Spec.Ports[0].Name).To(Equal(alerts.OperatorPortName))
+		Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+	})
+
+	It("uses default selector name from the env var if it set", func() {
+		varVal, varExists := os.LookupEnv(alerts.OperatorNameEnv)
+		DeferCleanup(func() {
+			if varExists {
+				Expect(os.Setenv(alerts.OperatorNameEnv, varVal)).To(Succeed())
+			} else {
+				Expect(os.Unsetenv(alerts.OperatorNameEnv)).To(Succeed())
+			}
+		})
+
+		const customWebhookName = "custom-webhook-name"
+		Expect(os.Setenv(alerts.OperatorNameEnv, customWebhookName)).To(Succeed())
+
+		owner := metav1.OwnerReference{Name: "o"}
+		svc := NewMetricsService(commontestutils.Namespace, owner)
+		Expect(svc.Spec.Selector).To(HaveKeyWithValue("name", customWebhookName))
+		Expect(svc.Spec.Ports).To(HaveLen(1))
+		Expect(svc.Spec.Ports[0].Port).To(Equal(hcoutil.MetricsPort))
+		Expect(svc.Spec.Ports[0].Name).To(Equal(alerts.OperatorPortName))
+		Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+	})
+})

--- a/controllers/webhooks/bearer-token-controller/webhooks_suite_test.go
+++ b/controllers/webhooks/bearer-token-controller/webhooks_suite_test.go
@@ -1,0 +1,13 @@
+package bearer_token_controller
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWebhookBearerToken(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Bearer Token Controller Suite")
+}

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.15.3/manifests/kubevirt-hyperconverged-operator.v1.15.3.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.15.3/manifests/kubevirt-hyperconverged-operator.v1.15.3.clusterserviceversion.yaml
@@ -3085,6 +3085,10 @@ spec:
                   initialDelaySeconds: 30
                   periodSeconds: 5
                 name: hyperconverged-cluster-operator
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
                 readinessProbe:
                   failureThreshold: 1
                   httpGet:
@@ -3150,6 +3154,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: HCO_KV_IO_VERSION
+                  value: 1.15.3
                 image: +WEBHOOK_IMAGE_TO_REPLACE+
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
@@ -3161,6 +3167,13 @@ spec:
                   initialDelaySeconds: 30
                   periodSeconds: 5
                 name: hyperconverged-cluster-webhook
+                ports:
+                - containerPort: 4343
+                  name: webhook
+                  protocol: TCP
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
                 readinessProbe:
                   failureThreshold: 1
                   httpGet:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.2/manifests/kubevirt-hyperconverged-operator.v1.15.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.2/manifests/kubevirt-hyperconverged-operator.v1.15.2.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.16.0-unstable
-    createdAt: "2025-08-05 14:47:05"
+    createdAt: "2025-08-14 10:03:27"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -33,7 +33,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: kubevirt-hyperconverged-operator.v1.15.2
+  name: kubevirt-hyperconverged-operator.v1.16.0
   namespace: kubevirt-hyperconverged
 spec:
   apiservicedefinitions: {}
@@ -357,6 +357,7 @@ spec:
           resources:
           - deployments
           - replicasets
+          - daemonsets
           verbs:
           - get
           - list
@@ -368,7 +369,9 @@ spec:
           - rbac.authorization.k8s.io
           resources:
           - roles
+          - clusterroles
           - rolebindings
+          - clusterrolebindings
           verbs:
           - get
           - list
@@ -582,6 +585,50 @@ spec:
           - list
           - create
           - delete
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
         serviceAccountName: hyperconverged-cluster-operator
       - rules: []
         serviceAccountName: hyperconverged-cluster-cli-download
@@ -652,6 +699,7 @@ spec:
           verbs:
           - list
           - watch
+          - get
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -1040,6 +1088,7 @@ spec:
           - persistentvolumeclaims
           verbs:
           - get
+          - list
         - apiGroups:
           - kubevirt.io
           resources:
@@ -1436,6 +1485,15 @@ spec:
           - get
           - delete
         - apiGroups:
+          - resource.k8s.io
+          resources:
+          - resourceslices
+          - resourceclaims
+          verbs:
+          - list
+          - watch
+          - get
+        - apiGroups:
           - kubevirt.io
           resources:
           - virtualmachineinstances
@@ -1509,6 +1567,48 @@ spec:
         - apiGroups:
           - kubevirt.io
           resources:
+          - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - update
+          - create
+          - patch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
           - kubevirts
           verbs:
           - get
@@ -1534,6 +1634,8 @@ spec:
           - virtualmachineinstances/sev/fetchcertchain
           - virtualmachineinstances/sev/querylaunchmeasurement
           - virtualmachineinstances/usbredir
+          - virtualmachines/objectgraph
+          - virtualmachineinstances/objectgraph
           verbs:
           - get
         - apiGroups:
@@ -1690,6 +1792,8 @@ spec:
           - virtualmachineinstances/sev/fetchcertchain
           - virtualmachineinstances/sev/querylaunchmeasurement
           - virtualmachineinstances/usbredir
+          - virtualmachines/objectgraph
+          - virtualmachineinstances/objectgraph
           verbs:
           - get
         - apiGroups:
@@ -1850,6 +1954,8 @@ spec:
           - virtualmachineinstances/userlist
           - virtualmachineinstances/sev/fetchcertchain
           - virtualmachineinstances/sev/querylaunchmeasurement
+          - virtualmachines/objectgraph
+          - virtualmachineinstances/objectgraph
           verbs:
           - get
         - apiGroups:
@@ -2114,6 +2220,17 @@ spec:
           - servicemonitors
           verbs:
           - create
+          - delete
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
           - list
           - update
           - watch
@@ -2459,6 +2576,7 @@ spec:
           - get
         - apiGroups:
           - cdi.kubevirt.io
+          - forklift.cdi.kubevirt.io
           resources:
           - '*'
           verbs:
@@ -2518,15 +2636,6 @@ spec:
           - virtualmachines/finalizers
           verbs:
           - update
-        - apiGroups:
-          - forklift.cdi.kubevirt.io
-          resources:
-          - ovirtvolumepopulators
-          - openstackvolumepopulators
-          verbs:
-          - get
-          - list
-          - watch
         - apiGroups:
           - ""
           resources:
@@ -3006,7 +3115,7 @@ spec:
           app.kubernetes.io/component: deployment
           app.kubernetes.io/managed-by: olm
           app.kubernetes.io/part-of: hyperconverged-cluster
-          app.kubernetes.io/version: 1.15.2
+          app.kubernetes.io/version: 1.16.0
           name: hyperconverged-cluster-operator
         name: hco-operator
         spec:
@@ -3022,7 +3131,7 @@ spec:
                 app.kubernetes.io/component: deployment
                 app.kubernetes.io/managed-by: olm
                 app.kubernetes.io/part-of: hyperconverged-cluster
-                app.kubernetes.io/version: 1.15.2
+                app.kubernetes.io/version: 1.16.0
                 name: hyperconverged-cluster-operator
             spec:
               containers:
@@ -3035,7 +3144,7 @@ spec:
                   value: OPERATOR
                 - name: KVM_EMULATION
                 - name: OPERATOR_IMAGE
-                  value: quay.io/kubevirt/hyperconverged-cluster-operator:1.15.2-unstable
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator:1.16.0-unstable
                 - name: OPERATOR_NAME
                   value: hyperconverged-cluster-operator
                 - name: OPERATOR_NAMESPACE
@@ -3057,24 +3166,30 @@ spec:
                 - name: ARM64_MACHINETYPE
                   value: virt
                 - name: HCO_KV_IO_VERSION
-                  value: 1.15.2
+                  value: 1.16.0
                 - name: KUBEVIRT_VERSION
-                  value: v1.5.2
+                  value: v1.6.0
                 - name: CDI_VERSION
-                  value: v1.62.0
+                  value: v1.63.0-alpha.0
                 - name: NETWORK_ADDONS_VERSION
-                  value: v0.98.2
+                  value: v0.100.0
                 - name: SSP_VERSION
-                  value: v0.23.1
+                  value: v0.24.0
                 - name: HPPO_VERSION
                   value: v0.22.0
                 - name: AAQ_VERSION
-                  value: v1.4.0
+                  value: v1.5.0
                 - name: KV_CONSOLE_PLUGIN_IMAGE
-                  value: quay.io/kubevirt-ui/kubevirt-plugin@sha256:9656716bf6aca3ae2b81d28de6d228c1797d3f81934ccd862854be62a895cc2a
+                  value: quay.io/kubevirt-ui/kubevirt-plugin@sha256:89269df1481bed69cac7095c8d8d875acbfa238e4b5735ab802cda90c9375a1b
                 - name: KV_CONSOLE_PROXY_IMAGE
                   value: quay.io/kubevirt-ui/kubevirt-apiserver-proxy@sha256:935475c2850466aa5ac57e4de627fb177515cb2c402a95842ead095d82b6df5f
-                image: quay.io/kubevirt/hyperconverged-cluster-operator:1.15.2-unstable
+                - name: PASST_SIDECAR_IMAGE
+                  value: quay.io/kubevirt/network-passt-binding@sha256:5851a49a26ba84c3144d3068a0b2c348e933439a149d781ee06146ba6af0adcb
+                - name: PASST_CNI_IMAGE
+                  value: quay.io/kubevirt/network-passt-binding-cni@sha256:8e9a0fe4c0096abfea49f4eb36038842621bcb770ab6358ff5a6315016b6a243
+                - name: WASP_AGENT_IMAGE
+                  value: quay.io/openshift-virtualization/wasp-agent@sha256:eabfa6a425213f520f7a9e5b81b43e8b6430779d42c5c8b1bfd48a4f1730447a
+                image: quay.io/kubevirt/hyperconverged-cluster-operator:1.16.0-unstable
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 1
@@ -3085,6 +3200,10 @@ spec:
                   initialDelaySeconds: 30
                   periodSeconds: 5
                 name: hyperconverged-cluster-operator
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
                 readinessProbe:
                   failureThreshold: 1
                   httpGet:
@@ -3113,7 +3232,7 @@ spec:
           app.kubernetes.io/component: deployment
           app.kubernetes.io/managed-by: olm
           app.kubernetes.io/part-of: hyperconverged-cluster
-          app.kubernetes.io/version: 1.15.2
+          app.kubernetes.io/version: 1.16.0
           name: hyperconverged-cluster-webhook
         name: hco-webhook
         spec:
@@ -3129,7 +3248,7 @@ spec:
                 app.kubernetes.io/component: deployment
                 app.kubernetes.io/managed-by: olm
                 app.kubernetes.io/part-of: hyperconverged-cluster
-                app.kubernetes.io/version: 1.15.2
+                app.kubernetes.io/version: 1.16.0
                 name: hyperconverged-cluster-webhook
             spec:
               containers:
@@ -3141,7 +3260,7 @@ spec:
                 - name: APP
                   value: WEBHOOK
                 - name: OPERATOR_IMAGE
-                  value: quay.io/kubevirt/hyperconverged-cluster-webhook:1.15.2-unstable
+                  value: quay.io/kubevirt/hyperconverged-cluster-webhook:1.16.0-unstable
                 - name: OPERATOR_NAME
                   value: hyperconverged-cluster-webhook
                 - name: OPERATOR_NAMESPACE
@@ -3150,7 +3269,9 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
-                image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.15.2-unstable
+                - name: HCO_KV_IO_VERSION
+                  value: 1.16.0
+                image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.16.0-unstable
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 1
@@ -3161,6 +3282,13 @@ spec:
                   initialDelaySeconds: 30
                   periodSeconds: 5
                 name: hyperconverged-cluster-webhook
+                ports:
+                - containerPort: 4343
+                  name: webhook
+                  protocol: TCP
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
                 readinessProbe:
                   failureThreshold: 1
                   httpGet:
@@ -3189,7 +3317,7 @@ spec:
           app.kubernetes.io/component: deployment
           app.kubernetes.io/managed-by: olm
           app.kubernetes.io/part-of: hyperconverged-cluster
-          app.kubernetes.io/version: 1.15.2
+          app.kubernetes.io/version: 1.16.0
           name: hyperconverged-cluster-cli-download
         name: hyperconverged-cluster-cli-download
         spec:
@@ -3205,12 +3333,12 @@ spec:
                 app.kubernetes.io/component: deployment
                 app.kubernetes.io/managed-by: olm
                 app.kubernetes.io/part-of: hyperconverged-cluster
-                app.kubernetes.io/version: 1.15.2
+                app.kubernetes.io/version: 1.16.0
                 name: hyperconverged-cluster-cli-download
             spec:
               automountServiceAccountToken: false
               containers:
-              - image: quay.io/kubevirt/virt-artifacts-server:1.15.2-unstable
+              - image: quay.io/kubevirt/virt-artifacts-server:1.16.0-unstable
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 1
@@ -3252,7 +3380,7 @@ spec:
           app.kubernetes.io/component: network
           app.kubernetes.io/managed-by: olm
           app.kubernetes.io/part-of: hyperconverged-cluster
-          app.kubernetes.io/version: 1.15.2
+          app.kubernetes.io/version: 1.16.0
         name: cluster-network-addons-operator
         spec:
           replicas: 1
@@ -3271,40 +3399,42 @@ spec:
                 app.kubernetes.io/component: network
                 app.kubernetes.io/managed-by: olm
                 app.kubernetes.io/part-of: hyperconverged-cluster
-                app.kubernetes.io/version: 1.15.2
+                app.kubernetes.io/version: 1.16.0
+                hco.kubevirt.io/allow-access-cluster-services: ""
+                hco.kubevirt.io/allow-prometheus-access: ""
                 name: cluster-network-addons-operator
                 prometheus.cnao.io: "true"
             spec:
               containers:
               - env:
                 - name: MULTUS_IMAGE
-                  value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:42ccc54689ea3003d3b6c7decadd85b4e296c15d3ad736da48d7e0c768d1f538
+                  value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:a60a21ee1d00c9f215b0b2fa03b3d5e384ab7ddb9ea0d231d36aef220e95a69c
                 - name: MULTUS_DYNAMIC_NETWORKS_CONTROLLER_IMAGE
-                  value: ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:8061bd1276ff022fe52a0b07bc6fa8d27e5f6f20cf3bf764e76d347d2e3c929b
+                  value: ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:2a2bb32c0ea8b232b3dbe81c0323a107e8b05f8cad06704fca2efd0d993a87be
                 - name: LINUX_BRIDGE_IMAGE
                   value: quay.io/kubevirt/cni-default-plugins@sha256:976a24392c2a096c38c2663d234b2d3131f5c24558889196d30b9ac1b6716788
                 - name: LINUX_BRIDGE_MARKER_IMAGE
-                  value: quay.io/kubevirt/bridge-marker@sha256:ca7fcc798603d9d4de02da00dbda6b0637e72bf1670d531aff070138fded01b4
+                  value: quay.io/kubevirt/bridge-marker@sha256:bf269af61e618857e7b14439cfc003aac2d65db9ee633147a73f5d9648dab377
                 - name: OVS_CNI_IMAGE
-                  value: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:64baa43b7149add55d7dc814ea180a3bf5480ac44c838cf4b5c4e3fff95aa84c
+                  value: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:435f374b434b3bc70a5cfaba0011fdcf5f433d96b98b06d29306cbd8db3a8c21
                 - name: KUBEMACPOOL_IMAGE
-                  value: quay.io/kubevirt/kubemacpool@sha256:158c77ad7a7e3c6cfb268def8f0b7341ba39a876d3095096873107c6e52d547a
+                  value: quay.io/kubevirt/kubemacpool@sha256:bc1c0b05cd71fd9cc3c15a4a90df7e8581bd19f69256895f6a711b412ba02a85
                 - name: MACVTAP_CNI_IMAGE
-                  value: quay.io/kubevirt/macvtap-cni@sha256:10e631dea111c070e67b03ab1fdd5563eb95fb3f14959ffc66386cdf215133c9
+                  value: quay.io/kubevirt/macvtap-cni@sha256:af31faae20c0128a469dd4c1aa866d6bf78d1d2f5972127adf4c9438dcde10f4
                 - name: KUBE_RBAC_PROXY_IMAGE
                   value: quay.io/openshift/origin-kube-rbac-proxy@sha256:e2def4213ec0657e72eb790ae8a115511d5b8f164a62d3568d2f1bff189917e8
                 - name: KUBE_SECONDARY_DNS_IMAGE
-                  value: ghcr.io/kubevirt/kubesecondarydns@sha256:13186a0512b59c71e975b4c30e69a6ed0122f83d64da762c7fc5b4a7f066a873
+                  value: ghcr.io/kubevirt/kubesecondarydns@sha256:f5fe9c98fb6d7e5e57a6df23fe82e43e65db5953d76af44adda9ab40c46ad0bf
                 - name: CORE_DNS_IMAGE
                   value: registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e
                 - name: KUBEVIRT_IPAM_CONTROLLER_IMAGE
-                  value: ghcr.io/kubevirt/ipam-controller@sha256:7f9574df14b5b6b0b8e8860a63c658fb683b3f13fdc3223bce5a6cf631c1a142
+                  value: ghcr.io/kubevirt/ipam-controller@sha256:4fdc9c77b9e683f274a31fcb7f6dbcf765799596efd93bc37512fb860f07b02f
                 - name: OPERATOR_IMAGE
-                  value: quay.io/kubevirt/cluster-network-addons-operator@sha256:f972239b2b82552fc4a32d95ac0522e4f1e66c299c5fb27e558d457efe5c3f42
+                  value: quay.io/kubevirt/cluster-network-addons-operator@sha256:076a856007ce3e3c84ea9c87b032f5b0adef9aaed93d91122d71dc76aa745201
                 - name: OPERATOR_NAME
                   value: cluster-network-addons-operator
                 - name: OPERATOR_VERSION
-                  value: v0.98.2
+                  value: v0.100.0
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -3324,9 +3454,24 @@ spec:
                   value: prometheus-k8s
                 - name: RUNBOOK_URL_TEMPLATE
                   value: https://kubevirt.io/monitoring/runbooks/%s
-                image: quay.io/kubevirt/cluster-network-addons-operator@sha256:f972239b2b82552fc4a32d95ac0522e4f1e66c299c5fb27e558d457efe5c3f42
+                image: quay.io/kubevirt/cluster-network-addons-operator@sha256:076a856007ce3e3c84ea9c87b032f5b0adef9aaed93d91122d71dc76aa745201
                 imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: healthprobe
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
                 name: cluster-network-addons-operator
+                ports:
+                - containerPort: 8081
+                  name: healthprobe
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: healthprobe
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
                 resources:
                   requests:
                     cpu: 50m
@@ -3336,6 +3481,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                terminationMessagePolicy: FallbackToLogsOnError
               - args:
                 - --logtostderr
                 - --secure-listen-address=:8443
@@ -3367,7 +3513,7 @@ spec:
           app.kubernetes.io/component: compute
           app.kubernetes.io/managed-by: olm
           app.kubernetes.io/part-of: hyperconverged-cluster
-          app.kubernetes.io/version: 1.15.2
+          app.kubernetes.io/version: 1.16.0
         name: virt-operator
         spec:
           replicas: 2
@@ -3384,7 +3530,7 @@ spec:
                 app.kubernetes.io/component: compute
                 app.kubernetes.io/managed-by: olm
                 app.kubernetes.io/part-of: hyperconverged-cluster
-                app.kubernetes.io/version: 1.15.2
+                app.kubernetes.io/version: 1.16.0
                 kubevirt.io: virt-operator
                 name: virt-operator
                 prometheus.kubevirt.io: "true"
@@ -3412,33 +3558,42 @@ spec:
                 - virt-operator
                 env:
                 - name: VIRT_OPERATOR_IMAGE
-                  value: quay.io/kubevirt/virt-operator@sha256:e0d40ae75785224f0e8c26f5b657a842e149251ac18e04e19d60c29509dbb376
+                  value: quay.io/kubevirt/virt-operator@sha256:fea0eac792ca269f936a9171e4e1f3b6be8319fe5550e63b00f3f63ffb82d1ef
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: VIRT_API_IMAGE
-                  value: quay.io/kubevirt/virt-api@sha256:6fe6c2c106327b9da54d8b4987a1a89da7ddf43d9e44c1131fc0e9d69bf7b50a
+                  value: quay.io/kubevirt/virt-api@sha256:7ef6c1aa7b76f693c7e2f4dbaaf1d52d63425d7ec521757e520d6e2adddfa69b
                 - name: VIRT_CONTROLLER_IMAGE
-                  value: quay.io/kubevirt/virt-controller@sha256:179f5f7e304de91bb307da6bdf99294e635df81268a3a6e6413e40f2175f059d
+                  value: quay.io/kubevirt/virt-controller@sha256:8612bab466360394646de5e3378826b8ba33dcb10ae1ce7c4ae4c18b86117b60
                 - name: VIRT_HANDLER_IMAGE
-                  value: quay.io/kubevirt/virt-handler@sha256:ce092fe4988a281b2ca6afe1ebfba7bd9073d50b433c63cfb19d1a9854c37004
+                  value: quay.io/kubevirt/virt-handler@sha256:162887264d760869f867eed68ea26489d485ed36022410b502ff7f018938bad8
                 - name: VIRT_LAUNCHER_IMAGE
-                  value: quay.io/kubevirt/virt-launcher@sha256:a4d63bbea787a10209da5e946b4086608e4078e93bb34f8aa30fb77a3b773830
+                  value: quay.io/kubevirt/virt-launcher@sha256:66fd042603f2f11e8e279dea52fdeef789d0b4d281ee3fa08437f50b331d5833
                 - name: VIRT_EXPORTPROXY_IMAGE
-                  value: quay.io/kubevirt/virt-exportproxy@sha256:5065a7d0873360bbc99bf028ade3b5af13a96d9c2ac70aca297337dba37a310f
+                  value: quay.io/kubevirt/virt-exportproxy@sha256:223df2b5933b0d9277d34934934fdb55ba3da393c3e09215fc980f47f17759c1
                 - name: VIRT_EXPORTSERVER_IMAGE
-                  value: quay.io/kubevirt/virt-exportserver@sha256:b031f8ff964e2e8c4653a616930645ebbbb9c376d12609dd211966b013a2539a
+                  value: quay.io/kubevirt/virt-exportserver@sha256:09bfbf6b1b911c5e641c601470ab34c2a69c81610d0c3a9a64ee89a18bc69415
+                - name: VIRT_SYNCHRONIZATIONCONTROLLER_IMAGE
+                  value: quay.io/kubevirt/virt-synchronization-controller@sha256:4c236292e2081ca2a5b705c99e073edd2603a16c0dd510a9932890aa57f9aa14
                 - name: GS_IMAGE
-                  value: quay.io/kubevirt/libguestfs-tools@sha256:e9574118343e5f9995a8d7634afe68a6ba1877ab105b9108fd4381093a7b7c5d
+                  value: quay.io/kubevirt/libguestfs-tools@sha256:92853b8bbd5e755d01541a2d68261220d89ad817e0b460b4a8c729f1f7181e2b
                 - name: PR_HELPER_IMAGE
-                  value: quay.io/kubevirt/pr-helper@sha256:1b3feddbec8da4f5557133281aa59e00affc3fb019251c476bf0b9d36c524ddc
+                  value: quay.io/kubevirt/pr-helper@sha256:4d6df4bca32cfd50816f84a3ef2d087e614fea0d0bf502655353352c08a7636f
                 - name: SIDECAR_SHIM_IMAGE
-                  value: quay.io/kubevirt/sidecar-shim@sha256:861192aabbe938b4db0cdbec318000b479ca2126a9f0e474939888d7f53137ff
+                  value: quay.io/kubevirt/sidecar-shim@sha256:d1b54b3ae99df9e257d78b03e4dc4feaebbf63327fe4ecaa4b45004f856e481f
                 - name: KUBEVIRT_VERSION
-                  value: v1.5.2
-                image: quay.io/kubevirt/virt-operator@sha256:e0d40ae75785224f0e8c26f5b657a842e149251ac18e04e19d60c29509dbb376
+                  value: v1.6.0
+                image: quay.io/kubevirt/virt-operator@sha256:fea0eac792ca269f936a9171e4e1f3b6be8319fe5550e63b00f3f63ffb82d1ef
                 imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /metrics
+                    port: 8443
+                    scheme: HTTPS
+                  initialDelaySeconds: 5
+                  timeoutSeconds: 10
                 name: virt-operator
                 ports:
                 - containerPort: 8443
@@ -3465,6 +3620,7 @@ spec:
                     - ALL
                   seccompProfile:
                     type: RuntimeDefault
+                terminationMessagePolicy: FallbackToLogsOnError
                 volumeMounts:
                 - mountPath: /etc/virt-operator/certificates
                   name: kubevirt-operator-certs
@@ -3493,7 +3649,7 @@ spec:
           app.kubernetes.io/component: schedule
           app.kubernetes.io/managed-by: olm
           app.kubernetes.io/part-of: hyperconverged-cluster
-          app.kubernetes.io/version: 1.15.2
+          app.kubernetes.io/version: 1.16.0
           control-plane: ssp-operator
           name: ssp-operator
         name: ssp-operator
@@ -3512,8 +3668,9 @@ spec:
                 app.kubernetes.io/component: schedule
                 app.kubernetes.io/managed-by: olm
                 app.kubernetes.io/part-of: hyperconverged-cluster
-                app.kubernetes.io/version: 1.15.2
+                app.kubernetes.io/version: 1.16.0
                 control-plane: ssp-operator
+                hco.kubevirt.io/allow-access-cluster-services: "true"
                 name: ssp-operator
                 prometheus.ssp.kubevirt.io: "true"
             spec:
@@ -3524,15 +3681,15 @@ spec:
                 - /manager
                 env:
                 - name: VALIDATOR_IMAGE
-                  value: quay.io/kubevirt/kubevirt-template-validator@sha256:8cc215af0f8d670e2714cdc2a8d6b5e02a01ebd5a3851853bf82c71ba2d741e1
+                  value: quay.io/kubevirt/kubevirt-template-validator@sha256:5eeff2736995e6694b428562b55afded3cfa78853245ceec9e3bb1f81fcd8d1f
                 - name: OPERATOR_VERSION
-                  value: v0.23.1
+                  value: v0.24.0
                 - name: VM_CONSOLE_PROXY_IMAGE
                 - name: POD_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kubevirt/ssp-operator@sha256:57fa09e8f7f2fe3b06faf59d63bafe1afbac9287670653114af93fe7898fb79f
+                image: quay.io/kubevirt/ssp-operator@sha256:d117ebaefda9cfbde21830abbcfd4ea72d1d9217e6f816f61a7499e8119e17b7
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3556,7 +3713,7 @@ spec:
                 resources:
                   requests:
                     cpu: 200m
-                    memory: 150Mi
+                    memory: 200Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:
@@ -3574,7 +3731,7 @@ spec:
           app.kubernetes.io/component: storage
           app.kubernetes.io/managed-by: olm
           app.kubernetes.io/part-of: hyperconverged-cluster
-          app.kubernetes.io/version: 1.15.2
+          app.kubernetes.io/version: 1.16.0
         name: cdi-operator
         spec:
           replicas: 1
@@ -3591,7 +3748,7 @@ spec:
                 app.kubernetes.io/component: storage
                 app.kubernetes.io/managed-by: olm
                 app.kubernetes.io/part-of: hyperconverged-cluster
-                app.kubernetes.io/version: 1.15.2
+                app.kubernetes.io/version: 1.16.0
                 cdi.kubevirt.io: cdi-operator
                 name: cdi-operator
                 operator.cdi.kubevirt.io: ""
@@ -3614,27 +3771,27 @@ spec:
                 - name: DEPLOY_CLUSTER_RESOURCES
                   value: "true"
                 - name: OPERATOR_VERSION
-                  value: v1.62.0
+                  value: v1.63.0-alpha.0
                 - name: CONTROLLER_IMAGE
-                  value: quay.io/kubevirt/cdi-controller@sha256:c4c35dce67ecbca97d3eb854d5468b6e60b06cd90e140fec83bb58ec566abb43
+                  value: quay.io/kubevirt/cdi-controller@sha256:0cd25b425f50e1e04c5d842bdf4587777e33b3f4abe1ff45c8120d22ba6890d6
                 - name: IMPORTER_IMAGE
-                  value: quay.io/kubevirt/cdi-importer@sha256:df76770eef8bfc218a6423dea41a0d597b80821cd0434528aaa84951d2242abc
+                  value: quay.io/kubevirt/cdi-importer@sha256:fff582ac5299857cc75b7d98035f5099b7277e69aa6a8d9d09d4e3af0a2c3a8d
                 - name: CLONER_IMAGE
-                  value: quay.io/kubevirt/cdi-cloner@sha256:ece16cb37976eb1a075b9b276b9d42d9a5c349dc9f29d1b7d08f0b985e119f07
+                  value: quay.io/kubevirt/cdi-cloner@sha256:ec8bfee04e5e6c0bd42c529a752cdcbf16adf5098f40b61e2419df168769f478
                 - name: OVIRT_POPULATOR_IMAGE
-                  value: quay.io/kubevirt/cdi-importer@sha256:df76770eef8bfc218a6423dea41a0d597b80821cd0434528aaa84951d2242abc
+                  value: quay.io/kubevirt/cdi-importer@sha256:fff582ac5299857cc75b7d98035f5099b7277e69aa6a8d9d09d4e3af0a2c3a8d
                 - name: APISERVER_IMAGE
-                  value: quay.io/kubevirt/cdi-apiserver@sha256:aa5c2e16c67545f449086b4e49a25f9b304a17174985b841d82e8ff618fb809e
+                  value: quay.io/kubevirt/cdi-apiserver@sha256:d6caa249afb47cd0f77778bb2adce5d1804a356a930efcfe3b47d2f8a136a931
                 - name: UPLOAD_SERVER_IMAGE
-                  value: quay.io/kubevirt/cdi-uploadserver@sha256:de0e6e49f7086c1fc526e339d435dc92c51d51e416e90ae4b988271bf5fafe42
+                  value: quay.io/kubevirt/cdi-uploadserver@sha256:02a9de4d24d83dd1ea156da2a59485f440bd1802b269bbe87d1939521807620a
                 - name: UPLOAD_PROXY_IMAGE
-                  value: quay.io/kubevirt/cdi-uploadproxy@sha256:28d70e20ca6b1435470a7c7dd2bc28d394705b730c7d760ef827addb768ab5b1
+                  value: quay.io/kubevirt/cdi-uploadproxy@sha256:64806a9602188e2bae10da3afdaf53c3ded75d1bdd68fcbdc1c779dc1db1dc5f
                 - name: VERBOSITY
                   value: "1"
                 - name: PULL_POLICY
                   value: IfNotPresent
                 - name: MONITORING_NAMESPACE
-                image: quay.io/kubevirt/cdi-operator@sha256:21fe82706f57bc5378ba17be79d6831b223605ecf1ea6f43f533b1bccae68c50
+                image: quay.io/kubevirt/cdi-operator@sha256:52574ec0c8e66ec51f85b5dd82714e8410dd77dbdad985c4a9cfdbc386e27464
                 imagePullPolicy: IfNotPresent
                 name: cdi-operator
                 ports:
@@ -3654,7 +3811,7 @@ spec:
                   seccompProfile:
                     type: RuntimeDefault
                 terminationMessagePath: /dev/termination-log
-                terminationMessagePolicy: File
+                terminationMessagePolicy: FallbackToLogsOnError
               nodeSelector:
                 kubernetes.io/os: linux
               priorityClassName: kubevirt-cluster-critical
@@ -3668,7 +3825,7 @@ spec:
           app.kubernetes.io/component: storage
           app.kubernetes.io/managed-by: olm
           app.kubernetes.io/part-of: hyperconverged-cluster
-          app.kubernetes.io/version: 1.15.2
+          app.kubernetes.io/version: 1.16.0
         name: hostpath-provisioner-operator
         spec:
           replicas: 1
@@ -3685,7 +3842,7 @@ spec:
                 app.kubernetes.io/component: storage
                 app.kubernetes.io/managed-by: olm
                 app.kubernetes.io/part-of: hyperconverged-cluster
-                app.kubernetes.io/version: 1.15.2
+                app.kubernetes.io/version: 1.16.0
                 name: hostpath-provisioner-operator
                 operator.hostpath-provisioner.kubevirt.io: ""
                 prometheus.hostpathprovisioner.kubevirt.io: "true"
@@ -3719,11 +3876,11 @@ spec:
                 - name: CSI_PROVISIONER_IMAGE
                   value: quay.io/kubevirt/hostpath-csi-driver@sha256:696e7b6c9fb92353579b8c003a43a27a7d78ce224a8119db3b3997295d330e3c
                 - name: NODE_DRIVER_REG_IMAGE
-                  value: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:d7138bcc3aa5f267403d45ad4292c95397e421ea17a0035888850f424c7de25d
+                  value: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:5244abbe87e01b35adeb8bb13882a74785df0c0619f8325c9e950395c3f72a97
                 - name: LIVENESS_PROBE_IMAGE
-                  value: registry.k8s.io/sig-storage/livenessprobe@sha256:2c5f9dc4ea5ac5509d93c664ae7982d4ecdec40ca7b0638c24e5b16243b8360f
+                  value: registry.k8s.io/sig-storage/livenessprobe@sha256:88092d100909918ae0a768956cf78c88bc59cd7232720f7cdbdfb5d2e235001e
                 - name: CSI_SNAPSHOT_IMAGE
-                  value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:5f4bb469fec51147ce157329dab598c758da1b018bad6dad26f0ff469326d769
+                  value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:bc7be893ecc3ad524194aa6573b2f5c06cd469bdf21a500ab6c99c2ba1c4d64d
                 - name: CSI_SIG_STORAGE_PROVISIONER_IMAGE
                   value: registry.k8s.io/sig-storage/csi-provisioner@sha256:d078dc174323407e8cc6f0f9abd4efaac5db27838f1564d0253d5e3233e3f17f
                 - name: VERBOSITY
@@ -3785,7 +3942,7 @@ spec:
           app.kubernetes.io/component: quota-management
           app.kubernetes.io/managed-by: olm
           app.kubernetes.io/part-of: hyperconverged-cluster
-          app.kubernetes.io/version: 1.15.2
+          app.kubernetes.io/version: 1.16.0
         name: aaq-operator
         spec:
           replicas: 1
@@ -3800,7 +3957,7 @@ spec:
                 app.kubernetes.io/component: quota-management
                 app.kubernetes.io/managed-by: olm
                 app.kubernetes.io/part-of: hyperconverged-cluster
-                app.kubernetes.io/version: 1.15.2
+                app.kubernetes.io/version: 1.16.0
                 name: aaq-operator
                 operator.aaq.kubevirt.io: ""
                 prometheus.aaq.kubevirt.io: "true"
@@ -3812,23 +3969,33 @@ spec:
                 - name: DEPLOY_CLUSTER_RESOURCES
                   value: "true"
                 - name: OPERATOR_VERSION
-                  value: v1.4.0
+                  value: v1.5.0
                 - name: CONTROLLER_IMAGE
-                  value: quay.io/kubevirt/aaq-controller@sha256:4d0ddbe05086bf03b0147fc7edc3ed38b7aaf05ceb799b46d6b179268fe91f98
+                  value: quay.io/kubevirt/aaq-controller@sha256:e955d7fb3910f79b64d4ef5c6750fd1e6174e47564803b520a0c698985efcc96
                 - name: AAQ_SERVER_IMAGE
-                  value: quay.io/kubevirt/aaq-server@sha256:e83a72e24db84f71f7d1cb66c3ca2ce5da568a53267356fe93858fa702e956bd
+                  value: quay.io/kubevirt/aaq-server@sha256:4ea9d00ead35530b3c58ce90dcba402a511e8981d8d170954683ad730a548f32
                 - name: VERBOSITY
                   value: "1"
                 - name: PULL_POLICY
                   value: IfNotPresent
                 - name: MONITORING_NAMESPACE
-                image: quay.io/kubevirt/aaq-operator@sha256:fcea54343a97b300a860ce2b09ae362b9397901ca20984333a2e755690ada93a
+                image: quay.io/kubevirt/aaq-operator@sha256:c7fbfc328d0993828447608a9b760dccbd68f8074c82c66c2c492add57f906a3
                 imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                    scheme: HTTP
                 name: aaq-operator
                 ports:
                 - containerPort: 8080
                   name: metrics
                   protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                    scheme: HTTP
                 resources:
                   requests:
                     cpu: 10m
@@ -3842,7 +4009,7 @@ spec:
                   seccompProfile:
                     type: RuntimeDefault
                 terminationMessagePath: /dev/termination-log
-                terminationMessagePolicy: File
+                terminationMessagePolicy: FallbackToLogsOnError
               nodeSelector:
                 kubernetes.io/os: linux
               priorityClassName: kubevirt-cluster-critical
@@ -3949,6 +4116,18 @@ spec:
           - create
           - update
           - delete
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
         serviceAccountName: cluster-network-addons-operator
       - rules:
         - apiGroups:
@@ -3962,6 +4141,8 @@ spec:
           - kubevirt-virt-api-certs
           - kubevirt-controller-certs
           - kubevirt-exportproxy-certs
+          - kubevirt-synchronization-controller-certs
+          - kubevirt-synchronization-controller-server-certs
           resources:
           - secrets
           verbs:
@@ -4073,6 +4254,28 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resourceNames:
+          - kubevirt-ca
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update
+          - create
+          - patch
         serviceAccountName: kubevirt-operator
       - rules:
         - apiGroups:
@@ -4563,39 +4766,39 @@ spec:
   provider:
     name: KubeVirt project
   relatedImages:
-  - image: quay.io/kubevirt/aaq-controller@sha256:4d0ddbe05086bf03b0147fc7edc3ed38b7aaf05ceb799b46d6b179268fe91f98
+  - image: quay.io/kubevirt/aaq-controller@sha256:e955d7fb3910f79b64d4ef5c6750fd1e6174e47564803b520a0c698985efcc96
     name: aaq-controller
-  - image: quay.io/kubevirt/aaq-operator@sha256:fcea54343a97b300a860ce2b09ae362b9397901ca20984333a2e755690ada93a
+  - image: quay.io/kubevirt/aaq-operator@sha256:c7fbfc328d0993828447608a9b760dccbd68f8074c82c66c2c492add57f906a3
     name: aaq-operator
-  - image: quay.io/kubevirt/aaq-server@sha256:e83a72e24db84f71f7d1cb66c3ca2ce5da568a53267356fe93858fa702e956bd
+  - image: quay.io/kubevirt/aaq-server@sha256:4ea9d00ead35530b3c58ce90dcba402a511e8981d8d170954683ad730a548f32
     name: aaq-server
-  - image: quay.io/kubevirt/bridge-marker@sha256:ca7fcc798603d9d4de02da00dbda6b0637e72bf1670d531aff070138fded01b4
+  - image: quay.io/kubevirt/bridge-marker@sha256:bf269af61e618857e7b14439cfc003aac2d65db9ee633147a73f5d9648dab377
     name: bridge-marker
-  - image: quay.io/kubevirt/cdi-apiserver@sha256:aa5c2e16c67545f449086b4e49a25f9b304a17174985b841d82e8ff618fb809e
+  - image: quay.io/kubevirt/cdi-apiserver@sha256:d6caa249afb47cd0f77778bb2adce5d1804a356a930efcfe3b47d2f8a136a931
     name: cdi-apiserver
-  - image: quay.io/kubevirt/cdi-cloner@sha256:ece16cb37976eb1a075b9b276b9d42d9a5c349dc9f29d1b7d08f0b985e119f07
+  - image: quay.io/kubevirt/cdi-cloner@sha256:ec8bfee04e5e6c0bd42c529a752cdcbf16adf5098f40b61e2419df168769f478
     name: cdi-cloner
-  - image: quay.io/kubevirt/cdi-controller@sha256:c4c35dce67ecbca97d3eb854d5468b6e60b06cd90e140fec83bb58ec566abb43
+  - image: quay.io/kubevirt/cdi-controller@sha256:0cd25b425f50e1e04c5d842bdf4587777e33b3f4abe1ff45c8120d22ba6890d6
     name: cdi-controller
-  - image: quay.io/kubevirt/cdi-importer@sha256:df76770eef8bfc218a6423dea41a0d597b80821cd0434528aaa84951d2242abc
+  - image: quay.io/kubevirt/cdi-importer@sha256:fff582ac5299857cc75b7d98035f5099b7277e69aa6a8d9d09d4e3af0a2c3a8d
     name: cdi-importer
-  - image: quay.io/kubevirt/cdi-operator@sha256:21fe82706f57bc5378ba17be79d6831b223605ecf1ea6f43f533b1bccae68c50
+  - image: quay.io/kubevirt/cdi-operator@sha256:52574ec0c8e66ec51f85b5dd82714e8410dd77dbdad985c4a9cfdbc386e27464
     name: cdi-operator
-  - image: quay.io/kubevirt/cdi-uploadproxy@sha256:28d70e20ca6b1435470a7c7dd2bc28d394705b730c7d760ef827addb768ab5b1
+  - image: quay.io/kubevirt/cdi-uploadproxy@sha256:64806a9602188e2bae10da3afdaf53c3ded75d1bdd68fcbdc1c779dc1db1dc5f
     name: cdi-uploadproxy
-  - image: quay.io/kubevirt/cdi-uploadserver@sha256:de0e6e49f7086c1fc526e339d435dc92c51d51e416e90ae4b988271bf5fafe42
+  - image: quay.io/kubevirt/cdi-uploadserver@sha256:02a9de4d24d83dd1ea156da2a59485f440bd1802b269bbe87d1939521807620a
     name: cdi-uploadserver
-  - image: quay.io/kubevirt/cluster-network-addons-operator@sha256:f972239b2b82552fc4a32d95ac0522e4f1e66c299c5fb27e558d457efe5c3f42
+  - image: quay.io/kubevirt/cluster-network-addons-operator@sha256:076a856007ce3e3c84ea9c87b032f5b0adef9aaed93d91122d71dc76aa745201
     name: cluster-network-addons-operator
   - image: quay.io/kubevirt/cni-default-plugins@sha256:976a24392c2a096c38c2663d234b2d3131f5c24558889196d30b9ac1b6716788
     name: cni-default-plugins
   - image: registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e
     name: coredns
-  - image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:d7138bcc3aa5f267403d45ad4292c95397e421ea17a0035888850f424c7de25d
+  - image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:5244abbe87e01b35adeb8bb13882a74785df0c0619f8325c9e950395c3f72a97
     name: csi-node-driver-registrar
   - image: registry.k8s.io/sig-storage/csi-provisioner@sha256:d078dc174323407e8cc6f0f9abd4efaac5db27838f1564d0253d5e3233e3f17f
     name: csi-provisioner
-  - image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:5f4bb469fec51147ce157329dab598c758da1b018bad6dad26f0ff469326d769
+  - image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:bc7be893ecc3ad524194aa6573b2f5c06cd469bdf21a500ab6c99c2ba1c4d64d
     name: csi-snapshotter
   - image: quay.io/kubevirt/hostpath-csi-driver@sha256:696e7b6c9fb92353579b8c003a43a27a7d78ce224a8119db3b3997295d330e3c
     name: hostpath-csi-driver
@@ -4603,66 +4806,74 @@ spec:
     name: hostpath-provisioner
   - image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:ac0c005304acb52033f3c4ad4af2aab81361346d5327c92ec6bcbd98097ae88b
     name: hostpath-provisioner-operator
-  - image: quay.io/kubevirt/hyperconverged-cluster-operator:1.15.2-unstable
+  - image: quay.io/kubevirt/hyperconverged-cluster-operator:1.16.0-unstable
     name: hyperconverged-cluster-operator
-  - image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.15.2-unstable
+  - image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.16.0-unstable
     name: hyperconverged-cluster-webhook
-  - image: ghcr.io/kubevirt/ipam-controller@sha256:7f9574df14b5b6b0b8e8860a63c658fb683b3f13fdc3223bce5a6cf631c1a142
+  - image: ghcr.io/kubevirt/ipam-controller@sha256:4fdc9c77b9e683f274a31fcb7f6dbcf765799596efd93bc37512fb860f07b02f
     name: ipam-controller
-  - image: quay.io/kubevirt/kubemacpool@sha256:158c77ad7a7e3c6cfb268def8f0b7341ba39a876d3095096873107c6e52d547a
+  - image: quay.io/kubevirt/kubemacpool@sha256:bc1c0b05cd71fd9cc3c15a4a90df7e8581bd19f69256895f6a711b412ba02a85
     name: kubemacpool
-  - image: ghcr.io/kubevirt/kubesecondarydns@sha256:13186a0512b59c71e975b4c30e69a6ed0122f83d64da762c7fc5b4a7f066a873
+  - image: ghcr.io/kubevirt/kubesecondarydns@sha256:f5fe9c98fb6d7e5e57a6df23fe82e43e65db5953d76af44adda9ab40c46ad0bf
     name: kubesecondarydns
   - image: quay.io/kubevirt-ui/kubevirt-apiserver-proxy@sha256:935475c2850466aa5ac57e4de627fb177515cb2c402a95842ead095d82b6df5f
     name: kubevirt-apiserver-proxy
-  - image: quay.io/kubevirt-ui/kubevirt-plugin@sha256:9656716bf6aca3ae2b81d28de6d228c1797d3f81934ccd862854be62a895cc2a
+  - image: quay.io/kubevirt-ui/kubevirt-plugin@sha256:89269df1481bed69cac7095c8d8d875acbfa238e4b5735ab802cda90c9375a1b
     name: kubevirt-plugin
-  - image: quay.io/kubevirt/kubevirt-template-validator@sha256:8cc215af0f8d670e2714cdc2a8d6b5e02a01ebd5a3851853bf82c71ba2d741e1
+  - image: quay.io/kubevirt/kubevirt-template-validator@sha256:5eeff2736995e6694b428562b55afded3cfa78853245ceec9e3bb1f81fcd8d1f
     name: kubevirt-template-validator
-  - image: quay.io/kubevirt/libguestfs-tools@sha256:e9574118343e5f9995a8d7634afe68a6ba1877ab105b9108fd4381093a7b7c5d
+  - image: quay.io/kubevirt/libguestfs-tools@sha256:92853b8bbd5e755d01541a2d68261220d89ad817e0b460b4a8c729f1f7181e2b
     name: libguestfs-tools
-  - image: registry.k8s.io/sig-storage/livenessprobe@sha256:2c5f9dc4ea5ac5509d93c664ae7982d4ecdec40ca7b0638c24e5b16243b8360f
+  - image: registry.k8s.io/sig-storage/livenessprobe@sha256:88092d100909918ae0a768956cf78c88bc59cd7232720f7cdbdfb5d2e235001e
     name: livenessprobe
-  - image: quay.io/kubevirt/macvtap-cni@sha256:10e631dea111c070e67b03ab1fdd5563eb95fb3f14959ffc66386cdf215133c9
+  - image: quay.io/kubevirt/macvtap-cni@sha256:af31faae20c0128a469dd4c1aa866d6bf78d1d2f5972127adf4c9438dcde10f4
     name: macvtap-cni
-  - image: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:42ccc54689ea3003d3b6c7decadd85b4e296c15d3ad736da48d7e0c768d1f538
+  - image: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:a60a21ee1d00c9f215b0b2fa03b3d5e384ab7ddb9ea0d231d36aef220e95a69c
     name: multus-cni
-  - image: ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:8061bd1276ff022fe52a0b07bc6fa8d27e5f6f20cf3bf764e76d347d2e3c929b
+  - image: ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:2a2bb32c0ea8b232b3dbe81c0323a107e8b05f8cad06704fca2efd0d993a87be
     name: multus-dynamic-networks-controller
+  - image: quay.io/kubevirt/network-passt-binding@sha256:5851a49a26ba84c3144d3068a0b2c348e933439a149d781ee06146ba6af0adcb
+    name: network-passt-binding
+  - image: quay.io/kubevirt/network-passt-binding-cni@sha256:8e9a0fe4c0096abfea49f4eb36038842621bcb770ab6358ff5a6315016b6a243
+    name: network-passt-binding-cni
   - image: quay.io/openshift/origin-kube-rbac-proxy@sha256:e2def4213ec0657e72eb790ae8a115511d5b8f164a62d3568d2f1bff189917e8
     name: origin-kube-rbac-proxy
-  - image: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:64baa43b7149add55d7dc814ea180a3bf5480ac44c838cf4b5c4e3fff95aa84c
+  - image: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:435f374b434b3bc70a5cfaba0011fdcf5f433d96b98b06d29306cbd8db3a8c21
     name: ovs-cni-plugin
-  - image: quay.io/kubevirt/pr-helper@sha256:1b3feddbec8da4f5557133281aa59e00affc3fb019251c476bf0b9d36c524ddc
+  - image: quay.io/kubevirt/pr-helper@sha256:4d6df4bca32cfd50816f84a3ef2d087e614fea0d0bf502655353352c08a7636f
     name: pr-helper
-  - image: quay.io/kubevirt/sidecar-shim@sha256:861192aabbe938b4db0cdbec318000b479ca2126a9f0e474939888d7f53137ff
+  - image: quay.io/kubevirt/sidecar-shim@sha256:d1b54b3ae99df9e257d78b03e4dc4feaebbf63327fe4ecaa4b45004f856e481f
     name: sidecar-shim
-  - image: quay.io/kubevirt/ssp-operator@sha256:57fa09e8f7f2fe3b06faf59d63bafe1afbac9287670653114af93fe7898fb79f
+  - image: quay.io/kubevirt/ssp-operator@sha256:d117ebaefda9cfbde21830abbcfd4ea72d1d9217e6f816f61a7499e8119e17b7
     name: ssp-operator
-  - image: quay.io/kubevirt/virt-api@sha256:6fe6c2c106327b9da54d8b4987a1a89da7ddf43d9e44c1131fc0e9d69bf7b50a
+  - image: quay.io/kubevirt/virt-api@sha256:7ef6c1aa7b76f693c7e2f4dbaaf1d52d63425d7ec521757e520d6e2adddfa69b
     name: virt-api
-  - image: quay.io/kubevirt/virt-artifacts-server:1.15.2-unstable
+  - image: quay.io/kubevirt/virt-artifacts-server:1.16.0-unstable
     name: virt-artifacts-server
-  - image: quay.io/kubevirt/virt-controller@sha256:179f5f7e304de91bb307da6bdf99294e635df81268a3a6e6413e40f2175f059d
+  - image: quay.io/kubevirt/virt-controller@sha256:8612bab466360394646de5e3378826b8ba33dcb10ae1ce7c4ae4c18b86117b60
     name: virt-controller
-  - image: quay.io/kubevirt/virt-exportproxy@sha256:5065a7d0873360bbc99bf028ade3b5af13a96d9c2ac70aca297337dba37a310f
+  - image: quay.io/kubevirt/virt-exportproxy@sha256:223df2b5933b0d9277d34934934fdb55ba3da393c3e09215fc980f47f17759c1
     name: virt-exportproxy
-  - image: quay.io/kubevirt/virt-exportserver@sha256:b031f8ff964e2e8c4653a616930645ebbbb9c376d12609dd211966b013a2539a
+  - image: quay.io/kubevirt/virt-exportserver@sha256:09bfbf6b1b911c5e641c601470ab34c2a69c81610d0c3a9a64ee89a18bc69415
     name: virt-exportserver
-  - image: quay.io/kubevirt/virt-handler@sha256:ce092fe4988a281b2ca6afe1ebfba7bd9073d50b433c63cfb19d1a9854c37004
+  - image: quay.io/kubevirt/virt-handler@sha256:162887264d760869f867eed68ea26489d485ed36022410b502ff7f018938bad8
     name: virt-handler
-  - image: quay.io/kubevirt/virt-launcher@sha256:a4d63bbea787a10209da5e946b4086608e4078e93bb34f8aa30fb77a3b773830
+  - image: quay.io/kubevirt/virt-launcher@sha256:66fd042603f2f11e8e279dea52fdeef789d0b4d281ee3fa08437f50b331d5833
     name: virt-launcher
-  - image: quay.io/kubevirt/virt-operator@sha256:e0d40ae75785224f0e8c26f5b657a842e149251ac18e04e19d60c29509dbb376
+  - image: quay.io/kubevirt/virt-operator@sha256:fea0eac792ca269f936a9171e4e1f3b6be8319fe5550e63b00f3f63ffb82d1ef
     name: virt-operator
+  - image: quay.io/kubevirt/virt-synchronization-controller@sha256:4c236292e2081ca2a5b705c99e073edd2603a16c0dd510a9932890aa57f9aa14
+    name: virt-synchronization-controller
   - image: quay.io/kubevirt/virtio-container-disk@sha256:bf2c634591d7fca1b90479785084fa108a66fe9da6777c4312bb4f57cc837faa
     name: virtio-container-disk
+  - image: quay.io/openshift-virtualization/wasp-agent@sha256:eabfa6a425213f520f7a9e5b81b43e8b6430779d42c5c8b1bfd48a4f1730447a
+    name: wasp-agent
   replaces: kubevirt-hyperconverged-operator.v1.15.0
   selector:
     matchLabels:
       alm-owner-kubevirt: kubevirt-hyperconverged
       operated-by: kubevirt-hyperconverged
-  version: 1.15.2
+  version: 1.16.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1beta1

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.3/manifests/kubevirt-hyperconverged-operator.v1.15.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.15.3/manifests/kubevirt-hyperconverged-operator.v1.15.3.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.15.3-unstable
-    createdAt: "2025-08-11 11:13:56"
+    createdAt: "2025-09-10 09:19:54"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -3085,6 +3085,10 @@ spec:
                   initialDelaySeconds: 30
                   periodSeconds: 5
                 name: hyperconverged-cluster-operator
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
                 readinessProbe:
                   failureThreshold: 1
                   httpGet:
@@ -3150,6 +3154,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: HCO_KV_IO_VERSION
+                  value: 1.15.3
                 image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.15.3-unstable
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
@@ -3161,6 +3167,13 @@ spec:
                   initialDelaySeconds: 30
                   periodSeconds: 5
                 name: hyperconverged-cluster-webhook
+                ports:
+                - containerPort: 4343
+                  name: webhook
+                  protocol: TCP
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
                 readinessProbe:
                   failureThreshold: 1
                   httpGet:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -81,6 +81,10 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 5
         name: hyperconverged-cluster-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:
@@ -148,6 +152,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: HCO_KV_IO_VERSION
+          value: 1.15.3
         image: quay.io/kubevirt/hyperconverged-cluster-webhook:1.15.3-unstable
         imagePullPolicy: Always
         livenessProbe:
@@ -159,6 +165,13 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 5
         name: hyperconverged-cluster-webhook
+        ports:
+        - containerPort: 4343
+          name: webhook
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/kubevirt/hyperconverged-cluster-operator
 
-go 1.23.6
+go 1.24.0
+
+toolchain go1.24.5
 
 require (
 	dario.cat/mergo v1.0.1
@@ -19,7 +21,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20190517100836-d5b34b957e91+incompatible
 	github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20250410114548-481d56a6c34e
 	github.com/openshift/custom-resource-status v1.1.2
-	github.com/openshift/library-go v0.0.0-20250402180609-ce2ba53fb2a4
+	github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a
 	github.com/operator-framework/api v0.30.0
 	github.com/operator-framework/operator-lib v0.17.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.81.0
@@ -33,10 +35,10 @@ require (
 	golang.org/x/tools v0.32.0
 	gomodules.xyz/jsonpatch/v2 v2.5.0
 	gopkg.in/yaml.v3 v3.0.1
-	k8s.io/api v0.32.3
-	k8s.io/apiextensions-apiserver v0.32.3
-	k8s.io/apimachinery v0.32.3
-	k8s.io/apiserver v0.32.3
+	k8s.io/api v0.33.2
+	k8s.io/apiextensions-apiserver v0.33.2
+	k8s.io/apimachinery v0.33.2
+	k8s.io/apiserver v0.33.2
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.32.3
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20250410114548-481
 github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20250410114548-481d56a6c34e/go.mod h1:wl2qvwuZU+YWNingOkAzabrH5BJwd4OhUH5FAtOG00U=
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
-github.com/openshift/library-go v0.0.0-20250402180609-ce2ba53fb2a4 h1:MDnTCGqFUULZ4+0fr0sQYlB80yTun8nEZ062azvFSCk=
-github.com/openshift/library-go v0.0.0-20250402180609-ce2ba53fb2a4/go.mod h1:DAa3BGl0CFtkfJn/g5rU8kDDTErfMVA/QlFm4cvU+MI=
+github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a h1:wZ0M/4DgILzW+8NKcARzBSG7w/BlSjtjQlBUj/VCk+0=
+github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/operator-framework/api v0.30.0 h1:44hCmGnEnZk/Miol5o44dhSldNH0EToQUG7vZTl29kk=
 github.com/operator-framework/api v0.30.0/go.mod h1:FYxAPhjtlXSAty/fbn5YJnFagt6SpJZJgFNNbvDe5W0=
 github.com/operator-framework/operator-lib v0.17.0 h1:cbz51wZ9+GpWR1ZYP4CSKSSBxDlWxmmnseaHVZZjZt4=

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -98,8 +98,8 @@ func (c *ClusterInfoImp) Init(ctx context.Context, cl client.Client, logger logr
 	uiProxyVarValue, uiProxyVarExists := os.LookupEnv(KVUIProxyImageEnvV)
 	c.consolePluginImageProvided = uiPluginVarExists && len(uiPluginVarValue) > 0 && uiProxyVarExists && len(uiProxyVarValue) > 0
 
-	c.monitoringAvailable = isPrometheusExists(ctx, cl)
-	c.deschedulerAvailable = isDeschedulerExists(ctx, cl)
+	c.monitoringAvailable = isPrometheusExists(ctx, cl, logger)
+	c.deschedulerAvailable = isDeschedulerExists(ctx, cl, logger)
 	c.logger.Info("addOns ",
 		"monitoring", c.monitoringAvailable,
 		"kubeDescheduler", c.deschedulerAvailable,
@@ -181,7 +181,7 @@ func (c *ClusterInfoImp) IsDeschedulerAvailable() bool {
 }
 
 func (c *ClusterInfoImp) IsDeschedulerCRDDeployed(ctx context.Context, cl client.Client) bool {
-	return isCRDExists(ctx, cl, DeschedulerCRDName)
+	return isCRDExists(ctx, cl, DeschedulerCRDName, logr.FromContextOrDiscard(ctx))
 }
 
 func (c *ClusterInfoImp) IsRunningLocally() bool {
@@ -245,21 +245,30 @@ func getClusterBaseDomain(ctx context.Context, cl client.Client) (string, error)
 	return clusterDNS.Spec.BaseDomain, nil
 }
 
-func isPrometheusExists(ctx context.Context, cl client.Client) bool {
-	prometheusRuleCRDExists := isCRDExists(ctx, cl, PrometheusRuleCRDName)
-	serviceMonitorCRDExists := isCRDExists(ctx, cl, ServiceMonitorCRDName)
+func isPrometheusExists(ctx context.Context, cl client.Client, logger logr.Logger) bool {
+	prometheusRuleCRDExists := isCRDExists(ctx, cl, PrometheusRuleCRDName, logger)
+	serviceMonitorCRDExists := isCRDExists(ctx, cl, ServiceMonitorCRDName, logger)
 
 	return prometheusRuleCRDExists && serviceMonitorCRDExists
 }
 
-func isDeschedulerExists(ctx context.Context, cl client.Client) bool {
-	return isCRDExists(ctx, cl, DeschedulerCRDName)
+func isDeschedulerExists(ctx context.Context, cl client.Client, logger logr.Logger) bool {
+	return isCRDExists(ctx, cl, DeschedulerCRDName, logger)
 }
 
-func isCRDExists(ctx context.Context, cl client.Client, crdName string) bool {
+func isCRDExists(ctx context.Context, cl client.Client, crdName string, logger logr.Logger) bool {
 	found := &apiextensionsv1.CustomResourceDefinition{}
 	key := client.ObjectKey{Name: crdName}
 	err := cl.Get(ctx, key, found)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			logger.Error(err, "cannot find CRD", "CRD", crdName)
+		} else {
+			logger.Info("CRD not found", "CRD", crdName)
+		}
+	} else {
+		logger.Info("CRD found", "CRD", crdName)
+	}
 	return err == nil
 }
 

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -1,5 +1,12 @@
 package util
 
+// pod names
+const (
+	HCOOperatorName  = "hyperconverged-cluster-operator"
+	HCOWebhookName   = "hyperconverged-cluster-webhook"
+	CLIDownloadsName = "hyperconverged-cluster-cli-download"
+)
+
 // HCO common constants
 const (
 	OperatorNamespaceEnv             = "OPERATOR_NAMESPACE"
@@ -52,7 +59,8 @@ const (
 	// HyperConvergedName is the name of the HyperConverged resource that will be reconciled
 	HyperConvergedName           = "kubevirt-hyperconverged"
 	MetricsHost                  = "0.0.0.0"
-	MetricsPort            int32 = 8383
+	MetricsPort            int32 = 8443
+	MetricsPortName              = "metrics"
 	HealthProbeHost              = "0.0.0.0"
 	HealthProbePort        int32 = 6060
 	ReadinessEndpointName        = "/readyz"
@@ -61,6 +69,7 @@ const (
 	HCOMutatingWebhookPath       = "/mutate-hco-kubevirt-io-v1beta1-hyperconverged"
 	HCONSWebhookPath             = "/mutate-ns-hco-kubevirt-io"
 	WebhookPort                  = 4343
+	WebhookPortName              = "webhook"
 
 	WebhookCertName       = "apiserver.crt"
 	WebhookKeyName        = "apiserver.key"

--- a/tests/func-tests/main_test.go
+++ b/tests/func-tests/main_test.go
@@ -47,7 +47,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	if isOpenshift {
 		By("adding temporary route")
 		Eventually(ctx, func(g Gomega) error {
-			return tests.CreateTempRoute(ctx, controllerCli)
+			return tests.CreateTempOperatorRoute(ctx, controllerCli)
 		}).WithTimeout(time.Second * 60).
 			WithPolling(time.Second).
 			WithContext(ctx).
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 		if isOpenshift {
 			By("removing the temporary route")
 			Eventually(ctx, func() error {
-				return tests.DeleteTempRoute(ctx, controllerCli)
+				return tests.DeleteTempOperatorRoute(ctx, controllerCli)
 			}).WithTimeout(time.Second * 60).
 				WithPolling(time.Second).
 				WithContext(ctx).

--- a/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
@@ -110,15 +110,6 @@ func DefaultTLSVersion() uint16 {
 	return tls.VersionTLS12
 }
 
-// ciphersTLS13 copies golang 1.13 implementation, where TLS1.3 suites are not
-// configurable (cipherSuites field is ignored for TLS1.3 flows and all of the
-// below three - and none other - are used)
-var ciphersTLS13 = map[string]uint16{
-	"TLS_AES_128_GCM_SHA256":       tls.TLS_AES_128_GCM_SHA256,
-	"TLS_AES_256_GCM_SHA384":       tls.TLS_AES_256_GCM_SHA384,
-	"TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
-}
-
 var ciphers = map[string]uint16{
 	"TLS_RSA_WITH_RC4_128_SHA":                      tls.TLS_RSA_WITH_RC4_128_SHA,
 	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":                 tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
@@ -144,6 +135,9 @@ var ciphers = map[string]uint16{
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":        tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
 	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_AES_128_GCM_SHA256":                        tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":                        tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256":                  tls.TLS_CHACHA20_POLY1305_SHA256,
 }
 
 // openSSLToIANACiphersMap maps OpenSSL cipher suite names to IANA names
@@ -223,10 +217,6 @@ func CipherSuite(cipherName string) (uint16, error) {
 		return cipher, nil
 	}
 
-	if _, ok := ciphersTLS13[cipherName]; ok {
-		return 0, fmt.Errorf("all golang TLSv1.3 ciphers are always used for TLSv1.3 flows")
-	}
-
 	return 0, fmt.Errorf("unknown cipher name %q", cipherName)
 }
 
@@ -281,6 +271,9 @@ func DefaultCiphers() []uint16 {
 		// tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,       // forbidden by http/2, disabled to mitigate SWEET32 attack
 		tls.TLS_RSA_WITH_AES_128_CBC_SHA, // forbidden by http/2
 		tls.TLS_RSA_WITH_AES_256_CBC_SHA, // forbidden by http/2
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
 	}
 }
 
@@ -636,7 +629,7 @@ func MakeSelfSignedCAConfig(name string, lifetime time.Duration) (*TLSCertificat
 func MakeSelfSignedCAConfigForSubject(subject pkix.Name, lifetime time.Duration) (*TLSCertificateConfig, error) {
 	if lifetime <= 0 {
 		lifetime = DefaultCACertificateLifetimeDuration
-		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %d years!\n", subject.CommonName, lifetime)
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
 	}
 
 	if lifetime > DefaultCACertificateLifetimeDuration {
@@ -1025,7 +1018,7 @@ func newSigningCertificateTemplateForDuration(subject pkix.Name, caLifetime time
 func newServerCertificateTemplate(subject pkix.Name, hosts []string, lifetime time.Duration, currentTime func() time.Time, authorityKeyId, subjectKeyId []byte) *x509.Certificate {
 	if lifetime <= 0 {
 		lifetime = DefaultCertificateLifetimeDuration
-		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %d years!\n", subject.CommonName, lifetime)
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
 	}
 
 	if lifetime > DefaultCertificateLifetimeDuration {
@@ -1112,7 +1105,7 @@ func CertsFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {
 func NewClientCertificateTemplate(subject pkix.Name, lifetime time.Duration, currentTime func() time.Time) *x509.Certificate {
 	if lifetime <= 0 {
 		lifetime = DefaultCertificateLifetimeDuration
-		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %d years!\n", subject.CommonName, lifetime)
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
 	}
 
 	if lifetime > DefaultCertificateLifetimeDuration {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -204,8 +204,8 @@ github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
 github.com/openshift/custom-resource-status/objectreferences/v1
-# github.com/openshift/library-go v0.0.0-20250402180609-ce2ba53fb2a4
-## explicit; go 1.23.0
+# github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a
+## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/crypto
 # github.com/operator-framework/api v0.30.0
 ## explicit; go 1.23.0
@@ -426,7 +426,7 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# k8s.io/api v0.32.3 => k8s.io/api v0.32.3
+# k8s.io/api v0.33.2 => k8s.io/api v0.32.3
 ## explicit; go 1.23.0
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
@@ -486,12 +486,12 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 k8s.io/api/storagemigration/v1alpha1
-# k8s.io/apiextensions-apiserver v0.32.3 => k8s.io/apiextensions-apiserver v0.32.3
+# k8s.io/apiextensions-apiserver v0.33.2 => k8s.io/apiextensions-apiserver v0.32.3
 ## explicit; go 1.23.0
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
-# k8s.io/apimachinery v0.32.3 => k8s.io/apimachinery v0.32.3
+# k8s.io/apimachinery v0.33.2 => k8s.io/apimachinery v0.32.3
 ## explicit; go 1.23.0
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
@@ -555,7 +555,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/apiserver v0.32.3 => k8s.io/apiserver v0.32.3
+# k8s.io/apiserver v0.33.2 => k8s.io/apiserver v0.32.3
 ## explicit; go 1.23.0
 k8s.io/apiserver/pkg/admission/plugin/webhook/errors
 k8s.io/apiserver/pkg/authentication/user


### PR DESCRIPTION
**What this PR does / why we need it**:
> **NOTE**: This is a semi-manual cherry-pick of #3708 and #3739 

PR #3303 introduced an authorization protection for the metrics endpoints in the operator and the webhook pods.

The HCO logic creates the Bearer token for the operator, but not for the webhook, as the operator does not have access to the webhook secrets, and it can't produce the bearer token for it.

The meaning of this is that the metrics endpoint of the webhook became not accessible, because there is no way to get the bearer token. And the meaning of that, is that Prometheus can't get any metric information from the webhook.

This PR fixes the issue by adding a new controller to the webhook pod, to create the required resources (a service, a bearer token secret, and a ServiceMonitor). Now Prometheus can fetch the bearer token and use it, and webhook metrics are visible.


### Move the APIServer controller into sub-pkg
The APIServer controller is currenlty the only webhook controller. In order to later add another webhook controller, move the webhook controller files into the new
"controllers/webhooks/apiserver-controller" sub-package.



### Expose several functions and consts in the alerts pkg
In order to share code with the new WH bearer token reconciler, expose several functions and consts.

### Add new Bearer token controller to the WH
The metrics endpoint in the operator and the webhook are protected with a bearer token. However, the creation of the related resources are only done for the operator. That makes the webhook metrics endpoint non-accessible.

This commit adds a controller to the webhook, to ceate and reconcile the missing resources.

### add e2e test to validate the WH bearer token

### fix bug: remove 3 left over services after uninstalling HCO

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where the webhook's metrics endpoint was not accessible.
```
