### PR TITLE
memory overcommit: bump minimum to 10 to match KubeVirt

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -237,7 +237,7 @@ type HyperConvergedSpec struct {
 	// +optional
 	ApplicationAwareConfig *ApplicationAwareConfigurations `json:"applicationAwareConfig,omitempty"`
 
-	// HigherWorkloadDensity holds configurataion aimed to increase virtual machine density
+	// HigherWorkloadDensity holds configuration aimed to increase virtual machine density
 	// +kubebuilder:default={"memoryOvercommitPercentage": 100}
 	// +default={"memoryOvercommitPercentage": 100}
 	// +optional
@@ -856,13 +856,13 @@ type ApplicationAwareConfigurations struct {
 	AllowApplicationAwareClusterResourceQuota bool `json:"allowApplicationAwareClusterResourceQuota,omitempty"`
 }
 
-// HigherWorkloadDensity holds configurataion aimed to increase virtual machine density
+// HigherWorkloadDensity holds configuration aimed to increase virtual machine density
 type HigherWorkloadDensityConfiguration struct {
 	// MemoryOvercommitPercentage is the percentage of memory we want to give VMIs compared to the amount
 	// given to its parent pod (virt-launcher). For example, a value of 102 means the VMI will
 	// "see" 2% more memory than its parent pod. Values under 100 are effectively "undercommits".
 	// Overcommits can lead to memory exhaustion, which in turn can lead to crashes. Use carefully.
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=10
 	// +kubebuilder:default=100
 	// +default=100
 	MemoryOvercommitPercentage int `json:"memoryOvercommitPercentage,omitempty"`

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -662,7 +662,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedS
 					},
 					"higherWorkloadDensity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "HigherWorkloadDensity holds configurataion aimed to increase virtual machine density",
+							Description: "HigherWorkloadDensity holds configuration aimed to increase virtual machine density",
 							Default:     map[string]interface{}{"memoryOvercommitPercentage": 100},
 							Ref:         ref("github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1.HigherWorkloadDensityConfiguration"),
 						},

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -1212,7 +1212,7 @@ spec:
               higherWorkloadDensity:
                 default:
                   memoryOvercommitPercentage: 100
-                description: HigherWorkloadDensity holds configurataion aimed to increase
+                description: HigherWorkloadDensity holds configuration aimed to increase
                   virtual machine density
                 properties:
                   memoryOvercommitPercentage:
@@ -1222,7 +1222,7 @@ spec:
                       given to its parent pod (virt-launcher). For example, a value of 102 means the VMI will
                       "see" 2% more memory than its parent pod. Values under 100 are effectively "undercommits".
                       Overcommits can lead to memory exhaustion, which in turn can lead to crashes. Use carefully.
-                    minimum: 1
+                    minimum: 10
                     type: integer
                 type: object
               infra:

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -1212,7 +1212,7 @@ spec:
               higherWorkloadDensity:
                 default:
                   memoryOvercommitPercentage: 100
-                description: HigherWorkloadDensity holds configurataion aimed to increase
+                description: HigherWorkloadDensity holds configuration aimed to increase
                   virtual machine density
                 properties:
                   memoryOvercommitPercentage:
@@ -1222,7 +1222,7 @@ spec:
                       given to its parent pod (virt-launcher). For example, a value of 102 means the VMI will
                       "see" 2% more memory than its parent pod. Values under 100 are effectively "undercommits".
                       Overcommits can lead to memory exhaustion, which in turn can lead to crashes. Use carefully.
-                    minimum: 1
+                    minimum: 10
                     type: integer
                 type: object
               infra:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.17.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.17.0/manifests/hco00.crd.yaml
@@ -1212,7 +1212,7 @@ spec:
               higherWorkloadDensity:
                 default:
                   memoryOvercommitPercentage: 100
-                description: HigherWorkloadDensity holds configurataion aimed to increase
+                description: HigherWorkloadDensity holds configuration aimed to increase
                   virtual machine density
                 properties:
                   memoryOvercommitPercentage:
@@ -1222,7 +1222,7 @@ spec:
                       given to its parent pod (virt-launcher). For example, a value of 102 means the VMI will
                       "see" 2% more memory than its parent pod. Values under 100 are effectively "undercommits".
                       Overcommits can lead to memory exhaustion, which in turn can lead to crashes. Use carefully.
-                    minimum: 1
+                    minimum: 10
                     type: integer
                 type: object
               infra:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.17.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.17.0/manifests/hco00.crd.yaml
@@ -1212,7 +1212,7 @@ spec:
               higherWorkloadDensity:
                 default:
                   memoryOvercommitPercentage: 100
