### PR TITLE
[Release 1.15] Fix kubevirt_hco_system_health_status

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1629,6 +1629,9 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(cond.Reason).To(Equal("HCOUpgrading"))
 					Expect(cond.Message).To(Equal("HCO is now upgrading to version " + newHCOVersion))
 
+					// system health should remain healthy during upgrade progression
+					verifySystemHealthStatusHealthy(foundResource)
+
 					// check that the upgrade is not done if the not all the versions are match.
 					// Conditions are valid
 					makeComponentReady()
@@ -1647,6 +1650,9 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 					Expect(cond.Reason).To(Equal("HCOUpgrading"))
 					Expect(cond.Message).To(Equal("HCO is now upgrading to version " + newHCOVersion))
+
+					// system health should remain healthy during upgrade progression
+					verifySystemHealthStatusHealthy(foundResource)
 
 					// now, complete the upgrade
 					updateComponentVersion()


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry pick of #3726

Fix kubevirt_hco_system_health_status.
System health should remain healthy during
upgrade progression.
**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-67426
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug in kubevirt_hco_system_health_status now reported as healthy also during upgrade.
```
