### PR TITLE
Fix the optional operator: ensure removal of related objects

### DIFF
--- a/controllers/operands/conditionalHandler.go
+++ b/controllers/operands/conditionalHandler.go
@@ -62,16 +62,24 @@ func (ch *ConditionalHandler) ensureDeleted(req *common.HcoRequest) *EnsureResul
 
 		if deleted {
 			res.SetDeleted()
-			objectRef, err := reference.GetReference(ch.operand.Scheme, cr)
-			if err != nil {
-				return res.Error(err)
-			}
-
-			if err = objectreferencesv1.RemoveObjectReference(&req.Instance.Status.RelatedObjects, *objectRef); err != nil {
-				return res.Error(err)
-			}
-			req.StatusDirty = true
 		}
+	}
+
+	objectRef, err := reference.GetReference(ch.operand.Scheme, cr)
+	if err != nil {
+		return res.Error(err)
+	}
+
+	ref, err := objectreferencesv1.FindObjectReference(req.Instance.Status.RelatedObjects, *objectRef)
+	if err != nil {
+		return res.Error(err)
+	}
+	if ref != nil {
+		if err = objectreferencesv1.RemoveObjectReference(&req.Instance.Status.RelatedObjects, *objectRef); err != nil {
+			return res.Error(err)
+		}
+
+		req.StatusDirty = true
 	}
 
 	return res.SetUpgradeDone(req.ComponentUpgradeInProgress)

--- a/tests/func-tests/conversion_test.go
+++ b/tests/func-tests/conversion_test.go
@@ -45,7 +45,7 @@ var _ = Describe("check v1 <=> v1beta1 API conversion", func() {
 		converted := &hcov1.HyperConverged{}
 		Expect(hcv1beta1.ConvertTo(converted)).To(Succeed())
 
-		diff := cmp.Diff(hcv1, converted)
+		diff := cmp.Diff(hcv1.Spec, converted.Spec)
 		if diff != "" {
 			GinkgoWriter.Println(diff)
 			Fail("v1 HyperConverged should be equal to the v1beta1 converted one")


### PR DESCRIPTION
* In the optional operator logic, if the operand should be removed, we also remove the object from the relatedObjects list in the HyperConverged status. If there was a problem during this process, the related image stays there forever. 
  
  This PR fixes the optional operator logic to make sure the deleted object is removed from the relatedObjects list, even if it was already deleted. It also should fix the E2 flaky sub-resource label test. 

* The conversion test sometimes fails when comparing the results of getting the HyperConverged in v1, to the result when reading in v1beta1 format. 
  
  This is happening for unrelated changes in the status or the metadata fields. The fix is to only compare the spec fields.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
