### PR TITLE
CNV-82451: Add ssl_ecdh_curve to kubevirt-plugin nginx config

### DIFF
--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -525,6 +525,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(nginxConf).To(ContainSubstring("listen"))
 				Expect(nginxConf).To(ContainSubstring("ssl_protocols"))
 				Expect(nginxConf).To(ContainSubstring("ssl_ciphers"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_protocols ;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
 			})
@@ -540,6 +541,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(cm.Data).To(HaveKey("nginx.conf"))
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).To(MatchRegexp(`ssl_protocols +TLSv1\.3`))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
 			})
 
@@ -555,6 +557,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).To(ContainSubstring("ssl_protocols"))
 				Expect(nginxConf).To(ContainSubstring("ssl_ciphers"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_protocols ;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
 			})
@@ -576,6 +579,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(cm.Data).To(HaveKey("nginx.conf"))
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).To(MatchRegexp(`ssl_protocols +TLSv1\.3`))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers"))
 			})
 
@@ -586,6 +590,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_protocols ;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
 			})
 		})
 

--- a/controllers/handlers/templates/nginx.conf.tmpl
+++ b/controllers/handlers/templates/nginx.conf.tmpl
@@ -17,6 +17,7 @@ http {
 {{- if .SSLCiphers }}
 			ssl_ciphers         {{ .SSLCiphers }};
 {{- end }}
+			ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;
 			root                /usr/share/nginx/html;
 
 			# Prevent caching for plugin-manifest.json and plugin-entry.js


### PR DESCRIPTION
Configure nginx for the console plugin with Post-Quantum / hybrid ECDH groups per security guidance, including MLKEM-based curves and standard X25519 / NIST curves.

Tests: extend nginx ConfigMap expectations for all TLS profile cases.
Made-with: Cursor

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
