### PR TITLE
CI: Fix the upgrade tests

### DIFF
--- a/hack/check-uptime.sh
+++ b/hack/check-uptime.sh
@@ -5,7 +5,7 @@ function check_uptime() {
   timeout=$2
 
   for _ in $(seq 1 $retries); do
-    BOOTTIME=$(~/virtctl ssh -i ./hack/test_ssh -n ${VMS_NAMESPACE} vmi/testvm --username=cirros --local-ssh=true --local-ssh-opts "-o UserKnownHostsFile=/dev/null" --local-ssh-opts "-o StrictHostKeyChecking=no" -c "echo BOOTTIME=\$((\$(date +%s) - \$(awk '{print int(\$1)}' /proc/uptime)))" 2>>/dev/null | grep "^BOOTTIME" | cut -d= -f2 | tr -dc '[:digit:]')
+    BOOTTIME=$(~/virtctl ssh -i ./hack/test_ssh -n ${VMS_NAMESPACE} vmi/testvm --username=cirros --local-ssh-opts "-o UserKnownHostsFile=/dev/null" --local-ssh-opts "-o StrictHostKeyChecking=no" -c "echo BOOTTIME=\$((\$(date +%s) - \$(awk '{print int(\$1)}' /proc/uptime)))" 2>>/dev/null | grep "^BOOTTIME" | cut -d= -f2 | tr -dc '[:digit:]')
     if [ -n "${BOOTTIME}" ]
       then
         echo "${BOOTTIME}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The upgrade tests are failing because the hack/check-uptime.sh is using the virtctl `--local-ssh=true` flag, that is no longer supported by virtctl in v1.7

The prev-upgrade tests are passing because the test uses the previous KubeVirt version to get virtctl version, and it's still v1.6.2. This is also why the bump PR for KV 1.7-beta.0 was passed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
