### PR TITLE
Allow virt-operator deployment on Hosted Control Planes Cluster

### DIFF
--- a/controllers/commontestutils/testUtils.go
+++ b/controllers/commontestutils/testUtils.go
@@ -328,6 +328,9 @@ func (c ClusterInfoMock) IsDeschedulerCRDDeployed(_ context.Context, _ client.Cl
 func (c ClusterInfoMock) IsSingleStackIPv6() bool {
 	return true
 }
+func (c ClusterInfoMock) IsHyperShiftManaged() bool {
+	return false
+}
 func (c ClusterInfoMock) GetPod() *corev1.Pod {
 	return pod
 }

--- a/controllers/nodes/nodes_controller.go
+++ b/controllers/nodes/nodes_controller.go
@@ -3,6 +3,7 @@ package nodes
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -25,6 +26,11 @@ import (
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
+const (
+	// HyperShift label value for worker nodes
+	hypershiftLabelValue = "set-to-allow-kubevirt-deployment"
+)
+
 var (
 	log               = logf.Log.WithName("controller_nodes")
 	randomConstSuffix = uuid.New().String()
@@ -37,19 +43,102 @@ var (
 	}
 )
 
+// startupNodeLabeler is a runnable that labels all nodes after the manager cache starts
+type startupNodeLabeler struct {
+	reconciler *ReconcileNodeCounter
+}
+
+// Start implements manager.Runnable
+func (s *startupNodeLabeler) Start(ctx context.Context) error {
+	log.Info("Starting node labeling after cache is ready")
+
+	const (
+		maxRetries    = 5
+		retryInterval = 10 * time.Second
+	)
+
+	// Label all nodes now that the cache is ready
+	err := s.reconciler.labelAllNodesAtStartup(ctx)
+	if err != nil {
+		log.Error(err, "Failed to label nodes at startup, will retry", "maxRetries", maxRetries, "retryInterval", retryInterval)
+
+		// Retry up to maxRetries times
+		for attempt := 1; attempt <= maxRetries && err != nil; attempt++ {
+			select {
+			case <-ctx.Done():
+				log.Info("Context cancelled during retry, stopping node labeling")
+				return nil
+			case <-time.After(retryInterval):
+				log.Info("Retrying node labeling at startup", "attempt", attempt, "maxRetries", maxRetries)
+				err = s.reconciler.labelAllNodesAtStartup(ctx)
+				if err == nil {
+					log.Info("Successfully labeled nodes at startup after retry", "attempt", attempt)
+				} else {
+					log.Error(err, "Failed to label nodes at startup", "attempt", attempt, "maxRetries", maxRetries)
+				}
+			}
+		}
+
+		if err != nil {
+			log.Error(err, "Failed to label nodes at startup after all retries, giving up", "maxRetries", maxRetries)
+		}
+	}
+
+	// Keep running until context is cancelled
+	<-ctx.Done()
+	return nil
+}
+
+// NeedLeaderElection implements manager.LeaderElectionRunnable
+func (s *startupNodeLabeler) NeedLeaderElection() bool {
+	return true
+}
+
 // RegisterReconciler creates a new Nodes Reconciler and registers it into manager.
 func RegisterReconciler(mgr manager.Manager, nodeEvents chan<- event.GenericEvent) error {
-	return add(mgr, newReconciler(mgr, nodeEvents))
+	reconciler := newReconciler(mgr, nodeEvents)
+
+	// Add a runnable to label all nodes after the cache starts if we're in a HyperShift cluster
+	clusterInfo := hcoutil.GetClusterInfo()
+	if clusterInfo.IsOpenshift() && clusterInfo.IsHyperShiftManaged() {
+		if err := mgr.Add(&startupNodeLabeler{reconciler: reconciler}); err != nil {
+			return fmt.Errorf("failed to add startup node labeler: %w", err)
+		}
+	}
+
+	return add(mgr, reconciler)
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, nodeEvents chan<- event.GenericEvent) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, nodeEvents chan<- event.GenericEvent) *ReconcileNodeCounter {
+	clusterInfo := hcoutil.GetClusterInfo()
+
+	// Evaluate once at initialization whether we should label nodes for HyperShift
+	shouldLabelNodes := clusterInfo.IsOpenshift() && clusterInfo.IsHyperShiftManaged()
+
+	log.Info("Initializing nodes controller",
+		"isOpenshift", clusterInfo.IsOpenshift(),
+		"isHyperShiftManaged", clusterInfo.IsHyperShiftManaged(),
+		"shouldLabelNodes", shouldLabelNodes,
+	)
+
 	r := &ReconcileNodeCounter{
 		Client:     mgr.GetClient(),
 		nodeEvents: nodeEvents,
 	}
 
+	if shouldLabelNodes {
+		r.HandleHyperShiftNodeLabeling = HandleHyperShiftNodeLabeling
+	} else {
+		r.HandleHyperShiftNodeLabeling = staleHyperShiftNodeLabeling
+	}
+
 	return r
+}
+
+// staleHyperShiftNodeLabeling is a no-op function used when HyperShift node labeling is not needed
+func staleHyperShiftNodeLabeling(_ context.Context, _ client.Client, _ string, _ logr.Logger) error {
+	return nil
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -84,8 +173,9 @@ type ReconcileNodeCounter struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client.Client
-	HyperConvergedQueue workqueue.TypedRateLimitingInterface[reconcile.Request]
-	nodeEvents          chan<- event.GenericEvent
+	HyperConvergedQueue          workqueue.TypedRateLimitingInterface[reconcile.Request]
+	nodeEvents                   chan<- event.GenericEvent
+	HandleHyperShiftNodeLabeling func(ctx context.Context, cli client.Client, nodeName string, logger logr.Logger) error
 }
 
 // Reconcile updates the nodes count on ClusterInfo singleton
@@ -110,6 +200,15 @@ func (r *ReconcileNodeCounter) Reconcile(ctx context.Context, req reconcile.Requ
 	nodeInfoChanged, err := nodeinfo.HandleNodeChanges(ctx, r, hc, logger)
 	if err != nil {
 		return reconcile.Result{}, err
+	}
+
+	// Handle HyperShift node labeling for hosted control plane clusters
+	// Only process if this is a node event (not HCO event)
+	if req != hcoReq {
+		if err := r.HandleHyperShiftNodeLabeling(ctx, r.Client, req.Name, logger); err != nil {
+			logger.Error(err, "Failed to handle HyperShift node labeling")
+			return reconcile.Result{}, err
+		}
 	}
 
 	if hc == nil || !hc.DeletionTimestamp.IsZero() {
@@ -139,4 +238,78 @@ func (r *ReconcileNodeCounter) readHyperConverged(ctx context.Context) (*hcov1be
 	}
 
 	return hc, nil
+}
+
+// labelAllNodesAtStartup labels all worker nodes at controller startup for HyperShift clusters
+func (r *ReconcileNodeCounter) labelAllNodesAtStartup(ctx context.Context) error {
+	log.Info("Labeling all worker nodes at startup for HyperShift")
+
+	// Get all nodes
+	nodesList := &corev1.NodeList{}
+	if err := r.List(ctx, nodesList); err != nil {
+		return fmt.Errorf("failed to list nodes for HyperShift labeling at startup: %w", err)
+	}
+
+	var errs []error
+	for i := range nodesList.Items {
+		node := &nodesList.Items[i]
+		if err := labelNode(ctx, r.Client, node, log); err != nil {
+			log.Error(err, "Failed to label node at startup", "node", node.Name)
+			errs = append(errs, fmt.Errorf("node %s: %w", node.Name, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to label %d node(s): %v", len(errs), errs)
+	}
+
+	log.Info("Completed labeling nodes at startup", "totalNodes", len(nodesList.Items))
+	return nil
+}
+
+// HandleHyperShiftNodeLabeling manages the control-plane label on a specific worker node for HyperShift managed clusters
+func HandleHyperShiftNodeLabeling(ctx context.Context, cli client.Client, nodeName string, logger logr.Logger) error {
+	// Get the specific node
+	node := &corev1.Node{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
+		if errors.IsNotFound(err) {
+			// Node was deleted, nothing to do
+			logger.V(1).Info("Node not found, skipping HyperShift labeling", "node", nodeName)
+			return nil
+		}
+		return fmt.Errorf("failed to get node %s for HyperShift labeling: %w", nodeName, err)
+	}
+
+	return labelNode(ctx, cli, node, logger)
+}
+
+// labelNode applies the HyperShift label on a single node
+func labelNode(ctx context.Context, cli client.Client, node *corev1.Node, logger logr.Logger) error {
+	if !isWorkerNode(node) {
+		return nil
+	}
+
+	logger.Info("Adding control-plane label to worker node",
+		"node", node.Name,
+		"labelValue", hypershiftLabelValue,
+	)
+
+	patch := client.MergeFrom(node.DeepCopy())
+	node.Labels[nodeinfo.LabelNodeRoleControlPlane] = hypershiftLabelValue
+
+	if err := cli.Patch(ctx, node, patch); err != nil {
+		return fmt.Errorf("failed to patch node %s: %w", node.Name, err)
+	}
+
+	logger.Info("Successfully patched node labels", "node", node.Name)
+	return nil
+}
+
+// isWorkerNode checks if a node has the worker role label
+func isWorkerNode(node *corev1.Node) bool {
+	// A node is a worker if it has the worker label and doesn't have control-plane label
+	_, hasWorkerLabel := node.Labels[nodeinfo.LabelNodeRoleWorker]
+	_, hasControlPlaneLabel := node.Labels[nodeinfo.LabelNodeRoleControlPlane]
+
+	return hasWorkerLabel && !hasControlPlaneLabel
 }

--- a/controllers/nodes/nodes_controller_test.go
+++ b/controllers/nodes/nodes_controller_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -58,8 +60,9 @@ var _ = Describe("NodesController", func() {
 				cl := commontestutils.InitClient(resources)
 
 				r := &ReconcileNodeCounter{
-					Client:     cl,
-					nodeEvents: nodeEvents,
+					Client:                       cl,
+					nodeEvents:                   nodeEvents,
+					HandleHyperShiftNodeLabeling: staleHyperShiftNodeLabeling,
 				}
 
 				// Reconcile
@@ -77,8 +80,9 @@ var _ = Describe("NodesController", func() {
 				cl := commontestutils.InitClient(nil)
 
 				r := &ReconcileNodeCounter{
-					Client:     cl,
-					nodeEvents: nodeEvents,
+					Client:                       cl,
+					nodeEvents:                   nodeEvents,
+					HandleHyperShiftNodeLabeling: staleHyperShiftNodeLabeling,
 				}
 
 				// Reconcile
@@ -98,8 +102,9 @@ var _ = Describe("NodesController", func() {
 				cl := commontestutils.InitClient(resources)
 
 				r := &ReconcileNodeCounter{
-					Client:     cl,
-					nodeEvents: nodeEvents,
+					Client:                       cl,
+					nodeEvents:                   nodeEvents,
+					HandleHyperShiftNodeLabeling: staleHyperShiftNodeLabeling,
 				}
 
 				// Reconcile
@@ -119,8 +124,9 @@ var _ = Describe("NodesController", func() {
 				cl := commontestutils.InitClient(resources)
 
 				r := &ReconcileNodeCounter{
-					Client:     cl,
-					nodeEvents: nodeEvents,
+					Client:                       cl,
+					nodeEvents:                   nodeEvents,
+					HandleHyperShiftNodeLabeling: staleHyperShiftNodeLabeling,
 				}
 
 				// Reconcile
@@ -128,6 +134,311 @@ var _ = Describe("NodesController", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(res.IsZero()).To(BeTrue())
 				Expect(nodeEvents).ToNot(Receive())
+			})
+		})
+
+		Context("HyperShift Node Labeling", func() {
+			It("Should label worker node when shouldLabelNodes is true", func() {
+				workerNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-1",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleWorker: "",
+						},
+					},
+				}
+
+				hco := commontestutils.NewHco()
+				resources := []client.Object{hco, workerNode}
+				cl := commontestutils.InitClient(resources)
+
+				r := &ReconcileNodeCounter{
+					Client:                       cl,
+					nodeEvents:                   nodeEvents,
+					HandleHyperShiftNodeLabeling: HandleHyperShiftNodeLabeling,
+				}
+
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+					return false, nil
+				}
+
+				// Create a request for the worker node
+				nodeRequest := reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name: "worker-1",
+					},
+				}
+
+				// Reconcile
+				res, err := r.Reconcile(context.TODO(), nodeRequest)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.IsZero()).To(BeTrue())
+
+				// Verify the node was labeled
+				updatedNode := &corev1.Node{}
+				err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, updatedNode)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedNode.Labels).To(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
+				Expect(updatedNode.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(hypershiftLabelValue))
+			})
+
+			It("Should not label control plane node", func() {
+				cpNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "control-plane-1",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleControlPlane: "",
+						},
+					},
+				}
+
+				hco := commontestutils.NewHco()
+				resources := []client.Object{hco, cpNode}
+				cl := commontestutils.InitClient(resources)
+
+				r := &ReconcileNodeCounter{
+					Client:                       cl,
+					nodeEvents:                   nodeEvents,
+					HandleHyperShiftNodeLabeling: HandleHyperShiftNodeLabeling,
+				}
+
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+					return false, nil
+				}
+
+				nodeRequest := reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name: "control-plane-1",
+					},
+				}
+
+				res, err := r.Reconcile(context.TODO(), nodeRequest)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.IsZero()).To(BeTrue())
+
+				// Verify the node label wasn't changed
+				updatedNode := &corev1.Node{}
+				err = cl.Get(context.TODO(), client.ObjectKey{Name: "control-plane-1"}, updatedNode)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedNode.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(""))
+			})
+
+			It("Should skip labeling when shouldLabelNodes is false", func() {
+				workerNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-1",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleWorker: "",
+						},
+					},
+				}
+
+				hco := commontestutils.NewHco()
+				resources := []client.Object{hco, workerNode}
+				cl := commontestutils.InitClient(resources)
+
+				r := &ReconcileNodeCounter{
+					Client:                       cl,
+					nodeEvents:                   nodeEvents,
+					HandleHyperShiftNodeLabeling: staleHyperShiftNodeLabeling,
+				}
+
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+					return false, nil
+				}
+
+				nodeRequest := reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name: "worker-1",
+					},
+				}
+
+				res, err := r.Reconcile(context.TODO(), nodeRequest)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.IsZero()).To(BeTrue())
+
+				// Verify the node was not labeled
+				updatedNode := &corev1.Node{}
+				err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, updatedNode)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
+			})
+
+			It("Should handle missing node gracefully", func() {
+				hco := commontestutils.NewHco()
+				resources := []client.Object{hco}
+				cl := commontestutils.InitClient(resources)
+
+				r := &ReconcileNodeCounter{
+					Client:                       cl,
+					nodeEvents:                   nodeEvents,
+					HandleHyperShiftNodeLabeling: HandleHyperShiftNodeLabeling,
+				}
+
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+					return false, nil
+				}
+
+				nodeRequest := reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name: "non-existent-node",
+					},
+				}
+
+				// Should not return error for missing node
+				res, err := r.Reconcile(context.TODO(), nodeRequest)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.IsZero()).To(BeTrue())
+			})
+
+			It("Should not label nodes for HCO events", func() {
+				workerNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-1",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleWorker: "",
+						},
+					},
+				}
+
+				hco := commontestutils.NewHco()
+				resources := []client.Object{hco, workerNode}
+				cl := commontestutils.InitClient(resources)
+
+				r := &ReconcileNodeCounter{
+					Client:     cl,
+					nodeEvents: nodeEvents,
+				}
+
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+					return false, nil
+				}
+
+				// Use hcoReq instead of node request
+				res, err := r.Reconcile(context.TODO(), hcoReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.IsZero()).To(BeTrue())
+
+				// Verify the node was not labeled (HCO event should skip node labeling)
+				updatedNode := &corev1.Node{}
+				err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, updatedNode)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
+			})
+
+			It("Should label all nodes at startup", func() {
+				worker1 := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-1",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleWorker: "",
+						},
+					},
+				}
+				worker2 := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-2",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleWorker: "",
+						},
+					},
+				}
+				cpNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "control-plane-1",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleControlPlane: "",
+						},
+					},
+				}
+
+				resources := []client.Object{worker1, worker2, cpNode}
+				cl := commontestutils.InitClient(resources)
+
+				r := &ReconcileNodeCounter{
+					Client:     cl,
+					nodeEvents: nodeEvents,
+				}
+
+				err := r.labelAllNodesAtStartup(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify worker nodes were labeled
+				updatedWorker1 := &corev1.Node{}
+				err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, updatedWorker1)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedWorker1.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(hypershiftLabelValue))
+
+				updatedWorker2 := &corev1.Node{}
+				err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-2"}, updatedWorker2)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedWorker2.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(hypershiftLabelValue))
+
+				// Verify control plane node was not changed
+				updatedCP := &corev1.Node{}
+				err = cl.Get(context.TODO(), client.ObjectKey{Name: "control-plane-1"}, updatedCP)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedCP.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(""))
+			})
+		})
+
+		Context("isWorkerNode helper", func() {
+			It("Should identify worker node correctly", func() {
+				workerNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-1",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleWorker: "",
+						},
+					},
+				}
+				Expect(isWorkerNode(workerNode)).To(BeTrue())
+			})
+
+			It("Should not identify control plane node as worker", func() {
+				cpNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "control-plane-1",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleControlPlane: "",
+						},
+					},
+				}
+				Expect(isWorkerNode(cpNode)).To(BeFalse())
+			})
+
+			It("Should not identify master node as worker", func() {
+				masterNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master-1",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleMaster: "",
+						},
+					},
+				}
+				Expect(isWorkerNode(masterNode)).To(BeFalse())
+			})
+
+			It("Should not identify node with both worker and control-plane labels as worker", func() {
+				mixedNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mixed-1",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleWorker:       "",
+							nodeinfo.LabelNodeRoleControlPlane: "",
+						},
+					},
+				}
+				Expect(isWorkerNode(mixedNode)).To(BeFalse())
+			})
+
+			It("Should not identify node without labels as worker", func() {
+				unlabeledNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "unlabeled-1",
+					},
+				}
+				Expect(isWorkerNode(unlabeledNode)).To(BeFalse())
 			})
 		})
 

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -887,6 +887,7 @@ rules:
   - get
   - list
   - watch
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.17.0/manifests/kubevirt-hyperconverged-operator.v1.17.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.17.0/manifests/kubevirt-hyperconverged-operator.v1.17.0.clusterserviceversion.yaml
@@ -322,6 +322,7 @@ spec:
           - get
           - list
           - watch
