### PR TITLE
Fix two bugs

### DIFF
--- a/controllers/admissionpolicy/resources.go
+++ b/controllers/admissionpolicy/resources.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -58,7 +59,7 @@ func getRequiredPolicy(owner *metav1.OwnerReference) *admissionv1.ValidatingAdmi
 							RuleWithOperations: admissionv1.RuleWithOperations{
 								Rule: admissionv1.Rule{
 									APIGroups:   []string{hcov1beta1.APIVersionGroup},
-									APIVersions: []string{hcov1beta1.APIVersionBeta},
+									APIVersions: []string{hcov1.APIVersionV1, hcov1beta1.APIVersionBeta},
 									Resources:   []string{"hyperconvergeds"},
 									Scope:       ptr.To(admissionv1.NamespacedScope),
 								},

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -271,23 +271,23 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo, in
 		if err != nil {
 			return err
 		}
+	}
 
-		err = c.Watch(
-			source.Channel(
-				nodeEventChannel,
-				handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-					// the nodes controller initiate this by pushing an event to the nodeEventChannel channel
-					// This will force this controller to update the status fields related to the cluster nodes, and
-					// to re-generate the DataImportCronTemplates in the SSP CR.
-					log.Info("Reconciling for core.Node")
-					return []reconcile.Request{
-						reqresolver.GetNodeResource(),
-					}
-				}),
-			))
-		if err != nil {
-			return err
-		}
+	err = c.Watch(
+		source.Channel(
+			nodeEventChannel,
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+				// the nodes controller initiate this by pushing an event to the nodeEventChannel channel
+				// This will force this controller to update the status fields related to the cluster nodes, and
+				// to re-generate the DataImportCronTemplates in the SSP CR.
+				log.Info("Reconciling for core.Node")
+				return []reconcile.Request{
+					reqresolver.GetNodeResource(),
+				}
+			}),
+		))
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## What this PR does / why we need it
### Fix bug in the validatingAdmissionPolicy

The validatingAdmissionPolicy that forces the HyperConverged namespace is only checks the v1beta1 HyperConverged, and ignores the v1 one.

This PR fixes it.

### Fix a bug on on watching nodes
The nodes controller is always started, and is using a channel to trigger events in the hyperconverged controller. But the hyperconverged controller only watches this channel if running on openshift, so the full logic does not work in plain kubernetes. It's also blocks the nodes controller, because nothing is reading from the channel.

## Release note
```release-note
Fix bug in the validatingAdmissionPolicy and API v1
Fix a bug on on watching nodes
```
