### PR TITLE
csv-merger: make Replaces field optional in the CSV

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -789,7 +789,6 @@ type CSVBaseParams struct {
 	MetaDescription string
 	Description     string
 	Image           string
-	Replaces        string
 	Version         semver.Version
 	CrdDisplay      string
 	Icon            string
@@ -936,7 +935,6 @@ func GetCSVBase(params *CSVBaseParams) *csvv1alpha1.ClusterServiceVersion {
 			Description: params.Description,
 			Keywords:    stringListToSlice("KubeVirt", "Virtualization"),
 			Version:     csvVersion.OperatorVersion{Version: params.Version},
-			Replaces:    params.Replaces,
 			Maintainers: []csvv1alpha1.Maintainer{
 				{
 					Name:  kubevirtProjectName,

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -174,10 +174,15 @@ func getHcoCsv() {
 	version := semver.MustParse(*csvVersion)
 	replaces := getReplacesVersion()
 
-	csvParams := getCsvBaseParams(replaces, version)
+	csvParams := getCsvBaseParams(version)
 
 	// This is the basic CSV without an InstallStrategy defined
 	csvBase := components.GetCSVBase(csvParams)
+
+	// Only set the Replaces field if a replaces version was provided
+	if replaces != "" {
+		csvBase.Spec.Replaces = replaces
+	}
 
 	if *enableUniqueSemver {
 		csvBase.Annotations["olm.skipRange"] = fmt.Sprintf("<%v", version.String())
@@ -396,7 +401,7 @@ func getRelatedImages() []csvv1alpha1.RelatedImage {
 	return ris
 }
 
-func getCsvBaseParams(replaces string, version semver.Version) *components.CSVBaseParams {
+func getCsvBaseParams(version semver.Version) *components.CSVBaseParams {
 	return &components.CSVBaseParams{
 		Name:            operatorName,
 		Namespace:       *namespace,
@@ -404,7 +409,6 @@ func getCsvBaseParams(replaces string, version semver.Version) *components.CSVBa
 		MetaDescription: *metadataDescription,
 		Description:     *specDescription,
 		Image:           *operatorImage,
-		Replaces:        replaces,
 		Version:         version,
 		CrdDisplay:      *crdDisplay,
 		Icon:            *icon,


### PR DESCRIPTION
When using an FBC catalog, the upgrade graph is not determined by the replaces,skips and skipRange fields in the CSV itself, but in the file-based catalog. Make the replaces-csv-version flag optional, so if it hasn't been provided, the generated CSV won't include the Replaces field at all.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-62804
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
