### PR TITLE
Handle empty Network string

### DIFF
--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -681,6 +681,10 @@ func hcLiveMigrationToKv(lm hcov1beta1.LiveMigrationConfigurations) (*kubevirtco
 		bandwidthPerMigration = &bandwidthPerMigrationObject
 	}
 
+	if lm.Network != nil && *lm.Network == "" {
+		lm.Network = nil
+	}
+
 	return &kubevirtcorev1.MigrationConfiguration{
 		BandwidthPerMigration:             bandwidthPerMigration,
 		CompletionTimeoutPerGiB:           lm.CompletionTimeoutPerGiB,

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -4237,6 +4237,17 @@ Version: 1.2.3`)
 			Expect(mc.AllowPostCopy).To(HaveValue(BeTrue()))
 		})
 
+		It("should create valid KV LM config from Network with empty string", func() {
+
+			lmc := hcov1beta1.LiveMigrationConfigurations{
+				Network: ptr.To(""),
+			}
+
+			mc, err := hcLiveMigrationToKv(lmc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mc.Network).To(BeNil())
+		})
+
 		It("should create valid empty KV LM config from a valid empty HC LM config", func() {
 			lmc := hcov1beta1.LiveMigrationConfigurations{}
 			mc, err := hcLiveMigrationToKv(lmc)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR fixes an issue where liveMigrationConfig.network: "" (empty string) causes an error. When the network field is null or omitted, the default network is used. With this fix, an empty string will also default to the network instead of throwing an error.

This fix is needed because, in ACM, we deliver HyperConverged with an [AddonTemplate](https://open-cluster-management.io/docs/concepts/add-on-extensibility/addon/)
. We use a customVariable for the network field.
Users can provide a network name for their managed clusters. However, when this variable is left empty, it becomes an empty string (""), which causes an error and prevents HyperConverged from installing CNV.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [x] PR Message
- [ ] Commit Messages
- [x] How to test
- [ v] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
