### PR TITLE
fix: remove non-FIPS TLS curves from nginx ssl_ecdh_curve

### DIFF
--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -534,7 +534,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(nginxConf).To(ContainSubstring("listen"))
 				Expect(nginxConf).To(ContainSubstring("ssl_protocols"))
 				Expect(nginxConf).To(ContainSubstring("ssl_ciphers"))
-				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_protocols ;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
 			})
@@ -550,7 +550,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(cm.Data).To(HaveKey("nginx.conf"))
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).To(MatchRegexp(`ssl_protocols +TLSv1\.3`))
-				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
 			})
 
@@ -566,7 +566,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).To(ContainSubstring("ssl_protocols"))
 				Expect(nginxConf).To(ContainSubstring("ssl_ciphers"))
-				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_protocols ;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
 			})
@@ -588,7 +588,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(cm.Data).To(HaveKey("nginx.conf"))
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).To(MatchRegexp(`ssl_protocols +TLSv1\.3`))
-				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers"))
 			})
 
@@ -599,7 +599,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_protocols ;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
-				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;"))
 			})
 		})
 

--- a/controllers/handlers/templates/nginx.conf.tmpl
+++ b/controllers/handlers/templates/nginx.conf.tmpl
@@ -17,7 +17,7 @@ http {
 {{- if .SSLCiphers }}
 			ssl_ciphers         {{ .SSLCiphers }};
 {{- end }}
-			ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;
+			ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;
 			root                /usr/share/nginx/html;
 
 			# Prevent caching for plugin-manifest.json and plugin-entry.js


### PR DESCRIPTION
The console plugin nginx crashes on FIPS-enabled clusters because `X25519MLKEM768` and `X25519` are not available in the FIPS OpenSSL provider. Remove these curves and replace `prime256v1` with its canonical name `secp256r1` so the configuration works on both FIPS and non-FIPS clusters.

The practical security impact is negligible for this use case. Here's why:

What was removed:

X25519MLKEM768 -- hybrid post-quantum key exchange (X25519 + ML-KEM-768)
X25519 -- Curve25519-based ECDH
What remains:

SecP256r1MLKEM768 -- hybrid post-quantum (P-256 + ML-KEM-768)
SecP384r1MLKEM1024 -- hybrid post-quantum (P-384 + ML-KEM-1024)
secp256r1 (P-256) -- ~128-bit classical security
secp384r1 (P-384) -- ~192-bit classical security
Post-quantum protection is preserved. The two remaining MLKEM hybrids provide the same post-quantum resistance. The only difference is the classical ECDH component underneath (P-256/P-384 instead of X25519).

Classical key exchange is still strong. X25519 and P-256 both provide ~128-bit security. X25519 is often preferred because its simpler design makes constant-time implementation easier, reducing the risk of side-channel attacks. However, OpenSSL's P-256 implementation is well-hardened, and P-384 is actually stronger at ~192 bits.

No client compatibility concern. This nginx serves the console plugin UI to the OpenShift console, which supports P-256/P-384. Every modern TLS client does -- X25519-only clients essentially don't exist in practice.

In short: we lose X25519 as a key exchange option, but the remaining NIST curves are equally secure for practical purposes, post-quantum protection is still in place, and the only real-world client (the OpenShift console) fully supports the remaining curves. There is no meaningful reduction in security posture.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-82451
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
