### PR TITLE
Fix kubevirt_memory_delta_from_requested_bytes to the new name, and upgrade metrics linter 

### DIFF
--- a/hack/prom_metric_linter.sh
+++ b/hack/prom_metric_linter.sh
@@ -20,7 +20,7 @@
 #
 set -e
 
-linter_image_tag="v0.0.11"
+linter_image_tag="v0.0.12"
 
 PROJECT_ROOT="$(readlink -e "$(dirname "${BASH_SOURCE[0]}")"/../)"
 export METRICS_COLLECTOR_PATH="${METRICS_COLLECTOR_PATH:-${PROJECT_ROOT}/tools/prom-metrics-collector}"

--- a/pkg/monitoring/hyperconverged/rules/recordingrules/operator.go
+++ b/pkg/monitoring/hyperconverged/rules/recordingrules/operator.go
@@ -47,7 +47,7 @@ var operatorRecordingRules = []operatorrules.RecordingRule{
 			Help: "Monitors resources for potential problems",
 		},
 		MetricType: operatormetrics.GaugeType,
-		Expr:       intstr.FromString(`sum by (container, reason)(kubevirt_memory_delta_from_requested_bytes)`),
+		Expr:       intstr.FromString(`sum by (container, reason)(container:kubevirt_memory_delta_from_requested_bytes:max)`),
 	},
 }
 

--- a/tools/prom-metrics-collector/metrics_json_generator.go
+++ b/tools/prom-metrics-collector/metrics_json_generator.go
@@ -31,13 +31,6 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/rules"
 )
 
-// This should be used only for very rare cases where the naming conventions that are explained in the best practices:
-// https://sdk.operatorframework.io/docs/best-practices/observability-best-practices/#metrics-guidelines
-// should be ignored.
-var excludedMetrics = map[string]struct{}{
-	"cluster:vmi_request_cpu_cores:sum": {},
-}
-
 type RecordingRule struct {
 	Record string `json:"record,omitempty"`
 	Expr   string `json:"expr,omitempty"`
@@ -66,14 +59,12 @@ func main() {
 
 	var metricFamilies []*dto.MetricFamily
 	for _, m := range metricsList {
-		if _, isExcludedMetric := excludedMetrics[m.GetOpts().Name]; !isExcludedMetric {
-			pm := parser.Metric{
-				Name: m.GetOpts().Name,
-				Help: m.GetOpts().Help,
-				Type: strings.ToUpper(string(m.GetBaseType())),
-			}
-			metricFamilies = append(metricFamilies, parser.CreateMetricFamily(pm))
+		pm := parser.Metric{
+			Name: m.GetOpts().Name,
+			Help: m.GetOpts().Help,
+			Type: strings.ToUpper(string(m.GetBaseType())),
 		}
+		metricFamilies = append(metricFamilies, parser.CreateMetricFamily(pm))
 	}
 
 	// Build recording rules JSON and record names for filtering
@@ -81,9 +72,6 @@ func main() {
 	var recRules []RecordingRule
 	for _, r := range rulesList {
 		name := r.GetOpts().Name
-		if _, isExcludedMetric := excludedMetrics[name]; isExcludedMetric {
-			continue
-		}
 		recNames[name] = struct{}{}
 		recRules = append(recRules, RecordingRule{
 			Record: name,


### PR DESCRIPTION
In https://github.com/kubevirt/kubevirt/pull/17065 `kubevirt_memory_delta_from_requested_bytes`  is deprecated and replaced by `container:kubevirt_memory_delta_from_requested_bytes:max`. This pr fix `cnv_abnormal` expression to use the new name.

*This pr also upgrade the linter version to be able to remove `cluster:vmi_request_cpu_cores:sum` and excluded list.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
