### PR TITLE
Free disk-space on image build

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -76,4 +76,4 @@ jobs:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
           CSV_VERSION: ${{ env.CSV_VERSION }}
         run: |
-          IMAGE_TAG="${IMAGE_TAG}" NEW_TAG="${CSV_VERSION}-unstable" make retag-push-all-images
+          IMAGE_TAG="${IMAGE_TAG}" NEW_TAG="${CSV_VERSION}-unstable" MULTIARCH="false" make retag-push-all-images

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ INDEX_IMAGE        ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-index
 BUILDER_IMAGE      ?= $(IMAGE_REGISTRY)/$(REGISTRY_NAMESPACE)/hco-builder
 LDFLAGS            ?= -w -s
 GOLANDCI_LINT_VERSION ?= v2.6.0
+MULTIARCH          ?= true
 HCO_BUMP_LEVEL ?= minor
 ASSETS_DIR ?= assets
 DUMP_NETWORK_POLICIES ?= "false"
@@ -160,12 +161,12 @@ container-push-artifacts-server:
 	. "hack/cri-bin.sh" && $$CRI_BIN push $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG)
 
 retag-push-all-images:
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(OPERATOR_IMAGE) MULTIARCH=true CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE) MULTIARCH=true CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE) MULTIARCH=true CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER) MULTIARCH=true CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(OPERATOR_IMAGE) MULTIARCH=$(MULTIARCH) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE) MULTIARCH=$(MULTIARCH) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE) MULTIARCH=$(MULTIARCH) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER) MULTIARCH=$(MULTIARCH) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
 	IMAGE_REPO=$(IMAGE_REGISTRY)/$(BUNDLE_IMAGE) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(INDEX_IMAGE) MULTIARCH=true CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(INDEX_IMAGE) MULTIARCH=$(MULTIARCH) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
 
 cluster-up:
 	./cluster/up.sh

--- a/hack/build-push-multi-arch-images.sh
+++ b/hack/build-push-multi-arch-images.sh
@@ -12,6 +12,8 @@ if [[ -z ${DOCKER_FILE} ]]; then
   exit 1
 fi
 
+CLEANUP=${CLEANUP:-"true"}
+
 SHA=$(git describe --no-match  --always --abbrev=40 --dirty)
 
 . ./hack/cri-bin.sh && export CRI_BIN=${CRI_BIN}
@@ -27,3 +29,11 @@ for arch in ${ARCHITECTURES}; do
 done
 
 ./hack/retry.sh 3 10 "${CRI_BIN} manifest push ${IMAGE_NAME}"
+
+if [[ ${CLEANUP} == "true" ]]; then
+  for arch in ${ARCHITECTURES}; do
+    ${CRI_BIN} rmi "${IMAGE_NAME}-${arch}"
+  done
+
+  ${CRI_BIN} rmi $(${CRI_BIN} images -f "dangling=true" -q) -f
+fi


### PR DESCRIPTION
The github actions that builds the images, sometimes fail for out of storage in the device.

To fix it, we are now removing the local images after pushing them to the remote registry.

*Note*: redoing #3845 with a few changes: 
1. only remove the actual, architecture specific images, not the manifests image.
2. only retag and push the manifest image, not the already deleted architecture specific images.
3. also remove the dangling images.

**Release note**:
```release-note
None
```
