### PR TITLE
[release-1.14] Fix kubevirt_hco_system_health_status

### DIFF
--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -1011,7 +1011,7 @@ func (r *ReconcileHyperConverged) updateConditions(req *common.HcoRequest) {
 		req.StatusDirty = true
 	}
 
-	systemHealthStatus := r.getSystemHealthStatus(req.Conditions)
+	systemHealthStatus := r.getSystemHealthStatus(req)
 
 	if systemHealthStatus != req.Instance.Status.SystemHealthStatus {
 		req.Instance.Status.SystemHealthStatus = systemHealthStatus
@@ -1073,24 +1073,34 @@ func (r *ReconcileHyperConverged) detectTaintedConfiguration(req *common.HcoRequ
 	}
 }
 
-func (r *ReconcileHyperConverged) getSystemHealthStatus(conditions common.HcoConditions) string {
-	if isSystemHealthStatusError(conditions) {
+func (r *ReconcileHyperConverged) getSystemHealthStatus(req *common.HcoRequest) string {
+	if isSystemHealthStatusError(req) {
 		return systemHealthStatusError
 	}
 
-	if isSystemHealthStatusWarning(conditions) {
+	if isSystemHealthStatusWarning(req) {
 		return systemHealthStatusWarning
 	}
 
 	return systemHealthStatusHealthy
 }
 
-func isSystemHealthStatusError(conditions common.HcoConditions) bool {
-	return !conditions.IsStatusConditionTrue(hcov1beta1.ConditionAvailable) || conditions.IsStatusConditionTrue(hcov1beta1.ConditionDegraded)
+func isSystemHealthStatusError(req *common.HcoRequest) bool {
+	// During upgrade, only Degraded=True is an error. Temporary Available=false is expected.
+	if req.UpgradeMode {
+		return req.Conditions.IsStatusConditionTrue(hcov1beta1.ConditionDegraded)
+	}
+
+	return !req.Conditions.IsStatusConditionTrue(hcov1beta1.ConditionAvailable) || req.Conditions.IsStatusConditionTrue(hcov1beta1.ConditionDegraded)
 }
 
-func isSystemHealthStatusWarning(conditions common.HcoConditions) bool {
-	return !conditions.IsStatusConditionTrue(hcov1beta1.ConditionReconcileComplete) || conditions.IsStatusConditionTrue(hcov1beta1.ConditionProgressing)
+func isSystemHealthStatusWarning(req *common.HcoRequest) bool {
+	// During upgrade, treat health as non-warning while progressing; wait for reconcile complete.
+	if req.UpgradeMode {
+		return !req.Conditions.IsStatusConditionTrue(hcov1beta1.ConditionReconcileComplete)
+	}
+
+	return !req.Conditions.IsStatusConditionTrue(hcov1beta1.ConditionReconcileComplete) || req.Conditions.IsStatusConditionTrue(hcov1beta1.ConditionProgressing)
 }
 
 func getNumOfChangesJSONPatch(jsonPatch string) int {

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1681,6 +1681,9 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(cond.Reason).To(Equal("HCOUpgrading"))
 					Expect(cond.Message).To(Equal("HCO is now upgrading to version " + newHCOVersion))
 
+					// system health should remain healthy during upgrade progression
+					verifySystemHealthStatusHealthy(foundResource)
+
 					// check that the upgrade is not done if the not all the versions are match.
 					// Conditions are valid
 					makeComponentReady()
@@ -1699,6 +1702,9 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(cond.Status).To(BeEquivalentTo(metav1.ConditionTrue))
 					Expect(cond.Reason).To(Equal("HCOUpgrading"))
 					Expect(cond.Message).To(Equal("HCO is now upgrading to version " + newHCOVersion))
+
+					// system health should remain healthy during upgrade progression
+					verifySystemHealthStatusHealthy(foundResource)
 
 					// now, complete the upgrade
 					updateComponentVersion()


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry pick of #3726

Fix kubevirt_hco_system_health_status.
System health should remain healthy during
upgrade progression.
**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-67426
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug in kubevirt_hco_system_health_status now reported as healthy also during upgrade.
```
