### PR TITLE
[release-1.15] csv-merger: allow passing multi-line ags as files

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -287,12 +287,12 @@ done
 (cd ${PROJECT_ROOT}/tools/manifest-templator/ && go build)
 ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
   --api-sources=${PROJECT_ROOT}/api/... \
-  --cna-csv="$(<${cnaCsv})" \
-  --virt-csv="$(<${virtCsv})" \
-  --ssp-csv="$(<${sspCsv})" \
-  --cdi-csv="$(<${cdiCsv})" \
-  --hpp-csv="$(<${hppCsv})" \
-  --aaq-csv="$(<${aaqCsv})" \
+  --cna-csv-file="${cnaCsv}" \
+  --virt-csv-file="${virtCsv}" \
+  --ssp-csv-file="${sspCsv}" \
+  --cdi-csv-file="${cdiCsv}" \
+  --hpp-csv-file="${hppCsv}" \
+  --aaq-csv-file="${aaqCsv}" \
   --kv-virtiowin-image-name="${KUBEVIRT_VIRTIO_IMAGE}" \
   --operator-namespace="${OPERATOR_NAMESPACE}" \
   --smbios="${SMBIOS}" \
@@ -322,24 +322,24 @@ fi
 # Build and merge CSVs
 CSV_DIR=${CSV_DIR}/manifests
 ${PROJECT_ROOT}/tools/csv-merger/csv-merger \
-  --cna-csv="$(<${cnaCsv})" \
-  --virt-csv="$(<${virtCsv})" \
-  --ssp-csv="$(<${sspCsv})" \
-  --cdi-csv="$(<${cdiCsv})" \
-  --hpp-csv="$(<${hppCsv})" \
-  --aaq-csv="$(<${aaqCsv})" \
+  --cna-csv-file="${cnaCsv}" \
+  --virt-csv-file="${virtCsv}" \
+  --ssp-csv-file="${sspCsv}" \
+  --cdi-csv-file="${cdiCsv}" \
+  --hpp-csv-file="${hppCsv}" \
+  --aaq-csv-file="${aaqCsv}" \
   --kv-virtiowin-image-name="${KUBEVIRT_VIRTIO_IMAGE}" \
   --csv-version=${CSV_VERSION_PARAM} \
   --replaces-csv-version=${REPLACES_CSV_VERSION} \
   --hco-kv-io-version="${CSV_VERSION}" \
   --spec-displayname="KubeVirt HyperConverged Cluster Operator" \
-  --spec-description="$(<${PROJECT_ROOT}/docs/operator_description.md)" \
+  --spec-description-file="${PROJECT_ROOT}/docs/operator_description.md" \
   --metadata-description="A unified operator deploying and controlling KubeVirt and its supporting operators with opinionated defaults" \
   --crd-display="HyperConverged Cluster Operator" \
   --smbios="${SMBIOS}" \
   --amd64-machinetype="${amd64_machinetype}" \
   --arm64-machinetype="${arm64_machinetype}" \
