### PR TITLE
Use API v1 in the nodes controller

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -59,6 +59,7 @@ import (
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/api"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/cmd/cmdcommon"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/admissionpolicy"
@@ -349,6 +350,7 @@ func getCacheOption(operatorNamespace string, ci hcoutil.ClusterInfo, persesAvai
 
 	cacheOptions := cache.Options{
 		ByObject: map[client.Object]cache.ByObject{
+			&hcov1.HyperConverged{}:                {},
 			&hcov1beta1.HyperConverged{}:           {},
 			&kubevirtcorev1.KubeVirt{}:             {},
 			&cdiv1beta1.CDI{}:                      {},

--- a/controllers/commontestutils/testUtils.go
+++ b/controllers/commontestutils/testUtils.go
@@ -44,6 +44,7 @@ import (
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/api"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
@@ -67,8 +68,16 @@ var (
 	}
 )
 
-func NewHco() *hcov1beta1.HyperConverged {
+var NewHco = NewHcoV1beta1
+
+func NewHcoV1beta1() *hcov1beta1.HyperConverged {
 	hco := components.GetOperatorCR()
+	hco.Namespace = Namespace
+	return hco
+}
+
+func NewHcoV1() *hcov1.HyperConverged {
+	hco := components.GetOperatorV1CR()
 	hco.Namespace = Namespace
 	return hco
 }

--- a/controllers/nodes/nodes_controller.go
+++ b/controllers/nodes/nodes_controller.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -162,9 +162,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	return c.Watch(
-		source.Kind[*hcov1beta1.HyperConverged](
-			mgr.GetCache(), &hcov1beta1.HyperConverged{},
-			&handler.TypedEnqueueRequestForObject[*hcov1beta1.HyperConverged]{},
+		source.Kind[*hcov1.HyperConverged](
+			mgr.GetCache(), &hcov1.HyperConverged{},
+			&handler.TypedEnqueueRequestForObject[*hcov1.HyperConverged]{},
 			hyperconvergedPredicate{},
 		))
 }
@@ -223,8 +223,8 @@ func (r *ReconcileNodeCounter) Reconcile(ctx context.Context, req reconcile.Requ
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileNodeCounter) readHyperConverged(ctx context.Context) (*hcov1beta1.HyperConverged, error) {
-	hc := &hcov1beta1.HyperConverged{}
+func (r *ReconcileNodeCounter) readHyperConverged(ctx context.Context) (*hcov1.HyperConverged, error) {
+	hc := &hcov1.HyperConverged{}
 	hcoKey := k8stypes.NamespacedName{
 		Name:      hcoutil.HyperConvergedName,
 		Namespace: hcoutil.GetOperatorNamespaceFromEnv(),

--- a/controllers/nodes/nodes_controller_test.go
+++ b/controllers/nodes/nodes_controller_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -51,11 +51,11 @@ var _ = Describe("NodesController", func() {
 
 		Context("Node Count Change", func() {
 			It("Should send event if nodeInfo was changed", func() {
-				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
 					return true, nil
 				}
 
-				hco := commontestutils.NewHco()
+				hco := commontestutils.NewHcoV1()
 				resources := []client.Object{hco}
 				cl := commontestutils.InitClient(resources)
 
@@ -73,7 +73,7 @@ var _ = Describe("NodesController", func() {
 			})
 
 			It("Should not send event if nodeInfo was changed, but there is no HC CR", func() {
-				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
 					return true, nil
 				}
 
@@ -93,11 +93,11 @@ var _ = Describe("NodesController", func() {
 			})
 
 			It("Should not send event if nodeInfo was not changed", func() {
-				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
 					return false, nil
 				}
 
-				hco := commontestutils.NewHco()
+				hco := commontestutils.NewHcoV1()
 				resources := []client.Object{hco}
 				cl := commontestutils.InitClient(resources)
 
@@ -115,11 +115,11 @@ var _ = Describe("NodesController", func() {
 			})
 
 			It("Should return error is failed to handle nodeInfo", func() {
-				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
 					return false, errors.New("fake error")
 				}
 
-				hco := commontestutils.NewHco()
+				hco := commontestutils.NewHcoV1()
 				resources := []client.Object{hco}
 				cl := commontestutils.InitClient(resources)
 
@@ -148,7 +148,7 @@ var _ = Describe("NodesController", func() {
 					},
 				}
 
-				hco := commontestutils.NewHco()
+				hco := commontestutils.NewHcoV1()
 				resources := []client.Object{hco, workerNode}
 				cl := commontestutils.InitClient(resources)
 
@@ -158,7 +158,7 @@ var _ = Describe("NodesController", func() {
 					HandleHyperShiftNodeLabeling: HandleHyperShiftNodeLabeling,
 				}
 
-				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
 					return false, nil
 				}
 
@@ -192,7 +192,7 @@ var _ = Describe("NodesController", func() {
 					},
 				}
 
-				hco := commontestutils.NewHco()
+				hco := commontestutils.NewHcoV1()
 				resources := []client.Object{hco, cpNode}
 				cl := commontestutils.InitClient(resources)
 
@@ -202,7 +202,7 @@ var _ = Describe("NodesController", func() {
 					HandleHyperShiftNodeLabeling: HandleHyperShiftNodeLabeling,
 				}
 
-				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
 					return false, nil
 				}
 
@@ -233,7 +233,7 @@ var _ = Describe("NodesController", func() {
 					},
 				}
 
-				hco := commontestutils.NewHco()
+				hco := commontestutils.NewHcoV1()
 				resources := []client.Object{hco, workerNode}
 				cl := commontestutils.InitClient(resources)
 
@@ -243,7 +243,7 @@ var _ = Describe("NodesController", func() {
 					HandleHyperShiftNodeLabeling: staleHyperShiftNodeLabeling,
 				}
 
-				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
 					return false, nil
 				}
 
@@ -265,7 +265,7 @@ var _ = Describe("NodesController", func() {
 			})
 
 			It("Should handle missing node gracefully", func() {
-				hco := commontestutils.NewHco()
+				hco := commontestutils.NewHcoV1()
 				resources := []client.Object{hco}
 				cl := commontestutils.InitClient(resources)
 
@@ -275,7 +275,7 @@ var _ = Describe("NodesController", func() {
 					HandleHyperShiftNodeLabeling: HandleHyperShiftNodeLabeling,
 				}
 
-				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
 					return false, nil
 				}
 
@@ -301,7 +301,7 @@ var _ = Describe("NodesController", func() {
 					},
 				}
 
-				hco := commontestutils.NewHco()
+				hco := commontestutils.NewHcoV1()
 				resources := []client.Object{hco, workerNode}
 				cl := commontestutils.InitClient(resources)
 
@@ -310,7 +310,7 @@ var _ = Describe("NodesController", func() {
 					nodeEvents: nodeEvents,
 				}
 
-				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1beta1.HyperConverged, _ logr.Logger) (bool, error) {
+				nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
 					return false, nil
 				}
 

--- a/controllers/nodes/predicates.go
+++ b/controllers/nodes/predicates.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 )
 
 // Custom predicate to detect changes in node count
@@ -32,32 +32,37 @@ func (nodeCountChangePredicate) Generic(_ event.TypedGenericEvent[*corev1.Node])
 	return false
 }
 
-type hyperconvergedPredicate predicate.TypedFuncs[*v1beta1.HyperConverged]
+type hyperconvergedPredicate predicate.TypedFuncs[*hcov1.HyperConverged]
 
-func (hyperconvergedPredicate) Create(_ event.TypedCreateEvent[*v1beta1.HyperConverged]) bool {
+func (hyperconvergedPredicate) Create(_ event.TypedCreateEvent[*hcov1.HyperConverged]) bool {
 	// HyperConverged CR is created, we want to reconcile
 	return true
 }
 
-func (hyperconvergedPredicate) Update(e event.TypedUpdateEvent[*v1beta1.HyperConverged]) bool {
+func (hyperconvergedPredicate) Update(e event.TypedUpdateEvent[*hcov1.HyperConverged]) bool {
 	// HyperConverged CR is updated
 	if e.ObjectNew.DeletionTimestamp != nil {
 		// If the HyperConverged CR is being deleted, we do not want to reconcile
 		return false
 	}
 
-	if !reflect.DeepEqual(e.ObjectNew.Spec.Workloads, e.ObjectOld.Spec.Workloads) {
-		// If the Workloads spec not changed, we want to reconcile
-		return true
+	newNP := e.ObjectNew.Spec.Deployment.NodePlacements
+	oldNP := e.ObjectOld.Spec.Deployment.NodePlacements
+	newNPExists, oldNPExists := newNP != nil, oldNP != nil
+
+	if newNPExists != oldNPExists {
+		return (newNPExists && newNP.Workload != nil) || (oldNPExists && oldNP.Workload != nil)
+	} else if newNPExists && oldNPExists {
+		return !reflect.DeepEqual(newNP.Workload, oldNP.Workload)
 	}
 
 	return false
 }
 
-func (hyperconvergedPredicate) Delete(_ event.TypedDeleteEvent[*v1beta1.HyperConverged]) bool {
+func (hyperconvergedPredicate) Delete(_ event.TypedDeleteEvent[*hcov1.HyperConverged]) bool {
 	return true
 }
 
-func (hyperconvergedPredicate) Generic(_ event.TypedGenericEvent[*v1beta1.HyperConverged]) bool {
+func (hyperconvergedPredicate) Generic(_ event.TypedGenericEvent[*hcov1.HyperConverged]) bool {
 	return false
 }

--- a/controllers/nodes/predicates_test.go
+++ b/controllers/nodes/predicates_test.go
@@ -1,0 +1,297 @@
+package nodes
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+)
+
+var _ = Describe("test the hyperconvergedPredicate predicate", func() {
+	var predicate *hyperconvergedPredicate
+
+	BeforeEach(func() {
+		predicate = &hyperconvergedPredicate{}
+	})
+
+	DescribeTable("should return false", func(e event.TypedUpdateEvent[*hcov1.HyperConverged]) {
+		Expect(predicate.Update(e)).To(BeFalse())
+	},
+		Entry("when no node placement is defined for workloads no nodePlacements", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{},
+				},
+			},
+		}),
+		Entry("when only new empty NP is defined", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{},
+				},
+			},
+		}),
+		Entry("when only old empty NP is defined", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{},
+					},
+				},
+			},
+		}),
+		Entry("when empty NP is defined in both", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{},
+					},
+				},
+			},
+		}),
+		Entry("when only new Infra NP is defined", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Infra: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{},
+					},
+				},
+			},
+		}),
+		Entry("when only old Infra NP is defined", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Infra: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+		}),
+		Entry("when Infra NP is defined in both", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Infra: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Infra: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+		}),
+		Entry("when same workload NP is defined in both", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+		}),
+		Entry("when modified workload NP is defined in both, but the new is deleted", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewOtherNodePlacement(),
+						},
+					},
+				},
+			},
+		}),
+	)
+
+	DescribeTable("should return true", func(e event.TypedUpdateEvent[*hcov1.HyperConverged]) {
+		Expect(predicate.Update(e)).To(BeTrue())
+	},
+		Entry("when modified workload NP is defined in both", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewOtherNodePlacement(),
+						},
+					},
+				},
+			},
+		}),
+		Entry("when workload NP only defined in new", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{},
+					},
+				},
+			},
+		}),
+		Entry("when workload NP only defined in old", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+		}),
+		Entry("when NP only defined in new", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{},
+				},
+			},
+		}),
+		Entry("when NP only defined in old", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+		}),
+		Entry("when modified workload NP is defined in both, but the only old is deleted [not a real scenario]", event.TypedUpdateEvent[*hcov1.HyperConverged]{
+			ObjectNew: &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewNodePlacement(),
+						},
+					},
+				},
+			},
+			ObjectOld: &hcov1.HyperConverged{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: commontestutils.NewOtherNodePlacement(),
+						},
+					},
+				},
+			},
+		}),
+	)
+})

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -20,6 +20,7 @@ import (
 	migrationapi "kubevirt.io/kubevirt-migration-operator/api/v1alpha1"
 	sspapi "kubevirt.io/ssp-operator/api/v1beta3"
 
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -632,6 +633,22 @@ func GetOperatorCR() *hcov1beta1.HyperConverged {
 	defaultHco := &hcov1beta1.HyperConverged{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: util.APIVersion,
+			Kind:       util.HyperConvergedKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crName,
+		}}
+	defaultScheme.Default(defaultHco)
+	return defaultHco
+}
+
+func GetOperatorV1CR() *hcov1.HyperConverged {
+	defaultScheme := runtime.NewScheme()
+	_ = hcov1.AddToScheme(defaultScheme)
+	_ = hcov1.RegisterDefaults(defaultScheme)
+	defaultHco := &hcov1.HyperConverged{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: hcov1.APIVersionV1,
 			Kind:       util.HyperConvergedKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/internal/nodeinfo/architectures.go
+++ b/pkg/internal/nodeinfo/architectures.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 )
 
 const S390X = "s390x"
@@ -58,22 +58,22 @@ func (a *Architectures) set(archs sets.Set[string]) bool {
 	return false
 }
 
-func hasWorkloadRequirements(hc *v1beta1.HyperConverged) bool {
-	if hc == nil || hc.Spec.Workloads.NodePlacement == nil {
+func hasWorkloadRequirements(hc *hcov1.HyperConverged) bool {
+	if hc == nil || hc.Spec.Deployment.NodePlacements == nil || hc.Spec.Deployment.NodePlacements.Workload == nil {
 		return false
 	}
 
-	return len(hc.Spec.Workloads.NodePlacement.NodeSelector) > 0 ||
-		(hc.Spec.Workloads.NodePlacement.Affinity != nil &&
-			hc.Spec.Workloads.NodePlacement.Affinity.NodeAffinity != nil &&
-			hc.Spec.Workloads.NodePlacement.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil)
+	return len(hc.Spec.Deployment.NodePlacements.Workload.NodeSelector) > 0 ||
+		(hc.Spec.Deployment.NodePlacements.Workload.Affinity != nil &&
+			hc.Spec.Deployment.NodePlacements.Workload.Affinity.NodeAffinity != nil &&
+			hc.Spec.Deployment.NodePlacements.Workload.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil)
 }
 
-func getWorkloadMatcher(hc *v1beta1.HyperConverged) nodeaffinity.RequiredNodeAffinity {
+func getWorkloadMatcher(hc *hcov1.HyperConverged) nodeaffinity.RequiredNodeAffinity {
 	pod := &corev1.Pod{
 		Spec: corev1.PodSpec{
-			NodeSelector: hc.Spec.Workloads.NodePlacement.NodeSelector,
-			Affinity:     hc.Spec.Workloads.NodePlacement.Affinity,
+			NodeSelector: hc.Spec.Deployment.NodePlacements.Workload.NodeSelector,
+			Affinity:     hc.Spec.Deployment.NodePlacements.Workload.Affinity,
 		},
 	}
 

--- a/pkg/internal/nodeinfo/architectures_test.go
+++ b/pkg/internal/nodeinfo/architectures_test.go
@@ -14,7 +14,7 @@ import (
 
 	"kubevirt.io/controller-lifecycle-operator-sdk/api"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/internal/nodeinfo"
 )
 
@@ -24,7 +24,7 @@ var _ = Describe("test node architectures", func() {
 	BeforeEach(func() {
 		scheme = runtime.NewScheme()
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
-		Expect(v1beta1.AddToScheme(scheme)).To(Succeed())
+		Expect(hcov1.AddToScheme(scheme)).To(Succeed())
 	})
 
 	Context("no node selection", func() {
@@ -344,11 +344,15 @@ var _ = Describe("test node architectures", func() {
 	})
 
 	Context("with node selection", func() {
-		DescribeTable("When HyperConverged is deployed", func(ctx context.Context, nodes []client.Object, workloadsSettings v1beta1.HyperConvergedConfig, expectedWL types.GomegaMatcher) {
+		DescribeTable("When HyperConverged is deployed", func(ctx context.Context, nodes []client.Object, workloadsSettings *api.NodePlacement, expectedWL types.GomegaMatcher) {
 
-			hc := &v1beta1.HyperConverged{
-				Spec: v1beta1.HyperConvergedSpec{
-					Workloads: workloadsSettings,
+			hc := &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: workloadsSettings,
+						},
+					},
 				},
 			}
 
@@ -368,7 +372,7 @@ var _ = Describe("test node architectures", func() {
 				Status: corev1.NodeStatus{
 					NodeInfo: corev1.NodeSystemInfo{},
 				},
-			}}, v1beta1.HyperConvergedConfig{}, BeEmpty()),
+			}}, nil, BeEmpty()),
 			Entry("1 worker, node selector - not match", []client.Object{&corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "worker1",
@@ -380,11 +384,9 @@ var _ = Describe("test node architectures", func() {
 				Status: corev1.NodeStatus{
 					NodeInfo: corev1.NodeSystemInfo{},
 				},
-			}}, v1beta1.HyperConvergedConfig{
-				NodePlacement: &api.NodePlacement{
-					NodeSelector: map[string]string{
-						"label-b": "value-b",
-					},
+			}}, &api.NodePlacement{
+				NodeSelector: map[string]string{
+					"label-b": "value-b",
 				},
 			}, BeEmpty()),
 			Entry("1 worker, node selector - match", []client.Object{&corev1.Node{
@@ -398,11 +400,9 @@ var _ = Describe("test node architectures", func() {
 				Status: corev1.NodeStatus{
 					NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
 				},
-			}}, v1beta1.HyperConvergedConfig{
-				NodePlacement: &api.NodePlacement{
-					NodeSelector: map[string]string{
-						"label-a": "value-a",
-					},
+			}}, &api.NodePlacement{
+				NodeSelector: map[string]string{
+					"label-a": "value-a",
 				},
 			}, Equal([]string{"amd64"})),
 			Entry("non-worker, node selector - match", []client.Object{&corev1.Node{
@@ -415,11 +415,9 @@ var _ = Describe("test node architectures", func() {
 				Status: corev1.NodeStatus{
 					NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
 				},
-			}}, v1beta1.HyperConvergedConfig{
-				NodePlacement: &api.NodePlacement{
-					NodeSelector: map[string]string{
-						"label-a": "value-a",
-					},
+			}}, &api.NodePlacement{
+				NodeSelector: map[string]string{
+					"label-a": "value-a",
 				},
 			}, Equal([]string{"amd64"})),
 			Entry("control-plane, node selector - match", []client.Object{&corev1.Node{
@@ -433,11 +431,9 @@ var _ = Describe("test node architectures", func() {
 				Status: corev1.NodeStatus{
 					NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
 				},
-			}}, v1beta1.HyperConvergedConfig{
-				NodePlacement: &api.NodePlacement{
-					NodeSelector: map[string]string{
-						"label-a": "value-a",
-					},
+			}}, &api.NodePlacement{
+				NodeSelector: map[string]string{
+					"label-a": "value-a",
 				},
 			}, Equal([]string{"amd64"})),
 			Entry("node selector w/ 2 labels - 1 match, 1 not", []client.Object{&corev1.Node{
@@ -450,12 +446,10 @@ var _ = Describe("test node architectures", func() {
 				Status: corev1.NodeStatus{
 					NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
 				},
-			}}, v1beta1.HyperConvergedConfig{
-				NodePlacement: &api.NodePlacement{
-					NodeSelector: map[string]string{
-						"label-a": "value-a",
-						"label-b": "value-b",
-					},
+			}}, &api.NodePlacement{
+				NodeSelector: map[string]string{
+					"label-a": "value-a",
+					"label-b": "value-b",
 				},
 			}, BeEmpty()),
 			Entry("2 nodes, 2 match", []client.Object{
@@ -481,11 +475,9 @@ var _ = Describe("test node architectures", func() {
 						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
 					},
 				},
-			}, v1beta1.HyperConvergedConfig{
-				NodePlacement: &api.NodePlacement{
-					NodeSelector: map[string]string{
-						"label-a": "value-a",
-					},
+			}, &api.NodePlacement{
+				NodeSelector: map[string]string{
+					"label-a": "value-a",
 				},
 			}, Equal([]string{"amd64", "arm64"})),
 			Entry("non-worker, node affinity - not match", []client.Object{&corev1.Node{
@@ -498,16 +490,14 @@ var _ = Describe("test node architectures", func() {
 				Status: corev1.NodeStatus{
 					NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
 				},
-			}}, v1beta1.HyperConvergedConfig{
-				NodePlacement: &api.NodePlacement{
-					Affinity: &corev1.Affinity{
-						NodeAffinity: &corev1.NodeAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-								NodeSelectorTerms: []corev1.NodeSelectorTerm{
-									{
-										MatchExpressions: []corev1.NodeSelectorRequirement{
-											{Key: "label-a", Operator: corev1.NodeSelectorOpIn, Values: []string{"value-b", "value-c"}},
-										},
+			}}, &api.NodePlacement{
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{Key: "label-a", Operator: corev1.NodeSelectorOpIn, Values: []string{"value-b", "value-c"}},
 									},
 								},
 							},
@@ -525,16 +515,14 @@ var _ = Describe("test node architectures", func() {
 				Status: corev1.NodeStatus{
 					NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
 				},
-			}}, v1beta1.HyperConvergedConfig{
-				NodePlacement: &api.NodePlacement{
-					Affinity: &corev1.Affinity{
-						NodeAffinity: &corev1.NodeAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-								NodeSelectorTerms: []corev1.NodeSelectorTerm{
-									{
-										MatchExpressions: []corev1.NodeSelectorRequirement{
-											{Key: "label-a", Operator: corev1.NodeSelectorOpIn, Values: []string{"value-a", "value-b", "value-c"}},
-										},
+			}}, &api.NodePlacement{
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{Key: "label-a", Operator: corev1.NodeSelectorOpIn, Values: []string{"value-a", "value-b", "value-c"}},
 									},
 								},
 							},
@@ -576,16 +564,14 @@ var _ = Describe("test node architectures", func() {
 						NodeInfo: corev1.NodeSystemInfo{Architecture: "s390x"},
 					},
 				},
-			}, v1beta1.HyperConvergedConfig{
-				NodePlacement: &api.NodePlacement{
-					Affinity: &corev1.Affinity{
-						NodeAffinity: &corev1.NodeAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-								NodeSelectorTerms: []corev1.NodeSelectorTerm{
-									{
-										MatchExpressions: []corev1.NodeSelectorRequirement{
-											{Key: "label-a", Operator: corev1.NodeSelectorOpIn, Values: []string{"value-a", "value-c"}},
-										},
+			}, &api.NodePlacement{
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{Key: "label-a", Operator: corev1.NodeSelectorOpIn, Values: []string{"value-a", "value-c"}},
 									},
 								},
 							},
@@ -628,16 +614,14 @@ var _ = Describe("test node architectures", func() {
 						NodeInfo: corev1.NodeSystemInfo{Architecture: "s390x"},
 					},
 				},
-			}, v1beta1.HyperConvergedConfig{
-				NodePlacement: &api.NodePlacement{
-					Affinity: &corev1.Affinity{
-						NodeAffinity: &corev1.NodeAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-								NodeSelectorTerms: []corev1.NodeSelectorTerm{
-									{
-										MatchExpressions: []corev1.NodeSelectorRequirement{
-											{Key: "label-a", Operator: corev1.NodeSelectorOpIn, Values: []string{"value-a", "value-c"}},
-										},
+			}, &api.NodePlacement{
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{Key: "label-a", Operator: corev1.NodeSelectorOpIn, Values: []string{"value-a", "value-c"}},
 									},
 								},
 							},
@@ -811,12 +795,14 @@ var _ = Describe("test node architectures", func() {
 			nodes[4].(*corev1.Node).Labels["label-a"] = "value-a"
 			nodes[5].(*corev1.Node).Labels["label-a"] = "value-a"
 
-			hc := &v1beta1.HyperConverged{
-				Spec: v1beta1.HyperConvergedSpec{
-					Workloads: v1beta1.HyperConvergedConfig{
-						NodePlacement: &api.NodePlacement{
-							NodeSelector: map[string]string{
-								"label-a": "value-a",
+			hc := &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: &api.NodePlacement{
+								NodeSelector: map[string]string{
+									"label-a": "value-a",
+								},
 							},
 						},
 					},
@@ -847,12 +833,14 @@ var _ = Describe("test node architectures", func() {
 			nodes[3].(*corev1.Node).Labels["label-a"] = "value-a"
 			nodes[5].(*corev1.Node).Labels["label-a"] = "value-a"
 
-			hc := &v1beta1.HyperConverged{
-				Spec: v1beta1.HyperConvergedSpec{
-					Workloads: v1beta1.HyperConvergedConfig{
-						NodePlacement: &api.NodePlacement{
-							NodeSelector: map[string]string{
-								"label-a": "value-a",
+			hc := &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: &api.NodePlacement{
+								NodeSelector: map[string]string{
+									"label-a": "value-a",
+								},
 							},
 						},
 					},
@@ -885,12 +873,14 @@ var _ = Describe("test node architectures", func() {
 			nodes[5].(*corev1.Node).Labels["label-a"] = "value-a"
 			nodes[7].(*corev1.Node).Labels["label-a"] = "value-a"
 
-			hc := &v1beta1.HyperConverged{
-				Spec: v1beta1.HyperConvergedSpec{
-					Workloads: v1beta1.HyperConvergedConfig{
-						NodePlacement: &api.NodePlacement{
-							NodeSelector: map[string]string{
-								"label-a": "value-a",
+			hc := &hcov1.HyperConverged{
+				Spec: hcov1.HyperConvergedSpec{
+					Deployment: hcov1.DeploymentConfig{
+						NodePlacements: &hcov1.NodePlacements{
+							Workload: &api.NodePlacement{
+								NodeSelector: map[string]string{
+									"label-a": "value-a",
+								},
 							},
 						},
 					},

--- a/pkg/internal/nodeinfo/architectures_whitebox_test.go
+++ b/pkg/internal/nodeinfo/architectures_whitebox_test.go
@@ -8,50 +8,39 @@ import (
 
 	"kubevirt.io/controller-lifecycle-operator-sdk/api"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 )
 
 var _ = Describe("test hasWorkloadRequirements", func() {
-	DescribeTable("should select the node according to the HyperConverged CR", func(hc *v1beta1.HyperConverged, matcher types.GomegaMatcher) {
+	DescribeTable("should select the node according to the HyperConverged CR", func(hc *hcov1.HyperConverged, matcher types.GomegaMatcher) {
 		Expect(hasWorkloadRequirements(hc)).To(matcher)
 	},
-		Entry("nil NodePlacement", nil, BeFalse()),
-		Entry("empty Workloads settings", &v1beta1.HyperConverged{Spec: v1beta1.HyperConvergedSpec{Workloads: v1beta1.HyperConvergedConfig{}}}, BeFalse()),
-		Entry("empty NodePlacement", &v1beta1.HyperConverged{Spec: v1beta1.HyperConvergedSpec{Workloads: v1beta1.HyperConvergedConfig{
-			NodePlacement: &api.NodePlacement{},
-		}}}, BeFalse()),
-		Entry("empty NodeSelector", &v1beta1.HyperConverged{Spec: v1beta1.HyperConvergedSpec{Workloads: v1beta1.HyperConvergedConfig{
-			NodePlacement: &api.NodePlacement{
-				NodeSelector: map[string]string{},
+		Entry("nil HyperConverged", nil, BeFalse()),
+		Entry("nil NodePlacement", &hcov1.HyperConverged{Spec: hcov1.HyperConvergedSpec{Deployment: hcov1.DeploymentConfig{}}}, BeFalse()),
+		Entry("empty NodePlacements", &hcov1.HyperConverged{Spec: hcov1.HyperConvergedSpec{Deployment: hcov1.DeploymentConfig{NodePlacements: &hcov1.NodePlacements{}}}}, BeFalse()),
+		Entry("empty Workloads settings", &hcov1.HyperConverged{Spec: hcov1.HyperConvergedSpec{Deployment: hcov1.DeploymentConfig{NodePlacements: &hcov1.NodePlacements{Workload: &api.NodePlacement{}}}}}, BeFalse()),
+		Entry("empty NodeSelector", &hcov1.HyperConverged{Spec: hcov1.HyperConvergedSpec{Deployment: hcov1.DeploymentConfig{NodePlacements: &hcov1.NodePlacements{Workload: &api.NodePlacement{
+			NodeSelector: map[string]string{},
+		}}}}}, BeFalse()),
+		Entry("not-empty NodeSelector", &hcov1.HyperConverged{Spec: hcov1.HyperConvergedSpec{Deployment: hcov1.DeploymentConfig{NodePlacements: &hcov1.NodePlacements{Workload: &api.NodePlacement{
+			NodeSelector: map[string]string{
+				"label": "value",
 			},
-		}}}, BeFalse()),
-		Entry("non-empty NodeSelector", &v1beta1.HyperConverged{Spec: v1beta1.HyperConvergedSpec{Workloads: v1beta1.HyperConvergedConfig{
-			NodePlacement: &api.NodePlacement{
-				NodeSelector: map[string]string{
-					"label": "value",
+		}}}}}, BeTrue()),
+		Entry("empty Affinity", &hcov1.HyperConverged{Spec: hcov1.HyperConvergedSpec{Deployment: hcov1.DeploymentConfig{NodePlacements: &hcov1.NodePlacements{Workload: &api.NodePlacement{
+			Affinity: &corev1.Affinity{},
+		}}}}}, BeFalse()),
+		Entry("empty NodeAffinity", &hcov1.HyperConverged{Spec: hcov1.HyperConvergedSpec{Deployment: hcov1.DeploymentConfig{NodePlacements: &hcov1.NodePlacements{Workload: &api.NodePlacement{
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{},
+			},
+		}}}}}, BeFalse()),
+		Entry("non-empty NodeAffinity", &hcov1.HyperConverged{Spec: hcov1.HyperConvergedSpec{Deployment: hcov1.DeploymentConfig{NodePlacements: &hcov1.NodePlacements{Workload: &api.NodePlacement{
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{},
 				},
 			},
-		}}}, BeTrue()),
-		Entry("empty Affinity", &v1beta1.HyperConverged{Spec: v1beta1.HyperConvergedSpec{Workloads: v1beta1.HyperConvergedConfig{
-			NodePlacement: &api.NodePlacement{
-				Affinity: &corev1.Affinity{},
-			},
-		}}}, BeFalse()),
-		Entry("empty NodeAffinity", &v1beta1.HyperConverged{Spec: v1beta1.HyperConvergedSpec{Workloads: v1beta1.HyperConvergedConfig{
-			NodePlacement: &api.NodePlacement{
-				Affinity: &corev1.Affinity{
-					NodeAffinity: &corev1.NodeAffinity{},
-				},
-			},
-		}}}, BeFalse()),
-		Entry("non-empty NodeAffinity", &v1beta1.HyperConverged{Spec: v1beta1.HyperConvergedSpec{Workloads: v1beta1.HyperConvergedConfig{
-			NodePlacement: &api.NodePlacement{
-				Affinity: &corev1.Affinity{
-					NodeAffinity: &corev1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{},
-					},
-				},
-			},
-		}}}, BeTrue()),
+		}}}}}, BeTrue()),
 	)
 })

--- a/pkg/internal/nodeinfo/nodeinfo.go
+++ b/pkg/internal/nodeinfo/nodeinfo.go
@@ -9,10 +9,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 )
 
-func HandleNodeChanges(ctx context.Context, cl client.Client, hc *v1beta1.HyperConverged, logger logr.Logger) (bool, error) {
+func HandleNodeChanges(ctx context.Context, cl client.Client, hc *hcov1.HyperConverged, logger logr.Logger) (bool, error) {
 	logger.Info("reading cluster nodes")
 	nodes, err := getNodes(ctx, cl)
 	if err != nil {
@@ -32,7 +32,7 @@ func getNodes(ctx context.Context, cl client.Client) ([]corev1.Node, error) {
 	return nodesList.Items, nil
 }
 
-func processNodeInfo(nodes []corev1.Node, hc *v1beta1.HyperConverged) bool {
+func processNodeInfo(nodes []corev1.Node, hc *hcov1.HyperConverged) bool {
 	workerNodeCount := 0
 	cpNodeCount := 0
 	arbiterNodeCount := 0
@@ -88,7 +88,7 @@ func isWorkerNode(node corev1.Node) bool {
 	return exists
 }
 
-func isWorkloadNodeFunc(hc *v1beta1.HyperConverged) func(corev1.Node) bool {
+func isWorkloadNodeFunc(hc *hcov1.HyperConverged) func(corev1.Node) bool {
 	if hasWorkloadRequirements(hc) {
 
 		workloadMatcher := getWorkloadMatcher(hc)


### PR DESCRIPTION
**What this PR does / why we need it**:
Start moving to the API v1 in the application code. 

This PR moves the nodes controller to use v1. It also adds a helper function to the common utils package, to generate HyperConverged v1 object for tests.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-86216
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
