### PR TITLE
On metric token refresh, also delete the ServiceMonitor

### DIFF
--- a/controllers/alerts/reconciler.go
+++ b/controllers/alerts/reconciler.go
@@ -81,13 +81,14 @@ func getReconcilers(ci hcoutil.ClusterInfo, namespace string, owner metav1.Owner
 		logger.Error(err, "failed to create the 'PrometheusRule' reconciler")
 	}
 
+	refresh := NewRefresher()
 	reconcilers := []MetricReconciler{
 		alertRuleReconciler,
 		newRoleReconciler(namespace, owner),
 		newRoleBindingReconciler(namespace, owner, ci),
 		newMetricServiceReconciler(namespace, owner),
-		NewSecretReconciler(namespace, owner, secretName, newSecret),
-		newServiceMonitorReconciler(namespace, owner),
+		NewSecretReconciler(namespace, owner, secretName, newSecret, refresh),
+		newServiceMonitorReconciler(namespace, owner, refresh),
 	}
 
 	return reconcilers

--- a/controllers/alerts/refresher.go
+++ b/controllers/alerts/refresher.go
@@ -1,0 +1,46 @@
+package alerts
+
+import (
+	"sync"
+)
+
+type Refresher interface {
+	setShouldRefresh()
+	refresh(f func() error) error
+}
+
+type refresher struct {
+	*sync.Mutex
+	upToDate bool
+}
+
+func NewRefresher() Refresher {
+	return &refresher{
+		Mutex:    &sync.Mutex{},
+		upToDate: true,
+	}
+}
+
+func (r *refresher) setShouldRefresh() {
+	r.Lock()
+	defer r.Unlock()
+
+	r.upToDate = false
+}
+
+func (r *refresher) refresh(f func() error) error {
+	r.Lock()
+	defer r.Unlock()
+
+	if r.upToDate {
+		return nil
+	}
+
+	if err := f(); err != nil {
+		return err
+	}
+
+	r.upToDate = true
+
+	return nil
+}

--- a/controllers/webhooks/bearer-token-controller/bearer_token_controller.go
+++ b/controllers/webhooks/bearer-token-controller/bearer_token_controller.go
@@ -120,10 +120,12 @@ func (r *ReconcileWHBearerToken) Reconcile(ctx context.Context, request reconcil
 }
 
 func getReconcilers(_ hcoutil.ClusterInfo, namespace string, owner metav1.OwnerReference) []alerts.MetricReconciler {
+	refresher := alerts.NewRefresher()
+
 	reconcilers := []alerts.MetricReconciler{
 		newWHMetricServiceReconciler(namespace, owner),
-		newWHSecretReconciler(namespace, owner),
-		newWHServiceMonitorReconciler(namespace, owner),
+		newWHSecretReconciler(namespace, owner, refresher),
+		newWHServiceMonitorReconciler(namespace, owner, refresher),
 	}
 
 	return reconcilers

--- a/controllers/webhooks/bearer-token-controller/secret.go
+++ b/controllers/webhooks/bearer-token-controller/secret.go
@@ -11,8 +11,8 @@ const (
 	secretName = "hco-webhook-bearer-auth"
 )
 
-func newWHSecretReconciler(namespace string, owner metav1.OwnerReference) *alerts.SecretReconciler {
-	return alerts.NewSecretReconciler(namespace, owner, secretName, newSecret)
+func newWHSecretReconciler(namespace string, owner metav1.OwnerReference, refresher alerts.Refresher) *alerts.SecretReconciler {
+	return alerts.NewSecretReconciler(namespace, owner, secretName, newSecret, refresher)
 }
 
 func newSecret(namespace string, owner metav1.OwnerReference, token string) *corev1.Secret {

--- a/controllers/webhooks/bearer-token-controller/serviceMonitor.go
+++ b/controllers/webhooks/bearer-token-controller/serviceMonitor.go
@@ -9,8 +9,8 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts"
 )
 
-func newWHServiceMonitorReconciler(namespace string, owner metav1.OwnerReference) *alerts.ServiceMonitorReconciler {
-	return alerts.CreateServiceMonitorReconciler(newServiceMonitor(namespace, owner))
+func newWHServiceMonitorReconciler(namespace string, owner metav1.OwnerReference, refresher alerts.Refresher) *alerts.ServiceMonitorReconciler {
+	return alerts.CreateServiceMonitorReconciler(newServiceMonitor(namespace, owner), refresher)
 }
 
 func newServiceMonitor(namespace string, owner metav1.OwnerReference) *monitoringv1.ServiceMonitor {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, on token refresh, we're recreating the secret. But Prometheus does not fetch the new secret, and fails to access the metrics endpoint, rceiving 401 from the pod.

This PR fixes the issue by also remove the ServiceMonitor, letting the next reconcile loop to re-create it, to force Prometheus, afer a few minutes, to re fetch the token from the secret.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
