### PR TITLE
[Refactor - internal] Simplify handlers

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -521,7 +521,7 @@ func getManagerOptions(operatorNamespace string, needLeaderElection bool, ci hco
 // so we are never supposed to delete it: because the priority class
 // is completely opaque to OLM it will remain as a leftover on the cluster
 func createPriorityClass(ctx context.Context, mgr manager.Manager) error {
-	pc := handlers.NewKubeVirtPriorityClass(&hcov1beta1.HyperConverged{})
+	pc := handlers.NewKubeVirtPriorityClass()
 
 	err := mgr.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(pc), pc)
 	if err != nil && apierrors.IsNotFound(err) {

--- a/controllers/commontestutils/before_suite.go
+++ b/controllers/commontestutils/before_suite.go
@@ -1,0 +1,26 @@
+package commontestutils
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+func CommonBeforeSuite() {
+	GinkgoHelper()
+
+	origNS, origNSSet := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
+	Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, Namespace)).To(Succeed())
+
+	DeferCleanup(func() {
+		if origNSSet {
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(hcoutil.OperatorNamespaceEnv)).To(Succeed())
+		}
+	})
+
+}

--- a/controllers/handlers/aaq.go
+++ b/controllers/handlers/aaq.go
@@ -146,7 +146,7 @@ func NewAAQWithNameOnly(hc *hcov1beta1.HyperConverged) *aaqv1alpha1.AAQ {
 	return &aaqv1alpha1.AAQ{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "aaq-" + hc.Name,
-			Labels: operands.GetLabels(hc, hcoutil.AppComponentQuotaMngt),
+			Labels: operands.GetLabelsDeprecated(hc, hcoutil.AppComponentQuotaMngt),
 		},
 	}
 }

--- a/controllers/handlers/aaq.go
+++ b/controllers/handlers/aaq.go
@@ -28,8 +28,8 @@ func NewAAQHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operan
 		func(hc *hcov1beta1.HyperConverged) bool {
 			return hc.Spec.EnableApplicationAwareQuota != nil && *hc.Spec.EnableApplicationAwareQuota
 		},
-		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewAAQWithNameOnly(hc)
+		func(_ *hcov1beta1.HyperConverged) client.Object {
+			return NewAAQWithNameOnly()
 		},
 	)
 }
@@ -136,17 +136,17 @@ func NewAAQ(hc *hcov1beta1.HyperConverged) (*aaqv1alpha1.AAQ, error) {
 		spec.Configuration.AllowApplicationAwareClusterResourceQuota = config.AllowApplicationAwareClusterResourceQuota
 	}
 
-	aaq := NewAAQWithNameOnly(hc)
+	aaq := NewAAQWithNameOnly()
 	aaq.Spec = spec
 
 	return reformatobj.ReformatObj(aaq)
 }
 
-func NewAAQWithNameOnly(hc *hcov1beta1.HyperConverged) *aaqv1alpha1.AAQ {
+func NewAAQWithNameOnly() *aaqv1alpha1.AAQ {
 	return &aaqv1alpha1.AAQ{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "aaq-" + hc.Name,
-			Labels: operands.GetLabelsDeprecated(hc, hcoutil.AppComponentQuotaMngt),
+			Name:   "aaq-" + hcoutil.HyperConvergedName,
+			Labels: operands.GetLabels(hcoutil.AppComponentQuotaMngt),
 		},
 	}
 }

--- a/controllers/handlers/aaq_test.go
+++ b/controllers/handlers/aaq_test.go
@@ -309,7 +309,7 @@ var _ = Describe("AAQ tests", func() {
 		It("should update AAQ fields, if not matched to the requirements", func() {
 			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
 			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
-			aaq := NewAAQWithNameOnly(hco)
+			aaq := NewAAQWithNameOnly()
 			aaq.Spec.Infra = testNodePlacement
 			aaq.Spec.PriorityClass = ptr.To[aaqv1alpha1.AAQPriorityClass]("wrongPC")
 			aaq.Spec.CertConfig = &aaqv1alpha1.AAQCertConfig{
@@ -360,7 +360,7 @@ var _ = Describe("AAQ tests", func() {
 			const userLabelValue = "userLabelValue"
 			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
 			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
-			outdatedResource := NewAAQWithNameOnly(hco)
+			outdatedResource := NewAAQWithNameOnly()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
@@ -393,7 +393,7 @@ var _ = Describe("AAQ tests", func() {
 			const userLabelValue = "userLabelValue"
 			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
 			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
-			outdatedResource := NewAAQWithNameOnly(hco)
+			outdatedResource := NewAAQWithNameOnly()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)

--- a/controllers/handlers/aie/aie_webhook_suite_test.go
+++ b/controllers/handlers/aie/aie_webhook_suite_test.go
@@ -1,13 +1,28 @@
 package aie
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func TestAIEWebhook(t *testing.T) {
+	origNS, ok := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
+	_ = os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)
+
+	defer func() {
+		if ok {
+			_ = os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)
+		} else {
+			_ = os.Unsetenv(hcoutil.OperatorNamespaceEnv)
+		}
+	}()
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "AIE Webhook Suite")
 }

--- a/controllers/handlers/aie/aie_webhook_suite_test.go
+++ b/controllers/handlers/aie/aie_webhook_suite_test.go
@@ -1,28 +1,19 @@
 package aie
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func TestAIEWebhook(t *testing.T) {
-	origNS, ok := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
-	_ = os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)
-
-	defer func() {
-		if ok {
-			_ = os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)
-		} else {
-			_ = os.Unsetenv(hcoutil.OperatorNamespaceEnv)
-		}
-	}()
-
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "AIE Webhook Suite")
 }
+
+var _ = BeforeSuite(func() {
+	commontestutils.CommonBeforeSuite()
+})

--- a/controllers/handlers/aie/configmap.go
+++ b/controllers/handlers/aie/configmap.go
@@ -27,7 +27,7 @@ func newAIEWebhookConfigMapWithNameOnly(hc *hcov1beta1.HyperConverged) *corev1.C
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      aieWebhookConfigMapName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, appComponent),
+			Labels:    operands.GetLabelsDeprecated(hc, appComponent),
 		},
 	}
 }

--- a/controllers/handlers/aie/configmap.go
+++ b/controllers/handlers/aie/configmap.go
@@ -1,7 +1,6 @@
 package aie
 
 import (
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -9,31 +8,32 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-func NewAIEWebhookConfigMapHandler(_ logr.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	cm := newAIEWebhookConfigMap(hc)
+func NewAIEWebhookConfigMapHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
+	cm := newAIEWebhookConfigMap()
 	return operands.NewConditionalHandler(
 		operands.NewEditableCmHandler(Client, Scheme, cm),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return newAIEWebhookConfigMapWithNameOnly(hc)
+			return newAIEWebhookConfigMapWithNameOnly()
 		},
-	), nil
+	)
 }
 
-func newAIEWebhookConfigMapWithNameOnly(hc *hcov1beta1.HyperConverged) *corev1.ConfigMap {
+func newAIEWebhookConfigMapWithNameOnly() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      aieWebhookConfigMapName,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, appComponent),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(appComponent),
 		},
 	}
 }
 
-func newAIEWebhookConfigMap(hc *hcov1beta1.HyperConverged) *corev1.ConfigMap {
-	cm := newAIEWebhookConfigMapWithNameOnly(hc)
+func newAIEWebhookConfigMap() *corev1.ConfigMap {
+	cm := newAIEWebhookConfigMapWithNameOnly()
 	cm.Data = map[string]string{
 		"config.yaml": "rules:\n",
 	}

--- a/controllers/handlers/aie/configmap_test.go
+++ b/controllers/handlers/aie/configmap_test.go
@@ -3,7 +3,6 @@ package aie
 import (
 	"context"
 
-	log "github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +28,7 @@ var _ = Describe("AIE Webhook ConfigMap", func() {
 
 	Context("newAIEWebhookConfigMap", func() {
 		It("should create a ConfigMap with empty rules", func() {
-			cm := newAIEWebhookConfigMap(hco)
+			cm := newAIEWebhookConfigMap()
 			Expect(cm.Name).To(Equal("kubevirt-aie-launcher-config"))
 			Expect(cm.Data).To(HaveKey("config.yaml"))
 			Expect(cm.Data["config.yaml"]).To(Equal("rules:\n"))
@@ -40,8 +39,7 @@ var _ = Describe("AIE Webhook ConfigMap", func() {
 		It("should not create if deploy-aie-webhook annotation is absent", func() {
 			cl = commontestutils.InitClient([]client.Object{hco})
 
-			handler, err := NewAIEWebhookConfigMapHandler(log.Logger{}, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewAIEWebhookConfigMapHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -56,8 +54,7 @@ var _ = Describe("AIE Webhook ConfigMap", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
 			cl = commontestutils.InitClient([]client.Object{hco})
 
-			handler, err := NewAIEWebhookConfigMapHandler(log.Logger{}, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewAIEWebhookConfigMapHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -71,11 +68,10 @@ var _ = Describe("AIE Webhook ConfigMap", func() {
 		})
 
 		It("should delete configmap when deploy-aie-webhook annotation is removed", func() {
-			cm := newAIEWebhookConfigMap(hco)
+			cm := newAIEWebhookConfigMap()
 			cl = commontestutils.InitClient([]client.Object{hco, cm})
 
-			handler, err := NewAIEWebhookConfigMapHandler(log.Logger{}, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewAIEWebhookConfigMapHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 
 			Expect(res.Err).ToNot(HaveOccurred())

--- a/controllers/handlers/aie/daemonset.go
+++ b/controllers/handlers/aie/daemonset.go
@@ -45,7 +45,7 @@ func NewIOMMUFDDevicePluginDaemonSetWithNameOnly(hc *hcov1beta1.HyperConverged) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      iommufdDevicePluginName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, iommufdDevicePluginAppComponent),
+			Labels:    operands.GetLabelsDeprecated(hc, iommufdDevicePluginAppComponent),
 		},
 	}
 }
@@ -58,7 +58,7 @@ func newIOMMUFDDevicePluginDaemonSet(hc *hcov1beta1.HyperConverged) *appsv1.Daem
 		hcoutil.AppLabelComponent: string(iommufdDevicePluginAppComponent),
 	}
 
-	podLabels := operands.GetLabels(hc, iommufdDevicePluginAppComponent)
+	podLabels := operands.GetLabelsDeprecated(hc, iommufdDevicePluginAppComponent)
 
 	ds := NewIOMMUFDDevicePluginDaemonSetWithNameOnly(hc)
 	ds.Spec = appsv1.DaemonSetSpec{

--- a/controllers/handlers/aie/daemonset.go
+++ b/controllers/handlers/aie/daemonset.go
@@ -3,7 +3,6 @@ package aie
 import (
 	"os"
 
-	log "github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -28,16 +27,14 @@ var (
 	iommufdDevicePluginResourceMemory = resource.MustParse("50M")
 )
 
-func NewIOMMUFDDevicePluginDaemonSetHandler(
-	_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged,
-) (operands.Operand, error) {
+func NewIOMMUFDDevicePluginDaemonSetHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
-		operands.NewDaemonSetHandler(Client, Scheme, newIOMMUFDDevicePluginDaemonSet),
+		operands.NewDaemonSetHandler(cli, Scheme, newIOMMUFDDevicePluginDaemonSet),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
 			return NewIOMMUFDDevicePluginDaemonSetWithNameOnly(hc)
 		},
-	), nil
+	)
 }
 
 func NewIOMMUFDDevicePluginDaemonSetWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
@@ -45,7 +42,7 @@ func NewIOMMUFDDevicePluginDaemonSetWithNameOnly(hc *hcov1beta1.HyperConverged) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      iommufdDevicePluginName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, iommufdDevicePluginAppComponent),
+			Labels:    operands.GetLabels(iommufdDevicePluginAppComponent),
 		},
 	}
 }
@@ -58,7 +55,7 @@ func newIOMMUFDDevicePluginDaemonSet(hc *hcov1beta1.HyperConverged) *appsv1.Daem
 		hcoutil.AppLabelComponent: string(iommufdDevicePluginAppComponent),
 	}
 
-	podLabels := operands.GetLabelsDeprecated(hc, iommufdDevicePluginAppComponent)
+	podLabels := operands.GetLabels(iommufdDevicePluginAppComponent)
 
 	ds := NewIOMMUFDDevicePluginDaemonSetWithNameOnly(hc)
 	ds.Spec = appsv1.DaemonSetSpec{

--- a/controllers/handlers/aie/daemonset_test.go
+++ b/controllers/handlers/aie/daemonset_test.go
@@ -69,8 +69,7 @@ var _ = Describe("IOMMUFD Device Plugin DaemonSet", func() {
 			delete(hco.Annotations, DeployAIEAnnotation)
 			cl = commontestutils.InitClient([]client.Object{hco})
 
-			handler, err := NewIOMMUFDDevicePluginDaemonSetHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewIOMMUFDDevicePluginDaemonSetHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -88,8 +87,7 @@ var _ = Describe("IOMMUFD Device Plugin DaemonSet", func() {
 			ds := newIOMMUFDDevicePluginDaemonSet(hco)
 			cl = commontestutils.InitClient([]client.Object{hco, ds})
 
-			handler, err := NewIOMMUFDDevicePluginDaemonSetHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewIOMMUFDDevicePluginDaemonSetHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -107,8 +105,7 @@ var _ = Describe("IOMMUFD Device Plugin DaemonSet", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
 			cl = commontestutils.InitClient([]client.Object{hco})
 
-			handler, err := NewIOMMUFDDevicePluginDaemonSetHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewIOMMUFDDevicePluginDaemonSetHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -134,8 +131,7 @@ var _ = Describe("IOMMUFD Device Plugin DaemonSet", func() {
 			modifiedDs.Spec.Template.Spec.Volumes = nil
 			cl = commontestutils.InitClient([]client.Object{hco, modifiedDs})
 
-			handler, err := NewIOMMUFDDevicePluginDaemonSetHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewIOMMUFDDevicePluginDaemonSetHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -161,8 +157,7 @@ var _ = Describe("IOMMUFD Device Plugin DaemonSet", func() {
 			ds.Labels["user-added-label"] = "user-value"
 			cl = commontestutils.InitClient([]client.Object{hco, ds})
 
-			handler, err := NewIOMMUFDDevicePluginDaemonSetHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewIOMMUFDDevicePluginDaemonSetHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())

--- a/controllers/handlers/aie/deployment.go
+++ b/controllers/handlers/aie/deployment.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/go-logr/logr"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/crypto"
 	appsv1 "k8s.io/api/apps/v1"
@@ -29,16 +28,14 @@ var (
 	resourceMemoryLimit   = resource.MustParse("128Mi")
 )
 
-func NewAIEWebhookDeploymentHandler(
-	_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged,
-) (operands.Operand, error) {
+func NewAIEWebhookDeploymentHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
-		operands.NewDeploymentHandler(Client, Scheme, newAIEWebhookDeployment, hc),
+		operands.NewDeploymentHandler(cli, Scheme, newAIEWebhookDeployment),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
 			return newAIEWebhookDeploymentWithNameOnly(hc)
 		},
-	), nil
+	)
 }
 
 func newAIEWebhookDeploymentWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {

--- a/controllers/handlers/aie/deployment.go
+++ b/controllers/handlers/aie/deployment.go
@@ -46,7 +46,7 @@ func newAIEWebhookDeploymentWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      aieWebhookName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, appComponent),
+			Labels:    operands.GetLabelsDeprecated(hc, appComponent),
 		},
 	}
 }
@@ -62,7 +62,7 @@ func newAIEWebhookDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
 		hcoutil.AppLabelComponent: string(appComponent),
 	}
 
-	podLabels := operands.GetLabels(hc, appComponent)
+	podLabels := operands.GetLabelsDeprecated(hc, appComponent)
 
 	args := []string{
 		"--metrics-bind-address=:8443",

--- a/controllers/handlers/aie/deployment.go
+++ b/controllers/handlers/aie/deployment.go
@@ -33,17 +33,17 @@ func NewAIEWebhookDeploymentHandler(cli client.Client, Scheme *runtime.Scheme) o
 		operands.NewDeploymentHandler(cli, Scheme, newAIEWebhookDeployment),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return newAIEWebhookDeploymentWithNameOnly(hc)
+			return newAIEWebhookDeploymentWithNameOnly()
 		},
 	)
 }
 
-func newAIEWebhookDeploymentWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
+func newAIEWebhookDeploymentWithNameOnly() *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      aieWebhookName,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, appComponent),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(appComponent),
 		},
 	}
 }
@@ -59,7 +59,7 @@ func newAIEWebhookDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
 		hcoutil.AppLabelComponent: string(appComponent),
 	}
 
-	podLabels := operands.GetLabelsDeprecated(hc, appComponent)
+	podLabels := operands.GetLabels(appComponent)
 
 	args := []string{
 		"--metrics-bind-address=:8443",
@@ -74,7 +74,7 @@ func newAIEWebhookDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
 		args = append(args, "--tls-cipher-suites="+strings.Join(ianaCiphers, ","))
 	}
 
-	dep := newAIEWebhookDeploymentWithNameOnly(hc)
+	dep := newAIEWebhookDeploymentWithNameOnly()
 	dep.Spec = appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
 		Selector: &metav1.LabelSelector{

--- a/controllers/handlers/aie/deployment_test.go
+++ b/controllers/handlers/aie/deployment_test.go
@@ -1,0 +1,309 @@
+package aie
+
+import (
+	"context"
+	"maps"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	openshiftconfigv1 "github.com/openshift/api/config/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+var _ = Describe("AIE Webhook Deployment", func() {
+	const testImage = "quay.io/kubevirt/aieimage:test"
+
+	var (
+		hco *hcov1beta1.HyperConverged
+		req *common.HcoRequest
+		cl  client.Client
+	)
+
+	BeforeEach(func() {
+		hco = commontestutils.NewHco()
+		hco.Annotations = make(map[string]string)
+		req = commontestutils.NewReq(hco)
+		Expect(os.Setenv(hcoutil.AIEWebhookImageEnvV, testImage)).To(Succeed())
+
+		DeferCleanup(func() {
+			Expect(os.Unsetenv(hcoutil.AIEWebhookImageEnvV)).To(Succeed())
+		})
+	})
+
+	Context("newAIEWebhookDeployment", func() {
+		It("should have all default values", func() {
+			origFunc := tlssecprofile.GetCipherSuitesAndMinTLSVersion
+			tlssecprofile.GetCipherSuitesAndMinTLSVersion = func(fromHC *openshiftconfigv1.TLSSecurityProfile) ([]string, openshiftconfigv1.TLSProtocolVersion) {
+				return []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"}, openshiftconfigv1.VersionTLS11
+			}
+
+			DeferCleanup(func() {
+				tlssecprofile.GetCipherSuitesAndMinTLSVersion = origFunc
+			})
+
+			deployment := newAIEWebhookDeployment(hco)
+
+			Expect(deployment.Name).To(Equal(aieWebhookName))
+			Expect(deployment.Namespace).To(Equal(hco.Namespace))
+			Expect(deployment.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
+			Expect(deployment.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentAIEWebhook)))
+
+			Expect(deployment.Spec.Replicas).To(Equal(ptr.To[int32](1)))
+			Expect(deployment.Spec.Selector.MatchLabels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
+			Expect(deployment.Spec.Selector.MatchLabels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentAIEWebhook)))
+
+			Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
+			Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentAIEWebhook)))
+
+			Expect(deployment.Spec.Template.Spec.ServiceAccountName).To(Equal(aieWebhookServiceAccountName))
+
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.Name).To(Equal("webhook"))
+			Expect(container.Image).To(Equal(testImage))
+			Expect(container.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+			Expect(container.Args).To(ConsistOf("--metrics-bind-address=:8443",
+				"--metrics-secure=true",
+				"--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs",
+				"--metrics-cert-path=/tmp/k8s-webhook-server/serving-certs",
+				"--tls-min-version=VersionTLS11",
+				"--tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384"))
+
+			Expect(container.Ports).To(ConsistOf(
+				corev1.ContainerPort{Name: "https", ContainerPort: 9443, Protocol: corev1.ProtocolTCP},
+				corev1.ContainerPort{Name: "metrics", ContainerPort: 8443, Protocol: corev1.ProtocolTCP},
+				corev1.ContainerPort{Name: "health", ContainerPort: 8081, Protocol: corev1.ProtocolTCP},
+			))
+
+			Expect(container.Env).To(HaveLen(1))
+			Expect(container.Env[0].Name).To(Equal("NAMESPACE"))
+			Expect(container.Env[0].ValueFrom.FieldRef.FieldPath).To(Equal("metadata.namespace"))
+			Expect(container.Env[0].ValueFrom.FieldRef.APIVersion).To(Equal("v1"))
+
+			Expect(container.LivenessProbe).ToNot(BeNil())
+			Expect(container.LivenessProbe.HTTPGet.Path).To(Equal("/healthz"))
+			Expect(container.LivenessProbe.HTTPGet.Port).To(Equal(intstr.FromInt32(8081)))
+			Expect(container.LivenessProbe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTP))
+			Expect(container.LivenessProbe.InitialDelaySeconds).To(Equal(int32(5)))
+			Expect(container.LivenessProbe.PeriodSeconds).To(Equal(int32(10)))
+
+			Expect(container.ReadinessProbe).ToNot(BeNil())
+			Expect(container.ReadinessProbe.HTTPGet.Path).To(Equal("/readyz"))
+			Expect(container.ReadinessProbe.HTTPGet.Port).To(Equal(intstr.FromInt32(8081)))
+			Expect(container.ReadinessProbe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTP))
+			Expect(container.ReadinessProbe.InitialDelaySeconds).To(Equal(int32(5)))
+			Expect(container.ReadinessProbe.PeriodSeconds).To(Equal(int32(10)))
+
+			Expect(container.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, resourceCPURequest))
+			Expect(container.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, resourceMemoryRequest))
+			Expect(container.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, resourceCPULimit))
+			Expect(container.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, resourceMemoryLimit))
+
+			Expect(container.VolumeMounts).To(HaveLen(1))
+			Expect(container.VolumeMounts[0].Name).To(Equal("tls-cert"))
+			Expect(container.VolumeMounts[0].MountPath).To(Equal(aieWebhookCertMountPath))
+			Expect(container.VolumeMounts[0].ReadOnly).To(BeTrue())
+
+			Expect(container.SecurityContext).ToNot(BeNil())
+			Expect(container.SecurityContext.AllowPrivilegeEscalation).To(Equal(ptr.To(false)))
+			Expect(container.SecurityContext.ReadOnlyRootFilesystem).To(Equal(ptr.To(true)))
+			Expect(container.SecurityContext.RunAsNonRoot).To(Equal(ptr.To(true)))
+			Expect(container.SecurityContext.Capabilities).ToNot(BeNil())
+			Expect(container.SecurityContext.Capabilities.Drop).To(ConsistOf(corev1.Capability("ALL")))
+			Expect(container.SecurityContext.SeccompProfile).ToNot(BeNil())
+			Expect(container.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+
+			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
+			Expect(deployment.Spec.Template.Spec.Volumes[0].Name).To(Equal("tls-cert"))
+			Expect(deployment.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(aieWebhookTLSSecretName))
+		})
+
+		It("should not add ciphers for TLS 1.3", func() {
+			origFunc := tlssecprofile.GetCipherSuitesAndMinTLSVersion
+			tlssecprofile.GetCipherSuitesAndMinTLSVersion = func(fromHC *openshiftconfigv1.TLSSecurityProfile) ([]string, openshiftconfigv1.TLSProtocolVersion) {
+				return []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"}, openshiftconfigv1.VersionTLS13
+			}
+
+			DeferCleanup(func() {
+				tlssecprofile.GetCipherSuitesAndMinTLSVersion = origFunc
+			})
+
+			deployment := newAIEWebhookDeployment(hco)
+
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.Args).To(ConsistOf("--metrics-bind-address=:8443",
+				"--metrics-secure=true",
+				"--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs",
+				"--metrics-cert-path=/tmp/k8s-webhook-server/serving-certs",
+				"--tls-min-version=VersionTLS13"))
+			Expect(container.Args).ToNot(ContainElement(ContainSubstring("--tls-cipher-suites")))
+		})
+
+		It("should not add TLS version or ciphers when version is empty", func() {
+			origFunc := tlssecprofile.GetCipherSuitesAndMinTLSVersion
+			tlssecprofile.GetCipherSuitesAndMinTLSVersion = func(fromHC *openshiftconfigv1.TLSSecurityProfile) ([]string, openshiftconfigv1.TLSProtocolVersion) {
+				return nil, ""
+			}
+
+			DeferCleanup(func() {
+				tlssecprofile.GetCipherSuitesAndMinTLSVersion = origFunc
+			})
+
+			deployment := newAIEWebhookDeployment(hco)
+
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.Args).To(ConsistOf("--metrics-bind-address=:8443",
+				"--metrics-secure=true",
+				"--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs",
+				"--metrics-cert-path=/tmp/k8s-webhook-server/serving-certs"))
+			Expect(container.Args).ToNot(ContainElement(ContainSubstring("--tls-min-version")))
+			Expect(container.Args).ToNot(ContainElement(ContainSubstring("--tls-cipher-suites")))
+		})
+
+		It("should not add ciphers when cipher list is empty", func() {
+			origFunc := tlssecprofile.GetCipherSuitesAndMinTLSVersion
+			tlssecprofile.GetCipherSuitesAndMinTLSVersion = func(fromHC *openshiftconfigv1.TLSSecurityProfile) ([]string, openshiftconfigv1.TLSProtocolVersion) {
+				return nil, openshiftconfigv1.VersionTLS12
+			}
+
+			DeferCleanup(func() {
+				tlssecprofile.GetCipherSuitesAndMinTLSVersion = origFunc
+			})
+
+			deployment := newAIEWebhookDeployment(hco)
+
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.Args).To(ConsistOf("--metrics-bind-address=:8443",
+				"--metrics-secure=true",
+				"--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs",
+				"--metrics-cert-path=/tmp/k8s-webhook-server/serving-certs",
+				"--tls-min-version=VersionTLS12"))
+			Expect(container.Args).ToNot(ContainElement(ContainSubstring("--tls-cipher-suites")))
+		})
+	})
+
+	Context("AIE Webhook Deployment handler", func() {
+		It("should not create if deploy-aie-webhook annotation is absent", func() {
+			delete(hco.Annotations, DeployAIEAnnotation)
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewAIEWebhookDeploymentHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundDep := &appsv1.DeploymentList{}
+			Expect(cl.List(context.Background(), foundDep)).To(Succeed())
+			Expect(foundDep.Items).To(BeEmpty())
+		})
+
+		It("should delete Deployment when deploy-aie-webhook annotation is removed", func() {
+			delete(hco.Annotations, DeployAIEAnnotation)
+			dep := newAIEWebhookDeployment(hco)
+			cl = commontestutils.InitClient([]client.Object{hco, dep})
+
+			handler := NewAIEWebhookDeploymentHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(dep.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
+
+			foundDep := &appsv1.DeploymentList{}
+			Expect(cl.List(context.Background(), foundDep)).To(Succeed())
+			Expect(foundDep.Items).To(BeEmpty())
+		})
+
+		It("should create Deployment when deploy-aie-webhook annotation is true", func() {
+			hco.Annotations[DeployAIEAnnotation] = "true"
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewAIEWebhookDeploymentHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(aieWebhookName))
+			Expect(res.Created).To(BeTrue())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundDep := &appsv1.DeploymentList{}
+			Expect(cl.List(context.Background(), foundDep)).To(Succeed())
+			Expect(foundDep.Items).To(HaveLen(1))
+			Expect(foundDep.Items[0].Name).To(Equal(aieWebhookName))
+		})
+	})
+
+	Context("AIE Webhook Deployment update", func() {
+		It("should update Deployment fields if not matched to the requirements", func() {
+			hco.Annotations[DeployAIEAnnotation] = "true"
+			originalDep := newAIEWebhookDeployment(hco)
+			modifiedDep := originalDep.DeepCopy()
+			modifiedDep.Spec.Template.Spec.Containers[0].Image = "malicious:tag"
+			modifiedDep.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot = ptr.To(false)
+			modifiedDep.Spec.Template.Spec.Volumes = nil
+			cl = commontestutils.InitClient([]client.Object{hco, modifiedDep})
+
+			handler := NewAIEWebhookDeploymentHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Deleted).To(BeFalse())
+
+			reconciledDep := &appsv1.Deployment{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: res.Name, Namespace: hco.Namespace}, reconciledDep)).To(Succeed())
+			Expect(reconciledDep.Spec.Template.Spec.Containers[0].Image).
+				To(Equal(originalDep.Spec.Template.Spec.Containers[0].Image))
+			Expect(reconciledDep.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).
+				To(Equal(originalDep.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot))
+			Expect(reconciledDep.Spec.Template.Spec.Volumes).
+				To(Equal(originalDep.Spec.Template.Spec.Volumes))
+		})
+
+		It("should reconcile labels if they are missing while preserving user labels", func() {
+			hco.Annotations[DeployAIEAnnotation] = "true"
+			dep := newAIEWebhookDeployment(hco)
+			expectedLabels := maps.Clone(dep.Labels)
+			delete(dep.Labels, "app.kubernetes.io/component")
+			dep.Labels["user-added-label"] = "user-value"
+			cl = commontestutils.InitClient([]client.Object{hco, dep})
+
+			handler := NewAIEWebhookDeploymentHandler(cl, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeTrue())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundDep := &appsv1.Deployment{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: aieWebhookName, Namespace: hco.Namespace}, foundDep)).To(Succeed())
+
+			for key, value := range expectedLabels {
+				Expect(foundDep.Labels).To(HaveKeyWithValue(key, value))
+			}
+			Expect(foundDep.Labels).To(HaveKeyWithValue("user-added-label", "user-value"))
+		})
+	})
+})

--- a/controllers/handlers/aie/device_plugin_scc.go
+++ b/controllers/handlers/aie/device_plugin_scc.go
@@ -3,7 +3,6 @@ package aie
 import (
 	"fmt"
 
-	log "github.com/go-logr/logr"
 	securityv1 "github.com/openshift/api/security/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,35 +11,34 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 const (
 	iommufdDevicePluginSCCName = "iommufd-device-plugin"
 )
 
-func NewIOMMUFDDevicePluginSCCHandler(
-	_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged,
-) (operands.Operand, error) {
+func NewIOMMUFDDevicePluginSCCHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
-		operands.NewSecurityContextConstraintsHandler(Client, Scheme, newIOMMUFDDevicePluginSCC),
+		operands.NewSecurityContextConstraintsHandler(cli, Scheme, newIOMMUFDDevicePluginSCC()),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewIOMMUFDDevicePluginSCCWithNameOnly(hc)
+			return NewIOMMUFDDevicePluginSCCWithNameOnly()
 		},
-	), nil
+	)
 }
 
-func NewIOMMUFDDevicePluginSCCWithNameOnly(hc *hcov1beta1.HyperConverged) *securityv1.SecurityContextConstraints {
+func NewIOMMUFDDevicePluginSCCWithNameOnly() *securityv1.SecurityContextConstraints {
 	return &securityv1.SecurityContextConstraints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   iommufdDevicePluginSCCName,
-			Labels: operands.GetLabelsDeprecated(hc, iommufdDevicePluginAppComponent),
+			Labels: operands.GetLabels(iommufdDevicePluginAppComponent),
 		},
 	}
 }
 
-func newIOMMUFDDevicePluginSCC(hc *hcov1beta1.HyperConverged) *securityv1.SecurityContextConstraints {
-	scc := NewIOMMUFDDevicePluginSCCWithNameOnly(hc)
+func newIOMMUFDDevicePluginSCC() *securityv1.SecurityContextConstraints {
+	scc := NewIOMMUFDDevicePluginSCCWithNameOnly()
 
 	scc.AllowPrivilegedContainer = true
 	scc.AllowHostDirVolumePlugin = true
@@ -59,7 +57,7 @@ func newIOMMUFDDevicePluginSCC(hc *hcov1beta1.HyperConverged) *securityv1.Securi
 		Type: securityv1.SELinuxStrategyRunAsAny,
 	}
 	scc.Users = []string{
-		fmt.Sprintf("system:serviceaccount:%s:%s", hc.Namespace, iommufdDevicePluginServiceAccountName),
+		fmt.Sprintf("system:serviceaccount:%s:%s", hcoutil.GetOperatorNamespaceFromEnv(), iommufdDevicePluginServiceAccountName),
 	}
 	scc.Volumes = []securityv1.FSType{
 		securityv1.FSTypeHostPath,

--- a/controllers/handlers/aie/device_plugin_scc.go
+++ b/controllers/handlers/aie/device_plugin_scc.go
@@ -34,7 +34,7 @@ func NewIOMMUFDDevicePluginSCCWithNameOnly(hc *hcov1beta1.HyperConverged) *secur
 	return &securityv1.SecurityContextConstraints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   iommufdDevicePluginSCCName,
-			Labels: operands.GetLabels(hc, iommufdDevicePluginAppComponent),
+			Labels: operands.GetLabelsDeprecated(hc, iommufdDevicePluginAppComponent),
 		},
 	}
 }

