### PR TITLE
Bump golang to v1.25.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ goimport:
 
 
 lint:
-	GOTOOLCHAIN=go1.25.5 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANDCI_LINT_VERSION}
+	GOTOOLCHAIN=go1.25.9 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANDCI_LINT_VERSION}
 	golangci-lint run
 
 build: build-operator build-csv-merger build-webhook

--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -18,7 +18,7 @@ function dump() {
 
 # Get golang
 $CRI_BIN login --username "$(cat "${QUAY_USER}")" --password-stdin quay.io < "${QUAY_PASSWORD}"
-wget -q https://dl.google.com/go/go1.25.5.linux-amd64.tar.gz
+wget -q https://dl.google.com/go/go1.25.9.linux-amd64.tar.gz
 tar -C /usr/local -xf go*.tar.gz
 export PATH=/usr/local/go/bin:$PATH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubevirt/hyperconverged-cluster-operator
 
-go 1.25.7
+go 1.25.9
 
 require (
 	dario.cat/mergo v1.0.2

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -3,9 +3,9 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN dnf install -y make jq git curl rsync rsync-daemon && \
     dnf clean all && \
-    curl -L -O "https://go.dev/dl/go1.25.5.linux-${TARGETARCH}.tar.gz" && \
-    tar -C /usr/local -xzf "go1.25.5.linux-${TARGETARCH}.tar.gz" && \
-    rm -f "go1.25.5.linux-${TARGETARCH}.tar.gz" && \
+    curl -L -O "https://go.dev/dl/go1.25.9.linux-${TARGETARCH}.tar.gz" && \
+    tar -C /usr/local -xzf "go1.25.9.linux-${TARGETARCH}.tar.gz" && \
+    rm -f "go1.25.9.linux-${TARGETARCH}.tar.gz" && \
     mkdir -p /go
 COPY rsyncd.conf /etc/rsyncd.conf
 ADD entrypoint.sh /usr/bin/entrypoint.sh

--- a/tests/build/Dockerfile
+++ b/tests/build/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "diskspacecheck=0" >> /etc/dnf/dnf.conf && dnf update -y && dnf install
 
 RUN pip3 install j2cli && pip3 install operator-courier
 
-ENV GO_VERSION=1.24.3 \
+ENV GO_VERSION=1.25.9 \
     KUBEBUILDER_VERSION="3.2.0" \
     ARCH="amd64" \
     GOPATH="/go" \


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump golang to 1.25.9
```
