### PR TITLE
Add ipStackType to kubevirt-ui-features ConfigMap

### DIFF
--- a/controllers/handlers/aie/configmap.go
+++ b/controllers/handlers/aie/configmap.go
@@ -14,7 +14,7 @@ import (
 func NewAIEWebhookConfigMapHandler(_ logr.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
 	cm := newAIEWebhookConfigMap(hc)
 	return operands.NewConditionalHandler(
-		operands.NewCmHandler(Client, Scheme, cm),
+		operands.NewEditableCmHandler(Client, Scheme, cm),
 		shouldDeployAIE,
 		func(hc *hcov1beta1.HyperConverged) client.Object {
 			return newAIEWebhookConfigMapWithNameOnly(hc)

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/ipstacktype"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -116,12 +117,12 @@ func NewKvUINginxCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.S
 
 // **** UI user settings config map Handler ****
 func NewKvUIUserSettingsCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewCmHandler(Client, Scheme, NewKvUIUserSettingsCM(hc)), nil
+	return operands.NewEditableCmHandler(Client, Scheme, NewKvUIUserSettingsCM(hc)), nil
 }
 
 // **** UI features config map Handler ****
 func NewKvUIFeaturesCMHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	return operands.NewCmHandler(Client, Scheme, NewKvUIFeaturesCM(hc)), nil
+	return operands.NewEditableCmHandler(Client, Scheme, NewKvUIFeaturesCM(hc), "ipStackType"), nil
 }
 
 // **** Kubevirt UI Console Plugin Custom Resource Handler ****
@@ -440,13 +441,15 @@ var UIFeaturesConfig = map[string]string{
 }
 
 func NewKvUIFeaturesCM(hc *hcov1beta1.HyperConverged) *corev1.ConfigMap {
+	data := maps.Clone(UIFeaturesConfig)
+	data["ipStackType"] = ipstacktype.Get()
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIFeaturesCMName,
 			Labels:    operands.GetLabels(hc, hcoutil.AppComponentUIConfig),
 			Namespace: hc.Namespace,
 		},
-		Data: UIFeaturesConfig,
+		Data: data,
 	}
 }
 

--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -476,7 +476,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("should not reconcile UI settings config map data", func(appComponent hcoutil.AppComponent,
-				cmManifestor func(*hcov1beta1.HyperConverged) *v1.ConfigMap, handlerFunc operands.GetHandler) {
+				cmManifestor func(*hcov1beta1.HyperConverged) *v1.ConfigMap, handlerFunc operands.GetHandler, managedKeys []string) {
 				const userAddedDataKey = "userAddedDataKey"
 				const userAddedDataValue = "userAddedDataValue"
 
@@ -487,6 +487,11 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 					outdatedResource.Data[k] = "modified_" + v
 				}
 				outdatedResource.Data[userAddedDataKey] = userAddedDataValue
+
+				managedSet := make(map[string]bool, len(managedKeys))
+				for _, k := range managedKeys {
+					managedSet[k] = true
+				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
 				handler, err := handlerFunc(testLogger, cl, commontestutils.GetScheme(), hco)
@@ -504,12 +509,16 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				).To(Succeed())
 				Expect(foundResource.Name).To(Equal(outdatedResource.Name))
 				for k, v := range modifiedData {
-					Expect(foundResource.Data).ToNot(HaveKeyWithValue(k, v))
+					if managedSet[k] {
+						Expect(foundResource.Data).To(HaveKeyWithValue(k, v))
+					} else {
+						Expect(foundResource.Data).ToNot(HaveKeyWithValue(k, v))
+					}
 				}
 				Expect(foundResource.Data).To(HaveKeyWithValue(userAddedDataKey, userAddedDataValue))
 			},
-				Entry("user settings config", hcoutil.AppComponentUIConfig, NewKvUIUserSettingsCM, NewKvUIUserSettingsCMHandler),
-				Entry("UI features config", hcoutil.AppComponentUIConfig, NewKvUIFeaturesCM, NewKvUIFeaturesCMHandler),
+				Entry("user settings config", hcoutil.AppComponentUIConfig, NewKvUIUserSettingsCM, NewKvUIUserSettingsCMHandler, []string(nil)),
+				Entry("UI features config", hcoutil.AppComponentUIConfig, NewKvUIFeaturesCM, NewKvUIFeaturesCMHandler, []string{"ipStackType"}),
 			)
 		})
 

--- a/controllers/operands/cmHandler.go
+++ b/controllers/operands/cmHandler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"maps"
 	"reflect"
