### PR TITLE
wasp-agent: handle comma-separated autopilot annotation values

### DIFF
--- a/controllers/handlers/wasp-agent/daemonset.go
+++ b/controllers/handlers/wasp-agent/daemonset.go
@@ -3,6 +3,7 @@ package wasp_agent
 import (
 	"maps"
 	"os"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -185,9 +186,14 @@ func createDaemonSetEnvVar() []corev1.EnvVar {
 }
 
 func shouldDeployWaspAgent(hc *hcov1beta1.HyperConverged) bool {
-	autopilot := hc.Annotations[AutopilotSwapAnnotation]
-	if autopilot == AutopilotSwapAnnotationValue || autopilot == AutopilotFullOptInAnnotationValue {
+	val := strings.TrimSpace(hc.Annotations[AutopilotSwapAnnotation])
+	if val == AutopilotFullOptInAnnotationValue {
 		return false
+	}
+	for _, name := range strings.Split(val, ",") {
+		if strings.TrimSpace(name) == AutopilotSwapAnnotationValue {
+			return false
+		}
 	}
 
 	overcommitPercentage := hc.Spec.HigherWorkloadDensity.MemoryOvercommitPercentage

--- a/controllers/handlers/wasp-agent/daemonset_test.go
+++ b/controllers/handlers/wasp-agent/daemonset_test.go
@@ -181,6 +181,29 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 			Expect(ds.List(context.Background(), foundDs)).To(Succeed())
 			Expect(foundDs.Items).To(BeEmpty())
 		})
+
+		It("should not create DaemonSet when autopilot swap value is embedded in a comma-separated list", func() {
+			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+				MemoryOvercommitPercentage: 150,
+			}
+			// introducing whitespaces to verify the consistency with autopilot implementation
+			hco.Annotations[AutopilotSwapAnnotation] = "test123, " + AutopilotSwapAnnotationValue + " , test456"
+			ds = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewWaspAgentDaemonSetHandler(ds, commontestutils.GetScheme())
+
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
+			Expect(res.Deleted).To(BeFalse())
+
+			foundDs := &appsv1.DaemonSetList{}
+			Expect(ds.List(context.Background(), foundDs)).To(Succeed())
+			Expect(foundDs.Items).To(BeEmpty())
+		})
+
 	})
 	Context("Wasp agent DaemonSet update", func() {
 		It("should update DaemonSet fields if not matched to the requirements", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Parse the autopilot annotation as a comma-separated list (trimming whitespace) to align with ParseAutopilotScope semantics, so values like "test123,swap-enable,test456" correctly suppress WASP deployment.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [X] PR Message
- [X] Commit Messages
- [ ] How to test
- [X] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-85525
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
