### PR TITLE
handler, kv: Enable PCINUMAAwareTopology FG when deployAIE annotation is set

### DIFF
--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -30,6 +30,7 @@ import (
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/aie"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/passt"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
@@ -169,6 +170,7 @@ const (
 	kvConfigurableHypervisor     = "ConfigurableHypervisor"
 	kvOptOutRoleAggregation      = "OptOutRoleAggregation"
 	kvContainerPathVolumes       = "ContainerPathVolumes"
+	kvPCINUMAAwareTopology       = "PCINUMAAwareTopology"
 )
 
 // CPU Plugin default values
@@ -951,6 +953,10 @@ func getFeatureGateChecks(spec hcov1beta1.HyperConvergedSpec, annotations map[st
 
 	if annotations[passt.DeployPasstNetworkBindingAnnotation] == "true" {
 		fgs = append(fgs, kvPasstBinding)
+	}
+
+	if annotations[aie.DeployAIEAnnotation] == "true" {
+		fgs = append(fgs, kvPCINUMAAwareTopology)
 	}
 
 	if slices.Contains(nodeinfo.GetWorkloadsArchitectures(), nodeinfo.S390X) {

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -28,6 +28,7 @@ import (
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/aie"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/passt"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -2169,6 +2170,25 @@ Version: 1.2.3`)
 							Expect(kv.Spec.Configuration.NetworkConfiguration).NotTo(BeNil())
 							Expect(kv.Spec.Configuration.NetworkConfiguration.Binding).ToNot(HaveKey(passt.BindingName))
 						},
+					),
+					// PCINUMAAwareTopology
+					Entry("should add the PCINUMAAwareTopology FG to KubeVirt CR if deployAIE annotation is true",
+						func(hc *hcov1beta1.HyperConverged) {
+							hc.Annotations[aie.DeployAIEAnnotation] = "true"
+						},
+						ContainElement(kvPCINUMAAwareTopology),
+					),
+					Entry("should not add the PCINUMAAwareTopology FG to KubeVirt CR if deployAIE annotation is false",
+						func(hc *hcov1beta1.HyperConverged) {
+							hc.Annotations[aie.DeployAIEAnnotation] = "false"
+						},
+						Not(ContainElement(kvPCINUMAAwareTopology)),
+					),
+					Entry("should not add the PCINUMAAwareTopology FG to KubeVirt CR if deployAIE annotation is not set",
+						func(hc *hcov1beta1.HyperConverged) {
+							delete(hc.Annotations, aie.DeployAIEAnnotation)
+						},
+						Not(ContainElement(kvPCINUMAAwareTopology)),
 					),
 					Entry("should add the DeclarativeHotplugVolumes feature gate if DeclarativeHotplugVolumes is true in HyperConverged CR",
 						func(hc *hcov1beta1.HyperConverged) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable the KubeVirt `PCINUMAAwareTopology` feature gate when the `deployAIE` annotation is present on the HyperConverged CR. This allows NUMA-aware scheduling for PCI devices while the feature gate remains in alpha upstream.

As `PCINUMAAwareTopology` is still an alpha feature gate in KubeVirt it is not exposed directly in the HCO CR. Instead it is gated behind the existing `deployAIE` annotation until it graduates to beta upstream, at which point it can be added as a proper HCO feature gate field.

**Reviewer Checklist**

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-85392
```

**Release note**:
```release-note
Enable the KubeVirt PCINUMAAwareTopology feature gate when the deployAIE annotation is set on the HyperConverged CR
```