+	"slices"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +20,10 @@ func NewCmHandler(Client client.Client, Scheme *runtime.Scheme, required *corev1
 	return NewGenericOperand(Client, Scheme, "ConfigMap", &cmHooks{required: required}, false)
 }
 
+func NewEditableCmHandler(Client client.Client, Scheme *runtime.Scheme, required *corev1.ConfigMap, managedKeys ...string) *GenericOperand {
+	return NewGenericOperand(Client, Scheme, "ConfigMap", &cmHooks{required: required, editable: true, managedKeys: managedKeys}, false)
+}
+
 type newDynamicConfigMapFunc func(*hcov1beta1.HyperConverged) (*corev1.ConfigMap, error)
 
 func NewDynamicCmHandler(Client client.Client, Scheme *runtime.Scheme, makeCM newDynamicConfigMapFunc) *GenericOperand {
@@ -26,7 +31,9 @@ func NewDynamicCmHandler(Client client.Client, Scheme *runtime.Scheme, makeCM ne
 }
 
 type cmHooks struct {
-	required *corev1.ConfigMap
+	required    *corev1.ConfigMap
+	editable    bool
+	managedKeys []string
 }
 
 func (h cmHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
@@ -49,16 +56,8 @@ func (h cmHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exists r
 		util.MergeLabels(&h.required.ObjectMeta, &found.ObjectMeta)
 	}
 
-	// Don't reconcile contents of UI settings or AIE webhook config maps
-	if label, exist := found.Labels[util.AppLabelComponent]; exist &&
-		(label == string(util.AppComponentUIConfig) || label == string(util.AppComponentAIEWebhook)) {
-		if labelChanged {
-			err := Client.Update(req.Ctx, found)
-			if err != nil {
-				return false, false, err
-			}
-		}
-		return labelChanged, false, nil
+	if h.editable {
+		return h.reconcileUserEditableCM(req, Client, found, labelChanged)
 	}
 
 	if !reflect.DeepEqual(found.Data, h.required.Data) || labelChanged {
@@ -76,6 +75,29 @@ func (h cmHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exists r
 	}
 
 	return labelChanged, false, nil
+}
+
+// reconcileUserEditableCM seeds any missing keys from the required data and
+// always reconciles keys explicitly listed as operator-managed, without
+// overwriting other user-modified values.
+func (h cmHooks) reconcileUserEditableCM(req *common.HcoRequest, Client client.Client, found *corev1.ConfigMap, labelChanged bool) (bool, bool, error) {
+	dataChanged := false
+	if found.Data == nil {
+		found.Data = make(map[string]string)
+	}
+	for k, v := range h.required.Data {
+		if foundVal, exists := found.Data[k]; !exists || (slices.Contains(h.managedKeys, k) && foundVal != v) {
+			found.Data[k] = v
+			dataChanged = true
+		}
+	}
+	if labelChanged || dataChanged {
+		err := Client.Update(req.Ctx, found)
+		if err != nil {
+			return false, false, err
+		}
+	}
+	return labelChanged || dataChanged, false, nil
 }
 
 type dynamicCmHooks struct {

--- a/pkg/internal/ipstacktype/ipstacktype.go
+++ b/pkg/internal/ipstacktype/ipstacktype.go
@@ -1,0 +1,47 @@
+package ipstacktype
+
+import (
+	"sync/atomic"
+
+	openshiftconfigv1 "github.com/openshift/api/config/v1"
+	"k8s.io/utils/net"
+)
+
+const (
+	IPv4SingleStack = "IPv4SingleStack"
+	IPv6SingleStack = "IPv6SingleStack"
+	DualStack       = "DualStack"
+)
+
+var value atomic.Value
+
+func Set(v string) {
+	value.Store(v)
+}
+
+func Get() string {
+	if v := value.Load(); v != nil {
+		return v.(string)
+	}
+	return IPv4SingleStack
+}
+
+func Compute(clusterNetworks []openshiftconfigv1.ClusterNetworkEntry) string {
+	hasIPv4, hasIPv6 := false, false
+	for _, n := range clusterNetworks {
+		if net.IsIPv4CIDRString(n.CIDR) {
+			hasIPv4 = true
+		}
+		if net.IsIPv6CIDRString(n.CIDR) {
+			hasIPv6 = true
+		}
+	}
+	switch {
+	case hasIPv4 && hasIPv6:
+		return DualStack
+	case hasIPv6:
+		return IPv6SingleStack
+	default:
+		return IPv4SingleStack
+	}
+}

--- a/pkg/internal/ipstacktype/ipstacktype_test.go
+++ b/pkg/internal/ipstacktype/ipstacktype_test.go
@@ -1,0 +1,41 @@
+package ipstacktype
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	openshiftconfigv1 "github.com/openshift/api/config/v1"
+)
+
+func TestIPStackType(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "IP Stack Type Suite")
+}
+
+var _ = Describe("IP Stack Type", func() {
+	DescribeTable("Compute should detect the correct stack type",
+		func(entries []openshiftconfigv1.ClusterNetworkEntry, expected string) {
+			Expect(Compute(entries)).To(Equal(expected))
+		},
+		Entry("IPv4 only", []openshiftconfigv1.ClusterNetworkEntry{
+			{CIDR: "10.128.0.0/14"},
+		}, IPv4SingleStack),
+		Entry("IPv6 only", []openshiftconfigv1.ClusterNetworkEntry{
+			{CIDR: "fd01::/48"},
+		}, IPv6SingleStack),
+		Entry("dual stack", []openshiftconfigv1.ClusterNetworkEntry{
+			{CIDR: "10.128.0.0/14"},
+			{CIDR: "fd01::/48"},
+		}, DualStack),
+		Entry("empty cluster network", []openshiftconfigv1.ClusterNetworkEntry{}, IPv4SingleStack),
+	)
+
+	It("should store and retrieve values", func() {
+		Set(DualStack)
+		Expect(Get()).To(Equal(DualStack))
+
+		Set(IPv6SingleStack)
+		Expect(Get()).To(Equal(IPv6SingleStack))
+	})
+})

--- a/pkg/ipstacktype/ipstacktype.go
+++ b/pkg/ipstacktype/ipstacktype.go
@@ -1,0 +1,15 @@
+package ipstacktype
+
+import internal "github.com/kubevirt/hyperconverged-cluster-operator/pkg/internal/ipstacktype"
+
+const (
+	IPv4SingleStack = internal.IPv4SingleStack
+	IPv6SingleStack = internal.IPv6SingleStack
+	DualStack       = internal.DualStack
+)
+
+var (
+	Set     = internal.Set
+	Get     = internal.Get
+	Compute = internal.Compute
+)

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/utils/net"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/ipstacktype"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/metrics"
 )
 
@@ -141,6 +142,11 @@ func (c *ClusterInfoImp) initOpenshift(ctx context.Context, cl client.Client) er
 		)
 	}
 	c.singlestackipv6 = len(cn) == 1 && net.IsIPv6CIDRString(cn[0].CIDR)
