### PR TITLE
Fix iommufd-device-plugin SCC to allow projected volumes

### DIFF
--- a/controllers/handlers/aie/device_plugin_scc.go
+++ b/controllers/handlers/aie/device_plugin_scc.go
@@ -63,6 +63,7 @@ func newIOMMUFDDevicePluginSCC(hc *hcov1beta1.HyperConverged) *securityv1.Securi
 	}
 	scc.Volumes = []securityv1.FSType{
 		securityv1.FSTypeHostPath,
+		securityv1.FSProjected,
 	}
 	scc.AllowedCapabilities = []corev1.Capability{}
 

--- a/controllers/handlers/aie/device_plugin_scc_test.go
+++ b/controllers/handlers/aie/device_plugin_scc_test.go
@@ -52,6 +52,7 @@ var _ = Describe("IOMMUFD Device Plugin SecurityContextConstraints", func() {
 			Expect(scc.Users).To(ContainElement(expectedUser))
 
 			Expect(scc.Volumes).To(ContainElement(securityv1.FSTypeHostPath))
+			Expect(scc.Volumes).To(ContainElement(securityv1.FSProjected))
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The iommufd-device-plugin SCC only allowed `hostPath` volumes but Kubernetes automatically injects a `projected` volume for the service account token mount. This caused DaemonSet pod creation to fail with:

```
provider iommufd-device-plugin: .spec.volumes[3]: Invalid value: "projected": projected volumes are not allowed to be used
```

Adds `securityv1.FSProjected` to the allowed volume types in the SCC definition.

Introduced in #4141.

**Reviewer Checklist**

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [x] PR Message
- [x] Commit Messages
- [x] How to test
- [x] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [x] Backward Compatibility
- [x] Troubleshooting Friendly

**Jira Ticket**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-84553
```

**Release note**:
```release-note
Fix iommufd-device-plugin SCC to allow projected volumes for service account token mounts
```