--- a/controllers/handlers/aie/device_plugin_scc_test.go
+++ b/controllers/handlers/aie/device_plugin_scc_test.go
@@ -31,7 +31,7 @@ var _ = Describe("IOMMUFD Device Plugin SecurityContextConstraints", func() {
 
 	Context("newIOMMUFDDevicePluginSCC", func() {
 		It("should have all default fields", func() {
-			scc := newIOMMUFDDevicePluginSCC(hco)
+			scc := newIOMMUFDDevicePluginSCC()
 			Expect(scc.Name).To(Equal("iommufd-device-plugin"))
 			Expect(scc.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
 			Expect(scc.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentIOMMUFDDevicePlugin)))
@@ -60,8 +60,7 @@ var _ = Describe("IOMMUFD Device Plugin SecurityContextConstraints", func() {
 			delete(hco.Annotations, DeployAIEAnnotation)
 			cl = commontestutils.InitClient([]client.Object{hco})
 
-			handler, err := NewIOMMUFDDevicePluginSCCHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewIOMMUFDDevicePluginSCCHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -76,11 +75,10 @@ var _ = Describe("IOMMUFD Device Plugin SecurityContextConstraints", func() {
 
 		It("should delete SCC when deploy-aie-webhook annotation is removed", func() {
 			delete(hco.Annotations, DeployAIEAnnotation)
-			scc := newIOMMUFDDevicePluginSCC(hco)
+			scc := newIOMMUFDDevicePluginSCC()
 			cl = commontestutils.InitClient([]client.Object{hco, scc})
 
-			handler, err := NewIOMMUFDDevicePluginSCCHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewIOMMUFDDevicePluginSCCHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -98,8 +96,7 @@ var _ = Describe("IOMMUFD Device Plugin SecurityContextConstraints", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
 			cl = commontestutils.InitClient([]client.Object{hco})
 
-			handler, err := NewIOMMUFDDevicePluginSCCHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewIOMMUFDDevicePluginSCCHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -118,14 +115,13 @@ var _ = Describe("IOMMUFD Device Plugin SecurityContextConstraints", func() {
 	Context("SCC update", func() {
 		It("should update SCC fields if not matched to the requirements", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
-			scc := newIOMMUFDDevicePluginSCC(hco)
+			scc := newIOMMUFDDevicePluginSCC()
 			scc.AllowPrivilegedContainer = false
 			scc.Users = []string{"wrong-user"}
 
 			cl = commontestutils.InitClient([]client.Object{hco, scc})
 
-			handler, err := NewIOMMUFDDevicePluginSCCHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewIOMMUFDDevicePluginSCCHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -141,14 +137,13 @@ var _ = Describe("IOMMUFD Device Plugin SecurityContextConstraints", func() {
 
 		It("should reconcile labels if they are missing while preserving user labels", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
-			scc := newIOMMUFDDevicePluginSCC(hco)
+			scc := newIOMMUFDDevicePluginSCC()
 			expectedLabels := maps.Clone(scc.Labels)
 			delete(scc.Labels, "app.kubernetes.io/component")
 			scc.Labels["user-added-label"] = "user-value"
 			cl = commontestutils.InitClient([]client.Object{hco, scc})
 
-			handler, err := NewIOMMUFDDevicePluginSCCHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewIOMMUFDDevicePluginSCCHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())

--- a/controllers/handlers/aie/device_plugin_service_account.go
+++ b/controllers/handlers/aie/device_plugin_service_account.go
@@ -8,6 +8,7 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func NewIOMMUFDDevicePluginServiceAccountHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
@@ -15,17 +16,17 @@ func NewIOMMUFDDevicePluginServiceAccountHandler(Client client.Client, Scheme *r
 		operands.NewServiceAccountHandler(Client, Scheme, newIOMMUFDDevicePluginServiceAccount),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return newIOMMUFDDevicePluginServiceAccount(hc)
+			return newIOMMUFDDevicePluginServiceAccount()
 		},
 	)
 }
 
-func newIOMMUFDDevicePluginServiceAccount(hc *hcov1beta1.HyperConverged) *corev1.ServiceAccount {
+func newIOMMUFDDevicePluginServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      iommufdDevicePluginServiceAccountName,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, iommufdDevicePluginAppComponent),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(iommufdDevicePluginAppComponent),
 		},
 	}
 }

--- a/controllers/handlers/aie/device_plugin_service_account.go
+++ b/controllers/handlers/aie/device_plugin_service_account.go
@@ -25,7 +25,7 @@ func newIOMMUFDDevicePluginServiceAccount(hc *hcov1beta1.HyperConverged) *corev1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      iommufdDevicePluginServiceAccountName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, iommufdDevicePluginAppComponent),
+			Labels:    operands.GetLabelsDeprecated(hc, iommufdDevicePluginAppComponent),
 		},
 	}
 }

--- a/controllers/handlers/aie/device_plugin_service_account_test.go
+++ b/controllers/handlers/aie/device_plugin_service_account_test.go
@@ -30,7 +30,7 @@ var _ = Describe("IOMMUFD Device Plugin Service Account", func() {
 
 	Context("newIOMMUFDDevicePluginServiceAccount", func() {
 		It("should have all default values", func() {
-			sa := newIOMMUFDDevicePluginServiceAccount(hco)
+			sa := newIOMMUFDDevicePluginServiceAccount()
 			Expect(sa.Name).To(Equal("iommufd-device-plugin"))
 			Expect(sa.Namespace).To(BeEquivalentTo(hco.Namespace))
 			Expect(sa.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
@@ -58,7 +58,7 @@ var _ = Describe("IOMMUFD Device Plugin Service Account", func() {
 
 		It("should delete service account when deploy-aie-webhook annotation is removed", func() {
 			delete(hco.Annotations, DeployAIEAnnotation)
-			sa := newIOMMUFDDevicePluginServiceAccount(hco)
+			sa := newIOMMUFDDevicePluginServiceAccount()
 			cl = commontestutils.InitClient([]client.Object{hco, sa})
 
 			handler := NewIOMMUFDDevicePluginServiceAccountHandler(cl, commontestutils.GetScheme())
@@ -98,7 +98,7 @@ var _ = Describe("IOMMUFD Device Plugin Service Account", func() {
 	Context("IOMMUFD device plugin service account update", func() {
 		It("should reconcile labels if they are missing while preserving user labels", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
-			sa := newIOMMUFDDevicePluginServiceAccount(hco)
+			sa := newIOMMUFDDevicePluginServiceAccount()
 			expectedLabels := maps.Clone(sa.Labels)
 			delete(sa.Labels, "app.kubernetes.io/component")
 			sa.Labels["user-added-label"] = "user-value"

--- a/controllers/handlers/aie/rbac.go
+++ b/controllers/handlers/aie/rbac.go
@@ -43,7 +43,7 @@ func NewAIEWebhookClusterRoleWithNameOnly(hc *hcov1beta1.HyperConverged) *rbacv1
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   aieWebhookClusterRoleName,
-			Labels: operands.GetLabels(hc, appComponent),
+			Labels: operands.GetLabelsDeprecated(hc, appComponent),
 		},
 	}
 }
@@ -73,7 +73,7 @@ func NewAIEWebhookClusterRoleBindingWithNameOnly(hc *hcov1beta1.HyperConverged) 
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   aieWebhookClusterRoleName,
-			Labels: operands.GetLabels(hc, appComponent),
+			Labels: operands.GetLabelsDeprecated(hc, appComponent),
 		},
 	}
 }

--- a/controllers/handlers/aie/rbac.go
+++ b/controllers/handlers/aie/rbac.go
@@ -1,7 +1,6 @@
 package aie
 
 import (
-	log "github.com/go-logr/logr"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -9,33 +8,30 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-func NewAIEWebhookClusterRoleHandler(
-	_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged,
-) (operands.Operand, error) {
+func NewAIEWebhookClusterRoleHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
-		operands.NewClusterRoleHandler(Client, Scheme, newAIEWebhookClusterRole(hc)),
+		operands.NewClusterRoleHandler(cli, Scheme, newAIEWebhookClusterRole()),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewAIEWebhookClusterRoleWithNameOnly(hc)
+			return NewAIEWebhookClusterRoleWithNameOnly()
 		},
-	), nil
+	)
 }
 
-func NewAIEWebhookClusterRoleBindingHandler(
-	_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged,
-) (operands.Operand, error) {
+func NewAIEWebhookClusterRoleBindingHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
-		operands.NewClusterRoleBindingHandler(Client, Scheme, newAIEWebhookClusterRoleBinding(hc)),
+		operands.NewClusterRoleBindingHandler(cli, Scheme, newAIEWebhookClusterRoleBinding()),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewAIEWebhookClusterRoleBindingWithNameOnly(hc)
+			return NewAIEWebhookClusterRoleBindingWithNameOnly()
 		},
-	), nil
+	)
 }
 
-func NewAIEWebhookClusterRoleWithNameOnly(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRole {
+func NewAIEWebhookClusterRoleWithNameOnly() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
@@ -43,13 +39,13 @@ func NewAIEWebhookClusterRoleWithNameOnly(hc *hcov1beta1.HyperConverged) *rbacv1
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   aieWebhookClusterRoleName,
-			Labels: operands.GetLabelsDeprecated(hc, appComponent),
+			Labels: operands.GetLabels(appComponent),
 		},
 	}
 }
 
-func newAIEWebhookClusterRole(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRole {
-	cr := NewAIEWebhookClusterRoleWithNameOnly(hc)
+func newAIEWebhookClusterRole() *rbacv1.ClusterRole {
+	cr := NewAIEWebhookClusterRoleWithNameOnly()
 	cr.Rules = []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{"kubevirt.io"},
@@ -65,7 +61,7 @@ func newAIEWebhookClusterRole(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRole
 	return cr
 }
 
-func NewAIEWebhookClusterRoleBindingWithNameOnly(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRoleBinding {
+func NewAIEWebhookClusterRoleBindingWithNameOnly() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
@@ -73,13 +69,13 @@ func NewAIEWebhookClusterRoleBindingWithNameOnly(hc *hcov1beta1.HyperConverged) 
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   aieWebhookClusterRoleName,
-			Labels: operands.GetLabelsDeprecated(hc, appComponent),
+			Labels: operands.GetLabels(appComponent),
 		},
 	}
 }
 
-func newAIEWebhookClusterRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRoleBinding {
-	crb := NewAIEWebhookClusterRoleBindingWithNameOnly(hc)
+func newAIEWebhookClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	crb := NewAIEWebhookClusterRoleBindingWithNameOnly()
 	crb.RoleRef = rbacv1.RoleRef{
 		Kind:     "ClusterRole",
 		Name:     aieWebhookClusterRoleName,
@@ -89,7 +85,7 @@ func newAIEWebhookClusterRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.Clus
 		{
 			Kind:      "ServiceAccount",
 			Name:      aieWebhookServiceAccountName,
-			Namespace: hc.Namespace,
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 	}
 	return crb

--- a/controllers/handlers/aie/rbac_test.go
+++ b/controllers/handlers/aie/rbac_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"maps"
 
-	log "github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -31,7 +30,7 @@ var _ = Describe("AIE Webhook Cluster Role", func() {
 
 	Context("newAIEWebhookClusterRole", func() {
 		It("Should have all the default fields", func() {
-			cr := newAIEWebhookClusterRole(hco)
+			cr := newAIEWebhookClusterRole()
 			Expect(cr.Name).To(Equal("kubevirt-aie-webhook"))
 			Expect(cr.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
 			Expect(cr.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentAIEWebhook)))
@@ -47,11 +46,10 @@ var _ = Describe("AIE Webhook Cluster Role", func() {
 	Context("Cluster role deployment", func() {
 		It("should delete cluster role when deploy-aie-webhook annotation is absent", func() {
 			delete(hco.Annotations, DeployAIEAnnotation)
-			cr := newAIEWebhookClusterRole(hco)
+			cr := newAIEWebhookClusterRole()
 			cl = commontestutils.InitClient([]client.Object{hco, cr})
 
-			handler, err := NewAIEWebhookClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewAIEWebhookClusterRoleHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -69,8 +67,7 @@ var _ = Describe("AIE Webhook Cluster Role", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
 			cl = commontestutils.InitClient([]client.Object{hco})
 
-			handler, err := NewAIEWebhookClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewAIEWebhookClusterRoleHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -89,14 +86,13 @@ var _ = Describe("AIE Webhook Cluster Role", func() {
 	Context("Cluster role update", func() {
 		It("should reconcile labels if they are missing while preserving user labels", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
-			cr := newAIEWebhookClusterRole(hco)
+			cr := newAIEWebhookClusterRole()
 			expectedLabels := maps.Clone(cr.Labels)
 			delete(cr.Labels, "app.kubernetes.io/component")
 			cr.Labels["user-added-label"] = "user-value"
 			cl = commontestutils.InitClient([]client.Object{hco, cr})
 
-			handler, err := NewAIEWebhookClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewAIEWebhookClusterRoleHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -130,7 +126,7 @@ var _ = Describe("AIE Webhook Cluster Role Binding", func() {
 
 	Context("newAIEWebhookClusterRoleBinding", func() {
 		It("Should have all the default fields", func() {
-			crb := newAIEWebhookClusterRoleBinding(hco)
+			crb := newAIEWebhookClusterRoleBinding()
 			Expect(crb.Name).To(Equal("kubevirt-aie-webhook"))
 			Expect(crb.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
 			Expect(crb.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentAIEWebhook)))
@@ -144,11 +140,10 @@ var _ = Describe("AIE Webhook Cluster Role Binding", func() {
 	Context("Cluster role binding deployment", func() {
 		It("should delete cluster role binding when deploy-aie-webhook annotation is absent", func() {
 			delete(hco.Annotations, DeployAIEAnnotation)
-			crb := newAIEWebhookClusterRoleBinding(hco)
+			crb := newAIEWebhookClusterRoleBinding()
 			cl = commontestutils.InitClient([]client.Object{hco, crb})
 
-			handler, err := NewAIEWebhookClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewAIEWebhookClusterRoleBindingHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -166,8 +161,7 @@ var _ = Describe("AIE Webhook Cluster Role Binding", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
 			cl = commontestutils.InitClient([]client.Object{hco})
 
-			handler, err := NewAIEWebhookClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewAIEWebhookClusterRoleBindingHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -186,14 +180,13 @@ var _ = Describe("AIE Webhook Cluster Role Binding", func() {
 	Context("Cluster role binding update", func() {
 		It("should reconcile labels if they are missing while preserving user labels", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
-			crb := newAIEWebhookClusterRoleBinding(hco)
+			crb := newAIEWebhookClusterRoleBinding()
 			expectedLabels := maps.Clone(crb.Labels)
 			delete(crb.Labels, "app.kubernetes.io/component")
 			crb.Labels["user-added-label"] = "user-value"
 			cl = commontestutils.InitClient([]client.Object{hco, crb})
 
-			handler, err := NewAIEWebhookClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewAIEWebhookClusterRoleBindingHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())

--- a/controllers/handlers/aie/service.go
+++ b/controllers/handlers/aie/service.go
@@ -27,7 +27,7 @@ func newAIEWebhookServiceWithNameOnly(hc *hcov1beta1.HyperConverged) *corev1.Ser
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      aieWebhookName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, appComponent),
+			Labels:    operands.GetLabelsDeprecated(hc, appComponent),
 		},
 	}
 }

--- a/controllers/handlers/aie/service.go
+++ b/controllers/handlers/aie/service.go
@@ -14,26 +14,26 @@ import (
 
 func NewAIEWebhookServiceHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
-		operands.NewServiceHandler(Client, Scheme, newAIEWebhookService),
+		operands.NewServiceHandler(Client, Scheme, newAIEWebhookService()),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return newAIEWebhookServiceWithNameOnly(hc)
+			return newAIEWebhookServiceWithNameOnly()
 		},
 	)
 }
 
-func newAIEWebhookServiceWithNameOnly(hc *hcov1beta1.HyperConverged) *corev1.Service {
+func newAIEWebhookServiceWithNameOnly() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      aieWebhookName,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, appComponent),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(appComponent),
 		},
 	}
 }
 
-func newAIEWebhookService(hc *hcov1beta1.HyperConverged) *corev1.Service {
-	svc := newAIEWebhookServiceWithNameOnly(hc)
+func newAIEWebhookService() *corev1.Service {
+	svc := newAIEWebhookServiceWithNameOnly()
 	if hcoutil.GetClusterInfo().IsOpenshift() {
 		svc.Annotations = map[string]string{
 			"service.beta.openshift.io/serving-cert-secret-name": aieWebhookTLSSecretName,

--- a/controllers/handlers/aie/service_account.go
+++ b/controllers/handlers/aie/service_account.go
@@ -25,7 +25,7 @@ func newAIEWebhookServiceAccount(hc *hcov1beta1.HyperConverged) *corev1.ServiceA
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      aieWebhookServiceAccountName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, appComponent),
+			Labels:    operands.GetLabelsDeprecated(hc, appComponent),
 		},
 	}
 }

--- a/controllers/handlers/aie/service_account.go
+++ b/controllers/handlers/aie/service_account.go
@@ -8,6 +8,7 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func NewAIEWebhookServiceAccountHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
@@ -15,17 +16,17 @@ func NewAIEWebhookServiceAccountHandler(Client client.Client, Scheme *runtime.Sc
 		operands.NewServiceAccountHandler(Client, Scheme, newAIEWebhookServiceAccount),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return newAIEWebhookServiceAccount(hc)
+			return newAIEWebhookServiceAccount()
 		},
 	)
 }
 
-func newAIEWebhookServiceAccount(hc *hcov1beta1.HyperConverged) *corev1.ServiceAccount {
+func newAIEWebhookServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      aieWebhookServiceAccountName,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, appComponent),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(appComponent),
 		},
 	}
 }

--- a/controllers/handlers/aie/service_account_test.go
+++ b/controllers/handlers/aie/service_account_test.go
@@ -30,7 +30,7 @@ var _ = Describe("AIE Webhook Service Account", func() {
 
 	Context("newAIEWebhookServiceAccount", func() {
 		It("should have all default values", func() {
-			sa := newAIEWebhookServiceAccount(hco)
+			sa := newAIEWebhookServiceAccount()
 			Expect(sa.Name).To(Equal("kubevirt-aie-webhook"))
 			Expect(sa.Namespace).To(BeEquivalentTo(hco.Namespace))
 			Expect(sa.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
@@ -58,7 +58,7 @@ var _ = Describe("AIE Webhook Service Account", func() {
 
 		It("should delete service account when deploy-aie-webhook annotation is removed", func() {
 			delete(hco.Annotations, DeployAIEAnnotation)
-			sa := newAIEWebhookServiceAccount(hco)
+			sa := newAIEWebhookServiceAccount()
 			cl = commontestutils.InitClient([]client.Object{hco, sa})
 
 			handler := NewAIEWebhookServiceAccountHandler(cl, commontestutils.GetScheme())
@@ -98,7 +98,7 @@ var _ = Describe("AIE Webhook Service Account", func() {
 	Context("AIE webhook service account update", func() {
 		It("should reconcile labels if they are missing while preserving user labels", func() {
 			hco.Annotations[DeployAIEAnnotation] = "true"
-			sa := newAIEWebhookServiceAccount(hco)
+			sa := newAIEWebhookServiceAccount()
 			expectedLabels := maps.Clone(sa.Labels)
 			delete(sa.Labels, "app.kubernetes.io/component")
 			sa.Labels["user-added-label"] = "user-value"

--- a/controllers/handlers/aie/webhook_config.go
+++ b/controllers/handlers/aie/webhook_config.go
@@ -99,7 +99,7 @@ func NewAIEWebhookMutatingWebhookConfigurationWithNameOnly(hc *hcov1beta1.HyperC
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   aieWebhookName,
-			Labels: operands.GetLabels(hc, appComponent),
+			Labels: operands.GetLabelsDeprecated(hc, appComponent),
 		},
 	}
 }

--- a/controllers/handlers/aie/webhook_config.go
+++ b/controllers/handlers/aie/webhook_config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"reflect"
 
-	log "github.com/go-logr/logr"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,17 +16,15 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-func NewAIEWebhookMutatingWebhookConfigurationHandler(
-	_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged,
-) (operands.Operand, error) {
+func NewAIEWebhookMutatingWebhookConfigurationHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
-		operands.NewGenericOperand(Client, Scheme, "MutatingWebhookConfiguration",
-			&aieWebhookMWCHooks{required: newAIEMutatingWebhookConfiguration(hc)}, false),
+		operands.NewGenericOperand(cli, Scheme, "MutatingWebhookConfiguration",
+			&aieWebhookMWCHooks{required: newAIEMutatingWebhookConfiguration()}, false),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewAIEWebhookMutatingWebhookConfigurationWithNameOnly(hc)
+			return NewAIEWebhookMutatingWebhookConfigurationWithNameOnly()
 		},
-	), nil
+	)
 }
 
 type aieWebhookMWCHooks struct {
@@ -91,7 +88,7 @@ func (h *aieWebhookMWCHooks) UpdateCR(req *common.HcoRequest, Client client.Clie
 	return false, false, nil
 }
 
-func NewAIEWebhookMutatingWebhookConfigurationWithNameOnly(hc *hcov1beta1.HyperConverged) *admissionregistrationv1.MutatingWebhookConfiguration {
+func NewAIEWebhookMutatingWebhookConfigurationWithNameOnly() *admissionregistrationv1.MutatingWebhookConfiguration {
 	return &admissionregistrationv1.MutatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: admissionregistrationv1.SchemeGroupVersion.String(),
@@ -99,13 +96,13 @@ func NewAIEWebhookMutatingWebhookConfigurationWithNameOnly(hc *hcov1beta1.HyperC
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   aieWebhookName,
-			Labels: operands.GetLabelsDeprecated(hc, appComponent),
+			Labels: operands.GetLabels(appComponent),
 		},
 	}
 }
 
-func newAIEMutatingWebhookConfiguration(hc *hcov1beta1.HyperConverged) *admissionregistrationv1.MutatingWebhookConfiguration {
-	mwc := NewAIEWebhookMutatingWebhookConfigurationWithNameOnly(hc)
+func newAIEMutatingWebhookConfiguration() *admissionregistrationv1.MutatingWebhookConfiguration {
+	mwc := NewAIEWebhookMutatingWebhookConfigurationWithNameOnly()
 	if util.GetClusterInfo().IsOpenshift() {
 		mwc.Annotations = map[string]string{
 			"service.beta.openshift.io/inject-cabundle": "true",
@@ -123,7 +120,7 @@ func newAIEMutatingWebhookConfiguration(hc *hcov1beta1.HyperConverged) *admissio
 			ClientConfig: admissionregistrationv1.WebhookClientConfig{
 				Service: &admissionregistrationv1.ServiceReference{
 					Name:      aieWebhookName,
-					Namespace: hc.Namespace,
+					Namespace: util.GetOperatorNamespaceFromEnv(),
 					Path:      ptr.To("/mutate-pods"),
 					Port:      ptr.To[int32](443),
 				},

--- a/controllers/handlers/cdi.go
+++ b/controllers/handlers/cdi.go
@@ -101,7 +101,7 @@ func getDefaultFeatureGates() []string {
 	return []string{honorWaitForFirstConsumerGate, dataVolumeClaimAdoptionGate, webhookPvcRenderingGate}
 }
 
-func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, error) {
+func NewCDI(hc *hcov1beta1.HyperConverged) (*cdiv1beta1.CDI, error) {
 	uninstallStrategy := cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist
 	if hc.Spec.UninstallStrategy == hcov1.HyperConvergedUninstallStrategyRemoveWorkloads {
 		uninstallStrategy = cdiv1beta1.CDIUninstallStrategyRemoveWorkloads
@@ -156,7 +156,7 @@ func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, err
 		spec.Config.LogVerbosity = lv.CDI
 	}
 
-	cdi := NewCDIWithNameOnly(hc, opts...)
+	cdi := NewCDIWithNameOnly()
 	cdi.Spec = spec
 
 	if err := operands.ApplyPatchToSpec(hc, common.JSONPatchCDIAnnotationName, cdi); err != nil {
@@ -166,12 +166,11 @@ func NewCDI(hc *hcov1beta1.HyperConverged, opts ...string) (*cdiv1beta1.CDI, err
 	return reformatobj.ReformatObj(cdi)
 }
 
-func NewCDIWithNameOnly(hc *hcov1beta1.HyperConverged, opts ...string) *cdiv1beta1.CDI {
+func NewCDIWithNameOnly() *cdiv1beta1.CDI {
 	return &cdiv1beta1.CDI{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "cdi-" + hc.Name,
-			Labels:      operands.GetLabelsDeprecated(hc, util.AppComponentStorage),
-			Namespace:   operands.GetNamespace(util.UndefinedNamespace, opts),
+			Name:        "cdi-" + util.HyperConvergedName,
+			Labels:      operands.GetLabels(util.AppComponentStorage),
 			Annotations: map[string]string{cdiConfigAuthorityAnnotation: ""},
 		},
 	}

--- a/controllers/handlers/cdi.go
+++ b/controllers/handlers/cdi.go
@@ -170,7 +170,7 @@ func NewCDIWithNameOnly(hc *hcov1beta1.HyperConverged, opts ...string) *cdiv1bet
 	return &cdiv1beta1.CDI{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "cdi-" + hc.Name,
-			Labels:      operands.GetLabels(hc, util.AppComponentStorage),
+			Labels:      operands.GetLabelsDeprecated(hc, util.AppComponentStorage),
 			Namespace:   operands.GetNamespace(util.UndefinedNamespace, opts),
 			Annotations: map[string]string{cdiConfigAuthorityAnnotation: ""},
 		},

--- a/controllers/handlers/cdi_test.go
+++ b/controllers/handlers/cdi_test.go
@@ -42,7 +42,7 @@ var _ = Describe("CDI Operand", func() {
 		})
 
 		It("should create if not present", func() {
-			expectedResource := NewCDIWithNameOnly(hco)
+			expectedResource := NewCDIWithNameOnly()
 			cl := commontestutils.InitClient([]client.Object{})
 			handler := NewCdiHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
@@ -912,7 +912,7 @@ var _ = Describe("CDI Operand", func() {
 		})
 
 		It("should add cert configuration if missing in CDI", func() {
-			existingResource := NewCDIWithNameOnly(hco)
+			existingResource := NewCDIWithNameOnly()
 
 			cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 			handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -941,7 +941,7 @@ var _ = Describe("CDI Operand", func() {
 		})
 
 		It("should set cert config to defaults if missing in HCO CR", func() {
-			existingResource := NewCDIWithNameOnly(hco)
+			existingResource := NewCDIWithNameOnly()
 
 			cl := commontestutils.InitClient([]client.Object{hco})
 			handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -1137,7 +1137,7 @@ var _ = Describe("CDI Operand", func() {
 					}
 				]`}
 
-				expectedResource := NewCDIWithNameOnly(hco)
+				expectedResource := NewCDIWithNameOnly()
 				cl := commontestutils.InitClient([]client.Object{})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
 				res := handler.Ensure(req)
@@ -1169,7 +1169,7 @@ var _ = Describe("CDI Operand", func() {
 					}
 				]`}
 
-				expectedResource := NewCDIWithNameOnly(hco)
+				expectedResource := NewCDIWithNameOnly()
 				cl := commontestutils.InitClient([]client.Object{})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
 				res := handler.Ensure(req)
@@ -1210,7 +1210,7 @@ var _ = Describe("CDI Operand", func() {
 
 				cdi := &cdiv1beta1.CDI{}
 
-				expectedResource := NewCDIWithNameOnly(hco)
+				expectedResource := NewCDIWithNameOnly()
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
@@ -1247,7 +1247,7 @@ var _ = Describe("CDI Operand", func() {
 
 				cdi := &cdiv1beta1.CDI{}
 
-				expectedResource := NewCDIWithNameOnly(hco)
+				expectedResource := NewCDIWithNameOnly()
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},

--- a/controllers/handlers/cliDownload.go
+++ b/controllers/handlers/cliDownload.go
@@ -73,7 +73,7 @@ func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLID
 	return &consolev1.ConsoleCLIDownload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "virtctl-clidownloads-" + hc.Name,
-			Labels: operands.GetLabels(hc, util.AppComponentCompute),
+			Labels: operands.GetLabelsDeprecated(hc, util.AppComponentCompute),
 		},
 
 		Spec: consolev1.ConsoleCLIDownloadSpec{
@@ -122,7 +122,7 @@ func NewCliDownloadsService(hc *hcov1beta1.HyperConverged) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      downloadhost.CLIDownloadsServiceName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, util.AppComponentCompute),
+			Labels:    operands.GetLabelsDeprecated(hc, util.AppComponentCompute),
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
@@ -184,7 +184,7 @@ func NewCliDownloadsRoute(hc *hcov1beta1.HyperConverged) *routev1.Route {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      downloadhost.CLIDownloadsServiceName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, util.AppComponentCompute),
+			Labels:    operands.GetLabelsDeprecated(hc, util.AppComponentCompute),
 		},
 		Spec: routev1.RouteSpec{
 			Host: string(downloadhost.Get().CurrentHost),

--- a/controllers/handlers/cliDownload.go
+++ b/controllers/handlers/cliDownload.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 	"strconv"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,8 +35,8 @@ func NewCliDownloadHandler(Client client.Client, Scheme *runtime.Scheme) *operan
 
 type cliDownloadHooks struct{}
 
-func (*cliDownloadHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
-	return NewConsoleCLIDownload(hc), nil
+func (*cliDownloadHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+	return NewConsoleCLIDownload(), nil
 }
 
 func (*cliDownloadHooks) GetEmptyCr() client.Object {
@@ -66,14 +67,14 @@ func (*cliDownloadHooks) UpdateCR(req *common.HcoRequest, Client client.Client, 
 	return false, false, nil
 }
 
-func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLIDownload {
+func NewConsoleCLIDownload() *consolev1.ConsoleCLIDownload {
 	host := string(downloadhost.Get().CurrentHost)
 	baseURL := "https://" + host
 
 	return &consolev1.ConsoleCLIDownload{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "virtctl-clidownloads-" + hc.Name,
-			Labels: operands.GetLabelsDeprecated(hc, util.AppComponentCompute),
+			Name:   "virtctl-clidownloads-" + util.HyperConvergedName,
+			Labels: operands.GetLabels(util.AppComponentCompute),
 		},
 
 		Spec: consolev1.ConsoleCLIDownloadSpec{
@@ -116,13 +117,12 @@ func NewConsoleCLIDownload(hc *hcov1beta1.HyperConverged) *consolev1.ConsoleCLID
 // **** Handler for Service ****
 
 // NewCliDownloadsService creates a service object for the CLI downloads
-func NewCliDownloadsService(hc *hcov1beta1.HyperConverged) *corev1.Service {
-
+func NewCliDownloadsService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      downloadhost.CLIDownloadsServiceName,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, util.AppComponentCompute),
+			Namespace: util.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(util.AppComponentCompute),
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
@@ -141,13 +141,30 @@ func NewCliDownloadsService(hc *hcov1beta1.HyperConverged) *corev1.Service {
 }
 
 func NewCliDownloadsRouteHandler(Client client.Client, Scheme *runtime.Scheme) *operands.GenericOperand {
-	return operands.NewGenericOperand(Client, Scheme, "Route", &cliDownloadsRouteHooks{}, true)
+	return operands.NewGenericOperand(Client, Scheme, "Route", &cliDownloadsRouteHooks{Mutex: &sync.Mutex{}}, true)
 }
 
-type cliDownloadsRouteHooks struct{}
+type cliDownloadsRouteHooks struct {
+	*sync.Mutex
+	route *routev1.Route
+}
 
-func (cliDownloadsRouteHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
-	return NewCliDownloadsRoute(hc), nil
+func (h cliDownloadsRouteHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+	h.Lock()
+	defer h.Unlock()
+
+	if h.route == nil {
+		h.route = NewCliDownloadsRoute()
+	}
+
+	return h.route.DeepCopy(), nil
+}
+
+func (h cliDownloadsRouteHooks) Reset() {
+	h.Lock()
+	defer h.Unlock()
+
+	h.route = nil
 }
 
 func (cliDownloadsRouteHooks) GetEmptyCr() client.Object {
@@ -177,14 +194,14 @@ func (cliDownloadsRouteHooks) UpdateCR(req *common.HcoRequest, Client client.Cli
 	return false, false, nil
 }
 
-func NewCliDownloadsRoute(hc *hcov1beta1.HyperConverged) *routev1.Route {
+func NewCliDownloadsRoute() *routev1.Route {
 	host := downloadhost.Get()
 
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      downloadhost.CLIDownloadsServiceName,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, util.AppComponentCompute),
+			Namespace: util.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(util.AppComponentCompute),
 		},
 		Spec: routev1.RouteSpec{
 			Host: string(downloadhost.Get().CurrentHost),

--- a/controllers/handlers/cliDownload_test.go
+++ b/controllers/handlers/cliDownload_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"maps"
+	"os"
 	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,10 +33,17 @@ var _ = Describe("CLI Download", func() {
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
+
+			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
+			DeferCleanup(func() {
+				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+			})
 		})
 
 		It("should create if not present", func() {
-			expectedResource := NewConsoleCLIDownload(hco)
+			expectedResource := NewConsoleCLIDownload()
 			cl := commontestutils.InitClient([]client.Object{})
 			handler := NewCliDownloadHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
@@ -51,7 +59,7 @@ var _ = Describe("CLI Download", func() {
 		})
 
 		It("should find if present", func() {
-			expectedResource := NewConsoleCLIDownload(hco)
+			expectedResource := NewConsoleCLIDownload()
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
 			handler := NewCliDownloadHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
@@ -66,7 +74,7 @@ var _ = Describe("CLI Download", func() {
 		})
 
 		DescribeTable("should update if something changed", func(modify func(resource *consolev1.ConsoleCLIDownload)) {
-			expectedResource := NewConsoleCLIDownload(hco)
+			expectedResource := NewConsoleCLIDownload()
 			modifiedResource := &consolev1.ConsoleCLIDownload{}
 			expectedResource.DeepCopyInto(modifiedResource)
 			modify(modifiedResource)
@@ -107,7 +115,7 @@ var _ = Describe("CLI Download", func() {
 		It("should reconcile managed labels to default without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource := NewConsoleCLIDownload(hco)
+			outdatedResource := NewConsoleCLIDownload()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
@@ -138,7 +146,7 @@ var _ = Describe("CLI Download", func() {
 		It("should reconcile managed labels to default on label deletion without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource := NewConsoleCLIDownload(hco)
+			outdatedResource := NewConsoleCLIDownload()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
@@ -176,12 +184,19 @@ var _ = Describe("Downloads Service", func() {
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
+
+			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
+			DeferCleanup(func() {
+				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+			})
 		})
 
 		It("should create if not present", func() {
-			expectedResource := NewCliDownloadsService(hco)
+			expectedResource := NewCliDownloadsService()
 			cl := commontestutils.InitClient([]client.Object{})
-			handler := operands.NewServiceHandler(cl, commontestutils.GetScheme(), NewCliDownloadsService)
+			handler := operands.NewServiceHandler(cl, commontestutils.GetScheme(), NewCliDownloadsService())
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -194,9 +209,9 @@ var _ = Describe("Downloads Service", func() {
 		})
 
 		It("should find if present", func() {
-			expectedResource := NewCliDownloadsService(hco)
+			expectedResource := NewCliDownloadsService()
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
-			handler := operands.NewServiceHandler(cl, commontestutils.GetScheme(), NewCliDownloadsService)
+			handler := operands.NewServiceHandler(cl, commontestutils.GetScheme(), NewCliDownloadsService())
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -209,14 +224,14 @@ var _ = Describe("Downloads Service", func() {
 		})
 
 		DescribeTable("should update if something changed", func(modify func(resource *corev1.Service)) {
-			expectedResource := NewCliDownloadsService(hco)
+			expectedResource := NewCliDownloadsService()
 			modifiedResource := &corev1.Service{}
 			expectedResource.DeepCopyInto(modifiedResource)
 			modify(modifiedResource)
 
 			cl := commontestutils.InitClient([]client.Object{modifiedResource})
 
-			handler := operands.NewServiceHandler(cl, commontestutils.GetScheme(), NewCliDownloadsService)
+			handler := operands.NewServiceHandler(cl, commontestutils.GetScheme(), NewCliDownloadsService())
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -257,10 +272,17 @@ var _ = Describe("Cli Downloads Route", func() {
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
+
+			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
+			DeferCleanup(func() {
+				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+			})
 		})
 
 		It("should create if not present", func() {
-			expectedResource := NewCliDownloadsRoute(hco)
+			expectedResource := NewCliDownloadsRoute()
 			cl := commontestutils.InitClient([]client.Object{})
 			handler := NewCliDownloadsRouteHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
@@ -275,7 +297,7 @@ var _ = Describe("Cli Downloads Route", func() {
 		})
 
 		It("should find if present", func() {
-			expectedResource := NewCliDownloadsRoute(hco)
+			expectedResource := NewCliDownloadsRoute()
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
 			handler := NewCliDownloadsRouteHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
@@ -290,7 +312,7 @@ var _ = Describe("Cli Downloads Route", func() {
 		})
 
 		DescribeTable("should update if something changed", func(modify func(resource *routev1.Route)) {
-			expectedResource := NewCliDownloadsRoute(hco)
+			expectedResource := NewCliDownloadsRoute()
 			modifiedResource := &routev1.Route{}
 			expectedResource.DeepCopyInto(modifiedResource)
 			modify(modifiedResource)
@@ -355,7 +377,7 @@ var _ = Describe("Cli Downloads Route", func() {
 					Key:         "key",
 				})
 
-				expectedResource := NewCliDownloadsRoute(hco)
+				expectedResource := NewCliDownloadsRoute()
 
 				Expect(expectedResource.Spec.Host).To(Equal("cli-dl.example.com"))
 				Expect(expectedResource.Spec.TLS.Certificate).To(Equal("crt"))

--- a/controllers/handlers/cliDownload_test.go
+++ b/controllers/handlers/cliDownload_test.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"maps"
-	"os"
 	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -33,13 +32,6 @@ var _ = Describe("CLI Download", func() {
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
-
-			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
-
-			DeferCleanup(func() {
-				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
-			})
 		})
 
 		It("should create if not present", func() {
@@ -184,13 +176,6 @@ var _ = Describe("Downloads Service", func() {
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
-
-			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
-
-			DeferCleanup(func() {
-				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
-			})
 		})
 
 		It("should create if not present", func() {
@@ -272,13 +257,6 @@ var _ = Describe("Cli Downloads Route", func() {
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
-
-			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
-
-			DeferCleanup(func() {
-				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
-			})
 		})
 
 		It("should create if not present", func() {

--- a/controllers/handlers/dashboard.go
+++ b/controllers/handlers/dashboard.go
@@ -68,7 +68,7 @@ func processDashboardConfigMapFile(path string, dir fs.FS, logger log.Logger, hc
 	if err != nil {
 		logger.Error(err, "Can't generate a Configmap object from yaml file", "file name", path)
 	} else {
-		maps.Copy(cm.Labels, operands.GetLabelsDeprecated(hc, util.AppComponentCompute))
+		maps.Copy(cm.Labels, operands.GetLabels(util.AppComponentCompute))
 		return operands.NewCmHandler(Client, Scheme, cm), nil
 	}
 

--- a/controllers/handlers/dashboard.go
+++ b/controllers/handlers/dashboard.go
@@ -68,7 +68,7 @@ func processDashboardConfigMapFile(path string, dir fs.FS, logger log.Logger, hc
 	if err != nil {
 		logger.Error(err, "Can't generate a Configmap object from yaml file", "file name", path)
 	} else {
-		maps.Copy(cm.Labels, operands.GetLabels(hc, util.AppComponentCompute))
+		maps.Copy(cm.Labels, operands.GetLabelsDeprecated(hc, util.AppComponentCompute))
 		return operands.NewCmHandler(Client, Scheme, cm), nil
 	}
 

--- a/controllers/handlers/dashboard.go
+++ b/controllers/handlers/dashboard.go
@@ -22,16 +22,16 @@ const (
 	DashboardManifestLocation = "dashboard"
 )
 
-func GetDashboardHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged, dir fs.FS) ([]operands.Operand, error) {
+func GetDashboardHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, _ *hcov1beta1.HyperConverged, dir fs.FS) ([]operands.Operand, error) {
 	err := util.ValidateManifestDir(DashboardManifestLocation, dir)
 	if err != nil {
 		return nil, errors.Unwrap(err) // if not wrapped, then it's not an error that stops processing, and it return nil
 	}
 
-	return createDashboardHandlersFromFiles(logger, Client, Scheme, hc, DashboardManifestLocation, dir)
+	return createDashboardHandlersFromFiles(logger, Client, Scheme, DashboardManifestLocation, dir)
 }
 
-func createDashboardHandlersFromFiles(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged, filesLocation string, dir fs.FS) ([]operands.Operand, error) {
+func createDashboardHandlersFromFiles(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, filesLocation string, dir fs.FS) ([]operands.Operand, error) {
 	var handlers []operands.Operand
 	err := fs.WalkDir(dir, filesLocation, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
@@ -42,7 +42,7 @@ func createDashboardHandlersFromFiles(logger log.Logger, Client client.Client, S
 			return nil
 		}
 
-		qs, err := processDashboardConfigMapFile(path, dir, logger, hc, Client, Scheme)
+		qs, err := processDashboardConfigMapFile(path, dir, logger, Client, Scheme)
 		if err != nil {
 			return err
 		}
@@ -57,7 +57,7 @@ func createDashboardHandlersFromFiles(logger log.Logger, Client client.Client, S
 	return handlers, err
 }
 
-func processDashboardConfigMapFile(path string, dir fs.FS, logger log.Logger, hc *hcov1beta1.HyperConverged, Client client.Client, Scheme *runtime.Scheme) (operands.Operand, error) {
+func processDashboardConfigMapFile(path string, dir fs.FS, logger log.Logger, Client client.Client, Scheme *runtime.Scheme) (operands.Operand, error) {
 	file, err := dir.Open(path)
 	if err != nil {
 		logger.Error(err, "Can't open the dashboard yaml file", "file name", path)

--- a/controllers/handlers/handlers_suite_test.go
+++ b/controllers/handlers/handlers_suite_test.go
@@ -5,9 +5,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 )
 
 func TestOperators(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Handlers Suite")
 }
+
+var _ = BeforeSuite(func() {
+	commontestutils.CommonBeforeSuite()
+})

--- a/controllers/handlers/imageStream.go
+++ b/controllers/handlers/imageStream.go
@@ -316,7 +316,7 @@ func processImageStreamFile(path string, dir fs.FS, logger log.Logger, hc *hcov1
 		is.Namespace = *ns
 	}
 
-	is.Labels = operands.GetLabels(hc, util.AppComponentCompute)
+	is.Labels = operands.GetLabelsDeprecated(hc, util.AppComponentCompute)
 	imageStreamNames = append(imageStreamNames, is.Name)
 	return newImageStreamHandler(Client, Scheme, is, origNS), nil
 }

--- a/controllers/handlers/imageStream.go
+++ b/controllers/handlers/imageStream.go
@@ -316,7 +316,7 @@ func processImageStreamFile(path string, dir fs.FS, logger log.Logger, hc *hcov1
 		is.Namespace = *ns
 	}
 
-	is.Labels = operands.GetLabelsDeprecated(hc, util.AppComponentCompute)
+	is.Labels = operands.GetLabels(util.AppComponentCompute)
 	imageStreamNames = append(imageStreamNames, is.Name)
 	return newImageStreamHandler(Client, Scheme, is, origNS), nil
 }

--- a/controllers/handlers/imageStream_test.go
+++ b/controllers/handlers/imageStream_test.go
@@ -144,7 +144,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabels(util.AppComponentCompute)
 
 			ref, err := reference.GetReference(commontestutils.GetScheme(), exists)
 			Expect(err).ToNot(HaveOccurred())
@@ -209,7 +209,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabels(util.AppComponentCompute)
 
 			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -267,7 +267,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabels(util.AppComponentCompute)
 
 			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -335,7 +335,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabels(util.AppComponentCompute)
 
 			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -399,7 +399,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabels(util.AppComponentCompute)
 
 			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -528,7 +528,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabels(util.AppComponentCompute)
 
 			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -594,7 +594,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabels(util.AppComponentCompute)
 			expectedLabels := maps.Clone(exists.Labels)
 			exists.Labels[userLabelKey] = userLabelValue
 			for k, v := range expectedLabels {

--- a/controllers/handlers/imageStream_test.go
+++ b/controllers/handlers/imageStream_test.go
@@ -144,7 +144,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabels(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
 
 			ref, err := reference.GetReference(commontestutils.GetScheme(), exists)
 			Expect(err).ToNot(HaveOccurred())
@@ -209,7 +209,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabels(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
 
 			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -267,7 +267,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabels(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
 
 			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -335,7 +335,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabels(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
 
 			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -399,7 +399,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabels(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
 
 			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -528,7 +528,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabels(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
 
 			cli := commontestutils.InitClient([]client.Object{exists})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -594,7 +594,7 @@ var _ = Describe("imageStream tests", func() {
 					},
 				},
 			}
-			exists.Labels = operands.GetLabels(hco, util.AppComponentCompute)
+			exists.Labels = operands.GetLabelsDeprecated(hco, util.AppComponentCompute)
 			expectedLabels := maps.Clone(exists.Labels)
 			exists.Labels[userLabelKey] = userLabelValue
 			for k, v := range expectedLabels {

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -860,7 +860,7 @@ func NewKubeVirtWithNameOnly(hc *hcov1beta1.HyperConverged, opts ...string) *kub
 	return &kubevirtcorev1.KubeVirt{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubevirt-" + hc.Name,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentCompute),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentCompute),
 			Namespace: operands.GetNamespace(hc.Namespace, opts),
 		},
 	}
@@ -1051,7 +1051,7 @@ func NewKubeVirtPriorityClass(hc *hcov1beta1.HyperConverged) *schedulingv1.Prior
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   kvPriorityClass,
-			Labels: operands.GetLabels(hc, hcoutil.AppComponentCompute),
+			Labels: operands.GetLabelsDeprecated(hc, hcoutil.AppComponentCompute),
 		},
 		// 1 billion is the highest value we can set
 		// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -312,7 +312,7 @@ func NewKubeVirt(hc *hcov1beta1.HyperConverged, opts ...string) (*kubevirtcorev1
 		ServiceMonitorNamespace:     operands.GetNamespace(hc.Namespace, opts),
 	}
 
-	kv := NewKubeVirtWithNameOnly(hc, opts...)
+	kv := NewKubeVirtWithNameOnly()
 	setAnnotationsToReqState(hc, kv)
 	kv.Spec = spec
 
@@ -856,12 +856,12 @@ func getKVSeccompConfig() *kubevirtcorev1.SeccompConfiguration {
 	}
 }
 
-func NewKubeVirtWithNameOnly(hc *hcov1beta1.HyperConverged, opts ...string) *kubevirtcorev1.KubeVirt {
+func NewKubeVirtWithNameOnly() *kubevirtcorev1.KubeVirt {
 	return &kubevirtcorev1.KubeVirt{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubevirt-" + hc.Name,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentCompute),
-			Namespace: operands.GetNamespace(hc.Namespace, opts),
+			Name:      "kubevirt-" + hcoutil.HyperConvergedName,
+			Labels:    operands.GetLabels(hcoutil.AppComponentCompute),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 	}
 }
@@ -980,8 +980,8 @@ func NewKvPriorityClassHandler(Client client.Client, Scheme *runtime.Scheme) *op
 
 type kvPriorityClassHooks struct{}
 
-func (kvPriorityClassHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
-	return NewKubeVirtPriorityClass(hc), nil
+func (kvPriorityClassHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+	return NewKubeVirtPriorityClass(), nil
 }
 func (kvPriorityClassHooks) GetEmptyCr() client.Object { return &schedulingv1.PriorityClass{} }
 
@@ -1043,7 +1043,7 @@ func (kvPriorityClassHooks) UpdateCR(req *common.HcoRequest, Client client.Clien
 	return true, !req.HCOTriggered, nil
 }
 
-func NewKubeVirtPriorityClass(hc *hcov1beta1.HyperConverged) *schedulingv1.PriorityClass {
+func NewKubeVirtPriorityClass() *schedulingv1.PriorityClass {
 	return &schedulingv1.PriorityClass{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "scheduling.k8s.io/v1",
@@ -1051,7 +1051,7 @@ func NewKubeVirtPriorityClass(hc *hcov1beta1.HyperConverged) *schedulingv1.Prior
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   kvPriorityClass,
-			Labels: operands.GetLabelsDeprecated(hc, hcoutil.AppComponentCompute),
+			Labels: operands.GetLabels(hcoutil.AppComponentCompute),
 		},
 		// 1 billion is the highest value we can set
 		// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -116,13 +116,13 @@ func NewKvUINginxCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.S
 }
 
 // **** UI user settings config map Handler ****
-func NewKvUIUserSettingsCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewEditableCmHandler(Client, Scheme, NewKvUIUserSettingsCM(hc)), nil
+func NewKvUIUserSettingsCMHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewEditableCmHandler(cli, Scheme, NewKvUIUserSettingsCM())
 }
 
 // **** UI features config map Handler ****
-func NewKvUIFeaturesCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewEditableCmHandler(Client, Scheme, NewKvUIFeaturesCM(hc), "ipStackType"), nil
+func NewKvUIFeaturesCMHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewEditableCmHandler(cli, Scheme, NewKvUIFeaturesCM(), "ipStackType")
 }
 
 // **** Kubevirt UI Console Plugin Custom Resource Handler ****
@@ -419,12 +419,12 @@ func NewKVUINginxCM(hc *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {
 	}, nil
 }
 
-func NewKvUIUserSettingsCM(hc *hcov1beta1.HyperConverged) *corev1.ConfigMap {
+func NewKvUIUserSettingsCM() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIUserSettingsCMName,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIConfig),
-			Namespace: hc.Namespace,
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIConfig),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		Data: map[string]string{},
 	}
@@ -440,14 +440,14 @@ var UIFeaturesConfig = map[string]string{
 	"nodePortEnabled":                     "false",
 }
 
-func NewKvUIFeaturesCM(hc *hcov1beta1.HyperConverged) *corev1.ConfigMap {
+func NewKvUIFeaturesCM() *corev1.ConfigMap {
 	data := maps.Clone(UIFeaturesConfig)
 	data["ipStackType"] = ipstacktype.Get()
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIFeaturesCMName,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIConfig),
-			Namespace: hc.Namespace,
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIConfig),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		Data: data,
 	}

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -95,7 +95,7 @@ func NewKvUIPluginSA(hc *hcov1beta1.HyperConverged) *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIPluginDeploymentName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIPlugin),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
 		},
 	}
 }
@@ -105,7 +105,7 @@ func NewKvUIProxySA(hc *hcov1beta1.HyperConverged) *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIProxyDeploymentName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIProxy),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIProxy),
 		},
 	}
 }
@@ -194,7 +194,7 @@ func NewKvUIProxyDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
 
 func getKvUIDeployment(hc *hcov1beta1.HyperConverged, deploymentName string, image string,
 	servingCertName string, servingCertPath string, port int32, componentName hcoutil.AppComponent) *appsv1.Deployment {
-	labels := operands.GetLabels(hc, componentName)
+	labels := operands.GetLabelsDeprecated(hc, componentName)
 	infrastructureHighlyAvailable := nodeinfo.IsInfrastructureHighlyAvailable()
 	var replicas int32
 	if infrastructureHighlyAvailable {
@@ -318,7 +318,7 @@ func NewKvUIPluginSvc(hc *hcov1beta1.HyperConverged) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   kvUIPluginSvcName,
-			Labels: operands.GetLabels(hc, hcoutil.AppComponentUIPlugin),
+			Labels: operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
 			Annotations: map[string]string{
 				"service.beta.openshift.io/serving-cert-secret-name": kvUIPluginServingCertName,
 			},
@@ -346,7 +346,7 @@ func NewKvUIProxySvc(hc *hcov1beta1.HyperConverged) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   kvUIProxySvcName,
-			Labels: operands.GetLabels(hc, hcoutil.AppComponentUIProxy),
+			Labels: operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIProxy),
 			Annotations: map[string]string{
 				"service.beta.openshift.io/serving-cert-secret-name": kvUIProxyServingCertName,
 			},
@@ -410,7 +410,7 @@ func NewKVUINginxCM(hc *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nginxConfigMapName,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIPlugin),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
 			Namespace: hc.Namespace,
 		},
 		Data: map[string]string{
@@ -423,7 +423,7 @@ func NewKvUIUserSettingsCM(hc *hcov1beta1.HyperConverged) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIUserSettingsCMName,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIConfig),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIConfig),
 			Namespace: hc.Namespace,
 		},
 		Data: map[string]string{},
@@ -446,7 +446,7 @@ func NewKvUIFeaturesCM(hc *hcov1beta1.HyperConverged) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIFeaturesCMName,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIConfig),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIConfig),
 			Namespace: hc.Namespace,
 		},
 		Data: data,
@@ -457,7 +457,7 @@ func NewKVConsolePlugin(hc *hcov1beta1.HyperConverged) *consolev1.ConsolePlugin 
 	return &consolev1.ConsolePlugin{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   kvUIPluginName,
-			Labels: operands.GetLabels(hc, hcoutil.AppComponentUIPlugin),
+			Labels: operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
 		},
 		Spec: consolev1.ConsolePluginSpec{
 			DisplayName: "Kubevirt Console Plugin",
@@ -504,7 +504,7 @@ func NewKvUIConfigCMReaderRole(hc *hcov1beta1.HyperConverged) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIConfigReaderRoleName,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIPlugin),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
 			Namespace: hc.Namespace,
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -528,7 +528,7 @@ func NewKvUIConfigCMReaderRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.Rol
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIConfigReaderRBName,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIPlugin),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
 			Namespace: hc.Namespace,
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -640,7 +640,7 @@ func newKVConsolePluginNetworkPolicy(hc *hcov1beta1.HyperConverged) *networkingv
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubevirt-console-plugin-np",
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIPlugin),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
 		},
 
 		Spec: networkingv1.NetworkPolicySpec{
@@ -736,7 +736,7 @@ func newKVAPIServerProxyNetworkPolicy(hc *hcov1beta1.HyperConverged) *networking
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubevirt-apiserver-proxy-np",
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIProxy),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIProxy),
 		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"text/template"
 
-	log "github.com/go-logr/logr"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -637,18 +636,18 @@ func NewConsoleHandler(Client client.Client) operands.Operand {
 	return h
 }
 
-func newKVConsolePluginNetworkPolicy(hc *hcov1beta1.HyperConverged) *networkingv1.NetworkPolicy {
+func newKVConsolePluginNetworkPolicy() *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubevirt-console-plugin-np",
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIPlugin),
 		},
 
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					hcoutil.AppLabel:          hc.Name,
+					hcoutil.AppLabel:          hcoutil.HyperConvergedName,
 					hcoutil.AppLabelComponent: string(hcoutil.AppComponentUIPlugin),
 				},
 			},
@@ -684,10 +683,10 @@ func newKVConsolePluginNetworkPolicy(hc *hcov1beta1.HyperConverged) *networkingv
 	}
 }
 
-func NewKVConsolePluginNetworkPolicyHandler(_ log.Logger, cli client.Client, schm *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	np := newKVConsolePluginNetworkPolicy(hc)
+func NewKVConsolePluginNetworkPolicyHandler(cli client.Client, schm *runtime.Scheme) operands.Operand {
+	np := newKVConsolePluginNetworkPolicy()
 
-	return operands.NewNetworkPolicyHandler(cli, schm, np), nil
+	return operands.NewNetworkPolicyHandler(cli, schm, np)
 }
 
 func getApiServerEgressRule() networkingv1.NetworkPolicyEgressRule {
@@ -733,17 +732,17 @@ func getApiServerEgressRule() networkingv1.NetworkPolicyEgressRule {
 	}
 }
 
-func newKVAPIServerProxyNetworkPolicy(hc *hcov1beta1.HyperConverged) *networkingv1.NetworkPolicy {
+func newKVAPIServerProxyNetworkPolicy() *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubevirt-apiserver-proxy-np",
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIProxy),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIProxy),
 		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					hcoutil.AppLabel:          hc.Name,
+					hcoutil.AppLabel:          hcoutil.HyperConvergedName,
 					hcoutil.AppLabelComponent: string(hcoutil.AppComponentUIProxy),
 				},
 			},
@@ -776,8 +775,8 @@ func newKVAPIServerProxyNetworkPolicy(hc *hcov1beta1.HyperConverged) *networking
 	}
 }
 
-func NewKVAPIServerProxyNetworkPolicyHandler(_ log.Logger, cli client.Client, schm *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	np := newKVAPIServerProxyNetworkPolicy(hc)
+func NewKVAPIServerProxyNetworkPolicyHandler(cli client.Client, schm *runtime.Scheme) operands.Operand {
+	np := newKVAPIServerProxyNetworkPolicy()
 
-	return operands.NewNetworkPolicyHandler(cli, schm, np), nil
+	return operands.NewNetworkPolicyHandler(cli, schm, np)
 }

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -111,8 +111,8 @@ func NewKvUIProxySA() *corev1.ServiceAccount {
 }
 
 // **** nginx config map Handler ****
-func NewKvUINginxCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, _ *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewDynamicCmHandler(Client, Scheme, NewKVUINginxCM), nil
+func NewKvUINginxCMHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewDynamicCmHandler(Client, Scheme, NewKVUINginxCM)
 }
 
 // **** UI user settings config map Handler ****
@@ -126,8 +126,8 @@ func NewKvUIFeaturesCMHandler(cli client.Client, Scheme *runtime.Scheme) operand
 }
 
 // **** Kubevirt UI Console Plugin Custom Resource Handler ****
-func NewKvUIPluginCRHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return newConsolePluginHandler(Client, Scheme, NewKVConsolePlugin(hc)), nil
+func NewKvUIPluginCRHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return newConsolePluginHandler(Client, Scheme, NewKVConsolePlugin())
 }
 
 func NewKvUIPluginDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
@@ -410,8 +410,8 @@ func NewKVUINginxCM(hc *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nginxConfigMapName,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
-			Namespace: hc.Namespace,
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIPlugin),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		Data: map[string]string{
 			"nginx.conf": nginxConf,
@@ -453,11 +453,13 @@ func NewKvUIFeaturesCM() *corev1.ConfigMap {
 	}
 }
 
-func NewKVConsolePlugin(hc *hcov1beta1.HyperConverged) *consolev1.ConsolePlugin {
+func NewKVConsolePlugin() *consolev1.ConsolePlugin {
+	namespace := hcoutil.GetOperatorNamespaceFromEnv()
+
 	return &consolev1.ConsolePlugin{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   kvUIPluginName,
-			Labels: operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
+			Labels: operands.GetLabels(hcoutil.AppComponentUIPlugin),
 		},
 		Spec: consolev1.ConsolePluginSpec{
 			DisplayName: "Kubevirt Console Plugin",
@@ -465,7 +467,7 @@ func NewKVConsolePlugin(hc *hcov1beta1.HyperConverged) *consolev1.ConsolePlugin 
 				Type: consolev1.Service,
 				Service: &consolev1.ConsolePluginService{
 					Name:      kvUIPluginSvcName,
-					Namespace: hc.Namespace,
+					Namespace: namespace,
 					Port:      hcoutil.UIPluginServerPort,
 					BasePath:  "/",
 				},
@@ -477,7 +479,7 @@ func NewKVConsolePlugin(hc *hcov1beta1.HyperConverged) *consolev1.ConsolePlugin 
 					Type: consolev1.ProxyTypeService,
 					Service: &consolev1.ConsolePluginProxyServiceConfig{
 						Name:      kvUIProxySvcName,
-						Namespace: hc.Namespace,
+						Namespace: namespace,
 						Port:      hcoutil.UIProxyServerPort,
 					},
 				},

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -71,13 +71,13 @@ const ( // for network policies
 )
 
 // **** Kubevirt UI Plugin Deployment Handler ****
-func NewKvUIPluginDeploymentHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewDeploymentHandler(Client, Scheme, NewKvUIPluginDeployment, hc), nil
+func NewKvUIPluginDeploymentHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewDeploymentHandler(cli, Scheme, NewKvUIPluginDeployment)
 }
 
 // **** Kubevirt UI apiserver proxy Deployment Handler ****
-func NewKvUIProxyDeploymentHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewDeploymentHandler(Client, Scheme, NewKvUIProxyDeployment, hc), nil
+func NewKvUIProxyDeploymentHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewDeploymentHandler(cli, Scheme, NewKvUIProxyDeployment)
 }
 
 // **** Kubevirt UI Plugin ServiceAccount Handler ****
@@ -194,7 +194,7 @@ func NewKvUIProxyDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
 
 func getKvUIDeployment(hc *hcov1beta1.HyperConverged, deploymentName string, image string,
 	servingCertName string, servingCertPath string, port int32, componentName hcoutil.AppComponent) *appsv1.Deployment {
-	labels := operands.GetLabelsDeprecated(hc, componentName)
+	labels := operands.GetLabels(componentName)
 	infrastructureHighlyAvailable := nodeinfo.IsInfrastructureHighlyAvailable()
 	var replicas int32
 	if infrastructureHighlyAvailable {
@@ -209,7 +209,7 @@ func getKvUIDeployment(hc *hcov1beta1.HyperConverged, deploymentName string, ima
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,
 			Labels:    labels,
-			Namespace: hc.Namespace,
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: ptr.To(replicas),

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -300,7 +300,7 @@ func getKvUIDeployment(hc *hcov1beta1.HyperConverged, deploymentName string, ima
 	return deployment
 }
 
-func NewKvUIPluginSvc(hc *hcov1beta1.HyperConverged) *corev1.Service {
+func NewKvUIPluginSvc() *corev1.Service {
 	servicePorts := []corev1.ServicePort{
 		{
 			Port:       hcoutil.UIPluginServerPort,
@@ -318,17 +318,17 @@ func NewKvUIPluginSvc(hc *hcov1beta1.HyperConverged) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   kvUIPluginSvcName,
-			Labels: operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
+			Labels: operands.GetLabels(hcoutil.AppComponentUIPlugin),
 			Annotations: map[string]string{
 				"service.beta.openshift.io/serving-cert-secret-name": kvUIPluginServingCertName,
 			},
-			Namespace: hc.Namespace,
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		Spec: spec,
 	}
 }
 
-func NewKvUIProxySvc(hc *hcov1beta1.HyperConverged) *corev1.Service {
+func NewKvUIProxySvc() *corev1.Service {
 	servicePorts := []corev1.ServicePort{
 		{
 			Port:       hcoutil.UIProxyServerPort,
@@ -346,11 +346,11 @@ func NewKvUIProxySvc(hc *hcov1beta1.HyperConverged) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   kvUIProxySvcName,
-			Labels: operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIProxy),
+			Labels: operands.GetLabels(hcoutil.AppComponentUIProxy),
 			Annotations: map[string]string{
 				"service.beta.openshift.io/serving-cert-secret-name": kvUIProxyServingCertName,
 			},
-			Namespace: hc.Namespace,
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		Spec: spec,
 	}

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -81,31 +81,31 @@ func NewKvUIProxyDeploymentHandler(_ log.Logger, Client client.Client, Scheme *r
 }
 
 // **** Kubevirt UI Plugin ServiceAccount Handler ****
-func NewKvUIPluginSAHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewServiceAccountHandler(Client, Scheme, NewKvUIPluginSA), nil
+func NewKvUIPluginSAHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewServiceAccountHandler(cli, Scheme, NewKvUIPluginSA)
 }
 
 // **** Kubevirt UI Proxy ServiceAccount Handler ****
-func NewKvUIProxySAHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewServiceAccountHandler(Client, Scheme, NewKvUIProxySA), nil
+func NewKvUIProxySAHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewServiceAccountHandler(cli, Scheme, NewKvUIProxySA)
 }
 
-func NewKvUIPluginSA(hc *hcov1beta1.HyperConverged) *corev1.ServiceAccount {
+func NewKvUIPluginSA() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIPluginDeploymentName,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIPlugin),
 		},
 	}
 }
 
-func NewKvUIProxySA(hc *hcov1beta1.HyperConverged) *corev1.ServiceAccount {
+func NewKvUIProxySA() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIProxyDeploymentName,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIProxy),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIProxy),
 		},
 	}
 }

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -493,21 +493,21 @@ func newConsolePluginHandler(Client client.Client, Scheme *runtime.Scheme, requi
 }
 
 // NewKvUIConfigReaderRoleHandler returns UI configuration (user settings and features) ConfigMap Role Handler
-func NewKvUIConfigReaderRoleHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewRoleHandler(Client, Scheme, NewKvUIConfigCMReaderRole(hc)), nil
+func NewKvUIConfigReaderRoleHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewRoleHandler(Client, Scheme, NewKvUIConfigCMReaderRole())
 }
 
 // NewKvUIConfigReaderRoleBindingHandler returns UI configuration (user settings and features) ConfigMap RoleBinding Handler
-func NewKvUIConfigReaderRoleBindingHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewRoleBindingHandler(Client, Scheme, NewKvUIConfigCMReaderRoleBinding(hc)), nil
+func NewKvUIConfigReaderRoleBindingHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewRoleBindingHandler(Client, Scheme, NewKvUIConfigCMReaderRoleBinding())
 }
 
-func NewKvUIConfigCMReaderRole(hc *hcov1beta1.HyperConverged) *rbacv1.Role {
+func NewKvUIConfigCMReaderRole() *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIConfigReaderRoleName,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
-			Namespace: hc.Namespace,
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIPlugin),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -526,12 +526,12 @@ func NewKvUIConfigCMReaderRole(hc *hcov1beta1.HyperConverged) *rbacv1.Role {
 	}
 }
 
-func NewKvUIConfigCMReaderRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.RoleBinding {
+func NewKvUIConfigCMReaderRoleBinding() *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIConfigReaderRBName,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
-			Namespace: hc.Namespace,
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIPlugin),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",

--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"maps"
+	"os"
 	"reflect"
 	"slices"
 	"strings"
@@ -45,6 +46,13 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
 		req = commontestutils.NewReq(hco)
+
+		origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
+		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
+		DeferCleanup(func() {
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+		})
 	})
 
 	Context("Console Plugin CR", func() {
@@ -1022,99 +1030,97 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 	})
 
 	Context("Kubevirt Plugin and UI Proxy Service", func() {
-		DescribeTable("should create service if not present", func(appComponent hcoutil.AppComponent,
-			serviceManifestor func(*hcov1beta1.HyperConverged) *v1.Service) {
-			var expectedResource *v1.Service
-			var handler *operands.GenericOperand
-			cl := commontestutils.InitClient([]client.Object{})
-			expectedResource = serviceManifestor(hco)
-			handler = operands.NewServiceHandler(cl, commontestutils.GetScheme(), serviceManifestor)
+		DescribeTable("should create service if not present",
+			func(appComponent hcoutil.AppComponent, serviceManifestor func() *v1.Service) {
+				var expectedResource *v1.Service
+				var handler *operands.GenericOperand
+				cl := commontestutils.InitClient([]client.Object{})
+				expectedResource = serviceManifestor()
+				handler = operands.NewServiceHandler(cl, commontestutils.GetScheme(), serviceManifestor())
 
-			res := handler.Ensure(req)
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Err).ToNot(HaveOccurred())
+				res := handler.Ensure(req)
+				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.Err).ToNot(HaveOccurred())
 
-			foundResource := &v1.Service{}
-			Expect(
-				cl.Get(context.TODO(),
-					types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
-					foundResource),
-			).To(Succeed())
-			Expect(foundResource.Name).To(Equal(expectedResource.Name))
-			Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
-			Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
-		},
+				foundResource := &v1.Service{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
+						foundResource),
+				).To(Succeed())
+				Expect(foundResource.Name).To(Equal(expectedResource.Name))
+				Expect(foundResource.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, commontestutils.Name))
+				Expect(foundResource.Namespace).To(Equal(expectedResource.Namespace))
+			},
 			Entry("ui plugin service", hcoutil.AppComponentUIPlugin, NewKvUIPluginSvc),
 			Entry("ui proxy service", hcoutil.AppComponentUIProxy, NewKvUIProxySvc),
 		)
 
-		DescribeTable("should find service if present", func(appComponent hcoutil.AppComponent,
-			serviceManifestor func(*hcov1beta1.HyperConverged) *v1.Service) {
+		DescribeTable("should find service if present",
+			func(appComponent hcoutil.AppComponent, serviceManifestor func() *v1.Service) {
+				expectedResource := serviceManifestor()
+				cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
+				handler := operands.NewServiceHandler(cl, commontestutils.GetScheme(), serviceManifestor())
 
-			expectedResource := serviceManifestor(hco)
-			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
-			handler := operands.NewServiceHandler(cl, commontestutils.GetScheme(), serviceManifestor)
+				res := handler.Ensure(req)
+				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.Err).ToNot(HaveOccurred())
 
-			res := handler.Ensure(req)
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Err).ToNot(HaveOccurred())
+				foundResource := &v1.Service{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
+						foundResource),
+				).To(Succeed())
 
-			foundResource := &v1.Service{}
-			Expect(
-				cl.Get(context.TODO(),
-					types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
-					foundResource),
-			).To(Succeed())
-
-			// Check HCO's status
-			Expect(hco.Status.RelatedObjects).ToNot(BeNil())
-			objectRef, err := reference.GetReference(commontestutils.GetScheme(), foundResource)
-			Expect(err).ToNot(HaveOccurred())
-			// ObjectReference should have been added
-			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRef))
-		},
+				// Check HCO's status
+				Expect(hco.Status.RelatedObjects).ToNot(BeNil())
+				objectRef, err := reference.GetReference(commontestutils.GetScheme(), foundResource)
+				Expect(err).ToNot(HaveOccurred())
+				// ObjectReference should have been added
+				Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRef))
+			},
 			Entry("ui plugin service", hcoutil.AppComponentUIPlugin, NewKvUIPluginSvc),
 			Entry("ui proxy service", hcoutil.AppComponentUIProxy, NewKvUIProxySvc),
 		)
 
-		DescribeTable("should reconcile service to default if changed", func(appComponent hcoutil.AppComponent,
-			serviceManifestor func(*hcov1beta1.HyperConverged) *v1.Service) {
+		DescribeTable("should reconcile service to default if changed",
+			func(appComponent hcoutil.AppComponent, serviceManifestor func() *v1.Service) {
+				expectedResource := serviceManifestor()
+				outdatedResource := serviceManifestor()
 
-			expectedResource := serviceManifestor(hco)
-			outdatedResource := serviceManifestor(hco)
+				outdatedResource.Labels[hcoutil.AppLabel] = "wrong label"
+				outdatedResource.Spec.Ports[0].Port = 6666
 
-			outdatedResource.Labels[hcoutil.AppLabel] = "wrong label"
-			outdatedResource.Spec.Ports[0].Port = 6666
+				cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
+				handler := operands.NewServiceHandler(cl, commontestutils.GetScheme(), serviceManifestor())
 
-			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler := operands.NewServiceHandler(cl, commontestutils.GetScheme(), serviceManifestor)
+				res := handler.Ensure(req)
+				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.Updated).To(BeTrue())
+				Expect(res.Err).ToNot(HaveOccurred())
 
-			res := handler.Ensure(req)
-			Expect(res.UpgradeDone).To(BeFalse())
-			Expect(res.Updated).To(BeTrue())
-			Expect(res.Err).ToNot(HaveOccurred())
+				foundResource := &v1.Service{}
+				Expect(
+					cl.Get(context.TODO(),
+						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
+						foundResource),
+				).To(Succeed())
 
-			foundResource := &v1.Service{}
-			Expect(
-				cl.Get(context.TODO(),
-					types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
-					foundResource),
-			).To(Succeed())
+				Expect(foundResource.Labels).ToNot(Equal(outdatedResource.Labels))
+				Expect(foundResource.Labels).To(Equal(expectedResource.Labels))
+				Expect(foundResource.Spec.Ports).ToNot(Equal(outdatedResource.Spec.Ports))
+				Expect(foundResource.Spec.Ports).To(Equal(expectedResource.Spec.Ports))
 
-			Expect(foundResource.Labels).ToNot(Equal(outdatedResource.Labels))
-			Expect(foundResource.Labels).To(Equal(expectedResource.Labels))
-			Expect(foundResource.Spec.Ports).ToNot(Equal(outdatedResource.Spec.Ports))
-			Expect(foundResource.Spec.Ports).To(Equal(expectedResource.Spec.Ports))
-
-			// ObjectReference should have been updated
-			Expect(hco.Status.RelatedObjects).ToNot(BeNil())
-			objectRefOutdated, err := reference.GetReference(commontestutils.GetScheme(), outdatedResource)
-			Expect(err).ToNot(HaveOccurred())
-			objectRefFound, err := reference.GetReference(commontestutils.GetScheme(), foundResource)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hco.Status.RelatedObjects).ToNot(ContainElement(*objectRefOutdated))
-			Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
-		},
+				// ObjectReference should have been updated
+				Expect(hco.Status.RelatedObjects).ToNot(BeNil())
+				objectRefOutdated, err := reference.GetReference(commontestutils.GetScheme(), outdatedResource)
+				Expect(err).ToNot(HaveOccurred())
+				objectRefFound, err := reference.GetReference(commontestutils.GetScheme(), foundResource)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hco.Status.RelatedObjects).ToNot(ContainElement(*objectRefOutdated))
+				Expect(hco.Status.RelatedObjects).To(ContainElement(*objectRefFound))
+			},
 			Entry("ui plugin service", hcoutil.AppComponentUIPlugin, NewKvUIPluginSvc),
 			Entry("ui proxy service", hcoutil.AppComponentUIProxy, NewKvUIProxySvc),
 		)

--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			handler, _ := NewKvUIPluginCRHandler(testLogger, cl, commontestutils.GetScheme(), hco)
 
 			res := handler.Ensure(req)
-			Expect(res.UpgradeDone).To(BeFalse())
+			Expect(res.UpgradeDone).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
 
 			foundResource := &consolev1.ConsolePlugin{}
@@ -288,7 +288,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			res := handler.Ensure(req)
-			Expect(res.UpgradeDone).To(BeFalse())
+			Expect(res.UpgradeDone).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
 
 			foundResource := &appsv1.Deployment{}
@@ -1039,7 +1039,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				handler = operands.NewServiceHandler(cl, commontestutils.GetScheme(), serviceManifestor())
 
 				res := handler.Ensure(req)
-				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.UpgradeDone).To(BeTrue())
 				Expect(res.Err).ToNot(HaveOccurred())
 
 				foundResource := &v1.Service{}
@@ -1171,7 +1171,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				res := handler.Ensure(req)
-				Expect(res.UpgradeDone).To(BeFalse())
+				Expect(res.UpgradeDone).To(BeTrue())
 				Expect(res.Err).ToNot(HaveOccurred())
 
 				foundResource := &networkingv1.NetworkPolicy{}

--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -68,9 +68,9 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		}
 
 		It("should create plugin CR if not present", func() {
-			expectedResource := NewKVConsolePlugin(hco)
+			expectedResource := NewKVConsolePlugin()
 			cl := commontestutils.InitClient([]client.Object{})
-			handler, _ := NewKvUIPluginCRHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewKvUIPluginCRHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeTrue())
@@ -88,10 +88,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should find plugin CR if present", func() {
-			expectedResource := NewKVConsolePlugin(hco)
+			expectedResource := NewKVConsolePlugin()
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource, expectedConsoleConfig})
-			handler, _ := NewKvUIPluginCRHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewKvUIPluginCRHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -106,14 +106,14 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should reconcile plugin spec to default if changed", func() {
-			expectedResource := NewKVConsolePlugin(hco)
-			outdatedResource := NewKVConsolePlugin(hco)
+			expectedResource := NewKVConsolePlugin()
+			outdatedResource := NewKVConsolePlugin()
 
 			outdatedResource.Spec.Backend.Service.Port = int32(6666)
 			outdatedResource.Spec.DisplayName = "fake plugin name"
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource, expectedConsoleConfig})
-			handler, _ := NewKvUIPluginCRHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewKvUIPluginCRHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -140,13 +140,13 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should reconcile plugin labels to default if changed", func() {
-			expectedResource := NewKVConsolePlugin(hco)
-			outdatedResource := NewKVConsolePlugin(hco)
+			expectedResource := NewKVConsolePlugin()
+			outdatedResource := NewKVConsolePlugin()
 
 			outdatedResource.Labels[hcoutil.AppLabel] = "changed"
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource, expectedConsoleConfig})
-			handler, _ := NewKvUIPluginCRHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewKvUIPluginCRHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -164,14 +164,14 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should reconcile plugin labels to default if added", func() {
-			expectedResource := NewKVConsolePlugin(hco)
-			outdatedResource := NewKVConsolePlugin(hco)
+			expectedResource := NewKVConsolePlugin()
+			outdatedResource := NewKVConsolePlugin()
 
 			outdatedResource.Labels["app.kubernetes.io/managed-by"] = "something"
 			// TODO: add another test for extra labels!
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource, expectedConsoleConfig})
-			handler, _ := NewKvUIPluginCRHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewKvUIPluginCRHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -189,13 +189,13 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		})
 
 		It("should reconcile plugin labels to default if deleted", func() {
-			expectedResource := NewKVConsolePlugin(hco)
-			outdatedResource := NewKVConsolePlugin(hco)
+			expectedResource := NewKVConsolePlugin()
+			outdatedResource := NewKVConsolePlugin()
 
 			delete(outdatedResource.Labels, hcoutil.AppLabel)
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource, expectedConsoleConfig})
-			handler, _ := NewKvUIPluginCRHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewKvUIPluginCRHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -215,7 +215,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		It("should reconcile managed labels to default without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource := NewKVConsolePlugin(hco)
+			outdatedResource := NewKVConsolePlugin()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
@@ -223,7 +223,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler, _ := NewKvUIPluginCRHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewKvUIPluginCRHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())

--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 
@@ -39,9 +38,8 @@ import (
 
 var _ = Describe("Kubevirt Console Plugin", func() {
 	var (
-		testLogger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("consoleplugin_test")
-		hco        *hcov1beta1.HyperConverged
-		req        *common.HcoRequest
+		hco *hcov1beta1.HyperConverged
+		req *common.HcoRequest
 	)
 
 	BeforeEach(func() {
@@ -1130,8 +1128,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 			It("should deploy NetworkPolicies for console plugin", func() {
 				cl := commontestutils.InitClient([]client.Object{hco})
-				handler, err := NewKVConsolePluginNetworkPolicyHandler(testLogger, cl, commontestutils.GetScheme(), hco)
-				Expect(err).ToNot(HaveOccurred())
+				handler := NewKVConsolePluginNetworkPolicyHandler(cl, commontestutils.GetScheme())
 
 				res := handler.Ensure(req)
 				Expect(res.Created).To(BeTrue())
@@ -1144,7 +1141,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 						foundNP),
 				).To(Succeed())
 
-				expectedNP := newKVConsolePluginNetworkPolicy(hco)
+				expectedNP := newKVConsolePluginNetworkPolicy()
 
 				Expect(foundNP.Name).To(Equal(expectedNP.Name))
 				Expect(foundNP.Namespace).To(Equal(expectedNP.Namespace))
@@ -1155,8 +1152,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 			It("should deploy NetworkPolicies for api-server proxy", func() {
 				cl := commontestutils.InitClient([]client.Object{})
-				handler, err := NewKVAPIServerProxyNetworkPolicyHandler(testLogger, cl, commontestutils.GetScheme(), hco)
-				Expect(err).ToNot(HaveOccurred())
+				handler := NewKVAPIServerProxyNetworkPolicyHandler(cl, commontestutils.GetScheme())
 
 				res := handler.Ensure(req)
 				Expect(res.UpgradeDone).To(BeTrue())
@@ -1174,7 +1170,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			})
 
 			It("should update NetworkPolicies for console plugin, if it was modified", func() {
-				expectedNP := newKVConsolePluginNetworkPolicy(hco)
+				expectedNP := newKVConsolePluginNetworkPolicy()
 
 				existingNP := expectedNP.DeepCopy()
 				existingNP.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
@@ -1195,8 +1191,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingNP})
 
-				handler, err := NewKVConsolePluginNetworkPolicyHandler(testLogger, cl, commontestutils.GetScheme(), hco)
-				Expect(err).ToNot(HaveOccurred())
+				handler := NewKVConsolePluginNetworkPolicyHandler(cl, commontestutils.GetScheme())
 
 				res := handler.Ensure(req)
 				Expect(res.Created).To(BeFalse())
@@ -1230,7 +1225,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			})
 
 			It("should update NetworkPolicies for api-server proxy, if it was modified", func() {
-				expectedNP := newKVAPIServerProxyNetworkPolicy(hco)
+				expectedNP := newKVAPIServerProxyNetworkPolicy()
 				existingNP := expectedNP.DeepCopy()
 				existingNP.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
 					{
@@ -1249,8 +1244,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingNP.Labels[hcoutil.AppLabel] = "wrong-label"
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingNP})
-				handler, err := NewKVAPIServerProxyNetworkPolicyHandler(testLogger, cl, commontestutils.GetScheme(), hco)
-				Expect(err).ToNot(HaveOccurred())
+				handler := NewKVAPIServerProxyNetworkPolicyHandler(cl, commontestutils.GetScheme())
 
 				res := handler.Ensure(req)
 				Expect(res.UpgradeDone).To(BeFalse())

--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -18,6 +18,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/reference"
@@ -257,7 +258,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler := operands.NewDeploymentHandler(cl, commontestutils.GetScheme(), newExpectedDeployment, hco)
+			handler := operands.NewDeploymentHandler(cl, commontestutils.GetScheme(), newExpectedDeployment)
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -280,12 +281,11 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 	Context("Kubevirt Console Plugin and UI Proxy Deployments", func() {
 		DescribeTable("should create if not present", func(appComponent hcoutil.AppComponent,
-			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 			expectedResource := deploymentManifestor(hco)
 
 			cl := commontestutils.InitClient([]client.Object{})
-			handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := handlerFunc(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeTrue())
@@ -312,12 +312,11 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		)
 
 		DescribeTable("should find deployment if present", func(appComponent hcoutil.AppComponent,
-			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 			expectedResource := deploymentManifestor(hco)
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
-			handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := handlerFunc(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -342,7 +341,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		)
 
 		DescribeTable("should reconcile deployment to default if changed - (updatable fields)", func(appComponent hcoutil.AppComponent,
-			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 			expectedResource := deploymentManifestor(hco)
 			outdatedResource := deploymentManifestor(hco)
 
@@ -353,9 +352,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Spec.Template.Spec.Containers[0].Image = "quay.io/fake/image:latest"
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := handlerFunc(cl, commontestutils.GetScheme())
 
-			Expect(err).ToNot(HaveOccurred())
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -390,7 +388,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		)
 
 		DescribeTable("should reconcile deployment to default if changed - (immutable fields)", func(appComponent hcoutil.AppComponent,
-			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 			expectedResource := deploymentManifestor(hco)
 			outdatedResource := deploymentManifestor(hco)
 
@@ -402,9 +400,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.Spec.Template.Labels[hcoutil.AppLabel] = "wrong label"
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := handlerFunc(cl, commontestutils.GetScheme())
 
-			Expect(err).ToNot(HaveOccurred())
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -613,16 +610,15 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 		Context("Node Placement", func() {
 			DescribeTable("should add node placement if missing", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				existingResource := deploymentManifestor(hco)
 
 				hco.Spec.Workloads.NodePlacement = commontestutils.NewNodePlacement()
 				hco.Spec.Infra.NodePlacement = commontestutils.NewOtherNodePlacement()
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
-				Expect(err).ToNot(HaveOccurred())
 				res := handler.Ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
@@ -650,7 +646,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("should remove node placement if missing in HCO CR", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				hcoNodePlacement := commontestutils.NewHco()
 				hcoNodePlacement.Spec.Workloads.NodePlacement = commontestutils.NewNodePlacement()
 				hcoNodePlacement.Spec.Infra.NodePlacement = commontestutils.NewOtherNodePlacement()
@@ -658,9 +654,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingResource := deploymentManifestor(hcoNodePlacement)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
-				Expect(err).ToNot(HaveOccurred())
 				res := handler.Ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
@@ -688,7 +683,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("should modify node placement according to HCO CR", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 
 				hco.Spec.Workloads.NodePlacement = commontestutils.NewNodePlacement()
 				hco.Spec.Infra.NodePlacement = commontestutils.NewOtherNodePlacement()
@@ -702,9 +697,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				hco.Spec.Infra.NodePlacement.NodeSelector["key3"] = "something entirely else"
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
-				Expect(err).ToNot(HaveOccurred())
 				res := handler.Ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
@@ -734,7 +728,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("should overwrite node placement if directly set on Kubevirt Console Plugin Deployment", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 
 				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
 				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewOtherNodePlacement()}
@@ -750,9 +744,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingResource.Spec.Template.Spec.NodeSelector["key3"] = "BADvalue3"
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
-				Expect(err).ToNot(HaveOccurred())
 				res := handler.Ensure(req)
 				Expect(res.UpgradeDone).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
@@ -779,16 +772,15 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("apply only NodeSelector if missing", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				existingResource := deploymentManifestor(hco)
 
 				hco.Spec.Infra.NodePlacement = &sdkapi.NodePlacement{}
 				hco.Spec.Infra.NodePlacement.NodeSelector = commontestutils.NewNodePlacement().NodeSelector
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
-				Expect(err).ToNot(HaveOccurred())
 				res := handler.Ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
@@ -811,16 +803,15 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("apply only Affinity if missing", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				existingResource := deploymentManifestor(hco)
 
 				hco.Spec.Infra.NodePlacement = &sdkapi.NodePlacement{}
 				hco.Spec.Infra.NodePlacement.Affinity = commontestutils.NewNodePlacement().Affinity
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
-				Expect(err).ToNot(HaveOccurred())
 				res := handler.Ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
@@ -843,16 +834,15 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("apply only Tolerations if missing", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				existingResource := deploymentManifestor(hco)
 
 				hco.Spec.Infra.NodePlacement = &sdkapi.NodePlacement{}
 				hco.Spec.Infra.NodePlacement.Tolerations = commontestutils.NewNodePlacement().Tolerations
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
-				Expect(err).ToNot(HaveOccurred())
 				res := handler.Ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
@@ -875,7 +865,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("apply PodAntiAffinity and two replicas if HighlyAvailable", func(ctx context.Context, appComponent hcoutil.AppComponent,
-				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 
 				originalNodeInfoFunc := nodeinfo.IsInfrastructureHighlyAvailable
 				nodeinfo.IsInfrastructureHighlyAvailable = func() bool {
@@ -893,9 +883,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingResource.Spec.Replicas = ptr.To(int32(1))
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
-				Expect(err).ToNot(HaveOccurred())
 				res := handler.Ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())
@@ -922,7 +911,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("use one replica on SNO", func(ctx context.Context, appComponent hcoutil.AppComponent,
-				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc operands.GetHandler) {
+				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 
 				commontestutils.SNONodeInfoMock()
 				DeferCleanup(func() {
@@ -933,9 +922,8 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				existingResource.Spec.Replicas = ptr.To(int32(3))
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
-				Expect(err).ToNot(HaveOccurred())
 				res := handler.Ensure(req)
 				Expect(res.Created).To(BeFalse())
 				Expect(res.Updated).To(BeTrue())

--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"maps"
-	"os"
 	"reflect"
 	"slices"
 	"strings"
@@ -45,13 +44,6 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
 		req = commontestutils.NewReq(hco)
-
-		origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
-		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
-
-		DeferCleanup(func() {
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
-		})
 	})
 
 	Context("Console Plugin CR", func() {

--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -444,11 +444,11 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			})
 
 			DescribeTable("should reconcile managed labels to default on label deletion without touching user added ones", func(appComponent hcoutil.AppComponent,
-				cmManifestor func(*hcov1beta1.HyperConverged) *v1.ConfigMap, handlerFunc operands.GetHandler) {
+				cmManifestor func() *v1.ConfigMap, handlerFunc func(Client client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				const userLabelKey = "userLabelKey"
 				const userLabelValue = "userLabelValue"
 
-				outdatedResource := cmManifestor(hco)
+				outdatedResource := cmManifestor()
 
 				expectedLabels := maps.Clone(outdatedResource.Labels)
 				for k, v := range expectedLabels {
@@ -457,8 +457,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				outdatedResource.Labels[userLabelKey] = userLabelValue
 
 				cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
-				Expect(err).ToNot(HaveOccurred())
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
 				res := handler.Ensure(req)
 				Expect(res.UpgradeDone).To(BeFalse())
@@ -481,11 +480,11 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("should not reconcile UI settings config map data", func(appComponent hcoutil.AppComponent,
-				cmManifestor func(*hcov1beta1.HyperConverged) *v1.ConfigMap, handlerFunc operands.GetHandler, managedKeys []string) {
+				cmManifestor func() *v1.ConfigMap, handlerFunc func(Client client.Client, Scheme *runtime.Scheme) operands.Operand, managedKeys []string) {
 				const userAddedDataKey = "userAddedDataKey"
 				const userAddedDataValue = "userAddedDataValue"
 
-				outdatedResource := cmManifestor(hco)
+				outdatedResource := cmManifestor()
 
 				modifiedData := maps.Clone(outdatedResource.Data)
 				for k, v := range modifiedData {
@@ -499,8 +498,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
-				Expect(err).ToNot(HaveOccurred())
+				handler := handlerFunc(cl, commontestutils.GetScheme())
 
 				res := handler.Ensure(req)
 				Expect(res.UpgradeDone).To(BeFalse())
@@ -513,13 +511,15 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 						foundResource),
 				).To(Succeed())
 				Expect(foundResource.Name).To(Equal(outdatedResource.Name))
+
 				for k, v := range modifiedData {
 					if managedSet[k] {
 						Expect(foundResource.Data).To(HaveKeyWithValue(k, v))
 					} else {
-						Expect(foundResource.Data).ToNot(HaveKeyWithValue(k, v))
+						Expect(foundResource.Data).To(HaveKeyWithValue(k, Not(Equal(v))))
 					}
 				}
+
 				Expect(foundResource.Data).To(HaveKeyWithValue(userAddedDataKey, userAddedDataValue))
 			},
 				Entry("user settings config", hcoutil.AppComponentUIConfig, NewKvUIUserSettingsCM, NewKvUIUserSettingsCMHandler, []string(nil)),

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -56,13 +56,6 @@ var _ = Describe("KubeVirt Operand", func() {
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
-
-			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
-
-			DeferCleanup(func() {
-				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
-			})
 		})
 
 		It("should create if not present", func() {
@@ -274,9 +267,6 @@ var _ = Describe("KubeVirt Operand", func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 
-			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
-
 			Expect(os.Setenv(smbiosEnvName,
 				`Family: smbios family
 Product: smbios product
@@ -292,7 +282,6 @@ Version: 1.2.3`)).To(Succeed())
 			restArchConfig()
 
 			DeferCleanup(func() {
-				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
 				Expect(os.Unsetenv(smbiosEnvName)).To(Succeed())
 				Expect(os.Unsetenv(machineTypeEnvName)).To(Succeed())
 				Expect(os.Unsetenv(amd64MachineTypeEnvName)).To(Succeed())
@@ -4599,13 +4588,6 @@ Version: 1.2.3`)
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
-
-			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
-
-			DeferCleanup(func() {
-				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
-			})
 		})
 
 		oldTLSSecurityProfile := &openshiftconfigv1.TLSSecurityProfile{

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -70,7 +70,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			cl := commontestutils.InitClient([]client.Object{})
 			handler := NewKvPriorityClassHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
-			Expect(res.UpgradeDone).To(BeFalse())
+			Expect(res.UpgradeDone).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
 
 			key := client.ObjectKeyFromObject(expectedResource)

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -56,10 +56,17 @@ var _ = Describe("KubeVirt Operand", func() {
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
+
+			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
+			DeferCleanup(func() {
+				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+			})
 		})
 
 		It("should create if not present", func() {
-			expectedResource := NewKubeVirtPriorityClass(hco)
+			expectedResource := NewKubeVirtPriorityClass()
 			cl := commontestutils.InitClient([]client.Object{})
 			handler := NewKvPriorityClassHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
@@ -75,7 +82,7 @@ var _ = Describe("KubeVirt Operand", func() {
 		})
 
 		It("should do nothing if already exists", func() {
-			expectedResource := NewKubeVirtPriorityClass(hco)
+			expectedResource := NewKubeVirtPriorityClass()
 			cl := commontestutils.InitClient([]client.Object{expectedResource})
 			handler := NewKvPriorityClassHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
@@ -88,7 +95,7 @@ var _ = Describe("KubeVirt Operand", func() {
 		})
 
 		DescribeTable("should update if something changed", func(modifiedPC *schedulingv1.PriorityClass) {
-			expectedPC := NewKubeVirtPriorityClass(hco)
+			expectedPC := NewKubeVirtPriorityClass()
 			key := client.ObjectKeyFromObject(expectedPC)
 
 			cl := commontestutils.InitClient([]client.Object{modifiedPC})
@@ -143,7 +150,7 @@ var _ = Describe("KubeVirt Operand", func() {
 		)
 
 		DescribeTable("should return error when there is something wrong", func(initiateErrors func(testClient *commontestutils.HcoTestClient) error) {
-			modifiedResource := NewKubeVirtPriorityClass(hco)
+			modifiedResource := NewKubeVirtPriorityClass()
 			modifiedResource.Value = 1
 
 			cl := commontestutils.InitClient([]client.Object{modifiedResource})
@@ -191,7 +198,7 @@ var _ = Describe("KubeVirt Operand", func() {
 		Context("check labels", func() {
 			const origUID = types.UID("origPC")
 			It("should add missing labels", func(ctx context.Context) {
-				expectedResource := NewKubeVirtPriorityClass(hco)
+				expectedResource := NewKubeVirtPriorityClass()
 				expectedResource.UID = origUID
 				delete(expectedResource.Labels, hcoutil.AppLabelComponent)
 
@@ -212,7 +219,7 @@ var _ = Describe("KubeVirt Operand", func() {
 			})
 
 			It("should fix wrong labels", func(ctx context.Context) {
-				expectedResource := NewKubeVirtPriorityClass(hco)
+				expectedResource := NewKubeVirtPriorityClass()
 				expectedResource.UID = "origPC"
 				expectedResource.Labels[hcoutil.AppLabelComponent] = string(hcoutil.AppComponentStorage)
 
@@ -234,7 +241,7 @@ var _ = Describe("KubeVirt Operand", func() {
 
 			It("should keep user-defined labels", func(ctx context.Context) {
 				const customLabel = "custom-label"
-				expectedResource := NewKubeVirtPriorityClass(hco)
+				expectedResource := NewKubeVirtPriorityClass()
 				expectedResource.Labels[customLabel] = "test"
 				expectedResource.Labels[hcoutil.AppLabelComponent] = string(hcoutil.AppComponentStorage)
 				expectedResource.UID = "origPC"
@@ -266,6 +273,10 @@ var _ = Describe("KubeVirt Operand", func() {
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
+
+			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
 			Expect(os.Setenv(smbiosEnvName,
 				`Family: smbios family
 Product: smbios product
@@ -281,6 +292,7 @@ Version: 1.2.3`)).To(Succeed())
 			restArchConfig()
 
 			DeferCleanup(func() {
+				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
 				Expect(os.Unsetenv(smbiosEnvName)).To(Succeed())
 				Expect(os.Unsetenv(machineTypeEnvName)).To(Succeed())
 				Expect(os.Unsetenv(amd64MachineTypeEnvName)).To(Succeed())
@@ -2779,7 +2791,7 @@ Version: 1.2.3`)
 			})
 
 			It("should set certificate rotation strategy to defaults if missing in HCO CR", func() {
-				existingResource := NewKubeVirtWithNameOnly(hco)
+				existingResource := NewKubeVirtWithNameOnly()
 
 				cl := commontestutils.InitClient([]client.Object{hco})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -2961,7 +2973,7 @@ Version: 1.2.3`)
 			})
 
 			It("should set Workload Update Strategy to defaults if missing in HCO CR", func() {
-				existingResource := NewKubeVirtWithNameOnly(hco)
+				existingResource := NewKubeVirtWithNameOnly()
 
 				cl := commontestutils.InitClient([]client.Object{hco})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -3967,7 +3979,7 @@ Version: 1.2.3`)
 					}
 				]`}
 
-				expectedResource := NewKubeVirtWithNameOnly(hco)
+				expectedResource := NewKubeVirtWithNameOnly()
 				cl := commontestutils.InitClient([]client.Object{hco})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
 				res := handler.Ensure(req)
@@ -4004,7 +4016,7 @@ Version: 1.2.3`)
 					}
 				]`}
 
-				expectedResource := NewKubeVirtWithNameOnly(hco)
+				expectedResource := NewKubeVirtWithNameOnly()
 				cl := commontestutils.InitClient([]client.Object{hco})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
 				res := handler.Ensure(req)
@@ -4050,7 +4062,7 @@ Version: 1.2.3`)
 
 				kv := &kubevirtcorev1.KubeVirt{}
 
-				expectedResource := NewKubeVirtWithNameOnly(hco)
+				expectedResource := NewKubeVirtWithNameOnly()
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
@@ -4089,7 +4101,7 @@ Version: 1.2.3`)
 
 				kv := &kubevirtcorev1.KubeVirt{}
 
-				expectedResource := NewKubeVirtWithNameOnly(hco)
+				expectedResource := NewKubeVirtWithNameOnly()
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
@@ -4587,6 +4599,13 @@ Version: 1.2.3`)
 		BeforeEach(func() {
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
+
+			origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
+			DeferCleanup(func() {
+				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+			})
 		})
 
 		oldTLSSecurityProfile := &openshiftconfigv1.TLSSecurityProfile{

--- a/controllers/handlers/migration.go
+++ b/controllers/handlers/migration.go
@@ -100,18 +100,18 @@ func NewMigController(hc *hcov1beta1.HyperConverged) (*migrationv1alpha1.MigCont
 
 	spec.TLSSecurityProfile = openshift2MigrationSecProfile(tlssecprofile.GetTLSSecurityProfile(hc.Spec.TLSSecurityProfile))
 
-	migController := NewMigControllerWithNameOnly(hc)
+	migController := NewMigControllerWithNameOnly()
 	migController.Spec = spec
 
 	return reformatobj.ReformatObj(migController)
 }
 
-func NewMigControllerWithNameOnly(hc *hcov1beta1.HyperConverged) *migrationv1alpha1.MigController {
+func NewMigControllerWithNameOnly() *migrationv1alpha1.MigController {
 	return &migrationv1alpha1.MigController{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "migcontroller-" + hc.Name,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentMigration),
+			Name:      "migcontroller-" + hcoutil.HyperConvergedName,
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(hcoutil.AppComponentMigration),
 		},
 	}
 }

--- a/controllers/handlers/migration.go
+++ b/controllers/handlers/migration.go
@@ -111,7 +111,7 @@ func NewMigControllerWithNameOnly(hc *hcov1beta1.HyperConverged) *migrationv1alp
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "migcontroller-" + hc.Name,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentMigration),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentMigration),
 		},
 	}
 }

--- a/controllers/handlers/migration_test.go
+++ b/controllers/handlers/migration_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"maps"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -54,6 +55,14 @@ var _ = Describe("Migration tests", func() {
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
 		req = commontestutils.NewReq(hco)
+
+		origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
+		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
+		DeferCleanup(func() {
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+		})
+
 	})
 
 	Context("test NewMigController", func() {
@@ -104,7 +113,7 @@ var _ = Describe("Migration tests", func() {
 		})
 
 		It("should update MigController fields, if not matched to the requirements", func() {
-			migController := NewMigControllerWithNameOnly(hco)
+			migController := NewMigControllerWithNameOnly()
 			migController.Spec.ImagePullPolicy = corev1.PullAlways
 			migController.Spec.Infra = testNodePlacement
 
@@ -130,7 +139,7 @@ var _ = Describe("Migration tests", func() {
 		It("should reconcile managed labels to default without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource := NewMigControllerWithNameOnly(hco)
+			outdatedResource := NewMigControllerWithNameOnly()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
 				outdatedResource.Labels[k] = "wrong_" + v
@@ -161,7 +170,7 @@ var _ = Describe("Migration tests", func() {
 		It("should reconcile managed labels to default on label deletion without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource := NewMigControllerWithNameOnly(hco)
+			outdatedResource := NewMigControllerWithNameOnly()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)

--- a/controllers/handlers/migration_test.go
+++ b/controllers/handlers/migration_test.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"maps"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -55,14 +54,6 @@ var _ = Describe("Migration tests", func() {
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
 		req = commontestutils.NewReq(hco)
-
-		origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
-		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
-
-		DeferCleanup(func() {
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
-		})
-
 	})
 
 	Context("test NewMigController", func() {

--- a/controllers/handlers/networkAddons.go
+++ b/controllers/handlers/networkAddons.go
@@ -203,7 +203,7 @@ func NewNetworkAddonsWithNameOnly(hc *hcov1beta1.HyperConverged) *networkaddonsv
 	return &networkaddonsv1.NetworkAddonsConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   networkaddonsnames.OperatorConfig,
-			Labels: operands.GetLabels(hc, util.AppComponentNetwork),
+			Labels: operands.GetLabelsDeprecated(hc, util.AppComponentNetwork),
 		},
 	}
 }

--- a/controllers/handlers/networkAddons.go
+++ b/controllers/handlers/networkAddons.go
@@ -177,7 +177,7 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged) (*networkaddonsv1.NetworkAd
 
 	cnaoSpec.TLSSecurityProfile = tlssecprofile.GetTLSSecurityProfile(hc.Spec.TLSSecurityProfile)
 
-	cna := NewNetworkAddonsWithNameOnly(hc)
+	cna := NewNetworkAddonsWithNameOnly()
 	cna.Spec = cnaoSpec
 
 	if err = operands.ApplyPatchToSpec(hc, common.JSONPatchCNAOAnnotationName, cna); err != nil {
@@ -199,11 +199,11 @@ func getKSDNameServerIP(nameServerIPPtr *string) (string, error) {
 	return nameServerIP, nil
 }
 
-func NewNetworkAddonsWithNameOnly(hc *hcov1beta1.HyperConverged) *networkaddonsv1.NetworkAddonsConfig {
+func NewNetworkAddonsWithNameOnly() *networkaddonsv1.NetworkAddonsConfig {
 	return &networkaddonsv1.NetworkAddonsConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   networkaddonsnames.OperatorConfig,
-			Labels: operands.GetLabelsDeprecated(hc, util.AppComponentNetwork),
+			Labels: operands.GetLabels(util.AppComponentNetwork),
 		},
 	}
 }

--- a/controllers/handlers/networkAddons_test.go
+++ b/controllers/handlers/networkAddons_test.go
@@ -383,7 +383,7 @@ var _ = Describe("CNA Operand", func() {
 		})
 
 		It("should set self signed configuration to defaults if missing in HCO CR", func() {
-			existingResource := NewNetworkAddonsWithNameOnly(hco)
+			existingResource := NewNetworkAddonsWithNameOnly()
 
 			cl := commontestutils.InitClient([]client.Object{hco})
 			handler := NewCnaHandler(cl, commontestutils.GetScheme())
@@ -902,7 +902,7 @@ var _ = Describe("CNA Operand", func() {
 					}
 				]`}
 
-				expectedResource := NewNetworkAddonsWithNameOnly(hco)
+				expectedResource := NewNetworkAddonsWithNameOnly()
 				cl := commontestutils.InitClient([]client.Object{})
 				handler := NewCnaHandler(cl, commontestutils.GetScheme())
 				res := handler.Ensure(req)
@@ -931,7 +931,7 @@ var _ = Describe("CNA Operand", func() {
 					}
 				]`}
 
-				expectedResource := NewNetworkAddonsWithNameOnly(hco)
+				expectedResource := NewNetworkAddonsWithNameOnly()
 				cl := commontestutils.InitClient([]client.Object{})
 				handler := NewCnaHandler(cl, commontestutils.GetScheme())
 				res := handler.Ensure(req)
@@ -972,7 +972,7 @@ var _ = Describe("CNA Operand", func() {
 
 				cna := &networkaddonsv1.NetworkAddonsConfig{}
 
-				expectedResource := NewNetworkAddonsWithNameOnly(hco)
+				expectedResource := NewNetworkAddonsWithNameOnly()
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
@@ -1004,7 +1004,7 @@ var _ = Describe("CNA Operand", func() {
 
 				cna := &networkaddonsv1.NetworkAddonsConfig{}
 
-				expectedResource := NewNetworkAddonsWithNameOnly(hco)
+				expectedResource := NewNetworkAddonsWithNameOnly()
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},

--- a/controllers/handlers/passt/nad_test.go
+++ b/controllers/handlers/passt/nad_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Passt NetworkAttachmentDefinition tests", func() {
 
 	Context("test NewPasstBindingCNINetworkAttachmentDefinition", func() {
 		It("should have all default fields", func() {
-			nad := passt.NewPasstBindingCNINetworkAttachmentDefinition(hco)
+			nad := passt.NewPasstBindingCNINetworkAttachmentDefinition()
 
 			Expect(nad.Name).To(Equal("primary-udn-kubevirt-binding"))
 			Expect(nad.Namespace).To(Equal("default"))
@@ -65,7 +65,7 @@ var _ = Describe("Passt NetworkAttachmentDefinition tests", func() {
 
 		It("should delete NetworkAttachmentDefinition if the deployPasstNetworkBinding annotation is false", func() {
 			hco.Annotations[passt.DeployPasstNetworkBindingAnnotation] = "false"
-			nad := passt.NewPasstBindingCNINetworkAttachmentDefinition(hco)
+			nad := passt.NewPasstBindingCNINetworkAttachmentDefinition()
 			cl = commontestutils.InitClient([]client.Object{hco, nad})
 
 			handler := passt.NewPasstNetworkAttachmentDefinitionHandler(cl, commontestutils.GetScheme())
@@ -111,7 +111,7 @@ var _ = Describe("Passt NetworkAttachmentDefinition tests", func() {
 		It("should update NetworkAttachmentDefinition fields if not matched to the requirements", func() {
 			hco.Annotations[passt.DeployPasstNetworkBindingAnnotation] = "true"
 
-			nad := passt.NewPasstBindingCNINetworkAttachmentDefinition(hco)
+			nad := passt.NewPasstBindingCNINetworkAttachmentDefinition()
 			nad.Spec.Config = `{"cniVersion": "0.3.1", "name": "wrong-name", "type": "wrong-type"}`
 
 			cl = commontestutils.InitClient([]client.Object{hco, nad})
@@ -138,7 +138,7 @@ var _ = Describe("Passt NetworkAttachmentDefinition tests", func() {
 			const userLabelValue = "userLabelValue"
 			hco.Annotations[passt.DeployPasstNetworkBindingAnnotation] = "true"
 
-			outdatedResource := passt.NewPasstBindingCNINetworkAttachmentDefinition(hco)
+			outdatedResource := passt.NewPasstBindingCNINetworkAttachmentDefinition()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 
 			for k, v := range expectedLabels {
@@ -172,7 +172,7 @@ var _ = Describe("Passt NetworkAttachmentDefinition tests", func() {
 			const userLabelValue = "userLabelValue"
 			hco.Annotations[passt.DeployPasstNetworkBindingAnnotation] = "true"
 
-			outdatedResource := passt.NewPasstBindingCNINetworkAttachmentDefinition(hco)
+			outdatedResource := passt.NewPasstBindingCNINetworkAttachmentDefinition()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 
 			outdatedResource.Labels[userLabelKey] = userLabelValue

--- a/controllers/handlers/passt/networkAttachmentDefinitionHandler.go
+++ b/controllers/handlers/passt/networkAttachmentDefinitionHandler.go
@@ -1,4 +1,4 @@
-package operands
+package passt
 
 import (
 	"errors"
@@ -14,18 +14,12 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-type newNetworkAttachmentDefinitionFunc func(hc *hcov1beta1.HyperConverged) *netattdefv1.NetworkAttachmentDefinition
-
-func NewNetworkAttachmentDefinitionHandler(Client client.Client, Scheme *runtime.Scheme, newCrFunc newNetworkAttachmentDefinitionFunc) *GenericOperand {
-	return NewGenericOperand(Client, Scheme, "NetworkAttachmentDefinition", &networkAttachmentDefinitionHooks{newCrFunc: newCrFunc}, false)
-}
-
 type networkAttachmentDefinitionHooks struct {
-	newCrFunc newNetworkAttachmentDefinitionFunc
+	nad *netattdefv1.NetworkAttachmentDefinition
 }
 
 func (h networkAttachmentDefinitionHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
-	return h.newCrFunc(hc), nil
+	return h.nad.DeepCopy(), nil
 }
 
 func (networkAttachmentDefinitionHooks) GetEmptyCr() client.Object {

--- a/controllers/handlers/passt/passt.go
+++ b/controllers/handlers/passt/passt.go
@@ -66,12 +66,12 @@ func NetworkBinding() kubevirtcorev1.InterfaceBindingPlugin {
 }
 
 // NewPasstBindingCNISA creates a ServiceAccount for the passt binding CNI
-func NewPasstBindingCNISA(hc *hcov1beta1.HyperConverged) *corev1.ServiceAccount {
+func NewPasstBindingCNISA() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      passtCNIObjectName,
-			Namespace: hc.Namespace,
-			Labels:    hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentNetwork),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(hcoutil.AppComponentNetwork),
 		},
 	}
 }
@@ -262,7 +262,7 @@ func NewPasstServiceAccountHandler(Client client.Client, Scheme *runtime.Scheme)
 	return createPasstConditionalHandler(
 		operands.NewServiceAccountHandler(Client, Scheme, NewPasstBindingCNISA),
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewPasstBindingCNISA(hc)
+			return NewPasstBindingCNISA()
 		},
 	)
 }

--- a/controllers/handlers/passt/passt.go
+++ b/controllers/handlers/passt/passt.go
@@ -167,7 +167,7 @@ sleep 2147483647`,
 		spec.Template.Spec.ServiceAccountName = passtCNIObjectName
 	}
 
-	daemonSet := NewPasstBindingCNIDaemonSetWithNameOnly(hc)
+	daemonSet := NewPasstBindingCNIDaemonSetWithNameOnly()
 	daemonSet.Spec = spec
 
 	affinity := operands.GetPodAntiAffinity(daemonSet.Labels[hcoutil.AppLabelComponent], nodeinfo.IsInfrastructureHighlyAvailable())
@@ -193,26 +193,26 @@ sleep 2147483647`,
 }
 
 // NewPasstBindingCNIDaemonSetWithNameOnly creates a DaemonSet for the passt binding CNI with name only (for deletion)
-func NewPasstBindingCNIDaemonSetWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
-	labels := hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentNetwork)
+func NewPasstBindingCNIDaemonSetWithNameOnly() *appsv1.DaemonSet {
+	labels := operands.GetLabels(hcoutil.AppComponentNetwork)
 	labels["tier"] = "node"
 
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      passtCNIObjectName,
-			Namespace: hc.Namespace,
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 			Labels:    labels,
 		},
 	}
 }
 
 // NewPasstBindingCNINetworkAttachmentDefinition creates a NetworkAttachmentDefinition for the passt binding CNI
-func NewPasstBindingCNINetworkAttachmentDefinition(hc *hcov1beta1.HyperConverged) *netattdefv1.NetworkAttachmentDefinition {
+func NewPasstBindingCNINetworkAttachmentDefinition() *netattdefv1.NetworkAttachmentDefinition {
 	return &netattdefv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      networkBindingNADName,
 			Namespace: networkBindingNADNamespace,
-			Labels:    hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentNetwork),
+			Labels:    operands.GetLabels(hcoutil.AppComponentNetwork),
 		},
 		Spec: netattdefv1.NetworkAttachmentDefinitionSpec{
 			Config: `{
@@ -272,7 +272,7 @@ func NewPasstDaemonSetHandler(Client client.Client, Scheme *runtime.Scheme) oper
 	return createPasstConditionalHandler(
 		operands.NewDaemonSetHandler(Client, Scheme, NewPasstBindingCNIDaemonSet),
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewPasstBindingCNIDaemonSetWithNameOnly(hc)
+			return NewPasstBindingCNIDaemonSetWithNameOnly()
 		},
 	)
 }
@@ -280,9 +280,9 @@ func NewPasstDaemonSetHandler(Client client.Client, Scheme *runtime.Scheme) oper
 // NewPasstNetworkAttachmentDefinitionHandler creates a conditional handler for passt NetworkAttachmentDefinition
 func NewPasstNetworkAttachmentDefinitionHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return createPasstConditionalHandler(
-		operands.NewNetworkAttachmentDefinitionHandler(Client, Scheme, NewPasstBindingCNINetworkAttachmentDefinition),
+		operands.NewGenericOperand(Client, Scheme, "NetworkAttachmentDefinition", &networkAttachmentDefinitionHooks{nad: NewPasstBindingCNINetworkAttachmentDefinition()}, false),
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewPasstBindingCNINetworkAttachmentDefinition(hc)
+			return NewPasstBindingCNINetworkAttachmentDefinition()
 		},
 	)
 }

--- a/controllers/handlers/passt/passt.go
+++ b/controllers/handlers/passt/passt.go
@@ -229,11 +229,11 @@ func NewPasstBindingCNINetworkAttachmentDefinition(hc *hcov1beta1.HyperConverged
 }
 
 // NewPasstBindingCNISecurityContextConstraints creates a SecurityContextConstraints for the passt binding CNI
-func NewPasstBindingCNISecurityContextConstraints(hc *hcov1beta1.HyperConverged) *securityv1.SecurityContextConstraints {
+func NewPasstBindingCNISecurityContextConstraints() *securityv1.SecurityContextConstraints {
 	return &securityv1.SecurityContextConstraints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   passtCNIObjectName,
-			Labels: hcoutil.GetLabels(hcoutil.HyperConvergedName, hcoutil.AppComponentNetwork),
+			Labels: operands.GetLabels(hcoutil.AppComponentNetwork),
 		},
 		AllowPrivilegedContainer: true,
 		AllowHostDirVolumePlugin: true,
@@ -249,7 +249,7 @@ func NewPasstBindingCNISecurityContextConstraints(hc *hcov1beta1.HyperConverged)
 			Type: securityv1.SELinuxStrategyRunAsAny,
 		},
 		Users: []string{
-			fmt.Sprintf("system:serviceaccount:%s:%s", hc.Namespace, passtCNIObjectName),
+			fmt.Sprintf("system:serviceaccount:%s:%s", hcoutil.GetOperatorNamespaceFromEnv(), passtCNIObjectName),
 		},
 		Volumes: []securityv1.FSType{
 			securityv1.FSTypeAll,
@@ -288,11 +288,11 @@ func NewPasstNetworkAttachmentDefinitionHandler(Client client.Client, Scheme *ru
 }
 
 // NewPasstSecurityContextConstraintsHandler creates a conditional handler for passt SecurityContextConstraints
-func NewPasstSecurityContextConstraintsHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
+func NewPasstSecurityContextConstraintsHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return createPasstConditionalHandler(
-		operands.NewSecurityContextConstraintsHandler(Client, Scheme, NewPasstBindingCNISecurityContextConstraints),
-		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewPasstBindingCNISecurityContextConstraints(hc)
+		operands.NewSecurityContextConstraintsHandler(cli, Scheme, NewPasstBindingCNISecurityContextConstraints()),
+		func(_ *hcov1beta1.HyperConverged) client.Object {
+			return NewPasstBindingCNISecurityContextConstraints()
 		},
 	)
 }

--- a/controllers/handlers/passt/passt_suite_test.go
+++ b/controllers/handlers/passt/passt_suite_test.go
@@ -1,13 +1,28 @@
 package passt_test
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func TestPasst(t *testing.T) {
+	origNS, ok := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
+	_ = os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)
+
+	defer func() {
+		if ok {
+			_ = os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)
+		} else {
+			_ = os.Unsetenv(hcoutil.OperatorNamespaceEnv)
+		}
+	}()
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Passt Suite")
 }

--- a/controllers/handlers/passt/passt_suite_test.go
+++ b/controllers/handlers/passt/passt_suite_test.go
@@ -1,28 +1,19 @@
 package passt_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func TestPasst(t *testing.T) {
-	origNS, ok := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
-	_ = os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)
-
-	defer func() {
-		if ok {
-			_ = os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)
-		} else {
-			_ = os.Unsetenv(hcoutil.OperatorNamespaceEnv)
-		}
-	}()
-
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Passt Suite")
 }
+
+var _ = BeforeSuite(func() {
+	commontestutils.CommonBeforeSuite()
+})

--- a/controllers/handlers/passt/scc_test.go
+++ b/controllers/handlers/passt/scc_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Passt SecurityContextConstraints tests", func() {
 
 	Context("test NewPasstBindingCNISecurityContextConstraints", func() {
 		It("should have all default fields", func() {
-			scc := passt.NewPasstBindingCNISecurityContextConstraints(hco)
+			scc := passt.NewPasstBindingCNISecurityContextConstraints()
 
 			Expect(scc.Name).To(Equal("passt-binding-cni"))
 			Expect(scc.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
@@ -76,7 +76,7 @@ var _ = Describe("Passt SecurityContextConstraints tests", func() {
 
 		It("should delete SecurityContextConstraints if the deployPasstNetworkBinding annotation is false", func() {
 			hco.Annotations[passt.DeployPasstNetworkBindingAnnotation] = "false"
-			scc := passt.NewPasstBindingCNISecurityContextConstraints(hco)
+			scc := passt.NewPasstBindingCNISecurityContextConstraints()
 			cl = commontestutils.InitClient([]client.Object{hco, scc})
 
 			handler := passt.NewPasstSecurityContextConstraintsHandler(cl, commontestutils.GetScheme())
@@ -120,7 +120,7 @@ var _ = Describe("Passt SecurityContextConstraints tests", func() {
 		It("should update SecurityContextConstraints fields if not matched to the requirements", func() {
 			hco.Annotations[passt.DeployPasstNetworkBindingAnnotation] = "true"
 
-			scc := passt.NewPasstBindingCNISecurityContextConstraints(hco)
+			scc := passt.NewPasstBindingCNISecurityContextConstraints()
 			scc.AllowPrivilegedContainer = false
 			scc.AllowHostNetwork = true
 			scc.Users = []string{"wrong-user"}
@@ -147,7 +147,7 @@ var _ = Describe("Passt SecurityContextConstraints tests", func() {
 		It("should reconcile labels if they are missing while preserving user labels", func() {
 			hco.Annotations[passt.DeployPasstNetworkBindingAnnotation] = "true"
 
-			scc := passt.NewPasstBindingCNISecurityContextConstraints(hco)
+			scc := passt.NewPasstBindingCNISecurityContextConstraints()
 			expectedLabels := maps.Clone(scc.Labels)
 			delete(scc.Labels, "app.kubernetes.io/component")
 			scc.Labels["user-added-label"] = "user-value"
@@ -175,7 +175,7 @@ var _ = Describe("Passt SecurityContextConstraints tests", func() {
 		It("should reconcile labels if they are deleted while preserving user labels", func() {
 			hco.Annotations[passt.DeployPasstNetworkBindingAnnotation] = "true"
 
-			scc := passt.NewPasstBindingCNISecurityContextConstraints(hco)
+			scc := passt.NewPasstBindingCNISecurityContextConstraints()
 			expectedLabels := maps.Clone(scc.Labels)
 			scc.Labels = map[string]string{
 				"user-added-label": "user-value",

--- a/controllers/handlers/passt/service_account_test.go
+++ b/controllers/handlers/passt/service_account_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Passt ServiceAccount tests", func() {
 
 	Context("test NewPasstBindingCNISA", func() {
 		It("should have all default fields", func() {
-			sa := passt.NewPasstBindingCNISA(hco)
+			sa := passt.NewPasstBindingCNISA()
 
 			Expect(sa.Name).To(Equal("passt-binding-cni"))
 			Expect(sa.Namespace).To(Equal(hco.Namespace))
@@ -58,7 +58,7 @@ var _ = Describe("Passt ServiceAccount tests", func() {
 		})
 
 		It("should delete ServiceAccount if the deployPasstNetworkBinding annotation is not set", func() {
-			sa := passt.NewPasstBindingCNISA(hco)
+			sa := passt.NewPasstBindingCNISA()
 			cl = commontestutils.InitClient([]client.Object{hco, sa})
 
 			handler := passt.NewPasstServiceAccountHandler(cl, commontestutils.GetScheme())

--- a/controllers/handlers/quickStart.go
+++ b/controllers/handlers/quickStart.go
@@ -71,16 +71,16 @@ func (h qsHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exists r
 	return false, false, nil
 }
 
-func GetQuickStartHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged, dir fs.FS) ([]operands.Operand, error) {
+func GetQuickStartHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, _ *hcov1beta1.HyperConverged, dir fs.FS) ([]operands.Operand, error) {
 	err := util.ValidateManifestDir(QuickStartDefaultManifestLocation, dir)
 	if err != nil {
 		return nil, errors.Unwrap(err) // if not wrapped, then it's not an error that stops processing, and it return nil
 	}
 
-	return createQuickstartHandlersFromFiles(logger, Client, Scheme, hc, QuickStartDefaultManifestLocation, dir)
+	return createQuickstartHandlersFromFiles(logger, Client, Scheme, QuickStartDefaultManifestLocation, dir)
 }
 
-func createQuickstartHandlersFromFiles(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged, filesLocation string, dir fs.FS) ([]operands.Operand, error) {
+func createQuickstartHandlersFromFiles(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, filesLocation string, dir fs.FS) ([]operands.Operand, error) {
 	var handlers []operands.Operand
 	quickstartNames = []string{}
 
@@ -93,7 +93,7 @@ func createQuickstartHandlersFromFiles(logger log.Logger, Client client.Client, 
 			return nil
 		}
 
-		qs, err := processQuickstartFile(path, logger, hc, Client, Scheme, dir)
+		qs, err := processQuickstartFile(path, logger, Client, Scheme, dir)
 		if err != nil {
 			return err
 		}
@@ -108,7 +108,7 @@ func createQuickstartHandlersFromFiles(logger log.Logger, Client client.Client, 
 	return handlers, err
 }
 
-func processQuickstartFile(path string, logger log.Logger, hc *hcov1beta1.HyperConverged, Client client.Client, Scheme *runtime.Scheme, dir fs.FS) (operands.Operand, error) {
+func processQuickstartFile(path string, logger log.Logger, Client client.Client, Scheme *runtime.Scheme, dir fs.FS) (operands.Operand, error) {
 	file, err := dir.Open(path)
 	if err != nil {
 		logger.Error(err, "Can't open the quickStart yaml file", "file name", path)
@@ -119,7 +119,7 @@ func processQuickstartFile(path string, logger log.Logger, hc *hcov1beta1.HyperC
 	if err != nil {
 		logger.Error(err, "Can't generate a ConsoleQuickStart object from yaml file", "file name", path)
 	} else {
-		qs.Labels = operands.GetLabelsDeprecated(hc, util.AppComponentCompute)
+		qs.Labels = operands.GetLabels(util.AppComponentCompute)
 		quickstartNames = append(quickstartNames, qs.Name)
 		return newQuickStartHandler(Client, Scheme, qs), nil
 	}

--- a/controllers/handlers/quickStart.go
+++ b/controllers/handlers/quickStart.go
@@ -119,7 +119,7 @@ func processQuickstartFile(path string, logger log.Logger, hc *hcov1beta1.HyperC
 	if err != nil {
 		logger.Error(err, "Can't generate a ConsoleQuickStart object from yaml file", "file name", path)
 	} else {
-		qs.Labels = operands.GetLabels(hc, util.AppComponentCompute)
+		qs.Labels = operands.GetLabelsDeprecated(hc, util.AppComponentCompute)
 		quickstartNames = append(quickstartNames, qs.Name)
 		return newQuickStartHandler(Client, Scheme, qs), nil
 	}

--- a/controllers/handlers/ssp.go
+++ b/controllers/handlers/ssp.go
@@ -185,7 +185,7 @@ func NewSSP(hc *hcov1beta1.HyperConverged) (*sspv1beta3.SSP, []hcov1beta1.DataIm
 		spec.TemplateValidator.Placement = hc.Spec.Infra.NodePlacement.DeepCopy()
 	}
 
-	ssp := NewSSPWithNameOnly(hc)
+	ssp := NewSSPWithNameOnly()
 	ssp.Spec = spec
 
 	if err = operands.ApplyPatchToSpec(hc, common.JSONPatchSSPAnnotationName, ssp); err != nil {
@@ -200,12 +200,12 @@ func NewSSP(hc *hcov1beta1.HyperConverged) (*sspv1beta3.SSP, []hcov1beta1.DataIm
 	return ssp, dataImportCronStatuses, nil
 }
 
-func NewSSPWithNameOnly(hc *hcov1beta1.HyperConverged, opts ...string) *sspv1beta3.SSP {
+func NewSSPWithNameOnly() *sspv1beta3.SSP {
 	return &sspv1beta3.SSP{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ssp-" + hc.Name,
-			Labels:    operands.GetLabelsDeprecated(hc, util.AppComponentSchedule),
-			Namespace: operands.GetNamespace(hc.Namespace, opts),
+			Name:      "ssp-" + util.HyperConvergedName,
+			Labels:    operands.GetLabels(util.AppComponentSchedule),
+			Namespace: util.GetOperatorNamespaceFromEnv(),
 		},
 	}
 }

--- a/controllers/handlers/ssp.go
+++ b/controllers/handlers/ssp.go
@@ -204,7 +204,7 @@ func NewSSPWithNameOnly(hc *hcov1beta1.HyperConverged, opts ...string) *sspv1bet
 	return &sspv1beta3.SSP{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ssp-" + hc.Name,
-			Labels:    operands.GetLabels(hc, util.AppComponentSchedule),
+			Labels:    operands.GetLabelsDeprecated(hc, util.AppComponentSchedule),
 			Namespace: operands.GetNamespace(hc.Namespace, opts),
 		},
 	}

--- a/controllers/handlers/ssp_test.go
+++ b/controllers/handlers/ssp_test.go
@@ -473,7 +473,7 @@ var _ = Describe("SSP Operands", func() {
 					}
 				]`}
 
-				expectedResource := NewSSPWithNameOnly(hco)
+				expectedResource := NewSSPWithNameOnly()
 				cl := commontestutils.InitClient([]client.Object{})
 				handler := NewSspHandler(cl, commontestutils.GetScheme())
 				res := handler.Ensure(req)
@@ -501,7 +501,7 @@ var _ = Describe("SSP Operands", func() {
 					}
 				]`}
 
-				expectedResource := NewSSPWithNameOnly(hco)
+				expectedResource := NewSSPWithNameOnly()
 				cl := commontestutils.InitClient([]client.Object{})
 				handler := NewSspHandler(cl, commontestutils.GetScheme())
 				res := handler.Ensure(req)
@@ -537,7 +537,7 @@ var _ = Describe("SSP Operands", func() {
 
 				ssp := &sspv1beta3.SSP{}
 
-				expectedResource := NewSSPWithNameOnly(hco)
+				expectedResource := NewSSPWithNameOnly()
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
@@ -568,7 +568,7 @@ var _ = Describe("SSP Operands", func() {
 
 				ssp := &sspv1beta3.SSP{}
 
-				expectedResource := NewSSPWithNameOnly(hco)
+				expectedResource := NewSSPWithNameOnly()
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expectedResource.Name, Namespace: expectedResource.Namespace},
@@ -667,7 +667,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Created).To(BeTrue())
 
 						ssp := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), ssp)).To(Succeed())
 						Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
@@ -711,7 +711,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Created).To(BeTrue())
 
 						ssp := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), ssp)).To(Succeed())
 						Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
@@ -772,7 +772,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Created).To(BeTrue())
 
 						ssp := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), ssp)).To(Succeed())
 						Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(BeEmpty())
@@ -822,7 +822,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Updated).To(BeTrue())
 
 						newSSP := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), newSSP)).To(Succeed())
 						Expect(newSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
@@ -878,7 +878,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Updated).To(BeTrue())
 
 						newSSP := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), newSSP)).To(Succeed())
 						Expect(newSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
@@ -947,7 +947,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Updated).To(BeTrue())
 
 						newSSP := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), newSSP)).To(Succeed())
 						Expect(newSSP.Spec.CommonTemplates.DataImportCronTemplates).To(BeEmpty())
@@ -993,7 +993,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Created).To(BeTrue())
 
 						ssp := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), ssp)).To(Succeed())
 						Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
@@ -1037,7 +1037,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Created).To(BeTrue())
 
 						ssp := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), ssp)).To(Succeed())
 						Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
@@ -1075,7 +1075,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Created).To(BeTrue())
 
 						ssp := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), ssp)).To(Succeed())
 						Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
@@ -1123,7 +1123,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Updated).To(BeTrue())
 
 						newSSP := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), newSSP)).To(Succeed())
 						Expect(newSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
@@ -1175,7 +1175,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Updated).To(BeTrue())
 
 						newSSP := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), newSSP)).To(Succeed())
 						Expect(newSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))
@@ -1223,7 +1223,7 @@ var _ = Describe("SSP Operands", func() {
 						Expect(res.Updated).To(BeTrue())
 
 						newSSP := &sspv1beta3.SSP{}
-						expectedResource := NewSSPWithNameOnly(hco)
+						expectedResource := NewSSPWithNameOnly()
 
 						Expect(cli.Get(ctx, client.ObjectKeyFromObject(expectedResource), newSSP)).To(Succeed())
 						Expect(newSSP.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(2))

--- a/controllers/handlers/virtio_win_ConfigMap.go
+++ b/controllers/handlers/virtio_win_ConfigMap.go
@@ -4,14 +4,12 @@ import (
 	"errors"
 	"os"
 
-	log "github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -28,13 +26,13 @@ func NewVirtioWinCmHandler(cli client.Client, Scheme *runtime.Scheme) (operands.
 }
 
 // NewVirtioWinCmReaderRoleHandler creates the Virtio-Win ConfigMap Role Handler
-func NewVirtioWinCmReaderRoleHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewRoleHandler(Client, Scheme, NewVirtioWinCmReaderRole(hc)), nil
+func NewVirtioWinCmReaderRoleHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewRoleHandler(cli, Scheme, NewVirtioWinCmReaderRole())
 }
 
 // NewVirtioWinCmReaderRoleBindingHandler creates the Virtio-Win ConfigMap RoleBinding Handler
-func NewVirtioWinCmReaderRoleBindingHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewRoleBindingHandler(Client, Scheme, NewVirtioWinCmReaderRoleBinding(hc)), nil
+func NewVirtioWinCmReaderRoleBindingHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
+	return operands.NewRoleBindingHandler(cli, Scheme, NewVirtioWinCmReaderRoleBinding())
 }
 
 func NewVirtioWinCm() (*corev1.ConfigMap, error) {
@@ -55,12 +53,12 @@ func NewVirtioWinCm() (*corev1.ConfigMap, error) {
 	}, nil
 }
 
-func NewVirtioWinCmReaderRole(hc *hcov1beta1.HyperConverged) *rbacv1.Role {
+func NewVirtioWinCmReaderRole() *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      virtioWinCmName,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentDeployment),
-			Namespace: hc.Namespace,
+			Labels:    operands.GetLabels(hcoutil.AppComponentDeployment),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -73,12 +71,12 @@ func NewVirtioWinCmReaderRole(hc *hcov1beta1.HyperConverged) *rbacv1.Role {
 	}
 }
 
-func NewVirtioWinCmReaderRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.RoleBinding {
+func NewVirtioWinCmReaderRoleBinding() *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      virtioWinCmName,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentStorage),
-			Namespace: hc.Namespace,
+			Labels:    operands.GetLabels(hcoutil.AppComponentStorage),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",

--- a/controllers/handlers/virtio_win_ConfigMap.go
+++ b/controllers/handlers/virtio_win_ConfigMap.go
@@ -19,12 +19,12 @@ import (
 const virtioWinCmName = "virtio-win"
 
 // NewVirtioWinCmHandler creates the Virtio-Win ConfigMap Handler
-func NewVirtioWinCmHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	virtioWincm, err := NewVirtioWinCm(hc)
+func NewVirtioWinCmHandler(cli client.Client, Scheme *runtime.Scheme) (operands.Operand, error) {
+	virtioWincm, err := NewVirtioWinCm()
 	if err != nil {
 		return nil, err
 	}
-	return operands.NewCmHandler(Client, Scheme, virtioWincm), nil
+	return operands.NewCmHandler(cli, Scheme, virtioWincm), nil
 }
 
 // NewVirtioWinCmReaderRoleHandler creates the Virtio-Win ConfigMap Role Handler
@@ -37,7 +37,7 @@ func NewVirtioWinCmReaderRoleBindingHandler(_ log.Logger, Client client.Client, 
 	return operands.NewRoleBindingHandler(Client, Scheme, NewVirtioWinCmReaderRoleBinding(hc)), nil
 }
 
-func NewVirtioWinCm(hc *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {
+func NewVirtioWinCm() (*corev1.ConfigMap, error) {
 	virtiowinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
 	if virtiowinContainer == "" {
 		return nil, errors.New("kv-virtiowin-image-name was not specified")
@@ -46,8 +46,8 @@ func NewVirtioWinCm(hc *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      virtioWinCmName,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentDeployment),
-			Namespace: hc.Namespace,
+			Labels:    operands.GetLabels(hcoutil.AppComponentDeployment),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		Data: map[string]string{
 			"virtio-win-image": virtiowinContainer,

--- a/controllers/handlers/virtio_win_ConfigMap.go
+++ b/controllers/handlers/virtio_win_ConfigMap.go
@@ -46,7 +46,7 @@ func NewVirtioWinCm(hc *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      virtioWinCmName,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentDeployment),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentDeployment),
 			Namespace: hc.Namespace,
 		},
 		Data: map[string]string{
@@ -59,7 +59,7 @@ func NewVirtioWinCmReaderRole(hc *hcov1beta1.HyperConverged) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      virtioWinCmName,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentDeployment),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentDeployment),
 			Namespace: hc.Namespace,
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -77,7 +77,7 @@ func NewVirtioWinCmReaderRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.Role
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      virtioWinCmName,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentStorage),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentStorage),
 			Namespace: hc.Namespace,
 		},
 		RoleRef: rbacv1.RoleRef{

--- a/controllers/handlers/virtio_win_ConfigMap_test.go
+++ b/controllers/handlers/virtio_win_ConfigMap_test.go
@@ -52,7 +52,7 @@ var _ = Describe("VirtioWin", func() {
 			cl := commontestutils.InitClient([]client.Object{})
 			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
 			res := handler.Ensure(req)
-			Expect(res.UpgradeDone).To(BeFalse())
+			Expect(res.UpgradeDone).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
 
 			foundResource := &corev1.ConfigMap{}

--- a/controllers/handlers/virtio_win_ConfigMap_test.go
+++ b/controllers/handlers/virtio_win_ConfigMap_test.go
@@ -198,17 +198,6 @@ var _ = Describe("VirtioWin", func() {
 			os.Setenv("VIRTIOWIN_CONTAINER", "new-virtiowin-container-value")
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
-
-			origNS, origNSSet := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
-
-			DeferCleanup(func() {
-				if origNSSet {
-					Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
-				} else {
-					Expect(os.Unsetenv(hcoutil.OperatorNamespaceEnv)).To(Succeed())
-				}
-			})
 		})
 
 		It("should do nothing if exists", func() {
@@ -260,17 +249,6 @@ var _ = Describe("VirtioWin", func() {
 			os.Setenv("VIRTIOWIN_CONTAINER", "new-virtiowin-container-value")
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
-
-			origNS, origNSSet := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
-
-			DeferCleanup(func() {
-				if origNSSet {
-					Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
-				} else {
-					Expect(os.Unsetenv(hcoutil.OperatorNamespaceEnv)).To(Succeed())
-				}
-			})
 		})
 
 		It("should do nothing if exists", func() {

--- a/controllers/handlers/virtio_win_ConfigMap_test.go
+++ b/controllers/handlers/virtio_win_ConfigMap_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
@@ -22,9 +21,6 @@ import (
 )
 
 var _ = Describe("VirtioWin", func() {
-
-	var testLogger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("VirtioWin_test")
-
 	Context("Virtio-Win ConfigMap", func() {
 
 		var hco *hcov1beta1.HyperConverged
@@ -202,12 +198,24 @@ var _ = Describe("VirtioWin", func() {
 			os.Setenv("VIRTIOWIN_CONTAINER", "new-virtiowin-container-value")
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
+
+			origNS, origNSSet := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
+			DeferCleanup(func() {
+				if origNSSet {
+					Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+				} else {
+					Expect(os.Unsetenv(hcoutil.OperatorNamespaceEnv)).To(Succeed())
+				}
+			})
 		})
+
 		It("should do nothing if exists", func() {
-			expectedRole := NewVirtioWinCmReaderRole(hco)
+			expectedRole := NewVirtioWinCmReaderRole()
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRole})
 
-			handler, _ := NewVirtioWinCmReaderRoleHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewVirtioWinCmReaderRoleHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -223,13 +231,13 @@ var _ = Describe("VirtioWin", func() {
 		})
 
 		It("should update if labels are missing", func() {
-			expectedRole := NewVirtioWinCmReaderRole(hco)
+			expectedRole := NewVirtioWinCmReaderRole()
 			expectedLabels := expectedRole.Labels
 			expectedRole.Labels = nil
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRole})
 
-			handler, _ := NewVirtioWinCmReaderRoleHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewVirtioWinCmReaderRoleHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -252,13 +260,25 @@ var _ = Describe("VirtioWin", func() {
 			os.Setenv("VIRTIOWIN_CONTAINER", "new-virtiowin-container-value")
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
+
+			origNS, origNSSet := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
+
+			DeferCleanup(func() {
+				if origNSSet {
+					Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+				} else {
+					Expect(os.Unsetenv(hcoutil.OperatorNamespaceEnv)).To(Succeed())
+				}
+			})
 		})
+
 		It("should do nothing if exists", func() {
-			expectedRoleBinding := NewVirtioWinCmReaderRoleBinding(hco)
+			expectedRoleBinding := NewVirtioWinCmReaderRoleBinding()
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRoleBinding})
 
-			handler, _ := NewVirtioWinCmReaderRoleBindingHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewVirtioWinCmReaderRoleBindingHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -273,13 +293,13 @@ var _ = Describe("VirtioWin", func() {
 		})
 
 		It("should update if labels are missing", func() {
-			expectedRoleBinding := NewVirtioWinCmReaderRoleBinding(hco)
+			expectedRoleBinding := NewVirtioWinCmReaderRoleBinding()
 			expectedLabels := expectedRoleBinding.Labels
 			expectedRoleBinding.Labels = nil
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRoleBinding})
 
-			handler, _ := NewVirtioWinCmReaderRoleBindingHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler := NewVirtioWinCmReaderRoleBindingHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 

--- a/controllers/handlers/virtio_win_ConfigMap_test.go
+++ b/controllers/handlers/virtio_win_ConfigMap_test.go
@@ -40,17 +40,17 @@ var _ = Describe("VirtioWin", func() {
 			os.Unsetenv("VIRTIOWIN_CONTAINER")
 
 			cl := commontestutils.InitClient([]client.Object{})
-			handler, err := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, err := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
 
 			Expect(err).To(HaveOccurred())
 			Expect(handler).To(BeNil())
 		})
 
 		It("should create if not present", func() {
-			expectedResource, err := NewVirtioWinCm(hco)
+			expectedResource, err := NewVirtioWinCm()
 			Expect(err).ToNot(HaveOccurred())
 			cl := commontestutils.InitClient([]client.Object{})
-			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -67,11 +67,11 @@ var _ = Describe("VirtioWin", func() {
 		})
 
 		It("should find if present", func() {
-			expectedResource, err := NewVirtioWinCm(hco)
+			expectedResource, err := NewVirtioWinCm()
 			Expect(err).ToNot(HaveOccurred())
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
-			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -89,10 +89,10 @@ var _ = Describe("VirtioWin", func() {
 			updatableKeys := [...]string{virtiowink}
 			toBeRemovedKey := "toberemoved"
 
-			expectedResource, err := NewVirtioWinCm(hco)
+			expectedResource, err := NewVirtioWinCm()
 			Expect(err).ToNot(HaveOccurred())
 
-			outdatedResource, err := NewVirtioWinCm(hco)
+			outdatedResource, err := NewVirtioWinCm()
 			Expect(err).ToNot(HaveOccurred())
 
 			// values we should update
@@ -102,7 +102,7 @@ var _ = Describe("VirtioWin", func() {
 			outdatedResource.Data[toBeRemovedKey] = "value-we-should-remove"
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -135,7 +135,7 @@ var _ = Describe("VirtioWin", func() {
 		It("should reconcile managed labels to default without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource, err := NewVirtioWinCm(hco)
+			outdatedResource, err := NewVirtioWinCm()
 			Expect(err).ToNot(HaveOccurred())
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
@@ -144,7 +144,7 @@ var _ = Describe("VirtioWin", func() {
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -166,14 +166,14 @@ var _ = Describe("VirtioWin", func() {
 		It("should reconcile managed labels to default without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource, err := NewVirtioWinCm(hco)
+			outdatedResource, err := NewVirtioWinCm()
 			Expect(err).ToNot(HaveOccurred())
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())

--- a/controllers/handlers/wasp-agent/daemonset.go
+++ b/controllers/handlers/wasp-agent/daemonset.go
@@ -51,7 +51,7 @@ func NewWaspAgentWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      AppComponentWaspAgent,
-			Labels:    operands.GetLabels(hc, AppComponentWaspAgent),
+			Labels:    operands.GetLabelsDeprecated(hc, AppComponentWaspAgent),
 			Namespace: hc.Namespace,
 		},
 	}
@@ -60,7 +60,7 @@ func NewWaspAgentWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
 func newWaspAgentDaemonSet(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
 	waspImage, _ := os.LookupEnv(hcoutil.WaspAgentImageEnvV)
 
-	podLabels := operands.GetLabels(hc, AppComponentWaspAgent)
+	podLabels := operands.GetLabelsDeprecated(hc, AppComponentWaspAgent)
 	podLabels[hcoutil.AllowEgressToDNSAndAPIServerLabel] = "true"
 	podLabels["name"] = AppComponentWaspAgent
 

--- a/controllers/handlers/wasp-agent/daemonset.go
+++ b/controllers/handlers/wasp-agent/daemonset.go
@@ -42,17 +42,17 @@ func NewWaspAgentDaemonSetHandler(Client client.Client, Scheme *runtime.Scheme) 
 		operands.NewDaemonSetHandler(Client, Scheme, newWaspAgentDaemonSet),
 		shouldDeployWaspAgent,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewWaspAgentWithNameOnly(hc)
+			return NewWaspAgentWithNameOnly()
 		},
 	)
 }
 
-func NewWaspAgentWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
+func NewWaspAgentWithNameOnly() *appsv1.DaemonSet {
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      AppComponentWaspAgent,
-			Labels:    operands.GetLabelsDeprecated(hc, AppComponentWaspAgent),
-			Namespace: hc.Namespace,
+			Labels:    operands.GetLabels(AppComponentWaspAgent),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 	}
 }
@@ -60,7 +60,7 @@ func NewWaspAgentWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
 func newWaspAgentDaemonSet(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
 	waspImage, _ := os.LookupEnv(hcoutil.WaspAgentImageEnvV)
 
-	podLabels := operands.GetLabelsDeprecated(hc, AppComponentWaspAgent)
+	podLabels := operands.GetLabels(AppComponentWaspAgent)
 	podLabels[hcoutil.AllowEgressToDNSAndAPIServerLabel] = "true"
 	podLabels["name"] = AppComponentWaspAgent
 
@@ -141,7 +141,7 @@ func newWaspAgentDaemonSet(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
 		},
 	}
 
-	ds := NewWaspAgentWithNameOnly(hc)
+	ds := NewWaspAgentWithNameOnly()
 	ds.Spec = spec
 
 	if hc.Spec.Infra.NodePlacement != nil {

--- a/controllers/handlers/wasp-agent/rbac.go
+++ b/controllers/handlers/wasp-agent/rbac.go
@@ -50,7 +50,7 @@ func newWaspAgentClusterRoleBindingWithNameOnly(hc *hcov1beta1.HyperConverged) *
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   clusterRoleName,
-			Labels: operands.GetLabels(hc, AppComponentWaspAgent),
+			Labels: operands.GetLabelsDeprecated(hc, AppComponentWaspAgent),
 		},
 	}
 }
@@ -81,7 +81,7 @@ func newWaspAgentClusterRoleWithNameOnly(hc *hcov1beta1.HyperConverged) *rbacv1.
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   clusterRoleName,
-			Labels: operands.GetLabels(hc, AppComponentWaspAgent),
+			Labels: operands.GetLabelsDeprecated(hc, AppComponentWaspAgent),
 		},
 	}
 }

--- a/controllers/handlers/wasp-agent/rbac.go
+++ b/controllers/handlers/wasp-agent/rbac.go
@@ -1,7 +1,6 @@
 package wasp_agent
 
 import (
-	log "github.com/go-logr/logr"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -9,21 +8,21 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-func NewWaspAgentClusterRoleBindingHandler(
-	_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
+func NewWaspAgentClusterRoleBindingHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
-		operands.NewClusterRoleBindingHandler(Client, Scheme, newWaspAgentClusterRoleBinding(hc)),
+		operands.NewClusterRoleBindingHandler(cli, Scheme, newWaspAgentClusterRoleBinding()),
 		shouldDeployWaspAgent,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return newWaspAgentClusterRoleBindingWithNameOnly(hc)
+			return newWaspAgentClusterRoleBindingWithNameOnly()
 		},
-	), nil
+	)
 }
 
-func newWaspAgentClusterRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRoleBinding {
-	crb := newWaspAgentClusterRoleBindingWithNameOnly(hc)
+func newWaspAgentClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	crb := newWaspAgentClusterRoleBindingWithNameOnly()
 
 	crb.RoleRef = rbacv1.RoleRef{
 		Kind:     "ClusterRole",
@@ -35,14 +34,14 @@ func newWaspAgentClusterRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.Clust
 		{
 			Kind:      "ServiceAccount",
 			Name:      waspAgentServiceAccountName,
-			Namespace: hc.Namespace,
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 	}
 
 	return crb
 }
 
-func newWaspAgentClusterRoleBindingWithNameOnly(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRoleBinding {
+func newWaspAgentClusterRoleBindingWithNameOnly() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
@@ -50,30 +49,29 @@ func newWaspAgentClusterRoleBindingWithNameOnly(hc *hcov1beta1.HyperConverged) *
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   clusterRoleName,
-			Labels: operands.GetLabelsDeprecated(hc, AppComponentWaspAgent),
+			Labels: operands.GetLabels(AppComponentWaspAgent),
 		},
 	}
 }
 
-func NewWaspAgentClusterRoleHandler(
-	_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
+func NewWaspAgentClusterRoleHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
-		operands.NewClusterRoleHandler(Client, Scheme, newWaspAgentClusterRole(hc)),
+		operands.NewClusterRoleHandler(Client, Scheme, newWaspAgentClusterRole()),
 		shouldDeployWaspAgent,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return newWaspAgentClusterRoleWithNameOnly(hc)
+			return newWaspAgentClusterRoleWithNameOnly()
 		},
-	), nil
+	)
 }
 
-func newWaspAgentClusterRole(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRole {
-	cr := newWaspAgentClusterRoleWithNameOnly(hc)
+func newWaspAgentClusterRole() *rbacv1.ClusterRole {
+	cr := newWaspAgentClusterRoleWithNameOnly()
 	cr.Rules = getClusterPolicyRules()
 
 	return cr
 }
 
-func newWaspAgentClusterRoleWithNameOnly(hc *hcov1beta1.HyperConverged) *rbacv1.ClusterRole {
+func newWaspAgentClusterRoleWithNameOnly() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
@@ -81,7 +79,7 @@ func newWaspAgentClusterRoleWithNameOnly(hc *hcov1beta1.HyperConverged) *rbacv1.
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   clusterRoleName,
-			Labels: operands.GetLabelsDeprecated(hc, AppComponentWaspAgent),
+			Labels: operands.GetLabels(AppComponentWaspAgent),
 		},
 	}
 }

--- a/controllers/handlers/wasp-agent/rbac_test.go
+++ b/controllers/handlers/wasp-agent/rbac_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"maps"
 
-	log "github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -32,7 +31,7 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 
 	Context("newWaspAgentClusterRole", func() {
 		It("Should have all the default fields", func() {
-			cr := newWaspAgentClusterRole(hco)
+			cr := newWaspAgentClusterRole()
 			Expect(cr.Name).To(Equal("wasp-cluster"))
 			Expect(cr.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
 			Expect(cr.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, "wasp-agent"))
@@ -51,12 +50,11 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
-			cr := newWaspAgentClusterRole(hco)
+			cr := newWaspAgentClusterRole()
 
 			cl = commontestutils.InitClient([]client.Object{hco, cr})
 
-			handler, err := NewWaspAgentClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewWaspAgentClusterRoleHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 
@@ -74,12 +72,11 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
-			cr := newWaspAgentClusterRole(hco)
+			cr := newWaspAgentClusterRole()
 
 			cl = commontestutils.InitClient([]client.Object{hco, cr})
 
-			handler, err := NewWaspAgentClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewWaspAgentClusterRoleHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 
@@ -98,8 +95,7 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 				MemoryOvercommitPercentage: 150,
 			}
 
-			handler, err := NewWaspAgentClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewWaspAgentClusterRoleHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -119,12 +115,11 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 				MemoryOvercommitPercentage: 150,
 			}
 			hco.Annotations[AutopilotSwapAnnotation] = AutopilotSwapAnnotationValue
-			cr := newWaspAgentClusterRole(hco)
+			cr := newWaspAgentClusterRole()
 
 			cl = commontestutils.InitClient([]client.Object{hco, cr})
 
-			handler, err := NewWaspAgentClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewWaspAgentClusterRoleHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 
@@ -144,14 +139,13 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
-			cr := newWaspAgentClusterRole(hco)
+			cr := newWaspAgentClusterRole()
 			expectedLabels := maps.Clone(cr.Labels)
 			delete(cr.Labels, "app.kubernetes.io/component")
 			cr.Labels["user-added-label"] = "user-value"
 			cl = commontestutils.InitClient([]client.Object{hco, cr})
 
-			handler, err := NewWaspAgentClusterRoleHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewWaspAgentClusterRoleHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -185,7 +179,7 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 
 	Context("newWaspAgentClusterRoleBinding", func() {
 		It("Should have all the default fields", func() {
-			crb := newWaspAgentClusterRoleBinding(hco)
+			crb := newWaspAgentClusterRoleBinding()
 			Expect(crb.Name).To(Equal("wasp-cluster"))
 			Expect(crb.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
 			Expect(crb.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, "wasp-agent"))
@@ -200,12 +194,11 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
-			crb := newWaspAgentClusterRoleBinding(hco)
+			crb := newWaspAgentClusterRoleBinding()
 
 			cl = commontestutils.InitClient([]client.Object{hco, crb})
 
-			handler, err := NewWaspAgentClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewWaspAgentClusterRoleBindingHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 
@@ -223,12 +216,11 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
-			crb := newWaspAgentClusterRoleBinding(hco)
+			crb := newWaspAgentClusterRoleBinding()
 
 			cl = commontestutils.InitClient([]client.Object{hco, crb})
 
-			handler, err := NewWaspAgentClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewWaspAgentClusterRoleBindingHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 
@@ -247,8 +239,7 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 				MemoryOvercommitPercentage: 150,
 			}
 
-			handler, err := NewWaspAgentClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewWaspAgentClusterRoleBindingHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -268,12 +259,11 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 				MemoryOvercommitPercentage: 150,
 			}
 			hco.Annotations[AutopilotSwapAnnotation] = AutopilotSwapAnnotationValue
-			crb := newWaspAgentClusterRoleBinding(hco)
+			crb := newWaspAgentClusterRoleBinding()
 
 			cl = commontestutils.InitClient([]client.Object{hco, crb})
 
-			handler, err := NewWaspAgentClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewWaspAgentClusterRoleBindingHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 
@@ -293,14 +283,13 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
-			crb := newWaspAgentClusterRoleBinding(hco)
+			crb := newWaspAgentClusterRoleBinding()
 			expectedLabels := maps.Clone(crb.Labels)
 			delete(crb.Labels, "app.kubernetes.io/component")
 			crb.Labels["user-added-label"] = "user-value"
 			cl = commontestutils.InitClient([]client.Object{hco, crb})
 
-			handler, err := NewWaspAgentClusterRoleBindingHandler(log.New(nil), cl, commontestutils.GetScheme(), hco)
-			Expect(err).ToNot(HaveOccurred())
+			handler := NewWaspAgentClusterRoleBindingHandler(cl, commontestutils.GetScheme())
 
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())

--- a/controllers/handlers/wasp-agent/scc.go
+++ b/controllers/handlers/wasp-agent/scc.go
@@ -67,7 +67,7 @@ func NewWaspAgentSCCWithNameOnly(hc *hcov1beta1.HyperConverged) *securityv1.Secu
 	return &securityv1.SecurityContextConstraints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   waspAgentSCCName,
-			Labels: operands.GetLabels(hc, AppComponentWaspAgent),
+			Labels: operands.GetLabelsDeprecated(hc, AppComponentWaspAgent),
 		},
 	}
 }

--- a/controllers/handlers/wasp-agent/scc.go
+++ b/controllers/handlers/wasp-agent/scc.go
@@ -12,20 +12,21 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func NewWaspAgentSCCHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
-		operands.NewSecurityContextConstraintsHandler(Client, Scheme, newWaspAgentSCC),
+		operands.NewSecurityContextConstraintsHandler(Client, Scheme, newWaspAgentSCC()),
 		shouldDeployWaspAgent,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return NewWaspAgentSCCWithNameOnly(hc)
+			return NewWaspAgentSCCWithNameOnly()
 		},
 	)
 }
 
-func newWaspAgentSCC(hc *hcov1beta1.HyperConverged) *securityv1.SecurityContextConstraints {
-	scc := NewWaspAgentSCCWithNameOnly(hc)
+func newWaspAgentSCC() *securityv1.SecurityContextConstraints {
+	scc := NewWaspAgentSCCWithNameOnly()
 
 	scc.AllowPrivilegedContainer = true
 	scc.AllowHostDirVolumePlugin = true
@@ -45,7 +46,7 @@ func newWaspAgentSCC(hc *hcov1beta1.HyperConverged) *securityv1.SecurityContextC
 		Type: securityv1.SELinuxStrategyRunAsAny,
 	}
 	scc.Users = []string{
-		fmt.Sprintf("system:serviceaccount:%s:%s", hc.Namespace, waspAgentServiceAccountName),
+		fmt.Sprintf("system:serviceaccount:%s:%s", hcoutil.GetOperatorNamespaceFromEnv(), waspAgentServiceAccountName),
 	}
 	scc.Volumes = []securityv1.FSType{
 		securityv1.FSTypeAll,
@@ -63,11 +64,11 @@ func newWaspAgentSCC(hc *hcov1beta1.HyperConverged) *securityv1.SecurityContextC
 	return scc
 }
 
-func NewWaspAgentSCCWithNameOnly(hc *hcov1beta1.HyperConverged) *securityv1.SecurityContextConstraints {
+func NewWaspAgentSCCWithNameOnly() *securityv1.SecurityContextConstraints {
 	return &securityv1.SecurityContextConstraints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   waspAgentSCCName,
-			Labels: operands.GetLabelsDeprecated(hc, AppComponentWaspAgent),
+			Labels: operands.GetLabels(AppComponentWaspAgent),
 		},
 	}
 }

--- a/controllers/handlers/wasp-agent/scc_test.go
+++ b/controllers/handlers/wasp-agent/scc_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 
 	Context("newWaspAgentSCC", func() {
 		It("should have all default fields", func() {
-			scc := newWaspAgentSCC(hco)
+			scc := newWaspAgentSCC()
 			Expect(scc.Name).To(Equal("wasp"))
 			Expect(scc.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
 			Expect(scc.Labels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, "wasp-agent"))
@@ -82,7 +82,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
-			scc := newWaspAgentSCC(hco)
+			scc := newWaspAgentSCC()
 			cl = commontestutils.InitClient([]client.Object{hco, scc})
 
 			handler := NewWaspAgentSCCHandler(cl, commontestutils.GetScheme())
@@ -146,7 +146,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
-			scc := newWaspAgentSCC(hco)
+			scc := newWaspAgentSCC()
 			hco.Annotations[AutopilotSwapAnnotation] = AutopilotSwapAnnotationValue
 			cl = commontestutils.InitClient([]client.Object{hco, scc})
 
@@ -171,7 +171,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
-			scc := newWaspAgentSCC(hco)
+			scc := newWaspAgentSCC()
 			scc.AllowPrivilegedContainer = false
 			scc.AllowHostNetwork = false
 			scc.Users = []string{"wrong-user"}
@@ -198,7 +198,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
-			scc := newWaspAgentSCC(hco)
+			scc := newWaspAgentSCC()
 			expectedLabels := maps.Clone(scc.Labels)
 			delete(scc.Labels, "app.kubernetes.io/component")
 			scc.Labels["user-added-label"] = "user-value"

--- a/controllers/handlers/wasp-agent/service_account.go
+++ b/controllers/handlers/wasp-agent/service_account.go
@@ -6,9 +6,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
-
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func NewWaspAgentServiceAccountHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
@@ -16,17 +16,17 @@ func NewWaspAgentServiceAccountHandler(Client client.Client, Scheme *runtime.Sch
 		operands.NewServiceAccountHandler(Client, Scheme, newWaspAgentServiceAccount),
 		shouldDeployWaspAgent,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
-			return newWaspAgentServiceAccount(hc)
+			return newWaspAgentServiceAccount()
 		},
 	)
 }
 
-func newWaspAgentServiceAccount(hc *hcov1beta1.HyperConverged) *corev1.ServiceAccount {
+func newWaspAgentServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      waspAgentServiceAccountName,
-			Namespace: hc.Namespace,
-			Labels:    operands.GetLabelsDeprecated(hc, AppComponentWaspAgent),
+			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Labels:    operands.GetLabels(AppComponentWaspAgent),
 		},
 	}
 }

--- a/controllers/handlers/wasp-agent/service_account.go
+++ b/controllers/handlers/wasp-agent/service_account.go
@@ -26,7 +26,7 @@ func newWaspAgentServiceAccount(hc *hcov1beta1.HyperConverged) *corev1.ServiceAc
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      waspAgentServiceAccountName,
 			Namespace: hc.Namespace,
-			Labels:    operands.GetLabels(hc, AppComponentWaspAgent),
+			Labels:    operands.GetLabelsDeprecated(hc, AppComponentWaspAgent),
 		},
 	}
 }

--- a/controllers/handlers/wasp-agent/service_account_test.go
+++ b/controllers/handlers/wasp-agent/service_account_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Wasp Agent Service Account", func() {
 
 	Context("newWaspAgentServiceAccount", func() {
 		It("should have all default values", func() {
-			sa := newWaspAgentServiceAccount(hco)
+			sa := newWaspAgentServiceAccount()
 			Expect(sa.Name).To(Equal("wasp"))
 			Expect(sa.Namespace).To(BeEquivalentTo(hco.Namespace))
 			Expect(sa.Labels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
@@ -65,7 +65,7 @@ var _ = Describe("Wasp Agent Service Account", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
-			sa := newWaspAgentServiceAccount(hco)
+			sa := newWaspAgentServiceAccount()
 
 			cl = commontestutils.InitClient([]client.Object{hco, sa})
 
@@ -130,7 +130,7 @@ var _ = Describe("Wasp Agent Service Account", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
-			sa := newWaspAgentServiceAccount(hco)
+			sa := newWaspAgentServiceAccount()
 			hco.Annotations[AutopilotSwapAnnotation] = AutopilotSwapAnnotationValue
 			cl = commontestutils.InitClient([]client.Object{hco, sa})
 
@@ -154,7 +154,7 @@ var _ = Describe("Wasp Agent Service Account", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
-			sa := newWaspAgentServiceAccount(hco)
+			sa := newWaspAgentServiceAccount()
 			expectedLabels := maps.Clone(sa.Labels)
 			delete(sa.Labels, "app.kubernetes.io/component")
 			sa.Labels["user-added-label"] = "user-value"

--- a/controllers/handlers/wasp-agent/wasp_agent_suite_test.go
+++ b/controllers/handlers/wasp-agent/wasp_agent_suite_test.go
@@ -1,28 +1,19 @@
 package wasp_agent
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func TestWaspAgent(t *testing.T) {
-	origNS, ok := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
-	_ = os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)
-
-	defer func() {
-		if ok {
-			_ = os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)
-		} else {
-			_ = os.Unsetenv(hcoutil.OperatorNamespaceEnv)
-		}
-	}()
-
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Wasp Agent Suite")
 }
+
+var _ = BeforeSuite(func() {
+	commontestutils.CommonBeforeSuite()
+})

--- a/controllers/handlers/wasp-agent/wasp_agent_suite_test.go
+++ b/controllers/handlers/wasp-agent/wasp_agent_suite_test.go
@@ -1,13 +1,28 @@
 package wasp_agent
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func TestWaspAgent(t *testing.T) {
+	origNS, ok := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
+	_ = os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)
+
+	defer func() {
+		if ok {
+			_ = os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)
+		} else {
+			_ = os.Unsetenv(hcoutil.OperatorNamespaceEnv)
+		}
+	}()
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Wasp Agent Suite")
 }

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -117,6 +117,7 @@ func RegisterReconciler(mgr manager.Manager,
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo, upgradeableCond hcoutil.Condition) reconcile.Reconciler {
+	reqresolver.GeneratePlaceHolders()
 
 	ownVersion := cmp.Or(os.Getenv(hcoutil.HcoKvIoVersionName), version.Version)
 

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -49,7 +49,7 @@ import (
 // name and namespace of our primary resource
 const (
 	name      = "kubevirt-hyperconverged"
-	namespace = "kubevirt-hyperconverged"
+	namespace = commontestutils.Namespace
 )
 
 var _ = Describe("HyperconvergedController", func() {
@@ -58,7 +58,6 @@ var _ = Describe("HyperconvergedController", func() {
 
 	origOperatorCondVarName := os.Getenv(hcoutil.OperatorConditionNameEnvVar)
 	origVirtIOWinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
-	origOperatorNS := os.Getenv("OPERATOR_NAMESPACE")
 	origVersion := os.Getenv(hcoutil.HcoKvIoVersionName)
 
 	BeforeEach(func() {
@@ -69,7 +68,6 @@ var _ = Describe("HyperconvergedController", func() {
 
 		Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, "OPERATOR_CONDITION")).To(Succeed())
 		Expect(os.Setenv("VIRTIOWIN_CONTAINER", commontestutils.VirtioWinImage)).To(Succeed())
-		Expect(os.Setenv("OPERATOR_NAMESPACE", namespace)).To(Succeed())
 		Expect(os.Setenv(hcoutil.HcoKvIoVersionName, version.Version)).To(Succeed())
 
 		reqresolver.GeneratePlaceHolders()
@@ -80,7 +78,6 @@ var _ = Describe("HyperconvergedController", func() {
 
 			Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, origOperatorCondVarName)).To(Succeed())
 			Expect(os.Setenv("VIRTIOWIN_CONTAINER", origVirtIOWinContainer)).To(Succeed())
-			Expect(os.Setenv("OPERATOR_NAMESPACE", origOperatorNS)).To(Succeed())
 			Expect(os.Setenv(hcoutil.HcoKvIoVersionName, origVersion)).To(Succeed())
 		})
 	})

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1027,7 +1027,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.Spec.TLSSecurityProfile).To(BeNil(), "TLSSecurityProfile on HCO CR should still be nil")
 
 				By("Verify that Kubevirt was properly configured with initialTLSSecurityProfile")
-				kv := handlers.NewKubeVirtWithNameOnly(foundResource)
+				kv := handlers.NewKubeVirtWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: kv.Name, Namespace: kv.Namespace},
@@ -1105,7 +1105,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(tlssecprofile.GetTLSSecurityProfile(expected.hco.Spec.TLSSecurityProfile)).To(Equal(customTLSSecurityProfile), "should return the up-to-date value")
 
 				By("Verify that Kubevirt was properly updated with customTLSSecurityProfile")
-				kv = handlers.NewKubeVirtWithNameOnly(foundResource)
+				kv = handlers.NewKubeVirtWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: kv.Name, Namespace: kv.Namespace},
@@ -1192,7 +1192,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundHCO.Spec.TLSSecurityProfile).To(BeNil(), "TLSSecurityProfile on HCO CR should still be nil")
 
 				By("Verify that Kubevirt was properly configured with initialTLSSecurityProfile")
-				kv := handlers.NewKubeVirtWithNameOnly(foundHCO)
+				kv := handlers.NewKubeVirtWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: kv.Name, Namespace: kv.Namespace},
@@ -1260,7 +1260,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundHCO.Spec.TLSSecurityProfile).To(Equal(customTLSSecurityProfile), "TLSSecurityProfile on HCO CR should be updated")
 
 				By("Verify that Kubevirt was properly updated with customTLSSecurityProfile")
-				kv = handlers.NewKubeVirtWithNameOnly(foundHCO)
+				kv = handlers.NewKubeVirtWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: kv.Name, Namespace: kv.Namespace},
@@ -1884,7 +1884,7 @@ var _ = Describe("HyperconvergedController", func() {
 					})
 
 					By("Verify that KV was modified by the annotation", func() {
-						kv := handlers.NewKubeVirtWithNameOnly(hco)
+						kv := handlers.NewKubeVirtWithNameOnly()
 						Expect(
 							cl.Get(context.TODO(),
 								types.NamespacedName{Name: kv.Name, Namespace: kv.Namespace},
@@ -2492,7 +2492,7 @@ var _ = Describe("HyperconvergedController", func() {
 					})
 
 					By("Verify that KV was modified by the annotation", func() {
-						kv := handlers.NewKubeVirtWithNameOnly(hco)
+						kv := handlers.NewKubeVirtWithNameOnly()
 						Expect(
 							cl.Get(context.TODO(),
 								types.NamespacedName{Name: kv.Name, Namespace: kv.Namespace},

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1068,7 +1068,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cna.Spec.TLSSecurityProfile).To(Equal(initialTLSSecurityProfile))
 
 				By("Verify that SSP was properly configured with initialTLSSecurityProfile")
-				ssp := handlers.NewSSPWithNameOnly(foundResource)
+				ssp := handlers.NewSSPWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: ssp.Name, Namespace: ssp.Namespace},
@@ -1136,7 +1136,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cna.Spec.TLSSecurityProfile).To(Equal(customTLSSecurityProfile))
 
 				By("Verify that SSP was properly updated with customTLSSecurityProfile")
-				ssp = handlers.NewSSPWithNameOnly(foundResource)
+				ssp = handlers.NewSSPWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: ssp.Name, Namespace: ssp.Namespace},
@@ -1233,7 +1233,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cna.Spec.TLSSecurityProfile).To(Equal(initialTLSSecurityProfile))
 
 				By("Verify that SSP was properly configured with initialTLSSecurityProfile")
-				ssp := handlers.NewSSPWithNameOnly(foundHCO)
+				ssp := handlers.NewSSPWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: ssp.Name, Namespace: ssp.Namespace},
@@ -1291,7 +1291,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cna.Spec.TLSSecurityProfile).To(Equal(customTLSSecurityProfile))
 
 				By("Verify that SSP was properly updated with customTLSSecurityProfile")
-				ssp = handlers.NewSSPWithNameOnly(foundHCO)
+				ssp = handlers.NewSSPWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: ssp.Name, Namespace: ssp.Namespace},
@@ -2324,7 +2324,7 @@ var _ = Describe("HyperconvergedController", func() {
 					})
 
 					By("Verify that SSP was modified by the annotation", func() {
-						ssp := handlers.NewSSPWithNameOnly(hco)
+						ssp := handlers.NewSSPWithNameOnly()
 						Expect(
 							cl.Get(context.TODO(),
 								types.NamespacedName{Name: ssp.Name, Namespace: ssp.Namespace},
@@ -2533,7 +2533,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(cna.Spec.ImagePullPolicy).To(BeEquivalentTo("Always"))
 					})
 					By("Verify that SSP was modified by the annotation", func() {
-						ssp := handlers.NewSSPWithNameOnly(hco)
+						ssp := handlers.NewSSPWithNameOnly()
 						Expect(
 							cl.Get(context.TODO(),
 								types.NamespacedName{Name: ssp.Name, Namespace: ssp.Namespace},

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1058,7 +1058,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cdi.Spec.Config.TLSSecurityProfile).To(Equal(openshift2CdiSecProfile(initialTLSSecurityProfile)))
 
 				By("Verify that CNA was properly configured with initialTLSSecurityProfile")
-				cna := handlers.NewNetworkAddonsWithNameOnly(foundResource)
+				cna := handlers.NewNetworkAddonsWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: cna.Name, Namespace: cna.Namespace},
@@ -1126,7 +1126,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cdi.Spec.Config.TLSSecurityProfile).To(Equal(openshift2CdiSecProfile(customTLSSecurityProfile)))
 
 				By("Verify that CNA was properly updated with customTLSSecurityProfile")
-				cna = handlers.NewNetworkAddonsWithNameOnly(foundResource)
+				cna = handlers.NewNetworkAddonsWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: cna.Name, Namespace: cna.Namespace},
@@ -1223,7 +1223,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cdi.Spec.Config.TLSSecurityProfile).To(Equal(openshift2CdiSecProfile(initialTLSSecurityProfile)))
 
 				By("Verify that CNA was properly configured with initialTLSSecurityProfile")
-				cna := handlers.NewNetworkAddonsWithNameOnly(foundHCO)
+				cna := handlers.NewNetworkAddonsWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: cna.Name, Namespace: cna.Namespace},
@@ -1281,7 +1281,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(cdi.Spec.Config.TLSSecurityProfile).To(Equal(openshift2CdiSecProfile(customTLSSecurityProfile)))
 
 				By("Verify that CNA was properly updated with customTLSSecurityProfile")
-				cna = handlers.NewNetworkAddonsWithNameOnly(foundHCO)
+				cna = handlers.NewNetworkAddonsWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: cna.Name, Namespace: cna.Namespace},
@@ -2190,7 +2190,7 @@ var _ = Describe("HyperconvergedController", func() {
 					})
 
 					By("Verify that CNA was modified by the annotation", func() {
-						cna := handlers.NewNetworkAddonsWithNameOnly(hco)
+						cna := handlers.NewNetworkAddonsWithNameOnly()
 						Expect(
 							cl.Get(context.TODO(),
 								types.NamespacedName{Name: cna.Name, Namespace: cna.Namespace},
@@ -2520,7 +2520,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 					})
 					By("Verify that CNA was modified by the annotation", func() {
-						cna := handlers.NewNetworkAddonsWithNameOnly(hco)
+						cna := handlers.NewNetworkAddonsWithNameOnly()
 						Expect(
 							cl.Get(context.TODO(),
 								types.NamespacedName{Name: cna.Name, Namespace: cna.Namespace},

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -1048,7 +1048,7 @@ var _ = Describe("HyperconvergedController", func() {
 				}))
 
 				By("Verify that CDI was properly configured with initialTLSSecurityProfile")
-				cdi := handlers.NewCDIWithNameOnly(foundResource)
+				cdi := handlers.NewCDIWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: cdi.Name, Namespace: cdi.Namespace},
@@ -1116,7 +1116,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(kv.Spec.Configuration.TLSConfiguration.Ciphers).To(BeEmpty())
 
 				By("Verify that CDI was properly updated with customTLSSecurityProfile")
-				cdi = handlers.NewCDIWithNameOnly(foundResource)
+				cdi = handlers.NewCDIWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: cdi.Name, Namespace: cdi.Namespace},
@@ -1213,7 +1213,7 @@ var _ = Describe("HyperconvergedController", func() {
 				}))
 
 				By("Verify that CDI was properly configured with initialTLSSecurityProfile")
-				cdi := handlers.NewCDIWithNameOnly(foundHCO)
+				cdi := handlers.NewCDIWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: cdi.Name, Namespace: cdi.Namespace},
@@ -1271,7 +1271,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(kv.Spec.Configuration.TLSConfiguration.Ciphers).To(BeEmpty())
 
 				By("Verify that CDI was properly updated with customTLSSecurityProfile")
-				cdi = handlers.NewCDIWithNameOnly(foundHCO)
+				cdi = handlers.NewCDIWithNameOnly()
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: cdi.Name, Namespace: cdi.Namespace},
@@ -2039,7 +2039,7 @@ var _ = Describe("HyperconvergedController", func() {
 					})
 
 					By("Verify that CDI was modified by the annotation", func() {
-						cdi := handlers.NewCDIWithNameOnly(hco)
+						cdi := handlers.NewCDIWithNameOnly()
 						Expect(
 							cl.Get(context.TODO(),
 								types.NamespacedName{Name: cdi.Name, Namespace: cdi.Namespace},
@@ -2504,7 +2504,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(*kv.Spec.Configuration.MigrationConfiguration.AllowPostCopy).To(BeTrue())
 					})
 					By("Verify that CDI was modified by the annotation", func() {
-						cdi := handlers.NewCDIWithNameOnly(hco)
+						cdi := handlers.NewCDIWithNameOnly()
 						Expect(
 							cl.Get(context.TODO(),
 								types.NamespacedName{Name: cdi.Name, Namespace: cdi.Namespace},

--- a/controllers/hyperconverged/hyperconverged_suite_test.go
+++ b/controllers/hyperconverged/hyperconverged_suite_test.go
@@ -28,6 +28,8 @@ func TestHyperconverged(t *testing.T) {
 
 		pwdFS := dirtest.New(dirtest.WithFile(upgradepatch.UpgradeChangesFileLocation, upgradePatchesFileContent))
 		Expect(upgradepatch.Init(pwdFS, GinkgoLogr)).To(Succeed())
+
+		commontestutils.CommonBeforeSuite()
 	})
 
 	AfterSuite(func() {

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -216,7 +216,7 @@ func getBasicDeployment() *BasicExpected {
 		},
 	}
 
-	res.pc = handlers.NewKubeVirtPriorityClass(hco)
+	res.pc = handlers.NewKubeVirtPriorityClass()
 
 	deploymentRef := metav1.OwnerReference{
 		APIVersion:         appsv1.SchemeGroupVersion.String(),

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -299,7 +299,7 @@ func getBasicDeployment() *BasicExpected {
 	expectedConsoleProxyService := handlers.NewKvUIProxySvc()
 	res.consoleProxySvc = expectedConsoleProxyService
 
-	expectedConsolePlugin := handlers.NewKVConsolePlugin(hco)
+	expectedConsolePlugin := handlers.NewKVConsolePlugin()
 	res.consolePlugin = expectedConsolePlugin
 
 	expectedConsoleConfig := &operatorv1.Console{

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -277,7 +277,7 @@ func getBasicDeployment() *BasicExpected {
 	expectedCliDownloadsService := handlers.NewCliDownloadsService()
 	res.cliDownloadsService = expectedCliDownloadsService
 
-	expectedVirtioWinConfig, err := handlers.NewVirtioWinCm(hco)
+	expectedVirtioWinConfig, err := handlers.NewVirtioWinCm()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	res.virtioWinConfig = expectedVirtioWinConfig
 

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -268,13 +268,13 @@ func getBasicDeployment() *BasicExpected {
 	expectedMigController.Status.Conditions = getGenericCompletedConditions()
 	res.migController = expectedMigController
 
-	expectedCliDownload := handlers.NewConsoleCLIDownload(hco)
+	expectedCliDownload := handlers.NewConsoleCLIDownload()
 	res.cliDownload = expectedCliDownload
 
-	expectedCliDownloadsRoute := handlers.NewCliDownloadsRoute(hco)
+	expectedCliDownloadsRoute := handlers.NewCliDownloadsRoute()
 	res.cliDownloadsRoute = expectedCliDownloadsRoute
 
-	expectedCliDownloadsService := handlers.NewCliDownloadsService(hco)
+	expectedCliDownloadsService := handlers.NewCliDownloadsService()
 	res.cliDownloadsService = expectedCliDownloadsService
 
 	expectedVirtioWinConfig, err := handlers.NewVirtioWinCm(hco)
@@ -293,10 +293,10 @@ func getBasicDeployment() *BasicExpected {
 	expectedConsoleProxyDeployment := handlers.NewKvUIProxyDeployment(hco)
 	res.consoleProxyDeploy = expectedConsoleProxyDeployment
 
-	expectedConsolePluginService := handlers.NewKvUIPluginSvc(hco)
+	expectedConsolePluginService := handlers.NewKvUIPluginSvc()
 	res.consolePluginSvc = expectedConsolePluginService
 
-	expectedConsoleProxyService := handlers.NewKvUIProxySvc(hco)
+	expectedConsoleProxyService := handlers.NewKvUIProxySvc()
 	res.consoleProxySvc = expectedConsoleProxyService
 
 	expectedConsolePlugin := handlers.NewKVConsolePlugin(hco)

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -281,10 +281,10 @@ func getBasicDeployment() *BasicExpected {
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	res.virtioWinConfig = expectedVirtioWinConfig
 
-	expectedVirtioWinRole := handlers.NewVirtioWinCmReaderRole(hco)
+	expectedVirtioWinRole := handlers.NewVirtioWinCmReaderRole()
 	res.virtioWinRole = expectedVirtioWinRole
 
-	expectedVirtioWinRoleBinding := handlers.NewVirtioWinCmReaderRoleBinding(hco)
+	expectedVirtioWinRoleBinding := handlers.NewVirtioWinCmReaderRoleBinding()
 	res.virtioWinRoleBinding = expectedVirtioWinRoleBinding
 
 	expectedConsolePluginDeployment := handlers.NewKvUIPluginDeployment(hco)

--- a/controllers/hyperconverged/upgrade_test.go
+++ b/controllers/hyperconverged/upgrade_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Upgrade Mode", func() {
 
 		origOperatorCondVarName := os.Getenv(hcoutil.OperatorConditionNameEnvVar)
 		origVirtIOWinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
-		origOperatorNS := os.Getenv("OPERATOR_NAMESPACE")
+		origOperatorNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
 		origVersion := os.Getenv(hcoutil.HcoKvIoVersionName)
 
 		hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
@@ -59,7 +59,7 @@ var _ = Describe("Upgrade Mode", func() {
 		}
 		Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, "OPERATOR_CONDITION")).To(Succeed())
 		Expect(os.Setenv("VIRTIOWIN_CONTAINER", commontestutils.VirtioWinImage)).To(Succeed())
-		Expect(os.Setenv("OPERATOR_NAMESPACE", namespace)).To(Succeed())
+		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, namespace)).To(Succeed())
 		Expect(os.Setenv(hcoutil.HcoKvIoVersionName, version.Version)).To(Succeed())
 
 		reqresolver.GeneratePlaceHolders()
@@ -110,7 +110,7 @@ var _ = Describe("Upgrade Mode", func() {
 
 			Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, origOperatorCondVarName)).To(Succeed())
 			Expect(os.Setenv("VIRTIOWIN_CONTAINER", origVirtIOWinContainer)).To(Succeed())
-			Expect(os.Setenv("OPERATOR_NAMESPACE", origOperatorNS)).To(Succeed())
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origOperatorNS)).To(Succeed())
 			Expect(os.Setenv(hcoutil.HcoKvIoVersionName, origVersion)).To(Succeed())
 		})
 	})

--- a/controllers/hyperconverged/upgrade_test.go
+++ b/controllers/hyperconverged/upgrade_test.go
@@ -1199,7 +1199,7 @@ var _ = Describe("Upgrade Mode", func() {
 			foundNPs := &v1.NetworkPolicyList{}
 			Expect(cl.List(ctx, foundNPs)).To(Succeed())
 
-			Expect(foundNPs.Items).To(HaveLen(4))
+			Expect(foundNPs.Items).To(HaveLen(6))
 			Expect(foundNPs.Items).To(ContainElements(*upToDateNP1, *upToDateNP2, *nonOLMNP, *oldNPOtherNamespace))
 			Expect(foundNPs.Items).ToNot(ContainElements(*oldNP))
 		})

--- a/controllers/hyperconverged/upgrade_test.go
+++ b/controllers/hyperconverged/upgrade_test.go
@@ -51,7 +51,6 @@ var _ = Describe("Upgrade Mode", func() {
 
 		origOperatorCondVarName := os.Getenv(hcoutil.OperatorConditionNameEnvVar)
 		origVirtIOWinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
-		origOperatorNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
 		origVersion := os.Getenv(hcoutil.HcoKvIoVersionName)
 
 		hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
@@ -59,7 +58,6 @@ var _ = Describe("Upgrade Mode", func() {
 		}
 		Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, "OPERATOR_CONDITION")).To(Succeed())
 		Expect(os.Setenv("VIRTIOWIN_CONTAINER", commontestutils.VirtioWinImage)).To(Succeed())
-		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, namespace)).To(Succeed())
 		Expect(os.Setenv(hcoutil.HcoKvIoVersionName, version.Version)).To(Succeed())
 
 		reqresolver.GeneratePlaceHolders()
@@ -110,7 +108,6 @@ var _ = Describe("Upgrade Mode", func() {
 
 			Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, origOperatorCondVarName)).To(Succeed())
 			Expect(os.Setenv("VIRTIOWIN_CONTAINER", origVirtIOWinContainer)).To(Succeed())
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origOperatorNS)).To(Succeed())
 			Expect(os.Setenv(hcoutil.HcoKvIoVersionName, origVersion)).To(Succeed())
 		})
 	})

--- a/controllers/ingresscluster/ingress-cluster-controller.go
+++ b/controllers/ingresscluster/ingress-cluster-controller.go
@@ -41,8 +41,7 @@ const (
 )
 
 var (
-	selfNamespace = hcoutil.GetOperatorNamespaceFromEnv()
-	logger        = logf.Log.WithName("controller_ingress_cluster")
+	logger = logf.Log.WithName("controller_ingress_cluster")
 )
 
 type ReconcileIngressCluster struct {
@@ -100,7 +99,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 }
 
 func (r *ReconcileIngressCluster) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
-
 	clusterIngress := &configv1.Ingress{}
 
 	if err := r.Get(ctx, client.ObjectKey{Name: ingressName}, clusterIngress); err != nil {
@@ -168,6 +166,8 @@ func (r *ReconcileIngressCluster) Reconcile(ctx context.Context, _ reconcile.Req
 func updateComponentInStatus(clusterIngress *configv1.Ingress, hcExists bool, dh downloadhost.CLIDownloadHost) (int, bool, bool) {
 	needUpdate := false
 	deleted := false
+
+	selfNamespace := hcoutil.GetOperatorNamespaceFromEnv()
 	routeInd := slices.IndexFunc(clusterIngress.Status.ComponentRoutes, func(component configv1.ComponentRouteStatus) bool {
 		return component.Name == componentName && component.Namespace == selfNamespace
 	})
@@ -217,6 +217,8 @@ func (r *ReconcileIngressCluster) hyperConvergedExists(ctx context.Context, loog
 }
 
 func generateDefaultRouteStatus(host downloadhost.CLIDownloadHost) configv1.ComponentRouteStatus {
+	selfNamespace := hcoutil.GetOperatorNamespaceFromEnv()
+
 	serviceAccount := configv1.ConsumingUser(fmt.Sprintf("system:serviceaccount:%s:hyperconverged-cluster-operator", selfNamespace))
 
 	currentHostName := host.DefaultHost
@@ -242,7 +244,7 @@ func generateDefaultRouteStatus(host downloadhost.CLIDownloadHost) configv1.Comp
 }
 
 func getDefaultCLIIDownloadHost(domain string) configv1.Hostname {
-	return configv1.Hostname(fmt.Sprintf("%s-%s.%s", downloadhost.CLIDownloadsServiceName, selfNamespace, domain))
+	return configv1.Hostname(fmt.Sprintf("%s-%s.%s", downloadhost.CLIDownloadsServiceName, hcoutil.GetOperatorNamespaceFromEnv(), domain))
 }
 
 func (r *ReconcileIngressCluster) getDownloadHost(ctx context.Context, clusterIngress *configv1.Ingress) (downloadhost.CLIDownloadHost, error) {
@@ -252,6 +254,7 @@ func (r *ReconcileIngressCluster) getDownloadHost(ctx context.Context, clusterIn
 		CurrentHost: defaultHost,
 	}
 
+	selfNamespace := hcoutil.GetOperatorNamespaceFromEnv()
 	routeInd := slices.IndexFunc(clusterIngress.Spec.ComponentRoutes, func(component configv1.ComponentRouteSpec) bool {
 		return component.Name == componentName && component.Namespace == selfNamespace
 	})

--- a/controllers/ingresscluster/ingress-cluster-controller_test.go
+++ b/controllers/ingresscluster/ingress-cluster-controller_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/reqresolver"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
 	hcoutils "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -62,26 +63,22 @@ var _ = BeforeSuite(func() {
 var _ = Describe("IngressClusterController", func() {
 
 	var (
-		ingress                 *configv1.Ingress
-		hostBeforeTest          downloadhost.CLIDownloadHost
-		selfNamespaceBeforeTest string
-		defaultDomain           configv1.Hostname
+		ingress        *configv1.Ingress
+		hostBeforeTest downloadhost.CLIDownloadHost
+		defaultDomain  configv1.Hostname
 	)
 
 	BeforeEach(func() {
 		hostBeforeTest = downloadhost.Get()
 		ingress = getIngress()
-		selfNamespaceBeforeTest = hcoutils.GetOperatorNamespaceFromEnv()
-		Expect(os.Setenv("OPERATOR_NAMESPACE", testNS)).To(Succeed())
+		Expect(os.Setenv(hcoutils.OperatorNamespaceEnv, testNS)).To(Succeed())
 		reqresolver.GeneratePlaceHolders()
-		selfNamespace = testNS
 		defaultDomain = getDefaultCLIIDownloadHost(testDomain)
 	})
 
 	AfterEach(func() {
 		downloadhost.Set(hostBeforeTest)
-		selfNamespace = selfNamespaceBeforeTest
-		Expect(os.Setenv("OPERATOR_NAMESPACE", selfNamespace)).To(Succeed())
+		Expect(os.Setenv(hcoutils.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
 		reqresolver.GeneratePlaceHolders()
 	})
 

--- a/controllers/nodes/nodes_controller.go
+++ b/controllers/nodes/nodes_controller.go
@@ -3,6 +3,7 @@ package nodes
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -38,7 +39,7 @@ var (
 	hcoReq = reconcile.Request{
 		NamespacedName: k8stypes.NamespacedName{
 			Name:      "hyperconverged-req-" + randomConstSuffix,
-			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
+			Namespace: os.Getenv(hcoutil.OperatorNamespaceEnv),
 		},
 	}
 )

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -75,8 +75,11 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 			waspagent.NewWaspAgentServiceAccountHandler(client, scheme),
 			waspagent.NewWaspAgentSCCHandler(client, scheme),
 			waspagent.NewWaspAgentDaemonSetHandler(client, scheme),
+			waspagent.NewWaspAgentClusterRoleHandler(client, scheme),
+			waspagent.NewWaspAgentClusterRoleBindingHandler(client, scheme),
 			handlers.NewVirtioWinCmReaderRoleHandler(client, scheme),
 			handlers.NewVirtioWinCmReaderRoleBindingHandler(client, scheme),
+			aie.NewIOMMUFDDevicePluginSCCHandler(client, scheme),
 		}...)
 
 		virtioWinCMHandler, err := handlers.NewVirtioWinCmHandler(client, scheme)
@@ -143,16 +146,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 		handlers.GetImageStreamHandlers,
 	} {
 		h.addOperands(scheme, hc, fn, pwdFS)
-	}
-
-	getHandlerFuncs := []operands.GetHandler{
-		waspagent.NewWaspAgentClusterRoleHandler,
-		waspagent.NewWaspAgentClusterRoleBindingHandler,
-		aie.NewIOMMUFDDevicePluginSCCHandler,
-	}
-
-	for _, fn := range getHandlerFuncs {
-		h.addOperand(scheme, hc, fn)
 	}
 }
 
@@ -261,12 +254,12 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 		handlers.NewAAQWithNameOnly(),
 		handlers.NewMigControllerWithNameOnly(),
 		passt.NewPasstBindingCNINetworkAttachmentDefinition(req.Instance),
-		passt.NewPasstBindingCNISecurityContextConstraints(req.Instance),
-		waspagent.NewWaspAgentSCCWithNameOnly(req.Instance),
+		passt.NewPasstBindingCNISecurityContextConstraints(),
+		waspagent.NewWaspAgentSCCWithNameOnly(),
 		aie.NewAIEWebhookClusterRoleWithNameOnly(req.Instance),
 		aie.NewAIEWebhookClusterRoleBindingWithNameOnly(req.Instance),
 		aie.NewAIEWebhookMutatingWebhookConfigurationWithNameOnly(req.Instance),
-		aie.NewIOMMUFDDevicePluginSCCWithNameOnly(req.Instance),
+		aie.NewIOMMUFDDevicePluginSCCWithNameOnly(),
 	}
 
 	resources = append(resources, h.objects...)

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -75,6 +75,8 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 			waspagent.NewWaspAgentServiceAccountHandler(client, scheme),
 			waspagent.NewWaspAgentSCCHandler(client, scheme),
 			waspagent.NewWaspAgentDaemonSetHandler(client, scheme),
+			handlers.NewVirtioWinCmReaderRoleHandler(client, scheme),
+			handlers.NewVirtioWinCmReaderRoleBindingHandler(client, scheme),
 		}...)
 
 		virtioWinCMHandler, err := handlers.NewVirtioWinCmHandler(client, scheme)
@@ -97,6 +99,8 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 				handlers.NewKvUIFeaturesCMHandler(client, scheme),
 				handlers.NewKvUIPluginCRHandler(client, scheme),
 				handlers.NewKvUINginxCMHandler(client, scheme),
+				handlers.NewKvUIConfigReaderRoleHandler(client, scheme),
+				handlers.NewKvUIConfigReaderRoleBindingHandler(client, scheme),
 			}...)
 		}
 	}
@@ -140,8 +144,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 	}
 
 	getHandlerFuncs := []operands.GetHandler{
-		handlers.NewVirtioWinCmReaderRoleHandler,
-		handlers.NewVirtioWinCmReaderRoleBindingHandler,
 		waspagent.NewWaspAgentClusterRoleHandler,
 		waspagent.NewWaspAgentClusterRoleBindingHandler,
 		aie.NewIOMMUFDDevicePluginSCCHandler,
@@ -149,8 +151,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 
 	if ci.IsConsolePluginImageProvided() {
 		getHandlerFuncs = append(getHandlerFuncs,
-			handlers.NewKvUIConfigReaderRoleHandler,
-			handlers.NewKvUIConfigReaderRoleBindingHandler,
 			handlers.NewKVConsolePluginNetworkPolicyHandler,
 			handlers.NewKVAPIServerProxyNetworkPolicyHandler,
 		)

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -59,8 +59,9 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 		passt.NewPasstNetworkAttachmentDefinitionHandler(client, scheme),
 		aie.NewAIEWebhookServiceAccountHandler(client, scheme),
 		aie.NewAIEWebhookServiceHandler(client, scheme),
-		aie.NewIOMMUFDDevicePluginServiceAccountHandler(client, scheme),
 		aie.NewAIEWebhookDeploymentHandler(client, scheme),
+		aie.NewAIEWebhookConfigMapHandler(client, scheme),
+		aie.NewIOMMUFDDevicePluginServiceAccountHandler(client, scheme),
 	}
 
 	if ci.IsOpenshift() {
@@ -76,6 +77,13 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 			waspagent.NewWaspAgentDaemonSetHandler(client, scheme),
 		}...)
 
+		virtioWinCMHandler, err := handlers.NewVirtioWinCmHandler(client, scheme)
+		if err != nil {
+			logger.Error(err, "failed to create a handler for the virtio-win ConfigMap")
+		} else {
+			operandList = append(operandList, virtioWinCMHandler)
+		}
+
 		if ci.IsConsolePluginImageProvided() {
 			operandList = append(operandList, []operands.Operand{
 				handlers.NewConsoleHandler(client),
@@ -85,6 +93,8 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 				handlers.NewKvUIProxySAHandler(client, scheme),
 				handlers.NewKvUIPluginDeploymentHandler(client, scheme),
 				handlers.NewKvUIProxyDeploymentHandler(client, scheme),
+				handlers.NewKvUIUserSettingsCMHandler(client, scheme),
+				handlers.NewKvUIFeaturesCMHandler(client, scheme),
 			}...)
 		}
 	}
@@ -107,7 +117,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 	h.objects = make([]client.Object, 0)
 
 	for _, fn := range []operands.GetHandler{
-		aie.NewAIEWebhookConfigMapHandler,
 		aie.NewAIEWebhookClusterRoleHandler,
 		aie.NewAIEWebhookClusterRoleBindingHandler,
 		aie.NewAIEWebhookMutatingWebhookConfigurationHandler,
@@ -129,7 +138,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 	}
 
 	getHandlerFuncs := []operands.GetHandler{
-		handlers.NewVirtioWinCmHandler,
 		handlers.NewVirtioWinCmReaderRoleHandler,
 		handlers.NewVirtioWinCmReaderRoleBindingHandler,
 		waspagent.NewWaspAgentClusterRoleHandler,
@@ -141,8 +149,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 		getHandlerFuncs = append(getHandlerFuncs,
 			handlers.NewKvUINginxCMHandler,
 			handlers.NewKvUIPluginCRHandler,
-			handlers.NewKvUIUserSettingsCMHandler,
-			handlers.NewKvUIFeaturesCMHandler,
 			handlers.NewKvUIConfigReaderRoleHandler,
 			handlers.NewKvUIConfigReaderRoleBindingHandler,
 			handlers.NewKVConsolePluginNetworkPolicyHandler,

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -255,7 +255,7 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 	defer cancel()
 
 	resources := []client.Object{
-		handlers.NewNetworkAddonsWithNameOnly(req.Instance),
+		handlers.NewNetworkAddonsWithNameOnly(),
 		handlers.NewSSPWithNameOnly(req.Instance),
 		handlers.NewConsoleCLIDownload(),
 		handlers.NewAAQWithNameOnly(),

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -67,19 +67,21 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 			handlers.NewSspHandler(client, scheme),
 			handlers.NewCliDownloadHandler(client, scheme),
 			handlers.NewCliDownloadsRouteHandler(client, scheme),
-			operands.NewServiceHandler(client, scheme, handlers.NewCliDownloadsService),
+			operands.NewServiceHandler(client, scheme, handlers.NewCliDownloadsService()),
 			passt.NewPasstServiceAccountHandler(client, scheme),
 			passt.NewPasstSecurityContextConstraintsHandler(client, scheme),
 			waspagent.NewWaspAgentServiceAccountHandler(client, scheme),
 			waspagent.NewWaspAgentSCCHandler(client, scheme),
 			waspagent.NewWaspAgentDaemonSetHandler(client, scheme),
 		}...)
-	}
 
-	if ci.IsOpenshift() && ci.IsConsolePluginImageProvided() {
-		operandList = append(operandList, handlers.NewConsoleHandler(client))
-		operandList = append(operandList, operands.NewServiceHandler(client, scheme, handlers.NewKvUIPluginSvc))
-		operandList = append(operandList, operands.NewServiceHandler(client, scheme, handlers.NewKvUIProxySvc))
+		if ci.IsConsolePluginImageProvided() {
+			operandList = append(operandList, []operands.Operand{
+				handlers.NewConsoleHandler(client),
+				operands.NewServiceHandler(client, scheme, handlers.NewKvUIPluginSvc()),
+				operands.NewServiceHandler(client, scheme, handlers.NewKvUIProxySvc()),
+			}...)
+		}
 	}
 
 	if ci.IsManagedByOLM() {
@@ -254,7 +256,7 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 	resources := []client.Object{
 		handlers.NewNetworkAddonsWithNameOnly(req.Instance),
 		handlers.NewSSPWithNameOnly(req.Instance),
-		handlers.NewConsoleCLIDownload(req.Instance),
+		handlers.NewConsoleCLIDownload(),
 		handlers.NewAAQWithNameOnly(),
 		handlers.NewMigControllerWithNameOnly(req.Instance),
 		passt.NewPasstBindingCNINetworkAttachmentDefinition(req.Instance),

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -61,7 +61,11 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 		aie.NewAIEWebhookServiceHandler(client, scheme),
 		aie.NewAIEWebhookDeploymentHandler(client, scheme),
 		aie.NewAIEWebhookConfigMapHandler(client, scheme),
+		aie.NewAIEWebhookClusterRoleHandler(client, scheme),
+		aie.NewAIEWebhookClusterRoleBindingHandler(client, scheme),
+		aie.NewAIEWebhookMutatingWebhookConfigurationHandler(client, scheme),
 		aie.NewIOMMUFDDevicePluginServiceAccountHandler(client, scheme),
+		aie.NewIOMMUFDDevicePluginDaemonSetHandler(client, scheme),
 	}
 
 	if ci.IsOpenshift() {
@@ -126,15 +130,6 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 // Initial operations that need to read/write from the cluster can only be done when the client is already working.
 func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.ClusterInfo, hc *hcov1beta1.HyperConverged, pwdFS fs.FS) {
 	h.objects = make([]client.Object, 0)
-
-	for _, fn := range []operands.GetHandler{
-		aie.NewAIEWebhookClusterRoleHandler,
-		aie.NewAIEWebhookClusterRoleBindingHandler,
-		aie.NewAIEWebhookMutatingWebhookConfigurationHandler,
-		aie.NewIOMMUFDDevicePluginDaemonSetHandler,
-	} {
-		h.addOperand(scheme, hc, fn)
-	}
 
 	if !ci.IsOpenshift() {
 		return
@@ -256,9 +251,9 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 		passt.NewPasstBindingCNINetworkAttachmentDefinition(),
 		passt.NewPasstBindingCNISecurityContextConstraints(),
 		waspagent.NewWaspAgentSCCWithNameOnly(),
-		aie.NewAIEWebhookClusterRoleWithNameOnly(req.Instance),
-		aie.NewAIEWebhookClusterRoleBindingWithNameOnly(req.Instance),
-		aie.NewAIEWebhookMutatingWebhookConfigurationWithNameOnly(req.Instance),
+		aie.NewAIEWebhookClusterRoleWithNameOnly(),
+		aie.NewAIEWebhookClusterRoleBindingWithNameOnly(),
+		aie.NewAIEWebhookMutatingWebhookConfigurationWithNameOnly(),
 		aie.NewIOMMUFDDevicePluginSCCWithNameOnly(),
 	}
 

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -95,6 +95,8 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 				handlers.NewKvUIProxyDeploymentHandler(client, scheme),
 				handlers.NewKvUIUserSettingsCMHandler(client, scheme),
 				handlers.NewKvUIFeaturesCMHandler(client, scheme),
+				handlers.NewKvUIPluginCRHandler(client, scheme),
+				handlers.NewKvUINginxCMHandler(client, scheme),
 			}...)
 		}
 	}
@@ -147,8 +149,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 
 	if ci.IsConsolePluginImageProvided() {
 		getHandlerFuncs = append(getHandlerFuncs,
-			handlers.NewKvUINginxCMHandler,
-			handlers.NewKvUIPluginCRHandler,
 			handlers.NewKvUIConfigReaderRoleHandler,
 			handlers.NewKvUIConfigReaderRoleBindingHandler,
 			handlers.NewKVConsolePluginNetworkPolicyHandler,

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -60,6 +60,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 		aie.NewAIEWebhookServiceAccountHandler(client, scheme),
 		aie.NewAIEWebhookServiceHandler(client, scheme),
 		aie.NewIOMMUFDDevicePluginServiceAccountHandler(client, scheme),
+		aie.NewAIEWebhookDeploymentHandler(client, scheme),
 	}
 
 	if ci.IsOpenshift() {
@@ -82,6 +83,8 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 				operands.NewServiceHandler(client, scheme, handlers.NewKvUIProxySvc()),
 				handlers.NewKvUIPluginSAHandler(client, scheme),
 				handlers.NewKvUIProxySAHandler(client, scheme),
+				handlers.NewKvUIPluginDeploymentHandler(client, scheme),
+				handlers.NewKvUIProxyDeploymentHandler(client, scheme),
 			}...)
 		}
 	}
@@ -107,7 +110,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 		aie.NewAIEWebhookConfigMapHandler,
 		aie.NewAIEWebhookClusterRoleHandler,
 		aie.NewAIEWebhookClusterRoleBindingHandler,
-		aie.NewAIEWebhookDeploymentHandler,
 		aie.NewAIEWebhookMutatingWebhookConfigurationHandler,
 		aie.NewIOMMUFDDevicePluginDaemonSetHandler,
 	} {
@@ -137,8 +139,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 
 	if ci.IsConsolePluginImageProvided() {
 		getHandlerFuncs = append(getHandlerFuncs,
-			handlers.NewKvUIPluginDeploymentHandler,
-			handlers.NewKvUIProxyDeploymentHandler,
 			handlers.NewKvUINginxCMHandler,
 			handlers.NewKvUIPluginCRHandler,
 			handlers.NewKvUIUserSettingsCMHandler,

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -80,6 +80,8 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 				handlers.NewConsoleHandler(client),
 				operands.NewServiceHandler(client, scheme, handlers.NewKvUIPluginSvc()),
 				operands.NewServiceHandler(client, scheme, handlers.NewKvUIProxySvc()),
+				handlers.NewKvUIPluginSAHandler(client, scheme),
+				handlers.NewKvUIProxySAHandler(client, scheme),
 			}...)
 		}
 	}
@@ -135,8 +137,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 
 	if ci.IsConsolePluginImageProvided() {
 		getHandlerFuncs = append(getHandlerFuncs,
-			handlers.NewKvUIPluginSAHandler,
-			handlers.NewKvUIProxySAHandler,
 			handlers.NewKvUIPluginDeploymentHandler,
 			handlers.NewKvUIProxyDeploymentHandler,
 			handlers.NewKvUINginxCMHandler,

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -259,7 +259,7 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 		handlers.NewSSPWithNameOnly(req.Instance),
 		handlers.NewConsoleCLIDownload(),
 		handlers.NewAAQWithNameOnly(),
-		handlers.NewMigControllerWithNameOnly(req.Instance),
+		handlers.NewMigControllerWithNameOnly(),
 		passt.NewPasstBindingCNINetworkAttachmentDefinition(req.Instance),
 		passt.NewPasstBindingCNISecurityContextConstraints(req.Instance),
 		waspagent.NewWaspAgentSCCWithNameOnly(req.Instance),

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -101,6 +101,8 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 				handlers.NewKvUINginxCMHandler(client, scheme),
 				handlers.NewKvUIConfigReaderRoleHandler(client, scheme),
 				handlers.NewKvUIConfigReaderRoleBindingHandler(client, scheme),
+				handlers.NewKVConsolePluginNetworkPolicyHandler(client, scheme),
+				handlers.NewKVAPIServerProxyNetworkPolicyHandler(client, scheme),
 			}...)
 		}
 	}
@@ -147,13 +149,6 @@ func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.C
 		waspagent.NewWaspAgentClusterRoleHandler,
 		waspagent.NewWaspAgentClusterRoleBindingHandler,
 		aie.NewIOMMUFDDevicePluginSCCHandler,
-	}
-
-	if ci.IsConsolePluginImageProvided() {
-		getHandlerFuncs = append(getHandlerFuncs,
-			handlers.NewKVConsolePluginNetworkPolicyHandler,
-			handlers.NewKVAPIServerProxyNetworkPolicyHandler,
-		)
 	}
 
 	for _, fn := range getHandlerFuncs {

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -253,7 +253,7 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 		handlers.NewConsoleCLIDownload(),
 		handlers.NewAAQWithNameOnly(),
 		handlers.NewMigControllerWithNameOnly(),
-		passt.NewPasstBindingCNINetworkAttachmentDefinition(req.Instance),
+		passt.NewPasstBindingCNINetworkAttachmentDefinition(),
 		passt.NewPasstBindingCNISecurityContextConstraints(),
 		waspagent.NewWaspAgentSCCWithNameOnly(),
 		aie.NewAIEWebhookClusterRoleWithNameOnly(req.Instance),

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -275,7 +275,7 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 		return err
 	}
 
-	err = h.deleteSingleResource(tCtx, req, handlers.NewKubeVirtWithNameOnly(req.Instance), ErrVirtUninstall, uninstallVirtErrorMsg)
+	err = h.deleteSingleResource(tCtx, req, handlers.NewKubeVirtWithNameOnly(), ErrVirtUninstall, uninstallVirtErrorMsg)
 	if err != nil {
 		return err
 	}

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -183,18 +183,6 @@ func (h *OperandHandler) addOperands(scheme *runtime.Scheme, hc *hcov1beta1.Hype
 	}
 }
 
-func (h *OperandHandler) addOperand(scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged, getHandler operands.GetHandler) {
-	handler, err := getHandler(logger, h.client, scheme, hc)
-	if err != nil {
-		logger.Error(err, "can't create handler")
-		return
-	}
-
-	h.addOperandObject(handler, hc)
-
-	h.operands = append(h.operands, handler)
-}
-
 func (h *OperandHandler) Ensure(req *common.HcoRequest) error {
 	for _, handler := range h.operands {
 		res := handler.Ensure(req)

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -256,7 +256,7 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 
 	resources := []client.Object{
 		handlers.NewNetworkAddonsWithNameOnly(),
-		handlers.NewSSPWithNameOnly(req.Instance),
+		handlers.NewSSPWithNameOnly(),
 		handlers.NewConsoleCLIDownload(),
 		handlers.NewAAQWithNameOnly(),
 		handlers.NewMigControllerWithNameOnly(),

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -255,7 +255,7 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 		handlers.NewNetworkAddonsWithNameOnly(req.Instance),
 		handlers.NewSSPWithNameOnly(req.Instance),
 		handlers.NewConsoleCLIDownload(req.Instance),
-		handlers.NewAAQWithNameOnly(req.Instance),
+		handlers.NewAAQWithNameOnly(),
 		handlers.NewMigControllerWithNameOnly(req.Instance),
 		passt.NewPasstBindingCNINetworkAttachmentDefinition(req.Instance),
 		passt.NewPasstBindingCNISecurityContextConstraints(req.Instance),

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -278,7 +278,7 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 		return err
 	}
 
-	return h.deleteSingleResource(tCtx, req, handlers.NewCDIWithNameOnly(req.Instance), ErrCDIUninstall, uninstallCDIErrorMsg)
+	return h.deleteSingleResource(tCtx, req, handlers.NewCDIWithNameOnly(), ErrCDIUninstall, uninstallCDIErrorMsg)
 }
 
 func (h *OperandHandler) deleteMultipleResources(tCtx context.Context, req *common.HcoRequest, resources []client.Object) error {

--- a/controllers/operandhandler/operandHandler_test.go
+++ b/controllers/operandhandler/operandHandler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/dirtest"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers"
 	fakeownresources "github.com/kubevirt/hyperconverged-cluster-operator/pkg/ownresources/fake"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func TestOperandHandler(t *testing.T) {
@@ -44,16 +46,20 @@ var _ = Describe("Test operandHandler", func() {
 	BeforeEach(func() {
 		logger = GinkgoLogr
 		fakeownresources.OLMV0OwnResourcesMock()
-		DeferCleanup(func() {
-			logger = origLogger
-			fakeownresources.ResetOwnResources()
-		})
+		origNS := os.Getenv(hcoutil.OperatorNamespaceEnv)
+		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
 
 		pwdFS = dirtest.New(
 			dirtest.WithFile(path.Join(handlers.DashboardManifestLocation, "test-dashboard.yaml"), kubevirtTopConsumersFileContent),
 			dirtest.WithFile(path.Join(handlers.ImageStreamDefaultManifestLocation, "test-image-stream.yaml"), imageStreamFileContent),
 			dirtest.WithFile(path.Join(handlers.QuickStartDefaultManifestLocation, "test-quick-start.yaml"), quickstartFileContent),
 		)
+
+		DeferCleanup(func() {
+			logger = origLogger
+			fakeownresources.ResetOwnResources()
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)).To(Succeed())
+		})
 	})
 
 	Context("Test operandHandler", func() {

--- a/controllers/operands/deploymentHandler.go
+++ b/controllers/operands/deploymentHandler.go
@@ -17,8 +17,8 @@ import (
 
 type newDeploymentFunc func(hc *hcov1beta1.HyperConverged) *appsv1.Deployment
 
-func NewDeploymentHandler(Client client.Client, Scheme *runtime.Scheme, deploymentGenerator newDeploymentFunc, hc *hcov1beta1.HyperConverged) *GenericOperand {
-	return NewGenericOperand(Client, Scheme, "Deployment", newDeploymentHooks(deploymentGenerator, hc), false)
+func NewDeploymentHandler(cli client.Client, Scheme *runtime.Scheme, deploymentGenerator newDeploymentFunc) *GenericOperand {
+	return NewGenericOperand(cli, Scheme, "Deployment", newDeploymentHooks(deploymentGenerator), false)
 }
 
 type deploymentHooks struct {
@@ -27,9 +27,8 @@ type deploymentHooks struct {
 	cache               *appsv1.Deployment
 }
 
-func newDeploymentHooks(deploymentGenerator newDeploymentFunc, hc *hcov1beta1.HyperConverged) *deploymentHooks {
+func newDeploymentHooks(deploymentGenerator newDeploymentFunc) *deploymentHooks {
 	return &deploymentHooks{
-		cache:               deploymentGenerator(hc),
 		deploymentGenerator: deploymentGenerator,
 	}
 }

--- a/controllers/operands/deploymentHandler_test.go
+++ b/controllers/operands/deploymentHandler_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Deployment Handler", func() {
 			Expect(foundResource.GetUID()).To(Equal(types.UID("oldObjectUID")))
 
 			// let's Ensure the handler properly reconcile it back to the expected state
-			handler := NewDeploymentHandler(cl, commontestutils.GetScheme(), NewExpectedDeployment, hco)
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme(), NewExpectedDeployment)
 			res := handler.Ensure(req)
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -88,7 +88,7 @@ var _ = Describe("Deployment Handler", func() {
 			Expect(foundResource.GetUID()).To(Equal(types.UID("oldObjectUID")))
 
 			// let's Ensure the handler properly reconcile it back to the expected state
-			handler := NewDeploymentHandler(cl, commontestutils.GetScheme(), NewExpectedDeployment, hco)
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme(), NewExpectedDeployment)
 			res := handler.Ensure(req)
 			Expect(res.Updated).To(BeTrue())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -117,7 +117,7 @@ var _ = Describe("Deployment Handler", func() {
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler := NewDeploymentHandler(cl, commontestutils.GetScheme(), NewExpectedDeployment, hco)
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme(), NewExpectedDeployment)
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
@@ -153,7 +153,7 @@ var _ = Describe("Deployment Handler", func() {
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler := NewDeploymentHandler(cl, commontestutils.GetScheme(), NewExpectedDeployment, hco)
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme(), NewExpectedDeployment)
 
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())

--- a/controllers/operands/generic_operand.go
+++ b/controllers/operands/generic_operand.go
@@ -68,6 +68,11 @@ func (h *GenericOperand) Ensure(req *common.HcoRequest) *EnsureResult {
 				// Let's try updating it bypassing the client cache mechanism
 				return h.handleExistingCrSkipCache(req, key, found, cr, res)
 			}
+
+			if _, isHCOOperand := h.hooks.(HCOOperandHooks); !isHCOOperand {
+				return res.SetUpgradeDone(true)
+			}
+
 		} else {
 			return res.Error(err)
 		}

--- a/controllers/operands/labels.go
+++ b/controllers/operands/labels.go
@@ -1,24 +1,9 @@
 package operands
 
 import (
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func GetLabels(component hcoutil.AppComponent) map[string]string {
 	return hcoutil.GetLabels(hcoutil.HyperConvergedName, component)
-}
-
-// GetLabelsDeprecated is the old form, that requires the HyperConverged CR. This is not really needed, as the CR name
-// is known. and can be changed
-//
-// Deprecated: use GetLabels instead
-func GetLabelsDeprecated(hc *hcov1beta1.HyperConverged, component hcoutil.AppComponent) map[string]string {
-	hcoName := hcoutil.HyperConvergedName
-
-	if hc.Name != "" {
-		hcoName = hc.Name
-	}
-
-	return hcoutil.GetLabels(hcoName, component)
 }

--- a/controllers/operands/labels.go
+++ b/controllers/operands/labels.go
@@ -5,8 +5,16 @@ import (
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-func GetLabels(hc *hcov1beta1.HyperConverged, component hcoutil.AppComponent) map[string]string {
-	hcoName := hcov1beta1.HyperConvergedName
+func GetLabels(component hcoutil.AppComponent) map[string]string {
+	return hcoutil.GetLabels(hcoutil.HyperConvergedName, component)
+}
+
+// GetLabelsDeprecated is the old form, that requires the HyperConverged CR. This is not really needed, as the CR name
+// is known. and can be changed
+//
+// Deprecated: use GetLabels instead
+func GetLabelsDeprecated(hc *hcov1beta1.HyperConverged, component hcoutil.AppComponent) map[string]string {
+	hcoName := hcoutil.HyperConvergedName
 
 	if hc.Name != "" {
 		hcoName = hc.Name

--- a/controllers/operands/securityContextConstraintsHandler.go
+++ b/controllers/operands/securityContextConstraintsHandler.go
@@ -14,18 +14,16 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-type newSecurityContextConstraintsFunc func(hc *hcov1beta1.HyperConverged) *securityv1.SecurityContextConstraints
-
-func NewSecurityContextConstraintsHandler(Client client.Client, Scheme *runtime.Scheme, newCrFunc newSecurityContextConstraintsFunc) *GenericOperand {
-	return NewGenericOperand(Client, Scheme, "SecurityContextConstraints", &securityContextConstraintsHooks{newCrFunc: newCrFunc}, false)
+func NewSecurityContextConstraintsHandler(Client client.Client, Scheme *runtime.Scheme, scc *securityv1.SecurityContextConstraints) *GenericOperand {
+	return NewGenericOperand(Client, Scheme, "SecurityContextConstraints", &securityContextConstraintsHooks{scc: scc}, false)
 }
 
 type securityContextConstraintsHooks struct {
-	newCrFunc newSecurityContextConstraintsFunc
+	scc *securityv1.SecurityContextConstraints
 }
 
-func (h securityContextConstraintsHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
-	return h.newCrFunc(hc), nil
+func (h securityContextConstraintsHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+	return h.scc.DeepCopy(), nil
 }
 
 func (securityContextConstraintsHooks) GetEmptyCr() client.Object {

--- a/controllers/operands/serviceAccountHandler.go
+++ b/controllers/operands/serviceAccountHandler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-type newSvcAccountFunc func(hc *hcov1beta1.HyperConverged) *corev1.ServiceAccount
+type newSvcAccountFunc func() *corev1.ServiceAccount
 
 func NewServiceAccountHandler(Client client.Client, Scheme *runtime.Scheme, newCrFunc newSvcAccountFunc) *GenericOperand {
 	return NewGenericOperand(Client, Scheme, "ServiceAccount", &serviceAccountHooks{newCrFunc: newCrFunc}, true)
@@ -22,8 +22,8 @@ type serviceAccountHooks struct {
 	newCrFunc newSvcAccountFunc
 }
 
-func (h serviceAccountHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
-	return h.newCrFunc(hc), nil
+func (h serviceAccountHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+	return h.newCrFunc(), nil
 }
 
 func (serviceAccountHooks) GetEmptyCr() client.Object {

--- a/controllers/operands/serviceHandler.go
+++ b/controllers/operands/serviceHandler.go
@@ -13,26 +13,24 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-func NewServiceHandler(Client client.Client, Scheme *runtime.Scheme, newCrFunc newSvcFunc) *GenericOperand {
+func NewServiceHandler(Client client.Client, Scheme *runtime.Scheme, svc *corev1.Service) *GenericOperand {
 	h := &GenericOperand{
 		Client:                 Client,
 		Scheme:                 Scheme,
 		crType:                 "Service",
-		hooks:                  &serviceHooks{newCrFunc: newCrFunc},
+		hooks:                  &serviceHooks{svc: svc},
 		setControllerReference: true,
 	}
 
 	return h
 }
 
-type newSvcFunc func(hc *hcov1beta1.HyperConverged) *corev1.Service
-
 type serviceHooks struct {
-	newCrFunc newSvcFunc
+	svc *corev1.Service
 }
 
-func (h serviceHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
-	return h.newCrFunc(hc), nil
+func (h serviceHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+	return h.svc.DeepCopy(), nil
 }
 
 func (serviceHooks) GetEmptyCr() client.Object {

--- a/controllers/reqresolver/reqresolver.go
+++ b/controllers/reqresolver/reqresolver.go
@@ -138,7 +138,3 @@ func GeneratePlaceHolders() {
 		Namespace: ns,
 	}
 }
-
-func init() {
-	GeneratePlaceHolders()
-}

--- a/controllers/reqresolver/reqresolver_test.go
+++ b/controllers/reqresolver/reqresolver_test.go
@@ -9,12 +9,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/reqresolver"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-)
-
-const (
-	namespace = "test-ns"
 )
 
 func TestReqResolver(t *testing.T) {
@@ -23,16 +20,21 @@ func TestReqResolver(t *testing.T) {
 }
 
 var (
-	nsBefore string
-
 	_ = BeforeSuite(func() {
-		nsBefore = hcoutil.GetOperatorNamespaceFromEnv()
-		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, namespace)).To(Succeed())
+		nsBefore, nsIsSet := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
+		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
 		reqresolver.GeneratePlaceHolders()
+
+		DeferCleanup(func() {
+			if nsIsSet {
+				Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, nsBefore)).To(Succeed())
+			} else {
+				Expect(os.Unsetenv(hcoutil.OperatorNamespaceEnv)).To(Succeed())
+			}
+		})
 	})
 
 	_ = AfterSuite(func() {
-		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, nsBefore)).To(Succeed())
 		reqresolver.GeneratePlaceHolders()
 	})
 )
@@ -41,7 +43,7 @@ var _ = Describe("test ResolveReconcileRequest", func() {
 	It("should return original req and true for request triggered by HC", func() {
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Namespace: namespace,
+				Namespace: commontestutils.Namespace,
 				Name:      hcoutil.HyperConvergedName,
 			},
 		}
@@ -53,7 +55,7 @@ var _ = Describe("test ResolveReconcileRequest", func() {
 	It("should return original req and true for request triggered by unknown source", func() {
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Namespace: namespace,
+				Namespace: commontestutils.Namespace,
 				Name:      "unknown",
 			},
 		}
@@ -93,14 +95,14 @@ var _ = Describe("test ResolveReconcileRequest", func() {
 var _ = Describe("Check generated requests", func() {
 	It("test GetHyperConvergedNamespacedName", func() {
 		n := reqresolver.GetHyperConvergedNamespacedName()
-		Expect(n).To(Equal(types.NamespacedName{Name: hcoutil.HyperConvergedName, Namespace: namespace}))
+		Expect(n).To(Equal(types.NamespacedName{Name: hcoutil.HyperConvergedName, Namespace: commontestutils.Namespace}))
 		Expect(reqresolver.IsTriggeredByHyperConverged(n)).To(BeTrueBecause("should recognized as triggered by HyperConverged CR"))
 		Expect(reqresolver.IsTriggeredByAPIServerCR(reconcile.Request{NamespacedName: n})).To(BeFalseBecause("should not be recognized as triggered by APIServer CR"))
 	})
 
 	It("test GetAPIServerCRRequest", func() {
 		req := reqresolver.GetAPIServerCRRequest()
-		Expect(req.NamespacedName.Namespace).To(Equal(namespace))
+		Expect(req.NamespacedName.Namespace).To(Equal(commontestutils.Namespace))
 		Expect(req.NamespacedName.Name).To(HavePrefix("api-server-cr-"))
 		Expect(reqresolver.IsTriggeredByHyperConverged(req.NamespacedName)).To(BeFalseBecause("should not be recognized as triggered by HyperConverged CR"))
 		Expect(reqresolver.IsTriggeredByAPIServerCR(req)).To(BeTrueBecause("should be recognized as triggered by APIServer CR"))
@@ -108,7 +110,7 @@ var _ = Describe("Check generated requests", func() {
 
 	It("test GetSecondaryCRRequest", func() {
 		req := reqresolver.GetSecondaryCRRequest()
-		Expect(req.NamespacedName.Namespace).To(Equal(namespace))
+		Expect(req.NamespacedName.Namespace).To(Equal(commontestutils.Namespace))
 		Expect(req.NamespacedName.Name).To(HavePrefix("hco-controlled-cr-"))
 		Expect(reqresolver.IsTriggeredByHyperConverged(req.NamespacedName)).To(BeFalseBecause("should not be recognized as triggered by HyperConverged CR"))
 		Expect(reqresolver.IsTriggeredByAPIServerCR(req)).To(BeFalseBecause("should not be recognized as triggered by APIServer CR"))
@@ -116,7 +118,7 @@ var _ = Describe("Check generated requests", func() {
 
 	It("test GetIngressCRResource", func() {
 		req := reqresolver.GetIngressCRResource()
-		Expect(req.NamespacedName.Namespace).To(Equal(namespace))
+		Expect(req.NamespacedName.Namespace).To(Equal(commontestutils.Namespace))
 		Expect(req.NamespacedName.Name).To(HavePrefix("ingress-cr-"))
 		Expect(reqresolver.IsTriggeredByHyperConverged(req.NamespacedName)).To(BeFalseBecause("should not be recognized as triggered by HyperConverged CR"))
 		Expect(reqresolver.IsTriggeredByAPIServerCR(req)).To(BeFalseBecause("should not be recognized as triggered by APIServer CR"))

--- a/controllers/webhooks/bearer-token-controller/controller_test.go
+++ b/controllers/webhooks/bearer-token-controller/controller_test.go
@@ -71,8 +71,6 @@ var _ = Describe("Controller setup and reconcile", func() {
 	})
 
 	Describe("Reconcile", func() {
-		const nsName = "wb-bearer-token-test-ns"
-
 		var (
 			secret    *corev1.Secret
 			resources []client.Object
@@ -84,10 +82,10 @@ var _ = Describe("Controller setup and reconcile", func() {
 
 		JustBeforeEach(func() {
 			origNS, hadEnvVar := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
-			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, nsName)).To(Succeed())
+			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)).To(Succeed())
 
 			resources = []client.Object{
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: commontestutils.Namespace}},
 			}
 			if secret != nil {
 				resources = append(resources, secret)
@@ -98,7 +96,7 @@ var _ = Describe("Controller setup and reconcile", func() {
 			mgrIntf, err = commontestutils.NewManagerMock(&rest.Config{}, manager.Options{Scheme: commontestutils.GetScheme()}, cl, commontestutils.TestLogger)
 			Expect(err).ToNot(HaveOccurred())
 			r = newReconciler(mgrIntf, commontestutils.ClusterInfoMock{}, commontestutils.NewEventEmitterMock())
-			request = reconcile.Request{NamespacedName: k8stypes.NamespacedName{Name: "irrelevant", Namespace: nsName}}
+			request = reconcile.Request{NamespacedName: k8stypes.NamespacedName{Name: "irrelevant", Namespace: commontestutils.Namespace}}
 
 			DeferCleanup(func() {
 				if hadEnvVar {
@@ -117,17 +115,17 @@ var _ = Describe("Controller setup and reconcile", func() {
 
 			// Service
 			svc := &corev1.Service{}
-			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: serviceName}, svc)).To(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: serviceName}, svc)).To(Succeed())
 			Expect(svc.Spec.Ports).ToNot(BeEmpty())
 			Expect(svc.Labels).ToNot(BeEmpty())
 
 			// Secret
 			sec := &corev1.Secret{}
-			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: secretName}, sec)).To(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: secretName}, sec)).To(Succeed())
 			Expect(sec.StringData).To(HaveKey("token"))
 
 			sm := &monitoringv1.ServiceMonitor{}
-			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: serviceName}, sm)).To(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: serviceName}, sm)).To(Succeed())
 		})
 
 		It("propagates error from underlying metric reconciler and requeues quickly", func(ctx context.Context) {
@@ -154,7 +152,7 @@ var _ = Describe("Controller setup and reconcile", func() {
 
 			// Secret
 			sec := &corev1.Secret{}
-			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: secretName}, sec)).To(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: secretName}, sec)).To(Succeed())
 			Expect(sec.StringData).To(HaveKey("token"))
 
 			origToken := sec.StringData["token"]
@@ -162,7 +160,7 @@ var _ = Describe("Controller setup and reconcile", func() {
 			Expect(cl.Update(ctx, sec)).To(Succeed())
 
 			newSec := &corev1.Secret{}
-			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: secretName}, newSec)).To(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: secretName}, newSec)).To(Succeed())
 			Expect(newSec.StringData).To(HaveKey("token"))
 			Expect(newSec.StringData["token"]).To(Equal("some-wrong-token"))
 
@@ -172,17 +170,17 @@ var _ = Describe("Controller setup and reconcile", func() {
 			Expect(res.RequeueAfter).To(Equal(5 * time.Minute))
 
 			newSec = &corev1.Secret{}
-			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: secretName}, newSec)).To(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: secretName}, newSec)).To(Succeed())
 			Expect(newSec.StringData).To(HaveKey("token"))
 			Expect(newSec.StringData["token"]).To(Equal(origToken))
 
 			newSM := &monitoringv1.ServiceMonitor{}
-			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: serviceName}, newSM)).To(MatchError(apierrors.IsNotFound, "not found error"))
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: serviceName}, newSM)).To(MatchError(apierrors.IsNotFound, "not found error"))
 
 			res, err = r.Reconcile(ctx, request)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.RequeueAfter).To(Equal(5 * time.Minute))
-			Expect(cl.Get(ctx, client.ObjectKey{Namespace: nsName, Name: serviceName}, newSM)).To(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: commontestutils.Namespace, Name: serviceName}, newSM)).To(Succeed())
 		})
 
 		Context("secret labels", func() {
@@ -191,7 +189,7 @@ var _ = Describe("Controller setup and reconcile", func() {
 					token, err := authorization.CreateToken()
 					Expect(err).ToNot(HaveOccurred())
 
-					secret = newSecret(nsName, ownresources.GetDeploymentRef(), token)
+					secret = newSecret(commontestutils.Namespace, ownresources.GetDeploymentRef(), token)
 					secret.Data = map[string][]byte{"token": []byte(token)}
 				})
 
@@ -307,7 +305,7 @@ var _ = Describe("Controller setup and reconcile", func() {
 					token, err = authorization.CreateToken()
 					Expect(err).ToNot(HaveOccurred())
 
-					secret = newSecret(nsName, ownresources.GetDeploymentRef(), "something-else")
+					secret = newSecret(commontestutils.Namespace, ownresources.GetDeploymentRef(), "something-else")
 					secret.Data = map[string][]byte{"token": []byte("something-else")}
 				})
 

--- a/controllers/webhooks/bearer-token-controller/webhooks_suite_test.go
+++ b/controllers/webhooks/bearer-token-controller/webhooks_suite_test.go
@@ -1,13 +1,30 @@
 package bearer_token_controller
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func TestWebhookBearerToken(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Webhook Bearer Token Controller Suite")
 }
+
+var _ = BeforeSuite(func() {
+	origNS, origNSSet := os.LookupEnv(hcoutil.OperatorNamespaceEnv)
+	_ = os.Setenv(hcoutil.OperatorNamespaceEnv, commontestutils.Namespace)
+
+	DeferCleanup(func() {
+		if origNSSet {
+			_ = os.Setenv(hcoutil.OperatorNamespaceEnv, origNS)
+		} else {
+			_ = os.Unsetenv(hcoutil.OperatorNamespaceEnv)
+		}
+	})
+})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -48,8 +49,17 @@ var ErrNoNamespace = fmt.Errorf("namespace not found for current environment")
 // is returned by functions that only work on operators running in cluster mode)
 var ErrRunLocal = fmt.Errorf("operator run mode forced to local")
 
+var (
+	namespaceOnce     = &sync.Once{}
+	operatorNamespace string
+)
+
 func GetOperatorNamespaceFromEnv() string {
-	return os.Getenv(OperatorNamespaceEnv)
+	namespaceOnce.Do(func() {
+		operatorNamespace = os.Getenv(OperatorNamespaceEnv)
+	})
+
+	return operatorNamespace
 }
 
 func IsRunModeLocal() bool {

--- a/pkg/webhooks/validator/v1beta1_validator.go
+++ b/pkg/webhooks/validator/v1beta1_validator.go
@@ -180,7 +180,7 @@ func (wh *WebhookV1Beta1Handler) getOperands(ctx context.Context, requested *v1b
 		return nil, nil, nil, err
 	}
 
-	cdi := handlers.NewCDIWithNameOnly(requested)
+	cdi := handlers.NewCDIWithNameOnly()
 	err = wh.cli.Get(ctx, client.ObjectKeyFromObject(cdi), cdi)
 	if err != nil {
 		return nil, nil, nil, err
@@ -339,7 +339,7 @@ func (wh *WebhookV1Beta1Handler) ValidateDelete(ctx context.Context, logger logr
 	logger.Info("Validating delete", "name", hc.Name, "namespace", hc.Namespace)
 
 	kv := handlers.NewKubeVirtWithNameOnly(hc)
-	cdi := handlers.NewCDIWithNameOnly(hc)
+	cdi := handlers.NewCDIWithNameOnly()
 
 	for _, obj := range []client.Object{
 		kv,

--- a/pkg/webhooks/validator/v1beta1_validator.go
+++ b/pkg/webhooks/validator/v1beta1_validator.go
@@ -186,7 +186,7 @@ func (wh *WebhookV1Beta1Handler) getOperands(ctx context.Context, requested *v1b
 		return nil, nil, nil, err
 	}
 
-	cna := handlers.NewNetworkAddonsWithNameOnly(requested)
+	cna := handlers.NewNetworkAddonsWithNameOnly()
 	err = wh.cli.Get(ctx, client.ObjectKeyFromObject(cna), cna)
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/webhooks/validator/v1beta1_validator.go
+++ b/pkg/webhooks/validator/v1beta1_validator.go
@@ -174,7 +174,7 @@ func (wh *WebhookV1Beta1Handler) getOperands(ctx context.Context, requested *v1b
 		return nil, nil, nil, err
 	}
 
-	kv := handlers.NewKubeVirtWithNameOnly(requested)
+	kv := handlers.NewKubeVirtWithNameOnly()
 	err := wh.cli.Get(ctx, client.ObjectKeyFromObject(kv), kv)
 	if err != nil {
 		return nil, nil, nil, err
@@ -338,7 +338,7 @@ func (wh *WebhookV1Beta1Handler) updateOperatorCr(ctx context.Context, logger lo
 func (wh *WebhookV1Beta1Handler) ValidateDelete(ctx context.Context, logger logr.Logger, dryrun bool, hc *v1beta1.HyperConverged) error {
 	logger.Info("Validating delete", "name", hc.Name, "namespace", hc.Namespace)
 
-	kv := handlers.NewKubeVirtWithNameOnly(hc)
+	kv := handlers.NewKubeVirtWithNameOnly()
 	cdi := handlers.NewCDIWithNameOnly()
 
 	for _, obj := range []client.Object{

--- a/pkg/webhooks/validator/v1beta1_validator_test.go
+++ b/pkg/webhooks/validator/v1beta1_validator_test.go
@@ -1675,7 +1675,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 			Expect(util.GetRuntimeObject(ctx, cli, kv)).To(Succeed())
 
 			By("Validate that CDI still exists, as it a dry-run deletion")
-			cdi := handlers.NewCDIWithNameOnly(hco)
+			cdi := handlers.NewCDIWithNameOnly()
 			Expect(util.GetRuntimeObject(ctx, cli, cdi)).To(Succeed())
 		})
 
@@ -1747,7 +1747,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 		It("should ignore if CDI does not exist", func(ctx context.Context) {
 			cli := getFakeClient(hco)
 
-			cdi := handlers.NewCDIWithNameOnly(hco)
+			cdi := handlers.NewCDIWithNameOnly()
 			Expect(cli.Delete(ctx, cdi)).To(Succeed())
 
 			wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)

--- a/pkg/webhooks/validator/v1beta1_validator_test.go
+++ b/pkg/webhooks/validator/v1beta1_validator_test.go
@@ -849,7 +849,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 		It("should return error if KV CR is missing", func(ctx context.Context) {
 			cli := getFakeClient(hco)
 
-			kv := handlers.NewKubeVirtWithNameOnly(hco)
+			kv := handlers.NewKubeVirtWithNameOnly()
 			Expect(cli.Delete(ctx, kv)).To(Succeed())
 
 			wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)
@@ -1107,7 +1107,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 				// and so it exits with no error before finding that KV is not there.
 				// Later we'll check that there is no error from the webhook, and that will prove that
 				// the comparison works.
-				kv := handlers.NewKubeVirtWithNameOnly(hco)
+				kv := handlers.NewKubeVirtWithNameOnly()
 				Expect(cli.Delete(ctx, kv)).To(Succeed())
 
 				wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)
@@ -1163,7 +1163,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 				// and so it exits with no error before finding that KV is not there.
 				// Later we'll check that there is no error from the webhook, and that will prove that
 				// the comparison works.
-				kv := handlers.NewKubeVirtWithNameOnly(hco)
+				kv := handlers.NewKubeVirtWithNameOnly()
 				Expect(cli.Delete(ctx, kv)).To(Succeed())
 
 				wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)
@@ -1671,7 +1671,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 			Expect(wh.ValidateDelete(ctx, GinkgoLogr, dryRun, hco)).To(Succeed())
 
 			By("Validate that KV still exists, as it a dry-run deletion")
-			kv := handlers.NewKubeVirtWithNameOnly(hco)
+			kv := handlers.NewKubeVirtWithNameOnly()
 			Expect(util.GetRuntimeObject(ctx, cli, kv)).To(Succeed())
 
 			By("Validate that CDI still exists, as it a dry-run deletion")
@@ -1720,7 +1720,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 		It("should ignore if KV does not exist", func(ctx context.Context) {
 			cli := getFakeClient(hco)
 
-			kv := handlers.NewKubeVirtWithNameOnly(hco)
+			kv := handlers.NewKubeVirtWithNameOnly()
 			Expect(cli.Delete(ctx, kv)).To(Succeed())
 
 			wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)

--- a/pkg/webhooks/validator/v1beta1_validator_test.go
+++ b/pkg/webhooks/validator/v1beta1_validator_test.go
@@ -963,7 +963,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 		It("should return error if SSP CR is missing", func(ctx context.Context) {
 			cli := getFakeClient(hco)
 
-			Expect(cli.Delete(ctx, handlers.NewSSPWithNameOnly(hco))).To(Succeed())
+			Expect(cli.Delete(ctx, handlers.NewSSPWithNameOnly())).To(Succeed())
 			wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)
 
 			newHco := &v1beta1.HyperConverged{}

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -1591,7 +1591,7 @@ var _ = Describe("v1 webhooks validator", func() {
 			Expect(util.GetRuntimeObject(ctx, cli, kv)).To(Succeed())
 
 			By("Validate that CDI still exists, as it a dry-run deletion")
-			cdi := handlers.NewCDIWithNameOnly(v1Beta1CR)
+			cdi := handlers.NewCDIWithNameOnly()
 			Expect(util.GetRuntimeObject(ctx, cli, cdi)).To(Succeed())
 		})
 
@@ -1646,7 +1646,7 @@ var _ = Describe("v1 webhooks validator", func() {
 		})
 
 		It("should ignore if CDI does not exist", func(ctx context.Context) {
-			cdi := handlers.NewCDIWithNameOnly(v1Beta1CR)
+			cdi := handlers.NewCDIWithNameOnly()
 			Expect(cli.Delete(ctx, cdi)).To(Succeed())
 
 			req := newRequest(admissionv1.Delete, cr, hcoCodec, false)

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -900,7 +900,7 @@ var _ = Describe("v1 webhooks validator", func() {
 		})
 
 		It("should return error if SSP CR is missing", func(ctx context.Context) {
-			Expect(cli.Delete(ctx, handlers.NewSSPWithNameOnly(v1beta1CR))).To(Succeed())
+			Expect(cli.Delete(ctx, handlers.NewSSPWithNameOnly())).To(Succeed())
 
 			newHco := &hcov1.HyperConverged{}
 			cr.DeepCopyInto(newHco)

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -796,7 +796,7 @@ var _ = Describe("v1 webhooks validator", func() {
 		})
 
 		It("should return error if KV CR is missing", func(ctx context.Context) {
-			kv := handlers.NewKubeVirtWithNameOnly(v1beta1CR)
+			kv := handlers.NewKubeVirtWithNameOnly()
 			Expect(cli.Delete(ctx, kv)).To(Succeed())
 
 			tlssecprofile.SetHyperConvergedTLSSecurityProfile(nil)
@@ -1587,7 +1587,7 @@ var _ = Describe("v1 webhooks validator", func() {
 			checkAcceptedRequest(wh.Handle(ctx, req))
 
 			By("Validate that KV still exists, as it a dry-run deletion")
-			kv := handlers.NewKubeVirtWithNameOnly(v1Beta1CR)
+			kv := handlers.NewKubeVirtWithNameOnly()
 			Expect(util.GetRuntimeObject(ctx, cli, kv)).To(Succeed())
 
 			By("Validate that CDI still exists, as it a dry-run deletion")
@@ -1626,7 +1626,7 @@ var _ = Describe("v1 webhooks validator", func() {
 		})
 
 		It("should ignore if KV does not exist", func(ctx context.Context) {
-			kv := handlers.NewKubeVirtWithNameOnly(v1Beta1CR)
+			kv := handlers.NewKubeVirtWithNameOnly()
 			Expect(cli.Delete(ctx, kv)).To(Succeed())
 
 			req := newRequest(admissionv1.Delete, cr, hcoCodec, false)

--- a/tests/func-tests/network_policy_test.go
+++ b/tests/func-tests/network_policy_test.go
@@ -338,7 +338,7 @@ func createAllowAllIngressNetworkPolicy() *networkingv1.NetworkPolicy {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      allowAllNPPluginName,
 			Namespace: tests.InstallNamespace,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIPlugin),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
 		},
 
 		Spec: networkingv1.NetworkPolicySpec{
@@ -368,7 +368,7 @@ func createAllowAllEgressNetworkPolicy() *networkingv1.NetworkPolicy {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      allowAllNPProxyName,
 			Namespace: tests.InstallNamespace,
-			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIProxy),
+			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIProxy),
 		},
 
 		Spec: networkingv1.NetworkPolicySpec{

--- a/tests/func-tests/network_policy_test.go
+++ b/tests/func-tests/network_policy_test.go
@@ -338,7 +338,7 @@ func createAllowAllIngressNetworkPolicy() *networkingv1.NetworkPolicy {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      allowAllNPPluginName,
 			Namespace: tests.InstallNamespace,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIPlugin),
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIPlugin),
 		},
 
 		Spec: networkingv1.NetworkPolicySpec{

--- a/tests/func-tests/network_policy_test.go
+++ b/tests/func-tests/network_policy_test.go
@@ -368,7 +368,7 @@ func createAllowAllEgressNetworkPolicy() *networkingv1.NetworkPolicy {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      allowAllNPProxyName,
 			Namespace: tests.InstallNamespace,
-			Labels:    operands.GetLabelsDeprecated(hc, hcoutil.AppComponentUIProxy),
+			Labels:    operands.GetLabels(hcoutil.AppComponentUIProxy),
 		},
 
 		Spec: networkingv1.NetworkPolicySpec{

--- a/tools/crd-overlap-validator/crd_overlap_validator.go
+++ b/tools/crd-overlap-validator/crd_overlap_validator.go
@@ -72,7 +72,7 @@ func checkAPIOverlapMap(overlapsMap map[string]sets.Set[string]) error {
 		// WriteString always returns error=nil. no point to check it.
 		_, _ = sb.WriteString("ERROR: Overlapping API Groups were found between different operators.\n")
 		for apiGroup := range overlapsMap {
-			_, _ = sb.WriteString(fmt.Sprintf("The API Group %s is being used by these operators: %s\n", apiGroup, strings.Join(overlapsMap[apiGroup].UnsortedList(), ", ")))
+			_, _ = fmt.Fprintf(&sb, "The API Group %s is being used by these operators: %s\n", apiGroup, strings.Join(overlapsMap[apiGroup].UnsortedList(), ", "))
 		}
 		return errors.New(sb.String())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The current implementation of initializing the operand handlers, sets up many operand handlers only on the first time it can get the HyperConverged CR. This is originally done for handlers that should created dynamically, like quickstart or imagestream handlers. But over time, it got abused and many operand handlers are now created dynamically. 

The main reason for that is the implementation of the `operands.GetLabels()` function, that requires the HyperConverged CR, only for its name; however, the name is hard coded, and no other name is allowed for this CR, so we don't actually need the CR for its name. In other cases, the CR namespace is also required, but this can be fetched from an environment variable, and reading the HyperConverged CR is not actually required in order to get its namespace.

This PR refactors the `NewOperandHandler()` and the `FirstUseInitiation()` functions, so all the handlers are pre-initialized on boot, and only very few once are created on the first read of the HyperConverged CR, when it's really a must.

**Jira Ticket**:
```jira-ticket
None
```

**Release note**:
```release-note
None
```