+
+	stackType := ipstacktype.Compute(cn)
+	ipstacktype.Set(stackType)
+	c.logger.Info("Detected IP stack type", "ipStackType", stackType)
+
 	return nil
 }
 

--- a/pkg/util/cluster_test.go
+++ b/pkg/util/cluster_test.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/ipstacktype"
 )
 
 var _ = Describe("test clusterInfo", func() {
@@ -367,6 +369,7 @@ var _ = Describe("test clusterInfo", func() {
 
 		Expect(GetClusterInfo().IsOpenshift()).To(BeTrue(), "should return true for IsOpenshift()")
 		Expect(GetClusterInfo().IsManagedByOLM()).To(BeFalse(), "should return false for IsManagedByOLM()")
+		Expect(ipstacktype.Get()).To(Equal(ipstacktype.IPv4SingleStack))
 	})
 
 	It("check init on OpenShift, with single-stack IPv6 network", func() {
@@ -379,6 +382,7 @@ var _ = Describe("test clusterInfo", func() {
 
 		Expect(GetClusterInfo().IsOpenshift()).To(BeTrue())
 		Expect(GetClusterInfo().IsSingleStackIPv6()).To(BeTrue())
+		Expect(ipstacktype.Get()).To(Equal(ipstacktype.IPv6SingleStack))
 	})
 
 	It("checks init on OpenShift with dual stack ipv4/ipv6 network configuration", func() {
@@ -391,6 +395,7 @@ var _ = Describe("test clusterInfo", func() {
 
 		Expect(GetClusterInfo().IsOpenshift()).To(BeTrue())
 		Expect(GetClusterInfo().IsSingleStackIPv6()).To(BeFalse())
+		Expect(ipstacktype.Get()).To(Equal(ipstacktype.DualStack))
 	})
 
 	Context("HyperShift Detection", func() {


### PR DESCRIPTION
Detect the cluster IP stack type (`IPv4SingleStack`, `IPv6SingleStack`, or `DualStack`) at operator startup by examining the clusterNetwork CIDRs from the `network.config.openshift.io/cluster` status, and include it as the `ipStackType` key in the `kubevirt-ui-features` ConfigMap.


Signed-off-by: Oren Cohen <ocohen@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-79245
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ipStackType to kubevirt-ui-features ConfigMap
```
