### PR TITLE
Revert PR 3845, as it's not working

### DIFF
--- a/hack/build-push-multi-arch-images.sh
+++ b/hack/build-push-multi-arch-images.sh
@@ -12,8 +12,6 @@ if [[ -z ${DOCKER_FILE} ]]; then
   exit 1
 fi
 
-CLEANUP=${CLEANUP:-"true"}
-
 SHA=$(git describe --no-match  --always --abbrev=40 --dirty)
 
 . ./hack/cri-bin.sh && export CRI_BIN=${CRI_BIN}
@@ -29,10 +27,3 @@ for arch in ${ARCHITECTURES}; do
 done
 
 ./hack/retry.sh 3 10 "${CRI_BIN} manifest push ${IMAGE_NAME}"
-
-if [[ ${CLEANUP} == "true" ]]; then
-  for arch in ${ARCHITECTURES}; do
-    ${CRI_BIN} rmi "${IMAGE_NAME}-${arch}"
-  done
-  ${CRI_BIN} manifest rm "${IMAGE_NAME}"
-fi


### PR DESCRIPTION
**What this PR does / why we need it**:

The "Build and Push Images" github action is failing after merging PR 3845, because all the images are already removed when it tries to re-tag and re-push them.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
