### PR TITLE
[release-1.14] On metric token refresh, also delete the ServiceMonitor (#3790)

### DIFF
--- a/controllers/alerts/metrics_test.go
+++ b/controllers/alerts/metrics_test.go
@@ -10,11 +10,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -122,6 +122,43 @@ var _ = Describe("alert tests", func() {
 			err := r.Reconcile(req, false)
 			Expect(err).To(MatchError(fakeError))
 		})
+
+		It("should recreate Secret, and delete ServiceMonitor, if token is changed", func(ctx context.Context) {
+			cl := commontestutils.InitClient([]client.Object{ns})
+			r := NewMonitoringReconciler(ci, cl, ee, commontestutils.GetScheme())
+
+			Expect(r.Reconcile(req, false)).To(Succeed())
+
+			// Secret
+			sec := &corev1.Secret{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: secretName}, sec)).To(Succeed())
+			Expect(sec.StringData).To(HaveKey("token"))
+
+			origToken := sec.StringData["token"]
+			sec.StringData["token"] = "some-wrong-token"
+			Expect(cl.Update(ctx, sec)).To(Succeed())
+
+			newSec := &corev1.Secret{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: secretName}, newSec)).To(Succeed())
+			Expect(newSec.StringData).To(HaveKey("token"))
+			Expect(newSec.StringData["token"]).To(Equal("some-wrong-token"))
+
+			// Reconcile should delete the old secret and create a new one
+			Expect(r.Reconcile(req, false)).To(Succeed())
+
+			newSec = &corev1.Secret{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: secretName}, newSec)).To(Succeed())
+			Expect(newSec.StringData).To(HaveKey("token"))
+			Expect(newSec.StringData["token"]).To(Equal(origToken))
+
+			newSM := &monitoringv1.ServiceMonitor{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: serviceName}, newSM)).To(MatchError(apierrors.IsNotFound, "not found error"))
+
+			Expect(r.Reconcile(req, false)).To(Succeed())
+			newSM = &monitoringv1.ServiceMonitor{}
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: serviceName}, newSM)).To(Succeed())
+		})
+
 	})
 
 	Context("test PrometheusRule", func() {
@@ -345,7 +382,7 @@ var _ = Describe("alert tests", func() {
 
 		It("should use the desired runbook URL template when its ENV Variable is set", func() {
 			desiredRunbookURLTemplate := "desired/runbookURL/template/%s"
-			os.Setenv(runbookURLTemplateEnv, desiredRunbookURLTemplate)
+			Expect(os.Setenv(runbookURLTemplateEnv, desiredRunbookURLTemplate)).To(Succeed())
 
 			err := rules.SetupRules()
 			Expect(err).ToNot(HaveOccurred())

--- a/controllers/alerts/reconciler.go
+++ b/controllers/alerts/reconciler.go
@@ -63,14 +63,16 @@ func NewMonitoringReconciler(ci hcoutil.ClusterInfo, cl client.Client, ee hcouti
 		logger.Error(err, "failed to create the 'PrometheusRule' reconciler")
 	}
 
+	refresh := NewRefresher()
+
 	return &MonitoringReconciler{
 		reconcilers: []MetricReconciler{
 			alertRuleReconciler,
 			newRoleReconciler(namespace, owner),
 			newRoleBindingReconciler(namespace, owner, ci),
 			newMetricServiceReconciler(namespace, owner),
-			newSecretReconciler(namespace, owner),
-			newServiceMonitorReconciler(namespace, owner),
+			NewSecretReconciler(namespace, owner, secretName, newSecret, refresh),
+			newServiceMonitorReconciler(namespace, owner, refresh),
 		},
 		scheme:       scheme,
 		client:       cl,

--- a/controllers/alerts/refresher.go
+++ b/controllers/alerts/refresher.go
@@ -1,0 +1,46 @@
+package alerts
+
+import (
+	"sync"
+)
+
+type Refresher interface {
+	setShouldRefresh()
+	refresh(f func() error) error
+}
+
+type refresher struct {
+	*sync.Mutex
+	upToDate bool
+}
+
+func NewRefresher() Refresher {
+	return &refresher{
+		Mutex:    &sync.Mutex{},
+		upToDate: true,
+	}
+}
+
+func (r *refresher) setShouldRefresh() {
+	r.Lock()
+	defer r.Unlock()
+
+	r.upToDate = false
+}
+
+func (r *refresher) refresh(f func() error) error {
+	r.Lock()
+	defer r.Unlock()
+
+	if r.upToDate {
+		return nil
+	}
+
+	if err := f(); err != nil {
+		return err
+	}
+
+	r.upToDate = true
+
+	return nil
+}


### PR DESCRIPTION
Currently, on token refresh, we're recreating the secret. But Prometheus does not fetch the new secret, and fails to access the metrics endpoint, rceiving 401 from the pod.

This PR fixes the issue by also remove the ServiceMonitor, letting the next reconcile loop to re-create it, to force Prometheus, afer a few minutes, to re fetch the token from the secret.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual cherry-pick of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3764

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/OCPBUGS-59858
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
On metric token refresh, also delete the ServiceMonitor
```