+          - patch
         - apiGroups:
           - ""
           resources:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.17.0/manifests/kubevirt-hyperconverged-operator.v1.17.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.17.0/manifests/kubevirt-hyperconverged-operator.v1.17.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.17.0-unstable
-    createdAt: "2025-11-14 05:05:39"
+    createdAt: "2025-11-23 10:08:22"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -322,6 +322,7 @@ spec:
           - get
           - list
           - watch
+          - patch
         - apiGroups:
           - ""
           resources:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -544,7 +544,7 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 		{
 			APIGroups: emptyAPIGroup,
 			Resources: stringListToSlice("pods", "nodes"),
-			Verbs:     stringListToSlice("get", "list", "watch"),
+			Verbs:     stringListToSlice("get", "list", "watch", "patch"),
 		},
 		{
 			APIGroups: emptyAPIGroup,

--- a/pkg/nodeinfo/nodeinfo.go
+++ b/pkg/nodeinfo/nodeinfo.go
@@ -2,7 +2,16 @@ package nodeinfo
 
 import internal "github.com/kubevirt/hyperconverged-cluster-operator/pkg/internal/nodeinfo"
 
-const S390X = internal.S390X
+const (
+	S390X = internal.S390X
+
+	// LabelNodeRoleControlPlane is the label used to identify control plane nodes
+	LabelNodeRoleControlPlane = internal.LabelNodeRoleControlPlane
+	// LabelNodeRoleMaster is the old label used to identify control plane nodes
+	LabelNodeRoleMaster = internal.LabelNodeRoleMaster
+	// LabelNodeRoleWorker is the label used to identify worker nodes
+	LabelNodeRoleWorker = internal.LabelNodeRoleWorker
+)
 
 var (
 	HandleNodeChanges = internal.HandleNodeChanges


### PR DESCRIPTION
virt-operator deploymnet now requires to be scheduled only on control-plane nodes. In Hosted Control Plane cluster (HCP), there are no control plane nodes, but only worker nodes. This PR aims to address this issue, by labeling the worker nodes with additional 'node-role.kubernetes.io/control-plane' label on them, so the virt-operator pods will be scheduled and the deployment of kubevirt will succeed on such topology.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-61721
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow virt-operator deployment on Hosted Control Planes Cluster
```
