### PR TITLE
[descheduler] properly support the graduated name of KubeVirtRelieveAndMigrate profile

### DIFF
--- a/controllers/descheduler/descheduler_controller.go
+++ b/controllers/descheduler/descheduler_controller.go
@@ -101,13 +101,9 @@ func (r *ReconcileDescheduler) isDeschedulerMisconfigured(ctx context.Context) (
 		return false, err
 	}
 
-	// TODO: modify this once deschedulerv1.RelieveAndMigrate will graduate, loosing
-	// the "Dev" prefix, and will be "KubeVirtRelieveAndMigrate", then we will need
-	// to change it to:
-	// misconfiguredDescheduler = slices.Contains(instance.Spec.Profiles, deschedulerv1.RelieveAndMigrate)
 	return !slices.ContainsFunc(instance.Spec.Profiles, func(profile deschedulerv1.DeschedulerProfile) bool {
 		switch profile {
-		case deschedulerv1.RelieveAndMigrate, "KubeVirtRelieveAndMigrate":
+		case deschedulerv1.KubeVirtRelieveAndMigrate, deschedulerv1.DevKubeVirtRelieveAndMigrate, deschedulerv1.LifecycleAndUtilization:
 			return true
 		}
 		return false

--- a/controllers/descheduler/descheduler_controller_test.go
+++ b/controllers/descheduler/descheduler_controller_test.go
@@ -91,7 +91,7 @@ var _ = Describe("DeschedulerController", func() {
 					},
 					BeTrue(),
 				),
-				Entry("should set the metric to false for the KubeDescheduler with a valid configuration",
+				Entry("should set the metric to false for the KubeDescheduler with a valid configuration - LifecycleAndUtilization",
 					[]client.Object{
 						&deschedulerv1.KubeDescheduler{
 							ObjectMeta: metav1.ObjectMeta{
@@ -100,12 +100,44 @@ var _ = Describe("DeschedulerController", func() {
 							},
 							Spec: deschedulerv1.KubeDeschedulerSpec{
 								Profiles: []deschedulerv1.DeschedulerProfile{
-									deschedulerv1.RelieveAndMigrate,
+									deschedulerv1.LifecycleAndUtilization,
+								},
+							},
+						},
+					},
+					BeFalse(),
+				),
+				Entry("should set the metric to false for the KubeDescheduler with a valid configuration - DevKubeVirtRelieveAndMigrate",
+					[]client.Object{
+						&deschedulerv1.KubeDescheduler{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      hcoutil.DeschedulerCRName,
+								Namespace: hcoutil.DeschedulerNamespace,
+							},
+							Spec: deschedulerv1.KubeDeschedulerSpec{
+								Profiles: []deschedulerv1.DeschedulerProfile{
+									deschedulerv1.DevKubeVirtRelieveAndMigrate,
 								},
 								ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
 									DevDeviationThresholds:      &deschedulerv1.AsymmetricLowDeviationThreshold,
 									DevEnableSoftTainter:        true,
 									DevActualUtilizationProfile: deschedulerv1.PrometheusCPUCombinedProfile,
+								},
+							},
+						},
+					},
+					BeFalse(),
+				),
+				Entry("should set the metric to false for the KubeDescheduler with a valid configuration - KubeVirtRelieveAndMigrate",
+					[]client.Object{
+						&deschedulerv1.KubeDescheduler{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      hcoutil.DeschedulerCRName,
+								Namespace: hcoutil.DeschedulerNamespace,
+							},
+							Spec: deschedulerv1.KubeDeschedulerSpec{
+								Profiles: []deschedulerv1.DeschedulerProfile{
+									deschedulerv1.KubeVirtRelieveAndMigrate,
 								},
 							},
 						},

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
 	github.com/openshift/api v3.9.1-0.20190517100836-d5b34b957e91+incompatible
-	github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20250410114548-481d56a6c34e
+	github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20251008211450-f537ae654848
 	github.com/openshift/custom-resource-status v1.1.2
 	github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a
 	github.com/operator-framework/api v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/openshift/api v0.0.0-20250409155250-8fcc4e71758a h1:d2WEiysc+Gx51E5pQUvB5CHuXiUTsuZdKZNPHkGAZZg=
 github.com/openshift/api v0.0.0-20250409155250-8fcc4e71758a/go.mod h1:yk60tHAmHhtVpJQo3TwVYq2zpuP70iJIFDCmeKMIzPw=
-github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20250410114548-481d56a6c34e h1:6wOQeIqOIoNdT+28OdECxT0TQ9NxkIzV7veI+IjOvUg=
-github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20250410114548-481d56a6c34e/go.mod h1:wl2qvwuZU+YWNingOkAzabrH5BJwd4OhUH5FAtOG00U=
+github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20251008211450-f537ae654848 h1:s700PiKhx3YqMQjR+T8EHLTkIw8sl9kgoWFfiSeEVMk=
+github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20251008211450-f537ae654848/go.mod h1:ei7BM+Y5K/THP2aLOpQVvd1vk5O3ZtomO9/wvW9PNFs=
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a h1:wZ0M/4DgILzW+8NKcARzBSG7w/BlSjtjQlBUj/VCk+0=

--- a/pkg/util/cluster_test.go
+++ b/pkg/util/cluster_test.go
@@ -214,7 +214,7 @@ var _ = Describe("test clusterInfo", func() {
 
 	DescribeTable(
 		"check Init on openshift, with KubeDescheduler CRD with a CR for it ...",
-		func(deschedulerCR *deschedulerv1.KubeDescheduler, expectedIsDeschedulerMisconfigured bool) {
+		func(deschedulerCR *deschedulerv1.KubeDescheduler) {
 			cl := fake.NewClientBuilder().
 				WithScheme(testScheme).
 				WithObjects(clusterVersion, infrastructure, ingress, apiServer, dns, ipv4network, deschedulerCRD, deschedulerNamespace, deschedulerCR).
@@ -235,10 +235,9 @@ var _ = Describe("test clusterInfo", func() {
 				},
 				Spec: deschedulerv1.KubeDeschedulerSpec{},
 			},
-			true,
 		),
 		Entry(
-			"with KubeVirt specific profile",
+			"with KubeVirt specific profile - KubeVirtRelieveAndMigrate",
 			&deschedulerv1.KubeDescheduler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      DeschedulerCRName,
@@ -246,7 +245,7 @@ var _ = Describe("test clusterInfo", func() {
 				},
 				Spec: deschedulerv1.KubeDeschedulerSpec{
 					Profiles: []deschedulerv1.DeschedulerProfile{
-						deschedulerv1.RelieveAndMigrate,
+						deschedulerv1.KubeVirtRelieveAndMigrate,
 					},
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
 						DevDeviationThresholds:      &deschedulerv1.AsymmetricLowDeviationThreshold,
@@ -255,7 +254,6 @@ var _ = Describe("test clusterInfo", func() {
 					},
 				},
 			},
-			false,
 		),
 		Entry(
 			"with obsolete configuration",
@@ -273,7 +271,6 @@ var _ = Describe("test clusterInfo", func() {
 					},
 				},
 			},
-			true,
 		),
 		Entry(
 			"with wrong configuration 1",
@@ -288,7 +285,6 @@ var _ = Describe("test clusterInfo", func() {
 					},
 				},
 			},
-			true,
 		),
 		Entry(
 			"with wrong configuration 2",
@@ -305,7 +301,6 @@ var _ = Describe("test clusterInfo", func() {
 					},
 				},
 			},
-			true,
 		),
 		Entry(
 			"with wrong configuration 3",
@@ -324,7 +319,6 @@ var _ = Describe("test clusterInfo", func() {
 					Mode:     "testvalue",
 				},
 			},
-			true,
 		),
 		Entry(
 			"with configuration tuned for KubeVirt but with a wrong name",
@@ -339,7 +333,6 @@ var _ = Describe("test clusterInfo", func() {
 					},
 				},
 			},
-			false,
 		),
 		Entry(
 			"with configuration tuned for KubeVirt but in the wrong namespace",
@@ -354,7 +347,6 @@ var _ = Describe("test clusterInfo", func() {
 					},
 				},
 			},
-			false,
 		),
 	)
 

--- a/vendor/github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/vendor/github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1/types_descheduler.go
@@ -50,6 +50,9 @@ type KubeDeschedulerSpec struct {
 type EvictionLimits struct {
 	// total restricts the maximum number of overall evictions
 	Total *int32 `json:"total,omitempty"`
+
+	// node restricts the maximum number of evictions per node
+	Node *int32 `json:"node,omitempty"`
 }
 
 // ProfileCustomizations contains various parameters for modifying the default behavior of certain profiles
@@ -78,6 +81,8 @@ type ProfileCustomizations struct {
 	// DevEnableSoftTainter enables SoftTainter alpha feature.
 	// The EnableSoftTainter alpha feature is a subject to change.
 	// Currently provided as an experimental feature.
+	// +kubebuilder:deprecatedversion:warning="devEnableSoftTainter field is deprecated and ignored"
+	// Deprecated: DevEnableSoftTainter field is deprecated and ignored.
 	DevEnableSoftTainter bool `json:"devEnableSoftTainter"`
 
 	// DevEnableEvictionsInBackground enables descheduler's EvictionsInBackground alpha feature.
@@ -191,7 +196,7 @@ type Namespaces struct {
 
 // DeschedulerProfile allows configuring the enabled strategy profiles for the descheduler
 // it allows multiple profiles to be enabled at once, which will have cumulative effects on the cluster.
-// +kubebuilder:validation:Enum=AffinityAndTaints;TopologyAndDuplicates;LifecycleAndUtilization;DevPreviewLongLifecycle;LongLifecycle;SoftTopologyAndDuplicates;EvictPodsWithLocalStorage;EvictPodsWithPVC;CompactAndScale;DevKubeVirtRelieveAndMigrate
+// +kubebuilder:validation:Enum=AffinityAndTaints;TopologyAndDuplicates;LifecycleAndUtilization;DevPreviewLongLifecycle;LongLifecycle;SoftTopologyAndDuplicates;EvictPodsWithLocalStorage;EvictPodsWithPVC;CompactAndScale;DevKubeVirtRelieveAndMigrate;KubeVirtRelieveAndMigrate
 type DeschedulerProfile string
 
 var (
@@ -226,8 +231,12 @@ var (
 	// CompactAndScale seeks to evict pods to enable the same workload to run on a smaller set of nodes.
 	CompactAndScale DeschedulerProfile = "CompactAndScale"
 
-	// RelieveAndMigrate seeks to evict pods from high-cost nodes to relieve overall expenses while considering workload migration.
-	RelieveAndMigrate DeschedulerProfile = "DevKubeVirtRelieveAndMigrate"
+	// KubeVirtRelieveAndMigrate seeks to evict pods from high-cost nodes to relieve overall expenses while considering workload migration.
+	KubeVirtRelieveAndMigrate DeschedulerProfile = "KubeVirtRelieveAndMigrate"
+
+	// DevKubeVirtRelieveAndMigrate seeks to evict pods from high-cost nodes to relieve overall expenses while considering workload migration.
+	// Deprecated: use KubeVirtRelieveAndMigrate instead
+	DevKubeVirtRelieveAndMigrate DeschedulerProfile = "DevKubeVirtRelieveAndMigrate"
 )
 
 // DeschedulerProfile allows configuring the enabled strategy profiles for the descheduler

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -289,8 +289,8 @@ github.com/openshift/api/operator/v1
 github.com/openshift/api/quota/v1
 github.com/openshift/api/route/v1
 github.com/openshift/api/security/v1
-# github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20250410114548-481d56a6c34e
-## explicit; go 1.23.3
+# github.com/openshift/cluster-kube-descheduler-operator v0.0.0-20251008211450-f537ae654848
+## explicit; go 1.24.2
 github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1
 # github.com/openshift/custom-resource-status v1.1.2
 ## explicit; go 1.12


### PR DESCRIPTION
**What this PR does / why we need it**:
Import a fresher descheduler operator.
Consume KubeVirtRelieveAndMigrate and DevKubeVirtRelieveAndMigrate with the p[roper names.
Consider the obsolete and not load aware `LifecycleAndUtilization` profile as still supported because it's still supported on the descheduler side.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [X] PR Message
- [X] Commit Messages
- [ ] How to test
- [X] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-67871
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Consider LifecycleAndUtilization descheduler profile as still supported
```
