### PR TITLE
Rename the NetworkPolicy common labels

### DIFF
--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -92,11 +92,12 @@ const (
 	DataImportCronEnabledAnnotation = "dataimportcrontemplate.kubevirt.io/enable"
 
 	HCOAnnotationPrefix = "hco.kubevirt.io/"
+	NPLabelPrefix       = "np.kubevirt.io/"
 
 	// AllowEgressToDNSAndAPIServerLabel if this label is set, the network policy will allow egress to DNS and API server
-	AllowEgressToDNSAndAPIServerLabel = HCOAnnotationPrefix + "allow-access-cluster-services"
+	AllowEgressToDNSAndAPIServerLabel = NPLabelPrefix + "allow-access-cluster-services"
 	// AllowIngressToMetricsEndpointLabel if this label is set, the network policy will allow ingress to the metrics endpoint
-	AllowIngressToMetricsEndpointLabel = HCOAnnotationPrefix + "allow-prometheus-access"
+	AllowIngressToMetricsEndpointLabel = NPLabelPrefix + "allow-prometheus-access"
 )
 
 type AppComponent string

--- a/tools/csv-merger/network-policies-template.tmpl
+++ b/tools/csv-merger/network-policies-template.tmpl
@@ -7,24 +7,24 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
-      - key: hco.kubevirt.io/allow-access-cluster-services
-        operator: Exists
+    - key: {{allowAccessClusterServicesLbl}}
+      operator: Exists
   policyTypes:
-    - Egress
+  - Egress
   egress:
 {{- range .DNSSelectors }}
-    - ports:
-        - protocol: TCP
-          port: {{.DNSPort}}
-        - protocol: UDP
-          port: {{.DNSPort}}
-      to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{.DNSNamespaceSelector}}
-          podSelector:
-            matchLabels:
-              {{.DNSPodSelectorLabel}}: {{.DNSPodSelectorVal}}
+  - ports:
+    - protocol: TCP
+      port: {{.DNSPort}}
+    - protocol: UDP
+      port: {{.DNSPort}}
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{.DNSNamespaceSelector}}
+      podSelector:
+        matchLabels:
+          {{.DNSPodSelectorLabel}}: {{.DNSPodSelectorVal}}
 {{- end }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -35,14 +35,14 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
-      - key: hco.kubevirt.io/allow-access-cluster-services
-        operator: Exists
+    - key: {{allowAccessClusterServicesLbl}}
+      operator: Exists
   policyTypes:
-    - Egress
+  - Egress
   egress:
-    - ports:
-        - protocol: TCP
-          port: 6443
+  - ports:
+    - protocol: TCP
+      port: 6443
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -52,16 +52,16 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
-      - key: hco.kubevirt.io/allow-prometheus-access
-        operator: Exists
+    - key: {{allowPrometheusAccessLbl}}
+      operator: Exists
   policyTypes:
-    - Ingress
+  - Ingress
   ingress:
-    - ports:
-        - protocol: TCP
-          port: 8443
-        - protocol: TCP
-          port: 8080
+  - ports:
+    - protocol: TCP
+      port: 8443
+    - protocol: TCP
+      port: 8080
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -72,18 +72,18 @@ spec:
   podSelector:
     matchLabels:
       name: hyperconverged-cluster-operator
-    egress:
-      - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: openshift-monitoring
-          podSelector:
-            matchLabels:
-              alertmanager: main
-              app.kubernetes.io/component: alert-router
-              app.kubernetes.io/instance: main
-    policyTypes:
-      - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+      podSelector:
+        matchLabels:
+          alertmanager: main
+          app.kubernetes.io/component: alert-router
+          app.kubernetes.io/instance: main
+  policyTypes:
+  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -95,11 +95,11 @@ spec:
     matchLabels:
       name: hyperconverged-cluster-webhook
   policyTypes:
-    - Ingress
+  - Ingress
   ingress:
-    - ports:
-        - protocol: TCP
-          port: {{ .WebhookPort }}
+  - ports:
+    - protocol: TCP
+      port: {{ .WebhookPort }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -111,8 +111,8 @@ spec:
     matchLabels:
       name: hyperconverged-cluster-cli-download
   policyTypes:
-    - Ingress
+  - Ingress
   ingress:
-    - ports:
-        - protocol: TCP
-          port: {{ .CLIDownloadsPort }}
+  - ports:
+    - protocol: TCP
+      port: {{ .CLIDownloadsPort }}

--- a/tools/csv-merger/network_policy_gen.go
+++ b/tools/csv-merger/network_policy_gen.go
@@ -58,7 +58,19 @@ type DNSSelector struct {
 }
 
 var (
-	networkPoliciesTemplate = template.Must(template.New("network-policies").Parse(networkPoliciesTemplateFile))
+	// lblFunMap makes the NetworkPolicy label go constants, available in the template
+	lblFuncMap = template.FuncMap{
+		"allowAccessClusterServicesLbl": func() string {
+			return hcoutil.AllowEgressToDNSAndAPIServerLabel
+		},
+		"allowPrometheusAccessLbl": func() string {
+			return hcoutil.AllowIngressToMetricsEndpointLabel
+		},
+	}
+
+	networkPoliciesTemplate = template.Must(template.New("network-policies").
+				Funcs(lblFuncMap).
+				Parse(networkPoliciesTemplateFile))
 
 	// deployK8sDNSNetworkPolicy is a flag to control whether the k8s DNS network policy should be deployed.
 	// By default, the bundle image that includes the network policy yaml files is going to be deployed on openshift.


### PR DESCRIPTION
**What this PR does / why we need it**:

Rename the `hco.kubevirt.io/allow-access-cluster-services` label to `np.kubevirt.io/allow-access-cluster-services`, and the `hco.kubevirt.io/allow-prometheus-access` label, to `np.kubevirt.io/allow-prometheus-access`m to match the KubeVirt and CDI implementations.

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-72058
```

**Release note**:
```release-note
None
```
