### PR TITLE
tests: tolerate missing swap MachineConfig in wasp-agent cleanup

### DIFF
--- a/tests/func-tests/wasp_agent_test.go
+++ b/tests/func-tests/wasp_agent_test.go
@@ -380,7 +380,11 @@ func deleteSwapMachineConfig(ctx context.Context, cli client.Client) {
 	})
 	mc.SetName(swapMachineConfig)
 
-	Expect(cli.Get(ctx, client.ObjectKeyFromObject(mc), mc)).To(Succeed(), "expected MachineConfig %q to exist before deletion", swapMachineConfig)
+	err := cli.Get(ctx, client.ObjectKeyFromObject(mc), mc)
+	if k8serrors.IsNotFound(err) {
+		return
+	}
+	Expect(err).ToNot(HaveOccurred(), "unexpected error getting MachineConfig %q", swapMachineConfig)
 
 	Eventually(func(ctx context.Context) error {
 		err := cli.Delete(ctx, mc)


### PR DESCRIPTION
The `AfterAll` cleanup unconditionally asserted that the `90-worker-swap-online` MachineConfig exists before deleting it. This MachineConfig is created asynchronously by wasp-agent pods, not by HCO. When DESTRUCTIVE tests are filtered out (e.g. downstream T1), only the first It block runs, leaving wasp-agent pods insufficient time to create the MachineConfig before AfterAll fires.

Skip deletion when the MachineConfig is not found instead of failing.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
