### PR TITLE
Fix the nightly build

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -76,4 +76,4 @@ jobs:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
           CSV_VERSION: ${{ env.CSV_VERSION }}
         run: |
-          IMAGE_TAG="${IMAGE_TAG}" NEW_TAG="${CSV_VERSION}-unstable" MULTIARCH="false" make retag-push-all-images
+          IMAGE_TAG="${IMAGE_TAG}" NEW_TAG="${CSV_VERSION}-unstable" make retag-push-all-images

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ BUILDER_IMAGE      ?= $(REGISTRY_NAMESPACE)/hco-builder
 BUILDER_IMAGE_TAG  ?= latest
 LDFLAGS            ?= -w -s
 GOLANDCI_LINT_VERSION ?= v2.6.0
-MULTIARCH          ?= true
 HCO_BUMP_LEVEL ?= minor
 ASSETS_DIR ?= assets
 DUMP_NETWORK_POLICIES ?= "false"
@@ -162,12 +161,12 @@ container-push-artifacts-server:
 	. "hack/cri-bin.sh" && $$CRI_BIN push $(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER):$(IMAGE_TAG)
 
 retag-push-all-images:
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(OPERATOR_IMAGE) MULTIARCH=$(MULTIARCH) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE) MULTIARCH=$(MULTIARCH) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE) MULTIARCH=$(MULTIARCH) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER) MULTIARCH=$(MULTIARCH) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(OPERATOR_IMAGE) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(WEBHOOK_IMAGE) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(FUNC_TEST_IMAGE) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(VIRT_ARTIFACTS_SERVER) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
 	IMAGE_REPO=$(IMAGE_REGISTRY)/$(BUNDLE_IMAGE) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(INDEX_IMAGE) MULTIARCH=$(MULTIARCH) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(INDEX_IMAGE) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(NEW_TAG) ./hack/retag-multi-arch-images.sh
 
 cluster-up:
 	./cluster/up.sh
@@ -314,7 +313,7 @@ create-builder-image:
 	IMAGE_NAME=$(IMAGE_REGISTRY)/$(BUILDER_IMAGE):$(IMAGE_TAG) ./hack/builder/create-builder-image.sh
 
 retag-builder-image:
-	IMAGE_REPO=$(IMAGE_REGISTRY)/$(BUILDER_IMAGE) MULTIARCH=false CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(BUILDER_IMAGE_TAG) ./hack/retag-multi-arch-images.sh
+	IMAGE_REPO=$(IMAGE_REGISTRY)/$(BUILDER_IMAGE) CURRENT_TAG=$(IMAGE_TAG) NEW_TAG=$(BUILDER_IMAGE_TAG) ./hack/retag-multi-arch-images.sh
 
 # Temporary alias, until changing the usage of this target, from another repo
 push-builder-image: retag-builder-image

--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -177,8 +177,8 @@ fi
 echo "${build_date}" > build-date
 gsutil cp ./build-date gs://${hco_bucket}/latest
 
-IMAGE_REPO=${HCO_OPERATOR_IMAGE_REPO} MULTIARCH=true CURRENT_TAG=${IMAGE_TAG} NEW_TAG=nightly ./hack/retag-multi-arch-images.sh
-IMAGE_REPO=${HCO_WEBHOOK_IMAGE_REPO}  MULTIARCH=true CURRENT_TAG=${IMAGE_TAG} NEW_TAG=nightly ./hack/retag-multi-arch-images.sh
-IMAGE_REPO=${HCO_DOWNLOAD_IMAGE_REPO} MULTIARCH=true CURRENT_TAG=${IMAGE_TAG} NEW_TAG=nightly ./hack/retag-multi-arch-images.sh
-IMAGE_REPO=${HCO_BUNDLE_IMAGE_REPO}                  CURRENT_TAG=${IMAGE_TAG} NEW_TAG=nightly ./hack/retag-multi-arch-images.sh
-IMAGE_REPO=${HCO_INDEX_IMAGE_REPO}    MULTIARCH=true CURRENT_TAG=${IMAGE_TAG} NEW_TAG=nightly ./hack/retag-multi-arch-images.sh
+IMAGE_REPO=${HCO_OPERATOR_IMAGE_REPO} CURRENT_TAG=${IMAGE_TAG} NEW_TAG=nightly ./hack/retag-multi-arch-images.sh
+IMAGE_REPO=${HCO_WEBHOOK_IMAGE_REPO}  CURRENT_TAG=${IMAGE_TAG} NEW_TAG=nightly ./hack/retag-multi-arch-images.sh
+IMAGE_REPO=${HCO_DOWNLOAD_IMAGE_REPO} CURRENT_TAG=${IMAGE_TAG} NEW_TAG=nightly ./hack/retag-multi-arch-images.sh
+IMAGE_REPO=${HCO_BUNDLE_IMAGE_REPO}   CURRENT_TAG=${IMAGE_TAG} NEW_TAG=nightly ./hack/retag-multi-arch-images.sh
+IMAGE_REPO=${HCO_INDEX_IMAGE_REPO}    CURRENT_TAG=${IMAGE_TAG} NEW_TAG=nightly ./hack/retag-multi-arch-images.sh

--- a/hack/retag-multi-arch-images.sh
+++ b/hack/retag-multi-arch-images.sh
@@ -21,14 +21,6 @@ fi
 
 . ./hack/cri-bin.sh && export CRI_BIN=${CRI_BIN}
 
-if [[ "${MULTIARCH}" == "true" ]]; then
-  for arch in ${ARCHITECTURES}; do
-    NEW_IMAGE="${NEW_IMAGE_REPO}:${NEW_TAG}-${arch}"
-    ${CRI_BIN} tag "${IMAGE_REPO}:${CURRENT_TAG}-${arch}" "${NEW_IMAGE}"
-    ./hack/retry.sh 3 10 "${CRI_BIN} push ${NEW_IMAGE}"
-  done
-fi
-
 # retag the manifest
 NEW_IMAGE="${NEW_IMAGE_REPO}:${NEW_TAG}"
 ${CRI_BIN} tag "${IMAGE_REPO}:${CURRENT_TAG}" "${NEW_IMAGE}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify the retag-multi-arch-images.sh script to not retag the architecture specific images, but only the multi-arch manifest image.

**Release note**:
```release-note
None
```
