### PR TITLE
Fix the failing nightly test

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -135,7 +135,7 @@ chmod +x operator-sdk
 OLM_VERSION=$(curl https://api.github.com/repos/operator-framework/operator-lifecycle-manager/releases/latest | jq -r .name)
 
 # start K8s cluster
-export KUBEVIRT_PROVIDER=k8s-1.32
+export KUBEVIRT_PROVIDER=k8s-1.34
 export KUBEVIRT_MEMORY_SIZE=12G
 export KUBEVIRT_NUM_NODES=4
 # cluster/kubevirtci_tag.txt is auto updated by hack/bump-kubevirtci.sh
@@ -145,12 +145,10 @@ make cluster-up
 export KUBECONFIG=$(_kubevirtci/cluster-up/kubeconfig.sh)
 export KUBECTL=$(pwd)/_kubevirtci/cluster-up/kubectl.sh
 
+CMD=${KUBECTL} ./hack/deploy-cert-manager.sh
+
 # install OLM on the cluster
 ./operator-sdk olm install --version "${OLM_VERSION}"
-
-# Deploy cert-manager for webhooks
-$KUBECTL apply -f deploy/cert-manager.yaml
-$KUBECTL -n cert-manager wait deployment/cert-manager-webhook --for=condition=Available --timeout="300s"
 
 trap "dump" INT TERM EXIT
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -4,6 +4,8 @@ set -ex
 
 hco_namespace=kubevirt-hyperconverged
 
+CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-"v1.18.2"}
+
 IS_OPENSHIFT=${IS_OPENSHIFT:-false}
 if kubectl api-resources |grep clusterversions |grep config.openshift.io; then
   IS_OPENSHIFT="true"
@@ -36,7 +38,7 @@ kubectl apply ${LABEL_SELECTOR_ARG} -f https://raw.githubusercontent.com/kubevir
 kubectl apply ${LABEL_SELECTOR_ARG} -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/application-aware-quota00.crd.yaml
 
 # Deploy cert-manager for webhook certificates
-kubectl apply ${LABEL_SELECTOR_ARG} -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/cert-manager.yaml
+kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
 kubectl -n cert-manager wait deployment/cert-manager --for=condition=Available --timeout="300s"
 kubectl -n cert-manager wait deployment/cert-manager-webhook --for=condition=Available --timeout="300s"
 

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -52,7 +52,7 @@ source hack/common.sh
 "${CMD}" delete -f _out/service_account.yaml --ignore-not-found || true
 
 # Remove cert-manager
-"${CMD}" delete -f _out/cert-manager.yaml --ignore-not-found || true
+"${CMD}" delete -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml" --ignore-not-found || true
 "${CMD}" delete validatingwebhookconfigurations cert-manager-webhook --ignore-not-found || true
 "${CMD}" delete mutatingwebhookconfigurations cert-manager-webhook --ignore-not-found || true
 "${CMD}" delete secrets -n kubevirt-hyperconverged -l controller.cert-manager.io/fao=true --ignore-not-found || true

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -39,6 +39,8 @@ KUBECTL=${KUBECTL:-}
 TEST_OUT_PATH=${TEST_OUT_PATH:-"tests/func-tests/_out"}
 JOB_TYPE=${JOB_TYPE:-}
 
+CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-"v1.18.2"}
+
 KUBECTL=$(which kubectl 2> /dev/null) || true
 
 if [ -z "${CMD}" ]; then

--- a/hack/deploy-cert-manager.sh
+++ b/hack/deploy-cert-manager.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+source hack/common.sh
+
+set -ex
+
+CERT_MANAGER_TIMEOUT=${CERT_MANAGER_TIMEOUT:-"120s"}
+
+echo "Installing cert-manager ${CERT_MANAGER_VERSION}"
+${CMD} apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
+
+echo "Waiting for cert-manager to be ready..."
+${CMD} wait --for=condition=Available --namespace=cert-manager deployment/cert-manager --timeout=${CERT_MANAGER_TIMEOUT}
+${CMD} wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-cainjector --timeout=${CERT_MANAGER_TIMEOUT}
+${CMD} wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=${CERT_MANAGER_TIMEOUT}
+
+echo "cert-manager ${CERT_MANAGER_VERSION} installed successfully"

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -114,9 +114,7 @@ if [ "$IS_OPENSHIFT" != "true" ]; then
     LABEL_SELECTOR_ARG="-l name!=ssp-operator,name!=hyperconverged-cluster-cli-download"
 fi
 
-# Deploy cert-manager for webhooks
-"${CMD}" apply -f _out/cert-manager.yaml
-"${CMD}" -n cert-manager wait deployment/cert-manager-webhook --for=condition=Available --timeout="300s"
+hack/deploy-cert-manager.sh
 
 # Deploy local manifests
 "${CMD}" apply $LABEL_SELECTOR_ARG -f _out/cluster_role.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

The test, as preparations, installs the latest version of OLM, then it installs the cert-manager.

But the latest version of OLM, rleased 2 days ago, requires cert-manager to be already installed.

This PR changes the order so the test will first install cert-manager, and only then install OLM.

Also, stop using the deploy/cert-manager.yaml file. Instead, use the file from the cert-manager source, directly.

We'll remove this file in a future PR.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
