### PR TITLE
wasp-agent: skip WASP deployment when autopilot full opt-in annotation is set

### DIFF
--- a/controllers/handlers/wasp-agent/daemonset.go
+++ b/controllers/handlers/wasp-agent/daemonset.go
@@ -28,8 +28,9 @@ const (
 	waspAgentSCCName            = "wasp"
 	NoOverCommitPercentage      = 100
 
-	AutopilotSwapAnnotation      = "platform.kubevirt.io/autopilot"
-	AutopilotSwapAnnotationValue = "swap-enable"
+	AutopilotSwapAnnotation           = "platform.kubevirt.io/autopilot"
+	AutopilotSwapAnnotationValue      = "swap-enable"
+	AutopilotFullOptInAnnotationValue = "true"
 )
 
 var (
@@ -184,7 +185,8 @@ func createDaemonSetEnvVar() []corev1.EnvVar {
 }
 
 func shouldDeployWaspAgent(hc *hcov1beta1.HyperConverged) bool {
-	if hc.Annotations[AutopilotSwapAnnotation] == AutopilotSwapAnnotationValue {
+	autopilot := hc.Annotations[AutopilotSwapAnnotation]
+	if autopilot == AutopilotSwapAnnotationValue || autopilot == AutopilotFullOptInAnnotationValue {
 		return false
 	}
 

--- a/controllers/handlers/wasp-agent/daemonset_test.go
+++ b/controllers/handlers/wasp-agent/daemonset_test.go
@@ -115,6 +115,50 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 			Expect(foundDs.Items).To(BeEmpty())
 		})
 
+		It("should not create DaemonSet when autopilot full opt-in annotation is set even with overcommit > 100", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			hco.Annotations[AutopilotSwapAnnotation] = AutopilotFullOptInAnnotationValue
+			ds = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewWaspAgentDaemonSetHandler(ds, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundDs := &appsv1.DaemonSetList{}
+			Expect(ds.List(context.Background(), foundDs)).To(Succeed())
+			Expect(foundDs.Items).To(BeEmpty())
+		})
+
+		It("should delete DaemonSet when autopilot full opt-in annotation is added", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			existingDs := newWaspAgentDaemonSet(hco)
+			hco.Annotations[AutopilotSwapAnnotation] = AutopilotFullOptInAnnotationValue
+			ds = commontestutils.InitClient([]client.Object{hco, existingDs})
+
+			handler := NewWaspAgentDaemonSetHandler(ds, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal(existingDs.Name))
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeTrue())
+
+			foundDs := &appsv1.DaemonSetList{}
+			Expect(ds.List(context.Background(), foundDs)).To(Succeed())
+			Expect(foundDs.Items).To(BeEmpty())
+		})
+
 		It("should delete DaemonSet when autopilot swap annotation is added", func() {
 			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,


### PR DESCRIPTION
**What this PR does / why we need it**:
virt-platform autopilot enables swap not only for `platform.kubevirt.io/autopilot=swap-enable` but also for `platform.kubevirt.io/autopilot=true` (full opt-in), so WASP must not be deployed in that case either.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [X] PR Message
- [X] Commit Messages
- [ ] How to test
- [X] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-85525
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
