### PR TITLE
Make the builder image multi-arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ FUNC_TEST_IMAGE    ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-functest
 VIRT_ARTIFACTS_SERVER ?= $(REGISTRY_NAMESPACE)/virt-artifacts-server
 BUNDLE_IMAGE       ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-bundle
 INDEX_IMAGE        ?= $(REGISTRY_NAMESPACE)/hyperconverged-cluster-index
-BUILDER_IMAGE      ?= $(IMAGE_REGISTRY)/$(REGISTRY_NAMESPACE)/hco-builder
+BUILDER_IMAGE      ?= $(REGISTRY_NAMESPACE)/hco-builder
+BUILDER_IMAGE_TAG  ?= latest
 LDFLAGS            ?= -w -s
 GOLANDCI_LINT_VERSION ?= v2.6.0
 MULTIARCH          ?= true
@@ -310,10 +311,13 @@ annotate-dicts: build-annotate-dicts
 	ASSETS_DIR=$(ASSETS_DIR) ./hack/annotate-dicts.sh
 
 create-builder-image:
-	IMAGE_NAME=$(BUILDER_IMAGE) ./hack/builder/create-builder-image.sh
+	IMAGE_NAME=$(IMAGE_REGISTRY)/$(BUILDER_IMAGE):$(IMAGE_TAG) ./hack/builder/create-builder-image.sh
 
-push-builder-image:
-	podman push $(BUILDER_IMAGE)
+retag-builder-image:
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(BUILDER_IMAGE) MULTIARCH=false CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(BUILDER_IMAGE_TAG) ./hack/retag-multi-arch-images.sh
+
+# Temporary alias, until changing the usage of this target, from another repo
+push-builder-image: retag-builder-image
 
 .PHONY: start \
 		clean \
@@ -383,4 +387,5 @@ push-builder-image:
 		annotate-dicts \
 		cp-json-patch \
 		create-builder-image \
-		push-builder-image
+		push-builder-image \
+		retag-builder-image

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -1,9 +1,11 @@
-FROM quay.io/fedora/fedora:42
+FROM quay.io/fedora/fedora:43
+ARG TARGETOS
+ARG TARGETARCH
 RUN dnf install -y make jq git curl rsync rsync-daemon && \
     dnf clean all && \
-    curl -L -O https://go.dev/dl/go1.24.7.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.24.7.linux-amd64.tar.gz && \
-    rm -f go1.24.7.linux-amd64.tar.gz && \
+    curl -L -O "https://go.dev/dl/go1.24.7.linux-${TARGETARCH}.tar.gz" && \
+    tar -C /usr/local -xzf "go1.24.7.linux-${TARGETARCH}.tar.gz" && \
+    rm -f "go1.24.7.linux-${TARGETARCH}.tar.gz" && \
     mkdir -p /go
 COPY rsyncd.conf /etc/rsyncd.conf
 ADD entrypoint.sh /usr/bin/entrypoint.sh
@@ -13,15 +15,17 @@ ENV PATH=$PATH:/usr/local/go/bin:/go/bin \
     PACKAGE=github.com/kubevirt/hyperconverged-cluster-operator \
     API_FOLDER=api \
     API_VERSION=v1beta1 \
-    PROJECT_ROOT=/root/hco
+    PROJECT_ROOT=/root/hco \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH}
 # Build args for code-generator versions
 ARG K8S_VER
 ARG KUBEOPENAPI_VER
 # Install code generation tools as root
-RUN go install \
+RUN GOOS=linux GOARCH=${TARGETARCH} go install \
     k8s.io/code-generator/cmd/deepcopy-gen@${K8S_VER} \
     k8s.io/code-generator/cmd/defaulter-gen@${K8S_VER} && \
-    go install \
+    GOOS=linux GOARCH=${TARGETARCH} go install \
     k8s.io/kube-openapi/cmd/openapi-gen@${KUBEOPENAPI_VER}
 # Verify installation
 RUN go version && \

--- a/hack/builder/create-builder-image.sh
+++ b/hack/builder/create-builder-image.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Load build arguments directly from go.mod
 
+source ./hack/architecture.sh
+. ./hack/cri-bin.sh && export CRI_BIN=${CRI_BIN}
+
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 IMAGE_NAME=${IMAGE_NAME:-hco-builder}
 
@@ -12,6 +15,15 @@ KUBEOPENAPI_VER=$(grep "k8s.io/kube-openapi => k8s.io/kube-openapi" go.mod | xar
 
 echo "Loaded from go.mod: K8S_VER=${K8S_VER}, KUBEOPENAPI_VER=${KUBEOPENAPI_VER}"
 
-podman build -t ${IMAGE_NAME} -f hack/builder/Dockerfile --build-arg K8S_VER=${K8S_VER} --build-arg KUBEOPENAPI_VER=${KUBEOPENAPI_VER} ${script_dir}
+if ${CRI_BIN} manifest exists "${IMAGE_NAME}"; then
+  ${CRI_BIN} manifest rm "${IMAGE_NAME}"
+fi
+${CRI_BIN} manifest create "${IMAGE_NAME}"
 
+for arch in ${ARCHITECTURES}; do
+  ${CRI_BIN} build --platform="linux/${arch}" -t ${IMAGE_NAME}-${arch} -f hack/builder/Dockerfile --build-arg K8S_VER=${K8S_VER} --build-arg KUBEOPENAPI_VER=${KUBEOPENAPI_VER} ${script_dir}
+  ./hack/retry.sh 3 10 "${CRI_BIN} push ${IMAGE_NAME}-${arch}"
+  ${CRI_BIN} manifest add "${IMAGE_NAME}" "${IMAGE_NAME}-${arch}"
+done
 
+./hack/retry.sh 3 10 "${CRI_BIN} manifest push ${IMAGE_NAME}"

--- a/hack/retag-multi-arch-images.sh
+++ b/hack/retag-multi-arch-images.sh
@@ -8,7 +8,7 @@ if [[ -z ${IMAGE_REPO} ]]; then
 fi
 
 NEW_IMAGE_REPO=${NEW_IMAGE_REPO:-${IMAGE_REPO}}
-
+CURRENT_TAG=${CURRENT_TAG:-${IMAGE_TAG}}
 if [[ -z ${CURRENT_TAG} ]]; then
   echo "CURRENT_TAG must be defined"
   exit 1


### PR DESCRIPTION
This will allow developers working on windows or mac to use it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
