### PR TITLE
CNV-82451: Tighten kubevirt console plugin nginx ssl_ecdh_curve

### DIFF
--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -534,7 +534,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(nginxConf).To(ContainSubstring("listen"))
 				Expect(nginxConf).To(ContainSubstring("ssl_protocols"))
 				Expect(nginxConf).To(ContainSubstring("ssl_ciphers"))
-				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_protocols ;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
 			})
@@ -550,7 +550,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(cm.Data).To(HaveKey("nginx.conf"))
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).To(MatchRegexp(`ssl_protocols +TLSv1\.3`))
-				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
 			})
 
@@ -566,7 +566,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).To(ContainSubstring("ssl_protocols"))
 				Expect(nginxConf).To(ContainSubstring("ssl_ciphers"))
-				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_protocols ;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
 			})
@@ -588,7 +588,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(cm.Data).To(HaveKey("nginx.conf"))
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).To(MatchRegexp(`ssl_protocols +TLSv1\.3`))
-				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers"))
 			})
 
@@ -599,7 +599,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				nginxConf := cm.Data["nginx.conf"]
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_protocols ;"))
 				Expect(nginxConf).NotTo(ContainSubstring("ssl_ciphers ;"))
-				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;"))
+				Expect(nginxConf).To(ContainSubstring("ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;"))
 			})
 		})
 

--- a/controllers/handlers/templates/nginx.conf.tmpl
+++ b/controllers/handlers/templates/nginx.conf.tmpl
@@ -17,7 +17,7 @@ http {
 {{- if .SSLCiphers }}
 			ssl_ciphers         {{ .SSLCiphers }};
 {{- end }}
-			ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;
+			ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;
 			root                /usr/share/nginx/html;
 
 			# Prevent caching for plugin-manifest.json and plugin-entry.js


### PR DESCRIPTION
**What this PR does / why we need it**

Narrows the `ssl_ecdh_curve` directive in the nginx configuration we render for the KubeVirt console plugin (`nginx-conf` ConfigMap) to:

`SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1`

instead of the previous broader hybrid / X25519 list. Tracks [CNV-82451](https://redhat.atlassian.net/browse/CNV-82451).

**How to test**

`go test ./controllers/handlers/ -ginkgo.focus="KubeVirt UI Nginx"`

**Reviewer Checklist**

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-82451
```

**Release note**:
```release-note
Console plugin nginx TLS now uses ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1.
```
