### PR TITLE
remove SingleStackIPv6Unsupported alert

### DIFF
--- a/pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go
+++ b/pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go
@@ -10,7 +10,6 @@ const (
 	outOfBandUpdateAlert             = "KubeVirtCRModified"
 	unsafeModificationAlert          = "UnsupportedHCOModification"
 	installationNotCompletedAlert    = "HCOInstallationIncomplete"
-	singleStackIPv6Alert             = "SingleStackIPv6Unsupported"
 	MisconfiguredDeschedulerAlert    = "HCOMisconfiguredDescheduler"
 	unsupportedArchitecturesAlert    = "HCOGoldenImageWithNoSupportedArchitecture"
 	dictWithNoArchAnnotationAlert    = "HCOGoldenImageWithNoArchitectureAnnotation"
@@ -56,18 +55,6 @@ func operatorAlerts() []promv1.Rule {
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:     "info",
-				healthImpactAlertLabelKey: "critical",
-			},
-		},
-		{
-			Alert: singleStackIPv6Alert,
-			Expr:  intstr.FromString("kubevirt_hco_single_stack_ipv6 == 1"),
-			Annotations: map[string]string{
-				"description": "KubeVirt Hyperconverged is not supported on a single stack IPv6 cluster",
-				"summary":     "KubeVirt Hyperconverged is not supported on a single stack IPv6 cluster",
-			},
-			Labels: map[string]string{
-				severityAlertLabelKey:     "critical",
 				healthImpactAlertLabelKey: "critical",
 			},
 		},


### PR DESCRIPTION
Starting with 4.19, IPv6 single stack is not "Unsupported" as "SingleStackIPv6Unsupported" critical alert suggests. It is supported as a tech preview. this alert is not needed.


**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket 
https://issues.redhat.com/browse/CNV-63076
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
IPv6 single stack is not "Unsupported" as "SingleStackIPv6Unsupported" critical alert suggests. This alert is removed
```