-                description: HigherWorkloadDensity holds configurataion aimed to increase
+                description: HigherWorkloadDensity holds configuration aimed to increase
                   virtual machine density
                 properties:
                   memoryOvercommitPercentage:
@@ -1222,7 +1222,7 @@ spec:
                       given to its parent pod (virt-launcher). For example, a value of 102 means the VMI will
                       "see" 2% more memory than its parent pod. Values under 100 are effectively "undercommits".
                       Overcommits can lead to memory exhaustion, which in turn can lead to crashes. Use carefully.
-                    minimum: 1
+                    minimum: 10
                     type: integer
                 type: object
               infra:

--- a/docs/api.md
+++ b/docs/api.md
@@ -108,7 +108,7 @@ DataImportCronTemplateStatus is a copy of a dataImportCronTemplate as defined in
 
 ## HigherWorkloadDensityConfiguration
 
-HigherWorkloadDensity holds configurataion aimed to increase virtual machine density
+HigherWorkloadDensity holds configuration aimed to increase virtual machine density
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
@@ -237,7 +237,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | ksmConfiguration | KSMConfiguration holds the information regarding the enabling the KSM in the nodes (if available). | *v1.KSMConfiguration |  | false |
 | networkBinding | NetworkBinding defines the network binding plugins. Those bindings can be used when defining virtual machine interfaces. | map[string]v1.InterfaceBindingPlugin |  | false |
 | applicationAwareConfig | ApplicationAwareConfig set the AAQ configurations | *[ApplicationAwareConfigurations](#applicationawareconfigurations) |  | false |
-| higherWorkloadDensity | HigherWorkloadDensity holds configurataion aimed to increase virtual machine density | *[HigherWorkloadDensityConfiguration](#higherworkloaddensityconfiguration) | {"memoryOvercommitPercentage": 100} | false |
+| higherWorkloadDensity | HigherWorkloadDensity holds configuration aimed to increase virtual machine density | *[HigherWorkloadDensityConfiguration](#higherworkloaddensityconfiguration) | {"memoryOvercommitPercentage": 100} | false |
 | enableCommonBootImageImport | Opt-in to automatic delivery/updates of the common data import cron templates. There are two sources for the data import cron templates: hard coded list of common templates, and custom (user defined) templates that can be added to the dataImportCronTemplates field. This field only controls the common templates. It is possible to use custom templates by adding them to the dataImportCronTemplates field. | *bool | true | false |
 | instancetypeConfig | InstancetypeConfig holds the configuration of instance type related functionality within KubeVirt. | *v1.InstancetypeConfiguration |  | false |
 | CommonInstancetypesDeployment | CommonInstancetypesDeployment holds the configuration of common-instancetypes deployment within KubeVirt. | *v1.CommonInstancetypesDeployment |  | false |

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -1212,7 +1212,7 @@ spec:
               higherWorkloadDensity:
                 default:
                   memoryOvercommitPercentage: 100
-                description: HigherWorkloadDensity holds configurataion aimed to increase
+                description: HigherWorkloadDensity holds configuration aimed to increase
                   virtual machine density
                 properties:
                   memoryOvercommitPercentage:
@@ -1222,7 +1222,7 @@ spec:
                       given to its parent pod (virt-launcher). For example, a value of 102 means the VMI will
                       "see" 2% more memory than its parent pod. Values under 100 are effectively "undercommits".
                       Overcommits can lead to memory exhaustion, which in turn can lead to crashes. Use carefully.
-                    minimum: 1
+                    minimum: 10
                     type: integer
                 type: object
               infra:

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -1212,7 +1212,7 @@ spec:
               higherWorkloadDensity:
                 default:
                   memoryOvercommitPercentage: 100
-                description: HigherWorkloadDensity holds configurataion aimed to increase
+                description: HigherWorkloadDensity holds configuration aimed to increase
                   virtual machine density
                 properties:
                   memoryOvercommitPercentage:
@@ -1222,7 +1222,7 @@ spec:
                       given to its parent pod (virt-launcher). For example, a value of 102 means the VMI will
                       "see" 2% more memory than its parent pod. Values under 100 are effectively "undercommits".
                       Overcommits can lead to memory exhaustion, which in turn can lead to crashes. Use carefully.
-                    minimum: 1
+                    minimum: 10
                     type: integer
                 type: object
               infra:


### PR DESCRIPTION
**What this PR does / why we need it**:
Until recently, KubeVirt had no restriction on the value of memoryOvercommit.
Instead of a minimum of 1 (which would multiply the guest memory by 100!) we opted for a minimum of 10, which is already an extreme value. It also ensures people won't set it to 1 thinking it's a 0/1 value for disabled/enabled.

I also fixed a typo.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Important: deployments that set a memoryOvercommitPercentage value below 10 need to bump to 10+ before upgrading.
```
