### PR TITLE
Fix the flaky MediatedDevices e2e test

### DIFF
--- a/controllers/alerts/reconciler.go
+++ b/controllers/alerts/reconciler.go
@@ -153,6 +153,8 @@ func (r *MonitoringReconciler) reconcileOneResource(req *common.HcoRequest, reco
 		return nil, err
 	}
 
+	req.Logger.Info(reconciler.Kind()+" already exists", reconciler.Kind()+".Namespace", r.namespace, reconciler.Kind()+".Name", reconciler.ResourceName())
+
 	resource, updated, err := reconciler.UpdateExistingResource(req.Ctx, r.client, existing, req.Logger)
 	if err != nil {
 		r.eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "UnexpectedError", fmt.Sprintf("failed to update the %s %s", reconciler.ResourceName(), reconciler.Kind()))

--- a/controllers/alerts/secret.go
+++ b/controllers/alerts/secret.go
@@ -96,6 +96,7 @@ func (r *SecretReconciler) UpdateExistingResource(ctx context.Context, cl client
 	}
 
 	// If the token is incorrect, delete the old secret and create a new one
+	logger.Info("the Secret token is outdated, deleting the old secret and creating a new one", "namespace", found.Namespace, "name", found.Name)
 	if err = cl.Delete(ctx, found); err != nil {
 		if !errors.IsNotFound(err) {
 			logger.Error(err, "failed to delete old secret")
@@ -113,6 +114,8 @@ func (r *SecretReconciler) UpdateExistingResource(ctx context.Context, cl client
 		logger.Error(err, "failed to create new secret")
 		return nil, false, err
 	}
+
+	logger.Info("successfully created the new secret", "namespace", sec.GetNamespace(), "name", sec.GetName())
 
 	return sec, true, nil
 }

--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -127,6 +127,13 @@ echo "Exiting... Exit code: $exitCode"
 # exit non-zero if exit code of functest is not zero
 [[ "${exitCode}" == "0" ]]
 
+echo "Read the HCO operator and webhook logs, before they are being deleted"
+LOG_DIR="${OUTPUT_DIR}/logs_after_test"
+mkdir -p "${LOG_DIR}"
+for pod in $(${KUBECTL_BINARY} get pod -n ${INSTALLED_NAMESPACE} -l "name in (hyperconverged-cluster-operator,hyperconverged-cluster-webhook)" -o jsonpath='{.items[*].metadata.name}'); do
+  ${KUBECTL_BINARY} logs -n ${INSTALLED_NAMESPACE} "${pod}" > "${LOG_DIR}/${pod}.log"
+done
+
 # Brutally delete HCO removing the namespace where it's running"
 source hack/test_delete_ns.sh
 CMD=${KUBECTL_BINARY} test_delete_ns

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -131,7 +131,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 				}
 				sort.Strings(imageNames)
 				return imageNames
-			}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Equal(expectedImages))
+			}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Equal(expectedImages))
 		})
 
 		It("should have all the images in the HyperConverged status", func(ctx context.Context) {
@@ -147,7 +147,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				sort.Strings(imageNames)
 				return imageNames
-			}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Equal(expectedImages))
+			}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Equal(expectedImages))
 		})
 
 		It("should have all the DataImportCron resources", func(ctx context.Context) {
@@ -250,7 +250,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			patch := []byte(`[{ "op": "replace", "path": "/spec/enableCommonBootImageImport", "value": true }]`)
 			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
+			}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
 		})
 
 		var isEntries []TableEntry
@@ -375,8 +375,8 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			const patchTmplt = `[{ "op": "replace", "path": "/spec/featureGates/enableMultiArchBootImageImport", "value": %t }]`
 			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, []byte(fmt.Sprintf(patchTmplt, true)))
-			}).WithTimeout(10 * time.Second).
-				WithPolling(500 * time.Millisecond).
+			}).WithTimeout(time.Minute).
+				WithPolling(10 * time.Second).
 				WithContext(ctx).
 				Should(Succeed())
 
@@ -864,7 +864,7 @@ func removeCustomDICTFromHC(ctx context.Context, cli client.Client) {
 	// clear the DICTs if they exist. ignore error of not found, as it may not exist
 	Eventually(func(ctx context.Context) error {
 		return tests.PatchHCO(ctx, cli, []byte(`[{"op": "remove", "path": "/spec/dataImportCronTemplates"}]`))
-	}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).
+	}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).
 		Should(Or(Not(HaveOccurred()), MatchError(ContainSubstring("the server rejected our request due to an error in our request"))))
 
 	Eventually(func(g Gomega, ctx context.Context) {
@@ -876,8 +876,8 @@ func removeCustomDICTFromHC(ctx context.Context, cli client.Client) {
 			g.Expect(dictStatus.Status.CommonTemplate).To(BeTrueBecause("should only have common DICT, but found non-common DICT %q", dictStatus.Name))
 			g.Expect(dictStatus.Status.Modified).To(BeFalseBecause("All DICTs should not be modified, but found modified DICT %q", dictStatus.Name))
 		}
-	}).WithTimeout(60 * time.Second).
-		WithPolling(time.Second).WithContext(ctx).
+	}).WithTimeout(time.Minute).
+		WithPolling(10 * time.Second).WithContext(ctx).
 		Should(Succeed())
 }
 

--- a/tests/func-tests/utils.go
+++ b/tests/func-tests/utils.go
@@ -159,7 +159,7 @@ func UpdateHCORetry(ctx context.Context, cli client.Client, input *v1beta1.Hyper
 
 		output, err = UpdateHCO(ctx, cli, hco)
 		return err
-	}).WithTimeout(10 * time.Second).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+	}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
 
 	return output
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Give some more time to update the HyperConverged CR, to avoid conflict error.

Also, the current test is actually two tests, with big "if". This Pr splits the test into two tests, to get better readability and maintenance.

**Additional small changes**:
* On successful tests, the install namespace is deleted, with all the pods and all the other resources.

  When extra-gather is called, the HCO pods are not running, and we don't have their logs. Many time these logs are needed, even if the tests passed. For example, to compare with failed test lane. This PR also reads the operator and the webhook logs before killing them.

* Add some missing log lines in the alerts controller.

**Release note**:
```release-note
None
```
