### PR TITLE
release-bumper: Reduce the size of the branch matrix

### DIFF
--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -28,7 +28,7 @@ jobs:
           if [[ ${{ github.event_name }} == "workflow_dispatch" && ${{ github.ref }} != "refs/heads/main" ]]; then
             matrix="[{\"branch\": \"${GITHUB_REF#refs/heads/}\"}]"
           else
-            matrix=$(git for-each-ref --format='%(refname:short)' refs/remotes/origin | grep -e "origin/main" -e "origin/release-1.[0-9]\+$" | grep -v "release-1\.[0,1,2,3]$" | sed -r 's/origin\/(.*)/{"branch": "\1"}/g' | jq -s)
+            matrix=$(git for-each-ref --format='%(refname:short)' refs/remotes/origin  | grep -e "origin/release-1.[0-9]\+$" | sort -V -r | head -3 | sed -r 's/origin\/(.*)/{"branch": "\1"}/g' | jq -s '. += [{"branch": "main"}] | sort')
           fi
           echo "matrix={\"branches\":$(echo $matrix)}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We should only support the latest 3 versions. Also, the release-bumper bot always fails for older versions anyway.

This PR changes the bot to only check the main branch, and the latest versions release branchs. it will also reduce the resurces we're using for this bot.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
