### PR TITLE
Deprecate the `spec.obsoleteCPUs.minCPUModel` field

### DIFF
--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -686,10 +686,8 @@ type OperandResourceRequirements struct {
 // HyperConvergedObsoleteCPUs allows avoiding scheduling of VMs for obsolete CPU models
 // +k8s:openapi-gen=true
 type HyperConvergedObsoleteCPUs struct {
-	// MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell.
-	// The default value for this field is nil, but in KubeVirt, the default value is "Penryn", if nothing else is set.
-	// Use this field to override KubeVirt default value.
-	// +optional
+	// MinCPUModel is not in use
+	// Deprecated: This field is not in use and is ignored.
 	MinCPUModel string `json:"minCPUModel,omitempty"`
 	// CPUModels is a list of obsolete CPU models. When the node-labeller obtains the list of obsolete CPU models, it
 	// eliminates those CPU models and creates labels for valid CPU models.

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -389,7 +389,7 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1beta1_HyperConvergedO
 				Properties: map[string]spec.Schema{
 					"minCPUModel": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell. The default value for this field is nil, but in KubeVirt, the default value is \"Penryn\", if nothing else is set. Use this field to override KubeVirt default value.",
+							Description: "MinCPUModel is not in use Deprecated: This field is not in use and is ignored.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2610,9 +2610,8 @@ spec:
                     x-kubernetes-list-type: set
                   minCPUModel:
                     description: |-
-                      MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell.
-                      The default value for this field is nil, but in KubeVirt, the default value is "Penryn", if nothing else is set.
-                      Use this field to override KubeVirt default value.
+                      MinCPUModel is not in use
+                      Deprecated: This field is not in use and is ignored.
                     type: string
                 type: object
               permittedHostDevices:

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -412,7 +412,7 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		return nil, err
 	}
 
-	obsoleteCPUs, minCPUModel := getObsoleteCPUConfig(hc.Spec.ObsoleteCPUs)
+	obsoleteCPUs := getObsoleteCPUConfig(hc.Spec.ObsoleteCPUs)
 
 	rateLimiter, err := hcoTuning2Kv(hc)
 	if err != nil {
@@ -433,7 +433,6 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 		PermittedHostDevices:         toKvPermittedHostDevices(hc.Spec.PermittedHostDevices),
 		MediatedDevicesConfiguration: toKvMediatedDevicesConfiguration(hc.Spec.MediatedDevicesConfiguration),
 		ObsoleteCPUModels:            obsoleteCPUs,
-		MinCPUModel:                  minCPUModel,
 		TLSConfiguration:             hcTLSSecurityProfileToKv(hcoutil.GetClusterInfo().GetTLSSecurityProfile(hc.Spec.TLSSecurityProfile)),
 		APIConfiguration:             rateLimiter,
 		WebhookConfiguration:         rateLimiter,
@@ -540,22 +539,19 @@ func getNetworkBindings(hcoNetworkBindings map[string]kubevirtcorev1.InterfaceBi
 	return networkBindings
 }
 
-func getObsoleteCPUConfig(hcObsoleteCPUConf *hcov1beta1.HyperConvergedObsoleteCPUs) (map[string]bool, string) {
+func getObsoleteCPUConfig(hcObsoleteCPUConf *hcov1beta1.HyperConvergedObsoleteCPUs) map[string]bool {
 	obsoleteCPUModels := make(map[string]bool)
 	for _, cpu := range hardcodedObsoleteCPUModels {
 		obsoleteCPUModels[cpu] = true
 	}
-	minCPUModel := ""
 
 	if hcObsoleteCPUConf != nil {
 		for _, cpu := range hcObsoleteCPUConf.CPUModels {
 			obsoleteCPUModels[cpu] = true
 		}
-
-		minCPUModel = hcObsoleteCPUConf.MinCPUModel
 	}
 
-	return obsoleteCPUModels, minCPUModel
+	return obsoleteCPUModels
 }
 
 func toKvMediatedDevicesConfiguration(mdevsConfig *hcov1beta1.MediatedDevicesConfiguration) *kubevirtcorev1.MediatedDevicesConfiguration {

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -2506,48 +2506,6 @@ Version: 1.2.3`)
 					for _, cpu := range hardcodedObsoleteCPUModels {
 						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
 					}
-
-					Expect(kv.Spec.Configuration.MinCPUModel).To(BeEmpty())
-				})
-
-				It("should add min CPU Model if exists in HC CR", func() {
-					hco.Spec.ObsoleteCPUs = &hcov1beta1.HyperConvergedObsoleteCPUs{
-						MinCPUModel: "Penryn",
-					}
-
-					kv, err := NewKubeVirt(hco)
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(kv.Spec.Configuration.ObsoleteCPUModels).ToNot(BeEmpty())
-					for _, cpu := range hardcodedObsoleteCPUModels {
-						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
-					}
-					Expect(kv.Spec.Configuration.MinCPUModel).To(Equal("Penryn"))
-				})
-
-				It("should not add min CPU Model and obsolete CPU Models if HC does not contain ObsoleteCPUs", func() {
-					kv, err := NewKubeVirt(hco)
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(len(hardcodedObsoleteCPUModels)))
-					for _, cpu := range hardcodedObsoleteCPUModels {
-						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
-					}
-
-					Expect(kv.Spec.Configuration.MinCPUModel).To(BeEmpty())
-				})
-
-				It("should not add min CPU Model and add only the hard coded obsolete CPU Models if ObsoleteCPUs is empty", func() {
-					hco.Spec.ObsoleteCPUs = &hcov1beta1.HyperConvergedObsoleteCPUs{}
-					kv, err := NewKubeVirt(hco)
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(kv.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(len(hardcodedObsoleteCPUModels)))
-					for _, cpu := range hardcodedObsoleteCPUModels {
-						Expect(kv.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
-					}
-
-					Expect(kv.Spec.Configuration.MinCPUModel).To(BeEmpty())
 				})
 			})
 
@@ -2557,8 +2515,7 @@ Version: 1.2.3`)
 					Expect(err).ToNot(HaveOccurred())
 
 					hco.Spec.ObsoleteCPUs = &hcov1beta1.HyperConvergedObsoleteCPUs{
-						CPUModels:   []string{"aaa", "bbb", "ccc"},
-						MinCPUModel: "Penryn",
+						CPUModels: []string{"aaa", "bbb", "ccc"},
 					}
 
 					cl := commontestutils.InitClient([]client.Object{hco, existingKV})
@@ -2576,7 +2533,7 @@ Version: 1.2.3`)
 							foundKV),
 					).ToNot(HaveOccurred())
 
-					By("KV CR should contain the HC obsolete CPU models and minCPUModel", func() {
+					By("KV CR should contain the HC obsolete CPU models", func() {
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("aaa", true))
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("bbb", true))
@@ -2584,8 +2541,6 @@ Version: 1.2.3`)
 						for _, cpu := range hardcodedObsoleteCPUModels {
 							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
 						}
-
-						Expect(foundKV.Spec.Configuration.MinCPUModel).To(Equal("Penryn"))
 					})
 
 				})
