### PR TITLE
csv-merger: allow sending multi-line strings as files

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -334,14 +334,14 @@ ${TOOLS}/csv-merger \
   --replaces-csv-version=${REPLACES_CSV_VERSION} \
   --hco-kv-io-version="${CSV_VERSION}" \
   --spec-displayname="KubeVirt HyperConverged Cluster Operator" \
-  --spec-description="$(<${PROJECT_ROOT}/docs/operator_description.md)" \
+  --spec-description-file="${PROJECT_ROOT}/docs/operator_description.md" \
   --icon="${ICON}" \
   --metadata-description="A unified operator deploying and controlling KubeVirt and its supporting operators with opinionated defaults" \
   --crd-display="HyperConverged Cluster Operator" \
   --smbios="${SMBIOS}" \
   --amd64-machinetype="${amd64_machinetype}" \
   --arm64-machinetype="${arm64_machinetype}" \
-  --csv-overrides="$(<${csvOverrides})" \
+  --csv-overrides-file="${csvOverrides}" \
   --enable-unique-version=${ENABLE_UNIQUE} \
   --kubevirt-version="${KUBEVIRT_VERSION}" \
   --cdi-version="${CDI_VERSION}" \


### PR DESCRIPTION
**What this PR does / why we need it**:
The hack/build-manifests.sh passes some multi-line text argument to the `csv-merger` tool, as very long strings.

This is very hard to debug. Also, some tools that run the `csv-merger`, fail to pass these long string properly.

This commit adds the `--smbios-file`, `--spec-description-file`, and the `--csv-overrides-file` flags, to the `csv-merger` tool, in order to pass the file names instead the very long CSV strings.

**Jira Ticket**:
```jira-ticket
https://issues.redhat.com/browse/CNV-72184
```

**Release note**:
```release-note
None
```