-  --csv-overrides="$(<${csvOverrides})" \
+  --csv-overrides-file="${csvOverrides}" \
   --enable-unique-version=${ENABLE_UNIQUE} \
   --kubevirt-version="${KUBEVIRT_VERSION}" \
   --cdi-version="${CDI_VERSION}" \

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -84,12 +85,6 @@ func (i *EnvVarFlags) Set(value string) error {
 var (
 	cwd, _              = os.Getwd()
 	outputMode          = flag.String("output-mode", CSVMode, "Working mode: "+validOutputModes)
-	cnaCsv              = flag.String("cna-csv", "", "Cluster Network Addons CSV string")
-	virtCsv             = flag.String("virt-csv", "", "KubeVirt CSV string")
-	sspCsv              = flag.String("ssp-csv", "", "Scheduling Scale Performance CSV string")
-	cdiCsv              = flag.String("cdi-csv", "", "Containerized Data Importer CSV String")
-	hppCsv              = flag.String("hpp-csv", "", "HostPath Provisioner Operator CSV String")
-	aaqCsv              = flag.String("aaq-csv", "", "Applications Aware Quota Operator CSV String")
 	operatorImage       = flag.String("operator-image-name", "", "HyperConverged Cluster Operator image")
 	webhookImage        = flag.String("webhook-image-name", "", "HyperConverged Cluster Webhook image")
 	cliDownloadsImage   = flag.String("cli-downloads-image-name", "", "Downloads Server image")
@@ -97,7 +92,8 @@ var (
 	kvUIProxyImage      = flag.String("kubevirt-consoleproxy-image-name", "", "KubeVirt Console Proxy image")
 	kvVirtIOWinImage    = flag.String("kv-virtiowin-image-name", "", "KubeVirt VirtIO Win image")
 	_                   = flag.String("primary-udn-binding-image-name", "", "deprecated. This flag is ignored")
-	smbios              = flag.String("smbios", "", "Custom SMBIOS string for KubeVirt ConfigMap")
+	smbios              = flag.String("smbios", "", "Custom SMBIOS string, used by HCO to configure the SMBIOS in KubeVirt CR")
+	smbiosFile          = flag.String("smbios-file", "", "Custom SMBIOS file name, used by HCO to configure the SMBIOS in KubeVirt CR")
 	machinetype         = flag.String("machinetype", "", "Custom MACHINETYPE string for KubeVirt ConfigMap (Deprecated, use amd64-machinetype)")
 	amd64MachineType    = flag.String("amd64-machinetype", "", "Custom AMD64_MACHINETYPE string for KubeVirt ConfigMap")
 	arm64MachineType    = flag.String("arm64-machinetype", "", "Custom ARM64_MACHINETYPE string for KubeVirt ConfigMap")
@@ -105,10 +101,12 @@ var (
 	replacesCsvVersion  = flag.String("replaces-csv-version", "", "CSV version to replace")
 	metadataDescription = flag.String("metadata-description", "", "One-Liner Description")
 	specDescription     = flag.String("spec-description", "", "Description")
+	specDescriptionFile = flag.String("spec-description-file", "", "Description file")
 	specDisplayName     = flag.String("spec-displayname", "", "Display Name")
 	namespace           = flag.String("namespace", "kubevirt-hyperconverged", "Namespace")
 	crdDisplay          = flag.String("crd-display", "KubeVirt HyperConverged Cluster", "Label show in OLM UI about the primary CRD")
-	csvOverrides        = flag.String("csv-overrides", "", "CSV like string with punctual changes that will be recursively applied (if possible)")
+	csvOverrides        = flag.String("csv-overrides", "", "CSV-like string with punctual changes that will be recursively applied (if possible)")
+	csvOverridesFile    = flag.String("csv-overrides-file", "", "path of file with CSV-like format, with punctual changes that will be recursively applied (if possible)")
 	visibleCRDList      = flag.String("visible-crds-list", "hyperconvergeds.hco.kubevirt.io,hostpathprovisioners.hostpathprovisioner.kubevirt.io",
 		"Comma separated list of all the CRDs that should be visible in OLM console")
 	relatedImagesList = flag.String("related-images-list", "",
@@ -261,11 +259,14 @@ func main() {
 }
 
 func getHcoCsv() {
+	panicOnError(getFilesOrStrings())
+
 	if *specDisplayName == "" || *specDescription == "" {
 		panic(errors.New("must specify spec-displayname and spec-description"))
 	}
 
-	componentsWithCsvs := getInitialCsvList()
+	componentsWithCsvs, err := util.GetInitialCsvList()
+	panicOnError(err)
 
 	version := semver.MustParse(*csvVersion)
 	replaces := getReplacesVersion()
@@ -444,41 +445,6 @@ func setSupported(csvBase *csvv1alpha1.ClusterServiceVersion) {
 	}
 }
 
-func getInitialCsvList() []util.CsvWithComponent {
-	return []util.CsvWithComponent{
-		{
-			Name:      "CNA",
-			Csv:       *cnaCsv,
-			Component: hcoutil.AppComponentNetwork,
-		},
-		{
-			Name:      "KubeVirt",
-			Csv:       *virtCsv,
-			Component: hcoutil.AppComponentCompute,
-		},
-		{
-			Name:      "SSP",
-			Csv:       *sspCsv,
-			Component: hcoutil.AppComponentSchedule,
-		},
-		{
-			Name:      "CDI",
-			Csv:       *cdiCsv,
-			Component: hcoutil.AppComponentStorage,
-		},
-		{
-			Name:      "HPP",
-			Csv:       *hppCsv,
-			Component: hcoutil.AppComponentStorage,
-		},
-		{
-			Name:      "AAQ",
-			Csv:       *aaqCsv,
-			Component: hcoutil.AppComponentQuotaMngt,
-		},
-	}
-}
-
 func getReplacesVersion() string {
 	if *replacesCsvVersion != "" {
 		return fmt.Sprintf("%v.v%v", operatorName, semver.MustParse(*replacesCsvVersion).String())
@@ -575,10 +541,7 @@ func addRelatedImage(images []csvv1alpha1.RelatedImage, image string) []csvv1alp
 
 func panicOnError(err error, info ...string) {
 	if err != nil {
-		moreInfo := ""
-		if len(info) > 0 {
-			moreInfo = strings.Join(info, " ")
-		}
+		moreInfo := strings.Join(info, " ")
 
 		log.Println("Error!", err, moreInfo)
 		panic(err)
@@ -599,4 +562,35 @@ func sortRelatedImages(slice []csvv1alpha1.RelatedImage) []csvv1alpha1.RelatedIm
 		return slice[i].Name < slice[j].Name
 	})
 	return slice
+}
+
+func getFilesOrStrings() error {
+	for _, f := range []struct {
+		str      *string
+		fileName string
+		flagName string
+	}{
+		{str: smbios, fileName: *smbiosFile, flagName: "smbios"},
+		{str: specDescription, fileName: *specDescriptionFile, flagName: "spec-description"},
+		{str: csvOverrides, fileName: *csvOverridesFile, flagName: "csv-overrides"},
+	} {
+		if f.fileName != "" {
+			if *f.str != "" {
+				return fmt.Errorf(`only one of the "--%[1]s" or the "--%[1]s-file" flags may be used, but not both`, f.flagName)
+			}
+
+			fileContent, err := os.ReadFile(f.fileName)
+			if err != nil {
+				return fmt.Errorf("can't read %q; %w", f.fileName, err)
+			}
+
+			// to match the non-flag behavior, that is used like this in the script:
+			// --spec-description-file=$(<"${PROJECT_ROOT}/docs/operator_description.md")
+			// in this case, the last newline is dropped from the content. We want to do
+			// the same when reading directly from a file.
+			*f.str = string(bytes.TrimSuffix(fileContent, []byte{'\n'}))
+		}
+	}
+
+	return nil
 }

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -28,19 +28,17 @@ import (
 	"strconv"
 	"strings"
 
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-
 	"github.com/ghodss/yaml"
-
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
-	"github.com/kubevirt/hyperconverged-cluster-operator/tools/util"
-
 	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	"github.com/kubevirt/hyperconverged-cluster-operator/tools/util"
 )
 
 var (
@@ -51,12 +49,6 @@ var (
 var (
 	cwd, _                  = os.Getwd()
 	deployDir               = flag.String("deploy-dir", "deploy", "Directory where manifests should be written")
-	cnaCsv                  = flag.String("cna-csv", "", "Cluster Network Addons CSV string")
-	virtCsv                 = flag.String("virt-csv", "", "KubeVirt CSV string")
-	sspCsv                  = flag.String("ssp-csv", "", "Scheduling Scale Performance CSV string")
-	cdiCsv                  = flag.String("cdi-csv", "", "Containerized Data Importer CSV String")
-	hppCsv                  = flag.String("hpp-csv", "", "HostPath Provisioner Operator CSV String")
-	aaqCsv                  = flag.String("aaq-csv", "", "Applications Aware Quota Operator CSV String")
 	operatorNamespace       = flag.String("operator-namespace", "kubevirt-hyperconverged", "Name of the Operator")
 	operatorImage           = flag.String("operator-image", "", "HyperConverged Cluster Operator image")
 	webhookImage            = flag.String("webhook-image", "", "HyperConverged Cluster Webhook image")
@@ -100,7 +92,8 @@ func processCommandlineParams() {
 
 func main() {
 	// the CSVs we expect to handle
-	componentsWithCSVs := getCsvWithComponent()
+	componentsWithCSVs, err := util.GetInitialCsvList()
+	check(err)
 
 	operatorParams := getOperatorParameters()
 
@@ -371,42 +364,6 @@ func createService(webhook csvv1alpha1.WebhookDescription, csvStruct *csvv1alpha
 			Type: corev1.ServiceTypeClusterIP,
 		},
 	}
-}
-
-func getCsvWithComponent() []util.CsvWithComponent {
-	componentsWithCsvs := []util.CsvWithComponent{
-		{
-			Name:      "CNA",
-			Csv:       *cnaCsv,
-			Component: hcoutil.AppComponentNetwork,
-		},
-		{
-			Name:      "KubeVirt",
-			Csv:       *virtCsv,
-			Component: hcoutil.AppComponentCompute,
-		},
-		{
-			Name:      "SSP",
-			Csv:       *sspCsv,
-			Component: hcoutil.AppComponentSchedule,
-		},
-		{
-			Name:      "CDI",
-			Csv:       *cdiCsv,
-			Component: hcoutil.AppComponentStorage,
-		},
-		{
-			Name:      "HPP",
-			Csv:       *hppCsv,
-			Component: hcoutil.AppComponentStorage,
-		},
-		{
-			Name:      "AAQ",
-			Csv:       *aaqCsv,
-			Component: hcoutil.AppComponentQuotaMngt,
-		},
-	}
-	return componentsWithCsvs
 }
 
 func getOperatorParameters() *components.DeploymentOperatorParams {

--- a/tools/util/csv_with_component.go
+++ b/tools/util/csv_with_component.go
@@ -1,9 +1,110 @@
 package util
 
-import hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
 
 type CsvWithComponent struct {
 	Name      string
 	Csv       string
 	Component hcoutil.AppComponent
+}
+
+var (
+	cnaCsv      = flag.String("cna-csv", "", "Cluster Network Addons CSV string")
+	cnaCsvFile  = flag.String("cna-csv-file", "", "Cluster Network Addons CSV yaml file")
+	virtCsv     = flag.String("virt-csv", "", "KubeVirt CSV string")
+	virtCsvFile = flag.String("virt-csv-file", "", "KubeVirt CSV yaml file")
+	sspCsv      = flag.String("ssp-csv", "", "Scheduling Scale Performance CSV string")
+	sspCsvFile  = flag.String("ssp-csv-file", "", "Scheduling Scale Performance CSV yaml file")
+	cdiCsv      = flag.String("cdi-csv", "", "Containerized Data Importer CSV String")
+	cdiCsvFile  = flag.String("cdi-csv-file", "", "Containerized Data Importer CSV yaml file")
+	hppCsv      = flag.String("hpp-csv", "", "HostPath Provisioner Operator CSV String")
+	hppCsvFile  = flag.String("hpp-csv-file", "", "HostPath Provisioner Operator CSV yaml file")
+	aaqCsv      = flag.String("aaq-csv", "", "Applications Aware Quota Operator CSV String")
+	aaqCsvFile  = flag.String("aaq-csv-file", "", "Applications Aware Quota Operator CSV yaml file")
+)
+
+func GetInitialCsvList() ([]CsvWithComponent, error) {
+	err := getAllCSVs()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return []CsvWithComponent{
+		{
+			Name:      "CNA",
+			Csv:       *cnaCsv,
+			Component: hcoutil.AppComponentNetwork,
+		},
+		{
+			Name:      "KubeVirt",
+			Csv:       *virtCsv,
+			Component: hcoutil.AppComponentCompute,
+		},
+		{
+			Name:      "SSP",
+			Csv:       *sspCsv,
+			Component: hcoutil.AppComponentSchedule,
+		},
+		{
+			Name:      "CDI",
+			Csv:       *cdiCsv,
+			Component: hcoutil.AppComponentStorage,
+		},
+		{
+			Name:      "HPP",
+			Csv:       *hppCsv,
+			Component: hcoutil.AppComponentStorage,
+		},
+		{
+			Name:      "AAQ",
+			Csv:       *aaqCsv,
+			Component: hcoutil.AppComponentQuotaMngt,
+		},
+	}, nil
+}
+
+func getAllCSVs() error {
+	for _, f := range []struct {
+		str      *string
+		fileName string
+		flagName string
+	}{
+		{str: cnaCsv, fileName: *cnaCsvFile, flagName: "cna-csv"},
+		{str: virtCsv, fileName: *virtCsvFile, flagName: "virt-csv"},
+		{str: sspCsv, fileName: *sspCsvFile, flagName: "ssp-csv"},
+		{str: cdiCsv, fileName: *cdiCsvFile, flagName: "cdi-csv"},
+		{str: hppCsv, fileName: *hppCsvFile, flagName: "hpp-csv"},
+		{str: aaqCsv, fileName: *aaqCsvFile, flagName: "aaq-csv"},
+	} {
+		if err := fileOrString(f.str, f.fileName, f.flagName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func fileOrString(str *string, fileName, csvName string) error {
+	if (*str == "") == (fileName == "") {
+		return fmt.Errorf(`one and only one of the "--%[1]s" and the "--%[1]s-file" flags must be used`, csvName)
+	}
+
+	if *str != "" {
+		return nil
+	}
+
+	csvFile, err := os.ReadFile(fileName)
+	if err != nil {
+		return fmt.Errorf("can't read %q; %w", fileName, err)
+	}
+
+	*str = string(csvFile)
+
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Note**: This is a manual cherry-pick of  #3844 and #3854.

The hack/build-manifests.sh pass the component CSVs and other multi-line long text arguments, to the csv-merger and the manifest-templator tools as very long strings.

This is very hard to debug. Also, some tools that run the csv-merger fail to pass these long string properly.

This commit adds the `--cna-csv-file`, `--virt-csv-file`, `--ssp-csv-file`, `--cdi-csv-file`, `--hpp-csv-file`, and the `--aaq-csv-file` flags, to the csv-merger and the manifest-templator tools, in order to pass the CSV file names instead the very long csv strings.

In addition, it adds the `--smbios-file`, `--spec-description-file` and the `--csv-overrides-file` flags to the csv-merger for the same reasons.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