@@ -2593,7 +2548,6 @@ Version: 1.2.3`)
 				It("Should modify obsolete CPU model if they are not the same as in HC CR", func() {
 					existingKV, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					existingKV.Spec.Configuration.MinCPUModel = "Haswell"
 					existingKV.Spec.Configuration.ObsoleteCPUModels = map[string]bool{
 						"shouldStay":      true,
 						"shouldBeTrue":    false,
@@ -2601,8 +2555,7 @@ Version: 1.2.3`)
 					}
 
 					hco.Spec.ObsoleteCPUs = &hcov1beta1.HyperConvergedObsoleteCPUs{
-						CPUModels:   []string{"shouldStay", "shouldBeTrue", "newOne"},
-						MinCPUModel: "Penryn",
+						CPUModels: []string{"shouldStay", "shouldBeTrue", "newOne"},
 					}
 
 					cl := commontestutils.InitClient([]client.Object{hco, existingKV})
@@ -2620,7 +2573,7 @@ Version: 1.2.3`)
 							foundKV),
 					).ToNot(HaveOccurred())
 
-					By("KV CR should contain the HC obsolete CPU models and minCPUModel", func() {
+					By("KV CR should contain the HC obsolete CPU models", func() {
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("shouldStay", true))
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("shouldBeTrue", true))
@@ -2630,15 +2583,12 @@ Version: 1.2.3`)
 						}
 
 						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).ToNot(HaveKey("shouldBeRemoved"))
