### PR TITLE
Extend the functional tests timeout

### DIFF
--- a/hack/run-tests-in-container.sh
+++ b/hack/run-tests-in-container.sh
@@ -102,7 +102,10 @@ spec:
   restartPolicy: Never
 EOF
 
-for i in $(seq 1 120); do
+NUM_WAIT_ITERATIONS=150
+ITERATION_WAIT_TIME=10
+
+for i in $(seq 1 ${NUM_WAIT_ITERATIONS}); do
   exitCode=$($KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" get pod/functest -o jsonpath='{.status .containerStatuses[?(@.name=="functest")] .state .terminated .exitCode}')
 
   if [[ -n ${exitCode} ]]; then
@@ -110,11 +113,15 @@ for i in $(seq 1 120); do
   fi
 
   echo "Waiting for completion... Iteration:$i"
-  sleep 10
+  sleep ${ITERATION_WAIT_TIME}
 done
 
 if [[ -z ${exitCode} ]]; then
   $KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" get pod functest -o yaml || true
+fi
+
+if [[ ${NUM_WAIT_ITERATIONS} -eq $i ]]; then
+  echo "ERROR: Timeout: the test pod didn't exit after $((${ITERATION_WAIT_TIME} * ${NUM_WAIT_ITERATIONS})) seconds"
 fi
 
 $KUBECTL_BINARY -n "${INSTALLED_NAMESPACE}" cp -c=copy functest:/test/output "$OUTPUT_DIR"


### PR DESCRIPTION
The functional tests strart failing for timeout, even though the tests pass, but not complete.

This PR extends the time we arewaiting for the test pod from 20 minutes to 25 minutes, and add an error message in case of timeout.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
