### PR TITLE
Align docs around completionTimeoutPerGiB

### DIFF
--- a/docs/cluster-configuration-v1-api.md
+++ b/docs/cluster-configuration-v1-api.md
@@ -266,7 +266,7 @@ higher completionTimeoutPerGiB to let workload with spikes in its memory dirty
 rate to converge.
 The format is a number.
 
-**default**: 800
+**default**: 150
 
 #### parallelMigrationsPerCluster
 
@@ -320,7 +320,7 @@ metadata:
 spec:
   virtualization:
     liveMigrationConfig:
-      completionTimeoutPerGiB: 800
+      completionTimeoutPerGiB: 150
       network: migration-network
       parallelMigrationsPerCluster: 5
       parallelOutboundMigrationsPerNode: 2

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -334,7 +334,7 @@ higher completionTimeoutPerGiB to let workload with spikes in its memory dirty
 rate to converge.
 The format is a number.
 
-**default**: 800
+**default**: 150
 
 ### parallelMigrationsPerCluster
 
@@ -387,7 +387,7 @@ metadata:
   name: kubevirt-hyperconverged
 spec:
   liveMigrationConfig:
-    completionTimeoutPerGiB: 800
+    completionTimeoutPerGiB: 150
     network: migration-network
     parallelMigrationsPerCluster: 5
     parallelOutboundMigrationsPerNode: 2


### PR DESCRIPTION
**What this PR does / why we need it**:
The default value for completionTimeoutPerGiB got amended to 150 with https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3195

Align also the documentation.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [X] PR Message
- [X] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [X] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
