### PR TITLE
e2e: prevent leftovers after golden-images test

### DIFF
--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -464,6 +464,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				customDictArchs := append(archs, "someOtherArch1", "someOtherArch2")
 				hcCustomDict.Annotations[goldenimages.MultiArchDICTAnnotation] = strings.Join(customDictArchs, ",")
+				hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
 
 				hc.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{hcCustomDict}
 
@@ -526,6 +527,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 				customDictArchs := append(archs, "someOtherArch1", "someOtherArch2")
 				testAnnotation := strings.Join(customDictArchs, ",")
 				hcCustomDict.Annotations[goldenimages.MultiArchDICTAnnotation] = testAnnotation
+				hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
 				expectedArches = getExpectedArchs(testAnnotation, archs)
 
 				hc.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{hcCustomDict}
@@ -598,6 +600,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 					hcCustomDict.Name = "custom-dict"
 					hcCustomDict.Spec.ManagedDataSource = "custom-source"
 					delete(hcCustomDict.Annotations, goldenimages.MultiArchDICTAnnotation)
+					hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
 
 					hc.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{hcCustomDict}
 
@@ -668,6 +671,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 					}
 
 					hcCustomDict.Annotations[goldenimages.MultiArchDICTAnnotation] = "someOtherArch1,someOtherArch2"
+					hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
 
 					hc.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{hcCustomDict}
 
@@ -738,6 +742,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 					hcCustomDict.Spec.Template.Spec.Source.Registry = nextDICT.Spec.Template.Spec.Source.Registry.DeepCopy()
 
 					hcCustomDict.Annotations[goldenimages.MultiArchDICTAnnotation] = "someOtherArch1,someOtherArch2"
+					hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
 
 					hc.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{hcCustomDict}
 
@@ -806,6 +811,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 					originalSupportedArchitectures = hc.Status.DataImportCronTemplates[0].Status.OriginalSupportedArchitectures
 					hcCustomDict.Annotations[goldenimages.MultiArchDICTAnnotation] = "someOtherArch1,someOtherArch2"
+					hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
 
 					hc.Spec.DataImportCronTemplates = []hcov1beta1.DataImportCronTemplate{hcCustomDict}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

To prevent having leftover DataSources after the golden-images functional test is running, set the `RetentionPolicy` of all the customized DICT to "None".

From CDI API:
```
DataImportCronRetainNone specifies that the created DataVolumes and
DataSources are deleted when their DataImportCron is deleted.
```

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-77530
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