-
-						Expect(foundKV.Spec.Configuration.MinCPUModel).To(Equal("Penryn"))
 					})
 				})
 
 				It("Should remove obsolete CPU model if they are not set in HC CR", func() {
 					existingKV, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
-					existingKV.Spec.Configuration.MinCPUModel = "Penryn"
 					existingKV.Spec.Configuration.ObsoleteCPUModels = map[string]bool{
 						"aaa": true,
 						"bbb": true,
@@ -2665,10 +2615,6 @@ Version: 1.2.3`)
 						for _, cpu := range hardcodedObsoleteCPUModels {
 							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
 						}
-					})
-
-					By("KV CR minCPUModel field should be empty", func() {
-						Expect(foundKV.Spec.Configuration.MinCPUModel).To(BeEmpty())
 					})
 				})
 			})

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2610,9 +2610,8 @@ spec:
                     x-kubernetes-list-type: set
                   minCPUModel:
                     description: |-
-                      MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell.
-                      The default value for this field is nil, but in KubeVirt, the default value is "Penryn", if nothing else is set.
-                      Use this field to override KubeVirt default value.
+                      MinCPUModel is not in use
+                      Deprecated: This field is not in use and is ignored.
                     type: string
                 type: object
               permittedHostDevices:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.17.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.17.0/manifests/hco00.crd.yaml
@@ -2610,9 +2610,8 @@ spec:
                     x-kubernetes-list-type: set
                   minCPUModel:
                     description: |-
-                      MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell.
-                      The default value for this field is nil, but in KubeVirt, the default value is "Penryn", if nothing else is set.
-                      Use this field to override KubeVirt default value.
+                      MinCPUModel is not in use
+                      Deprecated: This field is not in use and is ignored.
                     type: string
                 type: object
               permittedHostDevices:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.17.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.17.0/manifests/hco00.crd.yaml
@@ -2610,9 +2610,8 @@ spec:
                     x-kubernetes-list-type: set
                   minCPUModel:
                     description: |-
-                      MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell.
-                      The default value for this field is nil, but in KubeVirt, the default value is "Penryn", if nothing else is set.
-                      Use this field to override KubeVirt default value.
+                      MinCPUModel is not in use
+                      Deprecated: This field is not in use and is ignored.
                     type: string
                 type: object
               permittedHostDevices:

--- a/docs/api.md
+++ b/docs/api.md
@@ -195,7 +195,7 @@ HyperConvergedObsoleteCPUs allows avoiding scheduling of VMs for obsolete CPU mo
 
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | -------- |-------- |
-| minCPUModel | MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell. The default value for this field is nil, but in KubeVirt, the default value is \"Penryn\", if nothing else is set. Use this field to override KubeVirt default value. | string |  | false |
+| minCPUModel | MinCPUModel is not in use Deprecated: This field is not in use and is ignored. | string |  | false |
 | cpuModels | CPUModels is a list of obsolete CPU models. When the node-labeller obtains the list of obsolete CPU models, it eliminates those CPU models and creates labels for valid CPU models. The default values for this field is nil, however, HCO uses opinionated values, and adding values to this list will add them to the opinionated values. | []string |  | false |
 
 [Back to TOC](#table-of-contents)

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -657,13 +657,11 @@ HyperConverged custom resource, you can exclude them from the list of labels cre
 Through the process of iteration, the list of base CPU features in the minimum CPU model are eliminated from the list of
 labels generated for the node. For example, an environment might have two supported CPU models: `Penryn` and `Haswell`.
 
-Use the `spec.obsoleteCPUs` to configure the CPU plugin. Add the obsolete CPU list under `spec.obsoleteCPUs.cpuModels`,
-and the minCPUModel as the value of `spec.obsoleteCPUs.minCPUModel`.
+Use the `spec.obsoleteCPUs` to configure the CPU plugin. Add the obsolete CPU list under `spec.obsoleteCPUs.cpuModels`.
 
-The default value for the `spec.obsoleteCPUs.minCPUModel` field in KubeVirt is `"Penryn"`, but it won't be visible if
-missing in the CR. The default value for the `spec.obsoleteCPUs.cpuModels` field is hardcoded predefined list and is not
-visible. You can add new CPU models to the list, but can't remove CPU models from the predefined list. The predefined list
-is not visible in the HyperConverged CR.
+The default value for the `spec.obsoleteCPUs.cpuModels` field is hardcoded predefined list and is not visible. You can
+add new CPU models to the list, but can't remove CPU models from the predefined list. The predefined list is not visible
+in the HyperConverged CR.
 
 The hard-coded predefined list of obsolete CPU modes is:
 * `486`
@@ -698,7 +696,6 @@ spec:
       - "pentium2"
       - "pentium3"
       - "pentiumpro"
-    minCPUModel: "Penryn"
 ```
 
 ## Default CPU model configuration

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -2610,9 +2610,8 @@ spec:
                     x-kubernetes-list-type: set
                   minCPUModel:
                     description: |-
-                      MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell.
-                      The default value for this field is nil, but in KubeVirt, the default value is "Penryn", if nothing else is set.
-                      Use this field to override KubeVirt default value.
+                      MinCPUModel is not in use
+                      Deprecated: This field is not in use and is ignored.
                     type: string
                 type: object
               permittedHostDevices:

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -2610,9 +2610,8 @@ spec:
                     x-kubernetes-list-type: set
                   minCPUModel:
                     description: |-
-                      MinCPUModel is the Minimum CPU model that is used for basic CPU features; e.g. Penryn or Haswell.
-                      The default value for this field is nil, but in KubeVirt, the default value is "Penryn", if nothing else is set.
-                      Use this field to override KubeVirt default value.
+                      MinCPUModel is not in use
+                      Deprecated: This field is not in use and is ignored.
                     type: string
                 type: object
               permittedHostDevices:


### PR DESCRIPTION
**What this PR does / why we need it**:

KubeVirt `minCPUModel` field is deprecated and is no longer in use.

This PR deprecates the HyperConverged's `spec.obsoleteCPUs.minCPUModel` field, ignores it and stop populate the KubeVirt field by its value.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The HyperConverged's `spec.obsoleteCPUs.minCPUModel` field is now deprecated and ignored
```
