### PR TITLE
Use v1 in the hyperconverged controller

### DIFF
--- a/controllers/common/hcoRequest.go
+++ b/controllers/common/hcoRequest.go
@@ -6,22 +6,22 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 )
 
 // hcoRequest - gather data for a specific request
 type HcoRequest struct {
-	reconcile.Request                                     // inheritance of operator request
-	Logger                     logr.Logger                // request logger
-	Conditions                 HcoConditions              // in-memory conditions
-	Ctx                        context.Context            // context of this request, to be use for any other call
-	Instance                   *hcov1beta1.HyperConverged // the current state of the CR, as read from K8s
-	UpgradeMode                bool                       // copy of the reconciler upgrade mode
-	ComponentUpgradeInProgress bool                       // if in upgrade mode, accumulate the component upgrade status
-	Dirty                      bool                       // is something was changed in the CR
-	StatusDirty                bool                       // is something was changed in the CR's Status
-	HCOTriggered               bool                       // if the request got triggered by a direct modification on HCO CR
-	Upgradeable                bool                       // if all the operands are upgradeable
+	reconcile.Request                                // inheritance of operator request
+	Logger                     logr.Logger           // request logger
+	Conditions                 HcoConditions         // in-memory conditions
+	Ctx                        context.Context       // context of this request, to be use for any other call
+	Instance                   *hcov1.HyperConverged // the current state of the CR, as read from K8s
+	UpgradeMode                bool                  // copy of the reconciler upgrade mode
+	ComponentUpgradeInProgress bool                  // if in upgrade mode, accumulate the component upgrade status
+	Dirty                      bool                  // is something was changed in the CR
+	StatusDirty                bool                  // is something was changed in the CR's Status
+	HCOTriggered               bool                  // if the request got triggered by a direct modification on HCO CR
+	Upgradeable                bool                  // if all the operands are upgradeable
 }
 
 func NewHcoRequest(ctx context.Context, request reconcile.Request, log logr.Logger, upgradeMode, hcoTriggered bool) *HcoRequest {

--- a/controllers/commontestutils/testUtils.go
+++ b/controllers/commontestutils/testUtils.go
@@ -143,6 +143,17 @@ func NewNodePlacement() *sdkapi.NodePlacement {
 	return getNodePlacement(1, 2)
 }
 
+func SetNodeCustomPlacement(hc *hcov1.HyperConverged, infra, workload *sdkapi.NodePlacement) {
+	hc.Spec.Deployment.NodePlacements = &hcov1.NodePlacements{
+		Infra:    infra,
+		Workload: workload,
+	}
+}
+
+func SetNodePlacement(hc *hcov1.HyperConverged) {
+	SetNodeCustomPlacement(hc, NewNodePlacement(), NewNodePlacement())
+}
+
 func NewOtherNodePlacement() *sdkapi.NodePlacement {
 	return getNodePlacement(3, 4)
 }

--- a/controllers/commontestutils/testUtils.go
+++ b/controllers/commontestutils/testUtils.go
@@ -43,7 +43,6 @@ import (
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/api"
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -66,15 +65,7 @@ var (
 	}
 )
 
-var NewHco = NewHcoV1beta1
-
-func NewHcoV1beta1() *hcov1beta1.HyperConverged {
-	hco := components.GetOperatorCR()
-	hco.Namespace = Namespace
-	return hco
-}
-
-func NewHcoV1() *hcov1.HyperConverged {
+func NewHco() *hcov1.HyperConverged {
 	hco := components.GetOperatorV1CR()
 	hco.Namespace = Namespace
 	return hco
@@ -88,7 +79,7 @@ func NewHcoNamespace() *corev1.Namespace {
 	}
 }
 
-func NewReq(inst *hcov1beta1.HyperConverged) *common.HcoRequest {
+func NewReq(inst *hcov1.HyperConverged) *common.HcoRequest {
 	return &common.HcoRequest{
 		Request:      TestRequest,
 		Logger:       TestLogger,

--- a/controllers/handlers/aaq.go
+++ b/controllers/handlers/aaq.go
@@ -14,7 +14,7 @@ import (
 
 	aaqv1alpha1 "kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/reformatobj"
@@ -25,10 +25,10 @@ import (
 func NewAAQHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
 	return operands.NewConditionalHandler(
 		operands.NewGenericOperand(Client, Scheme, "AAQ", &aaqHooks{}, false),
-		func(hc *hcov1beta1.HyperConverged) bool {
-			return hc.Spec.EnableApplicationAwareQuota != nil && *hc.Spec.EnableApplicationAwareQuota
+		func(hc *hcov1.HyperConverged) bool {
+			return hc.Spec.Deployment.ApplicationAwareConfig != nil && ptr.Deref(hc.Spec.Deployment.ApplicationAwareConfig.Enable, false)
 		},
-		func(_ *hcov1beta1.HyperConverged) client.Object {
+		func(_ *hcov1.HyperConverged) client.Object {
 			return NewAAQWithNameOnly()
 		},
 	)
@@ -39,7 +39,7 @@ type aaqHooks struct {
 	cache *aaqv1alpha1.AAQ
 }
 
-func (h *aaqHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *aaqHooks) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -98,33 +98,35 @@ func (*aaqHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exists r
 	return false, false, nil
 }
 
-func NewAAQ(hc *hcov1beta1.HyperConverged) (*aaqv1alpha1.AAQ, error) {
+func NewAAQ(hc *hcov1.HyperConverged) (*aaqv1alpha1.AAQ, error) {
 	spec := aaqv1alpha1.AAQSpec{
 		PriorityClass:   ptr.To[aaqv1alpha1.AAQPriorityClass](kvPriorityClass),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		CertConfig: &aaqv1alpha1.AAQCertConfig{
 			CA: &aaqv1alpha1.CertConfig{
-				Duration:    hc.Spec.CertConfig.CA.Duration,
-				RenewBefore: hc.Spec.CertConfig.CA.RenewBefore,
+				Duration:    hc.Spec.Security.CertConfig.CA.Duration,
+				RenewBefore: hc.Spec.Security.CertConfig.CA.RenewBefore,
 			},
 			Server: &aaqv1alpha1.CertConfig{
-				Duration:    hc.Spec.CertConfig.Server.Duration,
-				RenewBefore: hc.Spec.CertConfig.Server.RenewBefore,
+				Duration:    hc.Spec.Security.CertConfig.Server.Duration,
+				RenewBefore: hc.Spec.Security.CertConfig.Server.RenewBefore,
 			},
 		},
-		TLSSecurityProfile: openshift2AAQSecProfile(tlssecprofile.GetTLSSecurityProfile(hc.Spec.TLSSecurityProfile)),
+		TLSSecurityProfile: openshift2AAQSecProfile(tlssecprofile.GetTLSSecurityProfile(hc.Spec.Security.TLSSecurityProfile)),
 	}
 
-	if hc.Spec.Infra.NodePlacement != nil {
-		hc.Spec.Infra.NodePlacement.DeepCopyInto(&spec.Infra)
-	}
+	if np := hc.Spec.Deployment.NodePlacements; np != nil {
+		if np.Infra != nil {
+			np.Infra.DeepCopyInto(&spec.Infra)
+		}
 
-	if hc.Spec.Workloads.NodePlacement != nil {
-		hc.Spec.Workloads.NodePlacement.DeepCopyInto(&spec.Workloads)
+		if np.Workload != nil {
+			np.Workload.DeepCopyInto(&spec.Workloads)
+		}
 	}
 
 	spec.Configuration.VmiCalculatorConfiguration.ConfigName = aaqv1alpha1.DedicatedVirtualResources
-	if config := hc.Spec.ApplicationAwareConfig; config != nil {
+	if config := hc.Spec.Deployment.ApplicationAwareConfig; config != nil {
 		if config.VmiCalcConfigName != nil {
 			spec.Configuration.VmiCalculatorConfiguration.ConfigName = *config.VmiCalcConfigName
 		}

--- a/controllers/handlers/aaq_test.go
+++ b/controllers/handlers/aaq_test.go
@@ -18,7 +18,6 @@ import (
 	"kubevirt.io/controller-lifecycle-operator-sdk/api"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -26,7 +25,7 @@ import (
 
 var _ = Describe("AAQ tests", func() {
 	var (
-		hco *v1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 
@@ -96,7 +95,7 @@ var _ = Describe("AAQ tests", func() {
 		It("should have namespaceSelector", func() {
 			labels := map[string]string{"name": "value"}
 
-			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{
+			hco.Spec.Deployment.ApplicationAwareConfig = &hcov1.ApplicationAwareConfigurations{
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchLabels: labels,
 				},
@@ -109,7 +108,7 @@ var _ = Describe("AAQ tests", func() {
 		})
 
 		It("should have ConfigName", func() {
-			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{
+			hco.Spec.Deployment.ApplicationAwareConfig = &hcov1.ApplicationAwareConfigurations{
 				VmiCalcConfigName: ptr.To(aaqv1alpha1.VmiPodUsage),
 			}
 
@@ -119,7 +118,7 @@ var _ = Describe("AAQ tests", func() {
 		})
 
 		It("should have ConfigName", func() {
-			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{
+			hco.Spec.Deployment.ApplicationAwareConfig = &hcov1.ApplicationAwareConfigurations{
 				AllowApplicationAwareClusterResourceQuota: true,
 			}
 
@@ -129,8 +128,7 @@ var _ = Describe("AAQ tests", func() {
 		})
 
 		It("should get node placement configurations from the HyperConverged CR", func() {
-			hco.Spec.Infra.NodePlacement = &testNodePlacement
-			hco.Spec.Workloads.NodePlacement = &testNodePlacement
+			commontestutils.SetNodeCustomPlacement(hco, &testNodePlacement, &testNodePlacement)
 
 			aaq, err := NewAAQ(hco)
 			Expect(err).ToNot(HaveOccurred())
@@ -141,7 +139,7 @@ var _ = Describe("AAQ tests", func() {
 
 		It("should get certification configurations from the HyperConverged CR", func() {
 
-			hco.Spec.CertConfig = hcov1.HyperConvergedCertConfig{
+			hco.Spec.Security.CertConfig = hcov1.HyperConvergedCertConfig{
 				CA: hcov1.CertRotateConfigCA{
 					Duration:    &metav1.Duration{Duration: time.Hour * 72},
 					RenewBefore: &metav1.Duration{Duration: time.Hour * 56},
@@ -183,8 +181,8 @@ var _ = Describe("AAQ tests", func() {
 				Expect(existingResource.Spec.TLSSecurityProfile).To(Equal(openshift2AAQSecProfile(intermediateTLSSecurityProfile)))
 
 				// now, modify HCO's TLSSecurityProfile
-				hco.Spec.TLSSecurityProfile = modernTLSSecurityProfile
-				hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
+				hco.Spec.Security.TLSSecurityProfile = modernTLSSecurityProfile
+				hco.Spec.Deployment.ApplicationAwareConfig = &hcov1.ApplicationAwareConfigurations{Enable: ptr.To(true)}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewAAQHandler(cl, commontestutils.GetScheme())
@@ -206,7 +204,7 @@ var _ = Describe("AAQ tests", func() {
 			})
 
 			It("should overwrite TLSSecurityProfile if directly set on AAQ CR", func(ctx context.Context) {
-				hco.Spec.TLSSecurityProfile = intermediateTLSSecurityProfile
+				hco.Spec.Security.TLSSecurityProfile = intermediateTLSSecurityProfile
 				existingResource, err := NewAAQ(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -216,8 +214,7 @@ var _ = Describe("AAQ tests", func() {
 				// now, modify AAQ node placement
 				existingResource.Spec.TLSSecurityProfile = openshift2AAQSecProfile(modernTLSSecurityProfile)
 
-				hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
-
+				hco.Spec.Deployment.ApplicationAwareConfig = &hcov1.ApplicationAwareConfigurations{Enable: ptr.To(true)}
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewAAQHandler(cl, commontestutils.GetScheme())
 				res := handler.Ensure(req)
@@ -233,7 +230,7 @@ var _ = Describe("AAQ tests", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 
-				Expect(foundResource.Spec.TLSSecurityProfile).To(Equal(openshift2AAQSecProfile(hco.Spec.TLSSecurityProfile)))
+				Expect(foundResource.Spec.TLSSecurityProfile).To(Equal(openshift2AAQSecProfile(hco.Spec.Security.TLSSecurityProfile)))
 				Expect(foundResource.Spec.TLSSecurityProfile).ToNot(Equal(existingResource.Spec.TLSSecurityProfile))
 
 				Expect(req.Conditions).To(BeEmpty())
@@ -280,7 +277,7 @@ var _ = Describe("AAQ tests", func() {
 		})
 
 		It("should create AAQ if the enableApplicationAwareQuota FG is true", func() {
-			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
+			hco.Spec.Deployment.ApplicationAwareConfig = &hcov1.ApplicationAwareConfigurations{Enable: ptr.To(true)}
 			cl = commontestutils.InitClient([]client.Object{hco})
 
 			handler := NewAAQHandler(cl, commontestutils.GetScheme())
@@ -307,8 +304,9 @@ var _ = Describe("AAQ tests", func() {
 	Context("check update", func() {
 
 		It("should update AAQ fields, if not matched to the requirements", func() {
-			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
-			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
+			hco.Spec.Deployment.ApplicationAwareConfig = &hcov1.ApplicationAwareConfigurations{
+				Enable: ptr.To(true),
+			}
 			aaq := NewAAQWithNameOnly()
 			aaq.Spec.Infra = testNodePlacement
 			aaq.Spec.PriorityClass = ptr.To[aaqv1alpha1.AAQPriorityClass]("wrongPC")
@@ -358,8 +356,10 @@ var _ = Describe("AAQ tests", func() {
 		It("should reconcile managed labels to default without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
-			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
+			hco.Spec.Deployment.ApplicationAwareConfig = &hcov1.ApplicationAwareConfigurations{
+				Enable: ptr.To(true),
+			}
+
 			outdatedResource := NewAAQWithNameOnly()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
@@ -391,8 +391,10 @@ var _ = Describe("AAQ tests", func() {
 		It("should reconcile managed labels to default on label deletion without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			hco.Spec.ApplicationAwareConfig = &v1beta1.ApplicationAwareConfigurations{}
-			hco.Spec.EnableApplicationAwareQuota = ptr.To(true)
+			hco.Spec.Deployment.ApplicationAwareConfig = &hcov1.ApplicationAwareConfigurations{
+				Enable: ptr.To(true),
+			}
+
 			outdatedResource := NewAAQWithNameOnly()
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue

--- a/controllers/handlers/aie/common.go
+++ b/controllers/handlers/aie/common.go
@@ -1,7 +1,7 @@
 package aie
 
 import (
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
@@ -17,6 +17,6 @@ const (
 	DeployAIEAnnotation = hcoutil.HCOAnnotationPrefix + "deployAIE"
 )
 
-func shouldDeployAIE(hc *hcov1beta1.HyperConverged) bool {
+func shouldDeployAIE(hc *hcov1.HyperConverged) bool {
 	return hc.Annotations[DeployAIEAnnotation] == "true"
 }

--- a/controllers/handlers/aie/configmap.go
+++ b/controllers/handlers/aie/configmap.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -16,7 +16,7 @@ func NewAIEWebhookConfigMapHandler(Client client.Client, Scheme *runtime.Scheme)
 	return operands.NewConditionalHandler(
 		operands.NewEditableCmHandler(Client, Scheme, cm),
 		shouldDeployAIE,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return newAIEWebhookConfigMapWithNameOnly()
 		},
 	)

--- a/controllers/handlers/aie/configmap_test.go
+++ b/controllers/handlers/aie/configmap_test.go
@@ -8,14 +8,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 )
 
 var _ = Describe("AIE Webhook ConfigMap", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)

--- a/controllers/handlers/aie/daemonset.go
+++ b/controllers/handlers/aie/daemonset.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -31,13 +31,13 @@ func NewIOMMUFDDevicePluginDaemonSetHandler(cli client.Client, Scheme *runtime.S
 	return operands.NewConditionalHandler(
 		operands.NewDaemonSetHandler(cli, Scheme, newIOMMUFDDevicePluginDaemonSet),
 		shouldDeployAIE,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return NewIOMMUFDDevicePluginDaemonSetWithNameOnly(hc)
 		},
 	)
 }
 
-func NewIOMMUFDDevicePluginDaemonSetWithNameOnly(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
+func NewIOMMUFDDevicePluginDaemonSetWithNameOnly(hc *hcov1.HyperConverged) *appsv1.DaemonSet {
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      iommufdDevicePluginName,
@@ -47,7 +47,7 @@ func NewIOMMUFDDevicePluginDaemonSetWithNameOnly(hc *hcov1beta1.HyperConverged) 
 	}
 }
 
-func newIOMMUFDDevicePluginDaemonSet(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
+func newIOMMUFDDevicePluginDaemonSet(hc *hcov1.HyperConverged) *appsv1.DaemonSet {
 	image := os.Getenv(hcoutil.IOMMUFDDevicePluginImageEnvV)
 
 	selectorLabels := map[string]string{

--- a/controllers/handlers/aie/daemonset_test.go
+++ b/controllers/handlers/aie/daemonset_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -20,7 +20,7 @@ import (
 
 var _ = Describe("IOMMUFD Device Plugin DaemonSet", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)

--- a/controllers/handlers/aie/deployment.go
+++ b/controllers/handlers/aie/deployment.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -32,7 +32,7 @@ func NewAIEWebhookDeploymentHandler(cli client.Client, Scheme *runtime.Scheme) o
 	return operands.NewConditionalHandler(
 		operands.NewDeploymentHandler(cli, Scheme, newAIEWebhookDeployment),
 		shouldDeployAIE,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return newAIEWebhookDeploymentWithNameOnly()
 		},
 	)
@@ -48,10 +48,10 @@ func newAIEWebhookDeploymentWithNameOnly() *appsv1.Deployment {
 	}
 }
 
-func newAIEWebhookDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
+func newAIEWebhookDeployment(hc *hcov1.HyperConverged) *appsv1.Deployment {
 	image := os.Getenv(hcoutil.AIEWebhookImageEnvV)
 
-	cipherNames, minTLSVersion := tlssecprofile.GetCipherSuitesAndMinTLSVersion(hc.Spec.TLSSecurityProfile)
+	cipherNames, minTLSVersion := tlssecprofile.GetCipherSuitesAndMinTLSVersion(hc.Spec.Security.TLSSecurityProfile)
 	ianaCiphers := crypto.OpenSSLToIANACipherSuites(cipherNames)
 
 	selectorLabels := map[string]string{

--- a/controllers/handlers/aie/deployment_test.go
+++ b/controllers/handlers/aie/deployment_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
@@ -25,7 +25,7 @@ var _ = Describe("AIE Webhook Deployment", func() {
 	const testImage = "quay.io/kubevirt/aieimage:test"
 
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)

--- a/controllers/handlers/aie/device_plugin_scc.go
+++ b/controllers/handlers/aie/device_plugin_scc.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -22,7 +22,7 @@ func NewIOMMUFDDevicePluginSCCHandler(cli client.Client, Scheme *runtime.Scheme)
 	return operands.NewConditionalHandler(
 		operands.NewSecurityContextConstraintsHandler(cli, Scheme, newIOMMUFDDevicePluginSCC()),
 		shouldDeployAIE,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return NewIOMMUFDDevicePluginSCCWithNameOnly()
 		},
 	)

--- a/controllers/handlers/aie/device_plugin_scc_test.go
+++ b/controllers/handlers/aie/device_plugin_scc_test.go
@@ -10,7 +10,7 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -18,7 +18,7 @@ import (
 
 var _ = Describe("IOMMUFD Device Plugin SecurityContextConstraints", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)

--- a/controllers/handlers/aie/device_plugin_service_account.go
+++ b/controllers/handlers/aie/device_plugin_service_account.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -15,7 +15,7 @@ func NewIOMMUFDDevicePluginServiceAccountHandler(Client client.Client, Scheme *r
 	return operands.NewConditionalHandler(
 		operands.NewServiceAccountHandler(Client, Scheme, newIOMMUFDDevicePluginServiceAccount),
 		shouldDeployAIE,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return newIOMMUFDDevicePluginServiceAccount()
 		},
 	)

--- a/controllers/handlers/aie/device_plugin_service_account_test.go
+++ b/controllers/handlers/aie/device_plugin_service_account_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("IOMMUFD Device Plugin Service Account", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)

--- a/controllers/handlers/aie/rbac.go
+++ b/controllers/handlers/aie/rbac.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -15,7 +15,7 @@ func NewAIEWebhookClusterRoleHandler(cli client.Client, Scheme *runtime.Scheme) 
 	return operands.NewConditionalHandler(
 		operands.NewClusterRoleHandler(cli, Scheme, newAIEWebhookClusterRole()),
 		shouldDeployAIE,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return NewAIEWebhookClusterRoleWithNameOnly()
 		},
 	)
@@ -25,7 +25,7 @@ func NewAIEWebhookClusterRoleBindingHandler(cli client.Client, Scheme *runtime.S
 	return operands.NewConditionalHandler(
 		operands.NewClusterRoleBindingHandler(cli, Scheme, newAIEWebhookClusterRoleBinding()),
 		shouldDeployAIE,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return NewAIEWebhookClusterRoleBindingWithNameOnly()
 		},
 	)

--- a/controllers/handlers/aie/rbac_test.go
+++ b/controllers/handlers/aie/rbac_test.go
@@ -9,7 +9,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("AIE Webhook Cluster Role", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)
@@ -113,7 +113,7 @@ var _ = Describe("AIE Webhook Cluster Role", func() {
 
 var _ = Describe("AIE Webhook Cluster Role Binding", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)

--- a/controllers/handlers/aie/service.go
+++ b/controllers/handlers/aie/service.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -16,7 +16,7 @@ func NewAIEWebhookServiceHandler(Client client.Client, Scheme *runtime.Scheme) o
 	return operands.NewConditionalHandler(
 		operands.NewServiceHandler(Client, Scheme, newAIEWebhookService()),
 		shouldDeployAIE,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return newAIEWebhookServiceWithNameOnly()
 		},
 	)

--- a/controllers/handlers/aie/service_account.go
+++ b/controllers/handlers/aie/service_account.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -15,7 +15,7 @@ func NewAIEWebhookServiceAccountHandler(Client client.Client, Scheme *runtime.Sc
 	return operands.NewConditionalHandler(
 		operands.NewServiceAccountHandler(Client, Scheme, newAIEWebhookServiceAccount),
 		shouldDeployAIE,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return newAIEWebhookServiceAccount()
 		},
 	)

--- a/controllers/handlers/aie/service_account_test.go
+++ b/controllers/handlers/aie/service_account_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("AIE Webhook Service Account", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)

--- a/controllers/handlers/aie/webhook_config.go
+++ b/controllers/handlers/aie/webhook_config.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -21,7 +21,7 @@ func NewAIEWebhookMutatingWebhookConfigurationHandler(cli client.Client, Scheme 
 		operands.NewGenericOperand(cli, Scheme, "MutatingWebhookConfiguration",
 			&aieWebhookMWCHooks{required: newAIEMutatingWebhookConfiguration()}, false),
 		shouldDeployAIE,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return NewAIEWebhookMutatingWebhookConfigurationWithNameOnly()
 		},
 	)
@@ -31,7 +31,7 @@ type aieWebhookMWCHooks struct {
 	required *admissionregistrationv1.MutatingWebhookConfiguration
 }
 
-func (h *aieWebhookMWCHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *aieWebhookMWCHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.required.DeepCopy(), nil
 }
 

--- a/controllers/handlers/cdi.go
+++ b/controllers/handlers/cdi.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"reflect"
+	"slices"
 	"sync"
 
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
@@ -13,7 +14,6 @@ import (
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/reformatobj"
@@ -42,7 +42,7 @@ type cdiHooks struct {
 	cache  *cdiv1beta1.CDI
 }
 
-func (h *cdiHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *cdiHooks) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -101,9 +101,9 @@ func getDefaultFeatureGates() []string {
 	return []string{honorWaitForFirstConsumerGate, dataVolumeClaimAdoptionGate, webhookPvcRenderingGate}
 }
 
-func NewCDI(hc *hcov1beta1.HyperConverged) (*cdiv1beta1.CDI, error) {
+func NewCDI(hc *hcov1.HyperConverged) (*cdiv1beta1.CDI, error) {
 	uninstallStrategy := cdiv1beta1.CDIUninstallStrategyBlockUninstallIfWorkloadsExist
-	if hc.Spec.UninstallStrategy == hcov1.HyperConvergedUninstallStrategyRemoveWorkloads {
+	if hc.Spec.Deployment.UninstallStrategy == hcov1.HyperConvergedUninstallStrategyRemoveWorkloads {
 		uninstallStrategy = cdiv1beta1.CDIUninstallStrategyRemoveWorkloads
 	}
 
@@ -111,48 +111,25 @@ func NewCDI(hc *hcov1beta1.HyperConverged) (*cdiv1beta1.CDI, error) {
 		UninstallStrategy: &uninstallStrategy,
 		Config: &cdiv1beta1.CDIConfigSpec{
 			FeatureGates:       getDefaultFeatureGates(),
-			TLSSecurityProfile: openshift2CdiSecProfile(tlssecprofile.GetTLSSecurityProfile(hc.Spec.TLSSecurityProfile)),
+			TLSSecurityProfile: openshift2CdiSecProfile(tlssecprofile.GetTLSSecurityProfile(hc.Spec.Security.TLSSecurityProfile)),
 		},
 		CertConfig: &cdiv1beta1.CDICertConfig{
 			CA: &cdiv1beta1.CertConfig{
-				Duration:    hc.Spec.CertConfig.CA.Duration,
-				RenewBefore: hc.Spec.CertConfig.CA.RenewBefore,
+				Duration:    hc.Spec.Security.CertConfig.CA.Duration,
+				RenewBefore: hc.Spec.Security.CertConfig.CA.RenewBefore,
 			},
 			Server: &cdiv1beta1.CertConfig{
-				Duration:    hc.Spec.CertConfig.Server.Duration,
-				RenewBefore: hc.Spec.CertConfig.Server.RenewBefore,
+				Duration:    hc.Spec.Security.CertConfig.Server.Duration,
+				RenewBefore: hc.Spec.Security.CertConfig.Server.RenewBefore,
 			},
 		},
 	}
 
-	if hc.Spec.ResourceRequirements != nil && hc.Spec.ResourceRequirements.StorageWorkloads != nil {
-		spec.Config.PodResourceRequirements = hc.Spec.ResourceRequirements.StorageWorkloads.DeepCopy()
-	}
+	hcoStorage2CDISpec(hc.Spec.Storage, &spec)
 
-	if hc.Spec.ScratchSpaceStorageClass != nil {
-		spec.Config.ScratchSpaceStorageClass = hc.Spec.ScratchSpaceStorageClass
-	}
+	hcoNodePlacementToCDI(hc.Spec.Deployment.NodePlacements, &spec)
 
-	if hc.Spec.FilesystemOverhead != nil {
-		spec.Config.FilesystemOverhead = hc.Spec.FilesystemOverhead.DeepCopy()
-	}
-
-	if hc.Spec.StorageImport != nil {
-		if length := len(hc.Spec.StorageImport.InsecureRegistries); length > 0 {
-			spec.Config.InsecureRegistries = make([]string, length)
-			copy(spec.Config.InsecureRegistries, hc.Spec.StorageImport.InsecureRegistries)
-		}
-	}
-
-	if hc.Spec.Infra.NodePlacement != nil {
-		hc.Spec.Infra.NodePlacement.DeepCopyInto(&spec.Infra.NodePlacement)
-	}
-
-	if hc.Spec.Workloads.NodePlacement != nil {
-		hc.Spec.Workloads.NodePlacement.DeepCopyInto(&spec.Workloads)
-	}
-
-	if lv := hc.Spec.LogVerbosityConfig; lv != nil {
+	if lv := hc.Spec.Deployment.LogVerbosityConfig; lv != nil {
 		spec.Config.LogVerbosity = lv.CDI
 	}
 
@@ -164,6 +141,39 @@ func NewCDI(hc *hcov1beta1.HyperConverged) (*cdiv1beta1.CDI, error) {
 	}
 
 	return reformatobj.ReformatObj(cdi)
+}
+
+func hcoNodePlacementToCDI(np *hcov1.NodePlacements, spec *cdiv1beta1.CDISpec) {
+	if np != nil {
+		if np.Infra != nil {
+			np.Infra.DeepCopyInto(&spec.Infra.NodePlacement)
+		}
+
+		if np.Workload != nil {
+			np.Workload.DeepCopyInto(&spec.Workloads)
+		}
+	}
+}
+
+func hcoStorage2CDISpec(storage *hcov1.StorageConfig, spec *cdiv1beta1.CDISpec) {
+	if storage == nil {
+		return
+	}
+	if storage.WorkloadResourceRequirements != nil {
+		spec.Config.PodResourceRequirements = storage.WorkloadResourceRequirements.DeepCopy()
+	}
+
+	if storage.ScratchSpaceStorageClass != nil {
+		spec.Config.ScratchSpaceStorageClass = storage.ScratchSpaceStorageClass
+	}
+
+	if storage.FilesystemOverhead != nil {
+		spec.Config.FilesystemOverhead = storage.FilesystemOverhead.DeepCopy()
+	}
+
+	if storage.StorageImport != nil {
+		spec.Config.InsecureRegistries = slices.Clone(storage.StorageImport.InsecureRegistries)
+	}
 }
 
 func NewCDIWithNameOnly() *cdiv1beta1.CDI {

--- a/controllers/handlers/cdi_test.go
+++ b/controllers/handlers/cdi_test.go
@@ -21,7 +21,6 @@ import (
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -30,7 +29,7 @@ import (
 var _ = Describe("CDI Operand", func() {
 	Context("CDI", func() {
 		var (
-			hco *hcov1beta1.HyperConverged
+			hco *hcov1.HyperConverged
 			req *common.HcoRequest
 		)
 
@@ -188,9 +187,7 @@ var _ = Describe("CDI Operand", func() {
 			It("should add node placement if missing in CDI", func() {
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
-
-				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				commontestutils.SetNodePlacement(hco)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -219,7 +216,7 @@ var _ = Describe("CDI Operand", func() {
 				Expect(foundResource.Spec.Infra.NodeSelector["key2"]).To(Equal("value2"))
 
 				Expect(foundResource.Spec.Workloads).ToNot(BeNil())
-				Expect(foundResource.Spec.Workloads.Tolerations).To(Equal(hco.Spec.Workloads.NodePlacement.Tolerations))
+				Expect(foundResource.Spec.Workloads.Tolerations).To(Equal(hco.Spec.Deployment.NodePlacements.Workload.Tolerations))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
@@ -227,8 +224,7 @@ var _ = Describe("CDI Operand", func() {
 			It("should remove node placement if missing in HCO CR", func() {
 
 				hcoNodePlacement := commontestutils.NewHco()
-				hcoNodePlacement.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hcoNodePlacement.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				commontestutils.SetNodePlacement(hcoNodePlacement)
 				existingResource, err := NewCDI(hcoNodePlacement)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -265,17 +261,16 @@ var _ = Describe("CDI Operand", func() {
 			})
 
 			It("should modify node placement according to HCO CR", func() {
-				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				commontestutils.SetNodePlacement(hco)
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				// now, modify HCO's node placement
-				hco.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+				hco.Spec.Deployment.NodePlacements.Infra.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, corev1.Toleration{
 					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
 
-				hco.Spec.Workloads.NodePlacement.NodeSelector["key1"] = "something else"
+				hco.Spec.Deployment.NodePlacements.Workload.NodeSelector["key1"] = "something else"
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -302,8 +297,7 @@ var _ = Describe("CDI Operand", func() {
 			})
 
 			It("should overwrite node placement if directly set on CDI CR", func() {
-				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				commontestutils.SetNodePlacement(hco)
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -311,10 +305,10 @@ var _ = Describe("CDI Operand", func() {
 				req.HCOTriggered = false
 
 				// now, modify CDI's node placement
-				existingResource.Spec.Infra.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+				existingResource.Spec.Infra.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, corev1.Toleration{
 					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
-				existingResource.Spec.Workloads.Tolerations = append(hco.Spec.Workloads.NodePlacement.Tolerations, corev1.Toleration{
+				existingResource.Spec.Workloads.Tolerations = append(hco.Spec.Deployment.NodePlacements.Workload.Tolerations, corev1.Toleration{
 					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
 
@@ -355,8 +349,8 @@ var _ = Describe("CDI Operand", func() {
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					StorageWorkloads: &corev1.ResourceRequirements{
+				hco.Spec.Storage = &hcov1.StorageConfig{
+					WorkloadResourceRequirements: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("500m"),
 							corev1.ResourceMemory: resource.MustParse("2Gi"),
@@ -394,8 +388,8 @@ var _ = Describe("CDI Operand", func() {
 			It("should remove Resource Requirements if missing in HCO CR", func() {
 
 				hcoResourceRequirements := commontestutils.NewHco()
-				hcoResourceRequirements.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					StorageWorkloads: &corev1.ResourceRequirements{
+				hcoResourceRequirements.Spec.Storage = &hcov1.StorageConfig{
+					WorkloadResourceRequirements: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("500m"),
 							corev1.ResourceMemory: resource.MustParse("2Gi"),
@@ -437,8 +431,8 @@ var _ = Describe("CDI Operand", func() {
 			})
 
 			It("should modify Resource Requirements according to HCO CR", func() {
-				hco.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					StorageWorkloads: &corev1.ResourceRequirements{
+				hco.Spec.Storage = &hcov1.StorageConfig{
+					WorkloadResourceRequirements: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("500m"),
 							corev1.ResourceMemory: resource.MustParse("2Gi"),
@@ -452,10 +446,10 @@ var _ = Describe("CDI Operand", func() {
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.ResourceRequirements.StorageWorkloads.Limits[corev1.ResourceCPU] = resource.MustParse("1024m")
-				hco.Spec.ResourceRequirements.StorageWorkloads.Limits[corev1.ResourceMemory] = resource.MustParse("4Gi")
-				hco.Spec.ResourceRequirements.StorageWorkloads.Requests[corev1.ResourceCPU] = resource.MustParse("500m")
-				hco.Spec.ResourceRequirements.StorageWorkloads.Requests[corev1.ResourceMemory] = resource.MustParse("2Gi")
+				hco.Spec.Storage.WorkloadResourceRequirements.Limits[corev1.ResourceCPU] = resource.MustParse("1024m")
+				hco.Spec.Storage.WorkloadResourceRequirements.Limits[corev1.ResourceMemory] = resource.MustParse("4Gi")
+				hco.Spec.Storage.WorkloadResourceRequirements.Requests[corev1.ResourceCPU] = resource.MustParse("500m")
+				hco.Spec.Storage.WorkloadResourceRequirements.Requests[corev1.ResourceMemory] = resource.MustParse("2Gi")
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -495,7 +489,7 @@ var _ = Describe("CDI Operand", func() {
 			It("should add FilesystemOverhead if missing in CDI", func() {
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
-				hco.Spec.FilesystemOverhead = &hcoFilesystemOverheadValue
+				hco.Spec.Storage = &hcov1.StorageConfig{FilesystemOverhead: &hcoFilesystemOverheadValue}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -548,14 +542,14 @@ var _ = Describe("CDI Operand", func() {
 			})
 
 			It("should modify FilesystemOverhead according to HCO CR", func() {
-				hco.Spec.FilesystemOverhead = &cdiFilesystemOverheadValue
+				hco.Spec.Storage = &hcov1.StorageConfig{FilesystemOverhead: &cdiFilesystemOverheadValue}
 				existingCDI, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(existingCDI.Spec.Config).ToNot(BeNil())
 				Expect(*existingCDI.Spec.Config.FilesystemOverhead).To(Equal(cdiFilesystemOverheadValue))
 
-				hco.Spec.FilesystemOverhead = &hcoFilesystemOverheadValue
+				hco.Spec.Storage = &hcov1.StorageConfig{FilesystemOverhead: &hcoFilesystemOverheadValue}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingCDI})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -580,7 +574,7 @@ var _ = Describe("CDI Operand", func() {
 		Context("Log verbosity", func() {
 
 			It("Should be defined for CDI CR if defined in HCO CR", func() {
-				hco.Spec.LogVerbosityConfig = &hcov1.LogVerbosityConfiguration{CDI: ptr.To[int32](4)}
+				hco.Spec.Deployment.LogVerbosityConfig = &hcov1.LogVerbosityConfiguration{CDI: ptr.To[int32](4)}
 				cdi, err := NewCDI(hco)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -589,7 +583,7 @@ var _ = Describe("CDI Operand", func() {
 			})
 
 			DescribeTable("Should not be defined for CDI CR if not defined in HCO CR", func(logConfig *hcov1.LogVerbosityConfiguration) {
-				hco.Spec.LogVerbosityConfig = logConfig
+				hco.Spec.Deployment.LogVerbosityConfig = logConfig
 				cdi, err := NewCDI(hco)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -611,7 +605,7 @@ var _ = Describe("CDI Operand", func() {
 			It("should add ScratchSpaceStorageClass if missing in CDI", func() {
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
-				hco.Spec.ScratchSpaceStorageClass = ptr.To(hcoScratchSpaceStorageClassValue)
+				hco.Spec.Storage = &hcov1.StorageConfig{ScratchSpaceStorageClass: ptr.To(hcoScratchSpaceStorageClassValue)}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -662,14 +656,14 @@ var _ = Describe("CDI Operand", func() {
 			})
 
 			It("should modify ScratchSpaceStorageClass according to HCO CR", func() {
-				hco.Spec.ScratchSpaceStorageClass = ptr.To(cdiScratchSpaceStorageClassValue)
+				hco.Spec.Storage = &hcov1.StorageConfig{ScratchSpaceStorageClass: ptr.To(cdiScratchSpaceStorageClassValue)}
 				existingCDI, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(existingCDI.Spec.Config).ToNot(BeNil())
 				Expect(*existingCDI.Spec.Config.ScratchSpaceStorageClass).To(Equal(cdiScratchSpaceStorageClassValue))
 
-				hco.Spec.ScratchSpaceStorageClass = ptr.To(hcoScratchSpaceStorageClassValue)
+				hco.Spec.Storage = &hcov1.StorageConfig{ScratchSpaceStorageClass: ptr.To(hcoScratchSpaceStorageClassValue)}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingCDI})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -695,8 +689,10 @@ var _ = Describe("CDI Operand", func() {
 			It("should add InsecureRegistries if exists in HC and missing in CDI", func() {
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
-				hco.Spec.StorageImport = &hcov1.StorageImportConfig{
-					InsecureRegistries: []string{"first:5000", "second:5000", "third:5000"},
+				hco.Spec.Storage = &hcov1.StorageConfig{
+					StorageImport: &hcov1.StorageImportConfig{
+						InsecureRegistries: []string{"first:5000", "second:5000", "third:5000"},
+					},
 				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
@@ -749,8 +745,10 @@ var _ = Describe("CDI Operand", func() {
 				Expect(err).ToNot(HaveOccurred())
 				existingCDI.Spec.Config.InsecureRegistries = []string{"first:5000", "second:5000", "third:5000"}
 
-				hco.Spec.StorageImport = &hcov1.StorageImportConfig{
-					InsecureRegistries: []string{"other1:5000", "other2:5000"},
+				hco.Spec.Storage = &hcov1.StorageConfig{
+					StorageImport: &hcov1.StorageImportConfig{
+						InsecureRegistries: []string{"other1:5000", "other2:5000"},
+					},
 				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingCDI})
@@ -778,7 +776,7 @@ var _ = Describe("CDI Operand", func() {
 			It("should set BlockUninstallIfWorkloadsExist if missing HCO CR", func() {
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
-				hco.Spec.UninstallStrategy = ""
+				hco.Spec.Deployment.UninstallStrategy = ""
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -800,7 +798,7 @@ var _ = Describe("CDI Operand", func() {
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
 				uninstallStrategy := hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
-				hco.Spec.UninstallStrategy = uninstallStrategy
+				hco.Spec.Deployment.UninstallStrategy = uninstallStrategy
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -822,7 +820,7 @@ var _ = Describe("CDI Operand", func() {
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
 				uninstallStrategy := hcov1.HyperConvergedUninstallStrategyRemoveWorkloads
-				hco.Spec.UninstallStrategy = uninstallStrategy
+				hco.Spec.Deployment.UninstallStrategy = uninstallStrategy
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -974,7 +972,7 @@ var _ = Describe("CDI Operand", func() {
 			existingResource, err := NewCDI(hcoCertConfig)
 			Expect(err).ToNot(HaveOccurred())
 
-			hco.Spec.CertConfig = hcov1.HyperConvergedCertConfig{
+			hco.Spec.Security.CertConfig = hcov1.HyperConvergedCertConfig{
 				CA: hcov1.CertRotateConfigCA{
 					Duration:    &metav1.Duration{Duration: 5 * time.Hour},
 					RenewBefore: &metav1.Duration{Duration: 6 * time.Hour},
@@ -1309,7 +1307,7 @@ var _ = Describe("CDI Operand", func() {
 				Expect(existingResource.Spec.Config.TLSSecurityProfile).To(Equal(openshift2CdiSecProfile(intermediateTLSSecurityProfile)))
 
 				// now, modify HCO's TLSSecurityProfile
-				hco.Spec.TLSSecurityProfile = modernTLSSecurityProfile
+				hco.Spec.Security.TLSSecurityProfile = modernTLSSecurityProfile
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewCdiHandler(cl, commontestutils.GetScheme())
@@ -1331,7 +1329,7 @@ var _ = Describe("CDI Operand", func() {
 			})
 
 			It("should overwrite TLSSecurityProfile if directly set on CDI CR", func() {
-				hco.Spec.TLSSecurityProfile = intermediateTLSSecurityProfile
+				hco.Spec.Security.TLSSecurityProfile = intermediateTLSSecurityProfile
 				existingResource, err := NewCDI(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1356,7 +1354,7 @@ var _ = Describe("CDI Operand", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 
-				Expect(foundResource.Spec.Config.TLSSecurityProfile).To(Equal(openshift2CdiSecProfile(hco.Spec.TLSSecurityProfile)))
+				Expect(foundResource.Spec.Config.TLSSecurityProfile).To(Equal(openshift2CdiSecProfile(hco.Spec.Security.TLSSecurityProfile)))
 				Expect(foundResource.Spec.Config.TLSSecurityProfile).ToNot(Equal(existingResource.Spec.Config.TLSSecurityProfile))
 
 				Expect(req.Conditions).To(BeEmpty())
@@ -1364,8 +1362,8 @@ var _ = Describe("CDI Operand", func() {
 		})
 
 		It("should reformat quantity field to add the quantity type, if missing", func() {
-			hco.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-				StorageWorkloads: &corev1.ResourceRequirements{
+			hco.Spec.Storage = &hcov1.StorageConfig{
+				WorkloadResourceRequirements: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("1.5"),
 					},
@@ -1381,5 +1379,4 @@ var _ = Describe("CDI Operand", func() {
 			Expect(cdi.Spec.Config.PodResourceRequirements.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("1500m")))
 		})
 	})
-
 })

--- a/controllers/handlers/cliDownload.go
+++ b/controllers/handlers/cliDownload.go
@@ -6,17 +6,16 @@ import (
 	"strconv"
 	"sync"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
@@ -35,7 +34,7 @@ func NewCliDownloadHandler(Client client.Client, Scheme *runtime.Scheme) *operan
 
 type cliDownloadHooks struct{}
 
-func (*cliDownloadHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (*cliDownloadHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return NewConsoleCLIDownload(), nil
 }
 
@@ -149,7 +148,7 @@ type cliDownloadsRouteHooks struct {
 	route *routev1.Route
 }
 
-func (h cliDownloadsRouteHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h cliDownloadsRouteHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	h.Lock()
 	defer h.Unlock()
 

--- a/controllers/handlers/cliDownload_test.go
+++ b/controllers/handlers/cliDownload_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
@@ -26,7 +26,7 @@ import (
 var _ = Describe("CLI Download", func() {
 	Context("ConsoleCLIDownload", func() {
 
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
@@ -170,7 +170,7 @@ var _ = Describe("CLI Download", func() {
 var _ = Describe("Downloads Service", func() {
 	Context("Downloads Service", func() {
 
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
@@ -251,7 +251,7 @@ var _ = Describe("Downloads Service", func() {
 var _ = Describe("Cli Downloads Route", func() {
 	Context("Cli Downloads Route", func() {
 
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {

--- a/controllers/handlers/csv.go
+++ b/controllers/handlers/csv.go
@@ -45,7 +45,7 @@ func (c csvHandler) Ensure(req *common.HcoRequest) *operands.EnsureResult {
 	}
 
 	foundDisableOperandDeletion := csv.Annotations[components.DisableOperandDeletionAnnotation]
-	requiredDisableOperandDeletion := req.Instance.Spec.UninstallStrategy == hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
+	requiredDisableOperandDeletion := req.Instance.Spec.Deployment.UninstallStrategy == hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
 
 	if foundDisableOperandDeletion != strconv.FormatBool(requiredDisableOperandDeletion) {
 		updateErr := c.updateCsv(req, csv, requiredDisableOperandDeletion)

--- a/controllers/handlers/csv_test.go
+++ b/controllers/handlers/csv_test.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
@@ -19,7 +18,7 @@ import (
 
 var _ = Describe("CSV Operand", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 	)
 
@@ -42,17 +41,17 @@ var _ = Describe("CSV Operand", func() {
 
 	Context("UninstallStrategy is BlockUninstallIfWorkloadsExist", func() {
 		It("should set console.openshift.io/disable-operand-delete to true", func() {
-			hco.Spec.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
+			hco.Spec.Deployment.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
 			foundResource := ensure(req, hco)
 			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "true"))
 		})
 
 		It("should set console.openshift.io/disable-operand-delete to true on changing from RemoveWorkloads", func() {
-			hco.Spec.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyRemoveWorkloads
+			hco.Spec.Deployment.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyRemoveWorkloads
 			foundResource := ensure(req, hco)
 			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "false"))
 
-			hco.Spec.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
+			hco.Spec.Deployment.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
 			foundResource = ensure(req, hco)
 			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "true"))
 		})
@@ -60,24 +59,24 @@ var _ = Describe("CSV Operand", func() {
 
 	Context("UninstallStrategy is RemoveWorkloads", func() {
 		It("should set console.openshift.io/disable-operand-delete to false", func() {
-			hco.Spec.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyRemoveWorkloads
+			hco.Spec.Deployment.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyRemoveWorkloads
 			foundResource := ensure(req, hco)
 			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "false"))
 		})
 
 		It("should set console.openshift.io/disable-operand-delete to false on changing from BlockUninstallIfWorkloadsExist", func() {
-			hco.Spec.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
+			hco.Spec.Deployment.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
 			foundResource := ensure(req, hco)
 			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "true"))
 
-			hco.Spec.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyRemoveWorkloads
+			hco.Spec.Deployment.UninstallStrategy = hcov1.HyperConvergedUninstallStrategyRemoveWorkloads
 			foundResource = ensure(req, hco)
 			Expect(foundResource.Annotations).To(HaveKeyWithValue(components.DisableOperandDeletionAnnotation, "false"))
 		})
 	})
 })
 
-func ensure(req *common.HcoRequest, hco *hcov1beta1.HyperConverged) *csvv1alpha1.ClusterServiceVersion {
+func ensure(req *common.HcoRequest, hco *hcov1.HyperConverged) *csvv1alpha1.ClusterServiceVersion {
 	GinkgoHelper()
 
 	csv := commontestutils.GetCSV()

--- a/controllers/handlers/dashboard.go
+++ b/controllers/handlers/dashboard.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -22,7 +22,7 @@ const (
 	DashboardManifestLocation = "dashboard"
 )
 
-func GetDashboardHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, _ *hcov1beta1.HyperConverged, dir fs.FS) ([]operands.Operand, error) {
+func GetDashboardHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, _ *hcov1.HyperConverged, dir fs.FS) ([]operands.Operand, error) {
 	err := util.ValidateManifestDir(DashboardManifestLocation, dir)
 	if err != nil {
 		return nil, errors.Unwrap(err) // if not wrapped, then it's not an error that stops processing, and it return nil

--- a/controllers/handlers/golden-images/golden_images.go
+++ b/controllers/handlers/golden-images/golden_images.go
@@ -22,7 +22,6 @@ import (
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/metrics"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -33,7 +32,8 @@ const (
 
 	CDIImmediateBindAnnotation = "cdi.kubevirt.io/storage.bind.immediate.requested"
 
-	MultiArchDICTAnnotation = "ssp.kubevirt.io/dict.architectures"
+	MultiArchDICTAnnotation    = "ssp.kubevirt.io/dict.architectures"
+	EnableMultiArchFeatureGate = "enableMultiArchBootImageImport"
 
 	DictConditionDeployedType    = "Deployed"
 	dictConditionDeployedReason  = "UnsupportedArchitectures"
@@ -48,19 +48,19 @@ var (
 	logger = logf.Log.WithName("dataImportCronTemplateInit")
 )
 
-var GetDataImportCronTemplates = func(hc *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+var GetDataImportCronTemplates = func(hc *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 	crDicts, err := getDicMapFromCr(hc)
 	if err != nil {
 		return nil, err
 	}
 
 	var dictList []hcov1.DataImportCronTemplateStatus
-	if ptr.Deref(hc.Spec.EnableCommonBootImageImport, true) {
+	if ptr.Deref(hc.Spec.WorkloadSources.EnableCommonBootImageImport, true) {
 		dictList = getCommonDicts(dictList, crDicts, hc)
 	}
 	dictList = getCustomDicts(dictList, crDicts)
 
-	if hc.Spec.FeatureGates.EnableMultiArchBootImageImport != nil && *hc.Spec.FeatureGates.EnableMultiArchBootImageImport {
+	if hc.Spec.FeatureGates.IsEnabled(EnableMultiArchFeatureGate) {
 		for i := range dictList {
 			setDataImportCronTemplateStatusMultiArch(&dictList[i], nodeinfo.GetWorkloadsArchitectures())
 		}
@@ -71,8 +71,8 @@ var GetDataImportCronTemplates = func(hc *hcov1beta1.HyperConverged) ([]hcov1.Da
 	return dictList, nil
 }
 
-func CheckDataImportCronTemplates(hc *hcov1beta1.HyperConverged) {
-	multiArchEnabled := ptr.Deref(hc.Spec.FeatureGates.EnableMultiArchBootImageImport, false)
+func CheckDataImportCronTemplates(hc *hcov1.HyperConverged) {
+	multiArchEnabled := hc.Spec.FeatureGates.IsEnabled(EnableMultiArchFeatureGate)
 
 	if multiArchEnabled {
 		for i := range hc.Status.DataImportCronTemplates {
@@ -97,11 +97,11 @@ func validateMultiArchDict(dict *hcov1.DataImportCronTemplateStatus) bool {
 	return true
 }
 
-func HCODictSliceToSSP(hc *hcov1beta1.HyperConverged, hcoDictStatuses []hcov1.DataImportCronTemplateStatus) []sspv1beta3.DataImportCronTemplate {
+func HCODictSliceToSSP(hc *hcov1.HyperConverged, hcoDictStatuses []hcov1.DataImportCronTemplateStatus) []sspv1beta3.DataImportCronTemplate {
 	return slices.Collect(hcoDictToSSPSeq(hc, slices.Values(hcoDictStatuses)))
 }
 
-func ApplyDataImportSchedule(hc *hcov1beta1.HyperConverged) {
+func ApplyDataImportSchedule(hc *hcov1.HyperConverged) {
 	if hc.Status.DataImportSchedule != "" {
 		overrideDataImportSchedule(hc.Status.DataImportSchedule)
 	}
@@ -185,8 +185,8 @@ func ensureDICTFields(dict *hcov1.DataImportCronTemplate) {
 	}
 }
 
-func getCommonDicts(list []hcov1.DataImportCronTemplateStatus, crDicts map[string]hcov1.DataImportCronTemplate, hc *hcov1beta1.HyperConverged) []hcov1.DataImportCronTemplateStatus {
-	enableMultiArchBootImageImport := ptr.Deref(hc.Spec.FeatureGates.EnableMultiArchBootImageImport, false)
+func getCommonDicts(list []hcov1.DataImportCronTemplateStatus, crDicts map[string]hcov1.DataImportCronTemplate, hc *hcov1.HyperConverged) []hcov1.DataImportCronTemplateStatus {
+	enableMultiArchBootImageImport := hc.Spec.FeatureGates.IsEnabled(EnableMultiArchFeatureGate)
 	for dictName, commonDict := range dataImportCronTemplateHardCodedMap {
 		targetDict := hcov1.DataImportCronTemplateStatus{
 			DataImportCronTemplate: *commonDict.DeepCopy(),
@@ -199,7 +199,7 @@ func getCommonDicts(list []hcov1.DataImportCronTemplateStatus, crDicts map[strin
 			if !customizeCommonDICT(&targetDict, crDict, enableMultiArchBootImageImport) {
 				continue
 			}
-		} else if ns := hc.Spec.CommonBootImageNamespace; ns != nil && len(*ns) > 0 {
+		} else if ns := hc.Spec.WorkloadSources.CommonBootImageNamespace; ns != nil && len(*ns) > 0 {
 			targetDict.Namespace = *ns
 		}
 
@@ -301,9 +301,9 @@ func getCustomDicts(list []hcov1.DataImportCronTemplateStatus, crDicts map[strin
 	return list
 }
 
-func getDicMapFromCr(hc *hcov1beta1.HyperConverged) (map[string]hcov1.DataImportCronTemplate, error) {
+func getDicMapFromCr(hc *hcov1.HyperConverged) (map[string]hcov1.DataImportCronTemplate, error) {
 	dictMap := make(map[string]hcov1.DataImportCronTemplate)
-	for _, dict := range hc.Spec.DataImportCronTemplates {
+	for _, dict := range hc.Spec.WorkloadSources.DataImportCronTemplates {
 		_, foundCustom := dictMap[dict.Name]
 		if foundCustom {
 			return nil, fmt.Errorf("%s DataImportCronTable is already defined", dict.Name)
@@ -385,9 +385,8 @@ func hcoDictToSSP(hcoDictStatus hcov1.DataImportCronTemplateStatus, multiArchEna
 	return dict, true
 }
 
-func hcoDictToSSPSeq(hc *hcov1beta1.HyperConverged, hcoDicts iter.Seq[hcov1.DataImportCronTemplateStatus]) iter.Seq[sspv1beta3.DataImportCronTemplate] {
-	multiArchEnabled := ptr.Deref(hc.Spec.FeatureGates.EnableMultiArchBootImageImport, false)
-
+func hcoDictToSSPSeq(hc *hcov1.HyperConverged, hcoDicts iter.Seq[hcov1.DataImportCronTemplateStatus]) iter.Seq[sspv1beta3.DataImportCronTemplate] {
+	multiArchEnabled := hc.Spec.FeatureGates.IsEnabled(EnableMultiArchFeatureGate)
 	return func(yield func(sspv1beta3.DataImportCronTemplate) bool) {
 		for hcoDict := range hcoDicts {
 			sspDict, valid := hcoDictToSSP(hcoDict, multiArchEnabled)

--- a/controllers/handlers/golden-images/golden_images_test.go
+++ b/controllers/handlers/golden-images/golden_images_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/dirtest"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
@@ -28,7 +27,7 @@ func TestGoldenImages(t *testing.T) {
 
 var _ = Describe("Test data import cron template", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 
 		image1, image2, image3, image4                         hcov1.DataImportCronTemplate
 		statusImage1, statusImage2, statusImage3, statusImage4 hcov1.DataImportCronTemplateStatus
@@ -166,18 +165,18 @@ var _ = Describe("Test data import cron template", func() {
 
 	Context("test GetDataImportCronTemplates", func() {
 		It("should not return the hard coded list dataImportCron FeatureGate is false", func() {
-			hco.Spec.EnableCommonBootImageImport = ptr.To(false)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(false)
 			dataImportCronTemplateHardCodedMap = map[string]hcov1.DataImportCronTemplate{
 				image1.Name: image1,
 				image2.Name: image2,
 			}
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
 			list, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list).To(HaveLen(2))
 			Expect(list).To(ContainElements(statusImage3, statusImage4))
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{}
 			list, err = GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list).To(BeEmpty())
@@ -185,11 +184,11 @@ var _ = Describe("Test data import cron template", func() {
 
 		It("should return an empty list if both the hard-coded list and the list from HC are empty", func() {
 			hcoWithEmptyList := commontestutils.NewHco()
-			hcoWithEmptyList.Spec.EnableCommonBootImageImport = ptr.To(true)
-			hcoWithEmptyList.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{}
+			hcoWithEmptyList.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+			hcoWithEmptyList.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{}
 			hcoWithNilList := commontestutils.NewHco()
-			hcoWithNilList.Spec.EnableCommonBootImageImport = ptr.To(true)
-			hcoWithNilList.Spec.DataImportCronTemplates = nil
+			hcoWithNilList.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+			hcoWithNilList.Spec.WorkloadSources.DataImportCronTemplates = nil
 
 			dataImportCronTemplateHardCodedMap = nil
 			Expect(GetDataImportCronTemplates(hcoWithNilList)).To(BeNil())
@@ -204,8 +203,8 @@ var _ = Describe("Test data import cron template", func() {
 				image1.Name: image1,
 				image2.Name: image2,
 			}
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
 			goldenImageList, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(goldenImageList).To(HaveLen(4))
@@ -218,7 +217,7 @@ var _ = Describe("Test data import cron template", func() {
 				image1.Name: image1,
 				image2.Name: image2,
 			}
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			disabledImage1, _ := makeDICT(1, true)
 			disableDict(&disabledImage1)
@@ -226,7 +225,7 @@ var _ = Describe("Test data import cron template", func() {
 			enableDict(&enabledImage2, &expectedStatus2)
 			expectedStatus2.Status.Modified = true
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{disabledImage1, enabledImage2, image3, image4}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{disabledImage1, enabledImage2, image3, image4}
 			goldenImageList, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(goldenImageList).To(HaveLen(3))
@@ -240,12 +239,12 @@ var _ = Describe("Test data import cron template", func() {
 
 		It("should not add user DIC template if it is disabled", func() {
 			dataImportCronTemplateHardCodedMap = nil
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			disableDict(&image1)
 			enableDict(&image2, &statusImage2)
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image1, image2}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image1, image2}
 			goldenImageList, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(goldenImageList).To(HaveLen(1))
@@ -263,21 +262,21 @@ var _ = Describe("Test data import cron template", func() {
 				image1.Name: image1,
 				image2.Name: image2,
 			}
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			image3.Name = image4.Name
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
 			_, err := GetDataImportCronTemplates(hco)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("Should reject if the CR list contain DIC templates with the same name", func() {
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			image3.Name = image4.Name
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
 			_, err := GetDataImportCronTemplates(hco)
 			Expect(err).To(HaveOccurred())
 		})
@@ -289,8 +288,8 @@ var _ = Describe("Test data import cron template", func() {
 				image2.Name: image2,
 			}
 
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-			hco.Spec.DataImportCronTemplates = nil
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.DataImportCronTemplates = nil
 			goldenImageList, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(goldenImageList).To(HaveLen(2))
@@ -298,7 +297,7 @@ var _ = Describe("Test data import cron template", func() {
 			Expect(goldenImageList).To(ContainElements(statusImage1, statusImage2))
 
 			By("CR list is empty")
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{}
 			goldenImageList, err = GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(goldenImageList).To(HaveLen(2))
@@ -306,8 +305,8 @@ var _ = Describe("Test data import cron template", func() {
 		})
 
 		It("Should return only the CR list, if the hard-coded list is empty", func() {
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
 
 			By("when dataImportCronTemplateHardCodedList is nil")
 			dataImportCronTemplateHardCodedMap = nil
@@ -341,7 +340,7 @@ var _ = Describe("Test data import cron template", func() {
 				image2.Name: image2,
 			}
 
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			modifiedImage1, _ := makeDICT(1, true)
 			modifiedImage1.Spec.Template.Spec.Source = &cdiv1beta1.DataVolumeSource{
@@ -351,7 +350,7 @@ var _ = Describe("Test data import cron template", func() {
 			By("check that if the CR schedule is empty, HCO adds it from the common dict")
 			modifiedImage1.Spec.Schedule = ""
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{modifiedImage1, image3, image4}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{modifiedImage1, image3, image4}
 
 			goldenImageList, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
@@ -384,7 +383,7 @@ var _ = Describe("Test data import cron template", func() {
 				image2.Name: image2,
 			}
 
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			storageFromCr := &cdiv1beta1.StorageSpec{
 				VolumeName: "another-class-name",
@@ -400,7 +399,7 @@ var _ = Describe("Test data import cron template", func() {
 			modifiedImage1 := image1.DeepCopy()
 			modifiedImage1.Spec.Template.Spec.Storage = storageFromCr.DeepCopy()
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{*modifiedImage1, image3, image4}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{*modifiedImage1, image3, image4}
 
 			goldenImageList, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
@@ -426,14 +425,14 @@ var _ = Describe("Test data import cron template", func() {
 				image2.Name: image2,
 			}
 
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			modifiedImage1 := image1.DeepCopy()
 			modifiedImage1.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainAll)
 			modifiedImage1.Spec.GarbageCollect = ptr.To(cdiv1beta1.DataImportCronGarbageCollectOutdated)
 			modifiedImage1.Spec.ImportsToKeep = ptr.To[int32](5)
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{*modifiedImage1, image3, image4}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{*modifiedImage1, image3, image4}
 
 			goldenImageList, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
@@ -470,9 +469,9 @@ var _ = Describe("Test data import cron template", func() {
 				image2.Name: image2,
 			}
 
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
 
 			goldenImageStatuses, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
@@ -517,9 +516,9 @@ var _ = Describe("Test data import cron template", func() {
 				image4.Name: image4,
 			}
 
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{*annotationModified, *annotationMissingInCR, *annotationExistsInCR, *annotationMissingInBoth}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{*annotationModified, *annotationMissingInCR, *annotationExistsInCR, *annotationMissingInBoth}
 
 			goldenImageStatuses, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
@@ -553,10 +552,10 @@ var _ = Describe("Test data import cron template", func() {
 			withModifiedNS := image2.DeepCopy()
 			withModifiedNS.Namespace = modifiedNS
 
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-			hco.Spec.CommonBootImageNamespace = ptr.To(customNS)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.CommonBootImageNamespace = ptr.To(customNS)
 
-			hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{*withModifiedNS, image3}
+			hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{*withModifiedNS, image3}
 
 			goldenImageList, err := GetDataImportCronTemplates(hco)
 			Expect(err).ToNot(HaveOccurred())
@@ -669,7 +668,7 @@ var _ = Describe("Test data import cron template", func() {
 					image2.Name: image2,
 				}
 
-				hco.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
+				hco.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{image3, image4}
 
 				nodeinfo.GetWorkloadsArchitectures = func() []string {
 					return []string{"amd64", "arm64", "s390x"}
@@ -677,8 +676,8 @@ var _ = Describe("Test data import cron template", func() {
 			})
 
 			It("should drop the ssp.kubevirt.io/dict.architectures annotation, when the FG is disabled (default)", func() {
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-				hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(false)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.FeatureGates.Disable(EnableMultiArchFeatureGate)
 
 				dictsStatuses, err := GetDataImportCronTemplates(hco)
 				Expect(err).ToNot(HaveOccurred())
@@ -701,8 +700,8 @@ var _ = Describe("Test data import cron template", func() {
 			})
 
 			It("should not drop the ssp.kubevirt.io/dict.architectures annotation, when the FG is enabled", func() {
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-				hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.FeatureGates.Enable(EnableMultiArchFeatureGate)
 
 				dictsStatuses, err := GetDataImportCronTemplates(hco)
 				Expect(err).ToNot(HaveOccurred())
@@ -725,8 +724,8 @@ var _ = Describe("Test data import cron template", func() {
 			})
 
 			It("should remove unsupported architectures from the annotation", func() {
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-				hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.FeatureGates.Enable(EnableMultiArchFeatureGate)
 
 				nodeinfo.GetWorkloadsArchitectures = func() []string {
 					return []string{"amd64", "arm64"}
@@ -758,8 +757,8 @@ var _ = Describe("Test data import cron template", func() {
 			})
 
 			It("should drop a DICT with no supported architectures", func() {
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-				hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.FeatureGates.Enable(EnableMultiArchFeatureGate)
 
 				nodeinfo.GetWorkloadsArchitectures = func() []string {
 					return []string{"amd64", "s390x"}
@@ -801,8 +800,8 @@ var _ = Describe("Test data import cron template", func() {
 			})
 
 			It("should not add the multi-arch annotation if wasn't already exist in the original DICT", func() {
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-				hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.FeatureGates.Enable(EnableMultiArchFeatureGate)
 
 				nodeinfo.GetWorkloadsArchitectures = func() []string {
 					return []string{"amd64", "s390x", "other-arch"}

--- a/controllers/handlers/imageStream.go
+++ b/controllers/handlers/imageStream.go
@@ -14,9 +14,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/reference"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -42,7 +43,7 @@ type imageStreamOperand struct {
 
 func (iso imageStreamOperand) Ensure(req *common.HcoRequest) *operands.EnsureResult {
 	// if the EnableCommonBootImageImport field is set, make sure the imageStream is in place and up-to-date
-	if req.Instance.Spec.EnableCommonBootImageImport != nil && *req.Instance.Spec.EnableCommonBootImageImport {
+	if ptr.Deref(req.Instance.Spec.WorkloadSources.EnableCommonBootImageImport, false) {
 		if result := iso.checkCustomNamespace(req); result != nil {
 			return result
 		}
@@ -76,7 +77,7 @@ func (iso imageStreamOperand) Ensure(req *common.HcoRequest) *operands.EnsureRes
 }
 
 func (iso imageStreamOperand) checkCustomNamespace(req *common.HcoRequest) *operands.EnsureResult {
-	if ns := req.Instance.Spec.CommonBootImageNamespace; ns != nil && len(*ns) > 0 && iso.hooks.required.Namespace != *ns {
+	if ns := req.Instance.Spec.WorkloadSources.CommonBootImageNamespace; ns != nil && len(*ns) > 0 && iso.hooks.required.Namespace != *ns {
 		if result := iso.deleteImageStream(req); result != nil {
 			return result
 		}
@@ -115,7 +116,7 @@ func (iso imageStreamOperand) Reset() {
 	iso.operand.Reset()
 }
 
-func (iso imageStreamOperand) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (iso imageStreamOperand) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	return iso.operand.GetFullCr(hc)
 }
 
@@ -141,7 +142,7 @@ func newIsHook(required *imagev1.ImageStream, origNS string) *isHooks {
 	return &isHooks{required: required, tags: tags, originalNS: origNS}
 }
 
-func (h isHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h isHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.required.DeepCopy(), nil
 }
 
@@ -233,7 +234,7 @@ func (h isHooks) addMissingTags(found *imagev1.ImageStream, newTags []imagev1.Ta
 	return newTags, modified
 }
 
-func GetImageStreamHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged, dir fs.FS) ([]operands.Operand, error) {
+func GetImageStreamHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1.HyperConverged, dir fs.FS) ([]operands.Operand, error) {
 	err := util.ValidateManifestDir(ImageStreamDefaultManifestLocation, dir)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -248,7 +249,7 @@ func GetImageStreamHandlers(logger log.Logger, Client client.Client, Scheme *run
 	return createImageStreamHandlersFromFiles(logger, Client, Scheme, hc, ImageStreamDefaultManifestLocation, dir)
 }
 
-func createImageStreamHandlersFromFiles(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged, filesLocation string, dir fs.FS) ([]operands.Operand, error) {
+func createImageStreamHandlersFromFiles(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1.HyperConverged, filesLocation string, dir fs.FS) ([]operands.Operand, error) {
 	var handlers []operands.Operand
 
 	logger.Info("walking over the files in " + filesLocation + ", to find imageStream files.")
@@ -293,7 +294,7 @@ func compareOneTag(foundTag, reqTag *imagev1.TagReference) bool {
 	return modified
 }
 
-func processImageStreamFile(path string, dir fs.FS, logger log.Logger, hc *hcov1beta1.HyperConverged, Client client.Client, Scheme *runtime.Scheme) (operands.Operand, error) {
+func processImageStreamFile(path string, dir fs.FS, logger log.Logger, hc *hcov1.HyperConverged, Client client.Client, Scheme *runtime.Scheme) (operands.Operand, error) {
 	file, err := dir.Open(path)
 	if err != nil {
 		logger.Error(err, "Can't open the ImageStream yaml file", "file name", path)
@@ -312,7 +313,7 @@ func processImageStreamFile(path string, dir fs.FS, logger log.Logger, hc *hcov1
 	}
 
 	origNS := is.Namespace
-	if ns := hc.Spec.CommonBootImageNamespace; ns != nil && len(*ns) > 0 {
+	if ns := hc.Spec.WorkloadSources.CommonBootImageNamespace; ns != nil && len(*ns) > 0 {
 		is.Namespace = *ns
 	}
 

--- a/controllers/handlers/imageStream_test.go
+++ b/controllers/handlers/imageStream_test.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/dirtest"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
@@ -28,7 +28,7 @@ import (
 var _ = Describe("imageStream tests", func() {
 
 	var (
-		hco           *hcov1beta1.HyperConverged
+		hco           *hcov1.HyperConverged
 		testLogger    = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("imagestream_test")
 		schemeForTest = commontestutils.GetScheme()
 	)
@@ -102,7 +102,7 @@ var _ = Describe("imageStream tests", func() {
 		})
 
 		It("should not create the ImageStream resource if the FG is not set", func() {
-			hco.Spec.EnableCommonBootImageImport = ptr.To(false)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(false)
 
 			cli := commontestutils.InitClient([]client.Object{})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -121,7 +121,7 @@ var _ = Describe("imageStream tests", func() {
 		})
 
 		It("should delete the ImageStream resource if the FG is not set", func() {
-			hco.Spec.EnableCommonBootImageImport = ptr.To(false)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(false)
 
 			exists := &imagev1.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
@@ -172,7 +172,7 @@ var _ = Describe("imageStream tests", func() {
 
 		It("should create the ImageStream resource if not exists", func() {
 			hco := commontestutils.NewHco()
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 			cli := commontestutils.InitClient([]client.Object{hco})
 			handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
 			Expect(err).ToNot(HaveOccurred())
@@ -218,7 +218,7 @@ var _ = Describe("imageStream tests", func() {
 			Expect(imageStreamNames).To(ContainElement("test-image-stream"))
 
 			hco := commontestutils.NewHco()
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 			By("apply the ImageStream CRs")
 			req := commontestutils.NewReq(hco)
 			res := handlers[0].Ensure(req)
@@ -276,7 +276,7 @@ var _ = Describe("imageStream tests", func() {
 			Expect(imageStreamNames).To(ContainElement("test-image-stream"))
 
 			hco := commontestutils.NewHco()
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			By("apply the ImageStream CRs", func() {
 				req := commontestutils.NewReq(hco)
@@ -344,7 +344,7 @@ var _ = Describe("imageStream tests", func() {
 			Expect(imageStreamNames).To(ContainElement("test-image-stream"))
 
 			hco := commontestutils.NewHco()
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			By("apply the ImageStream CRs", func() {
 				req := commontestutils.NewReq(hco)
@@ -408,7 +408,7 @@ var _ = Describe("imageStream tests", func() {
 			Expect(imageStreamNames).To(ContainElement("test-image-stream"))
 
 			hco := commontestutils.NewHco()
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			By("apply the ImageStream CRs", func() {
 				req := commontestutils.NewReq(hco)
@@ -472,7 +472,7 @@ var _ = Describe("imageStream tests", func() {
 			Expect(imageStreamNames).To(ContainElement("test-image-stream"))
 
 			hco := commontestutils.NewHco()
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			By("apply the ImageStream CRs", func() {
 				req := commontestutils.NewReq(hco)
@@ -537,7 +537,7 @@ var _ = Describe("imageStream tests", func() {
 			Expect(imageStreamNames).To(ContainElement("test-image-stream"))
 
 			hco := commontestutils.NewHco()
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			By("apply the ImageStream CRs", func() {
 				req := commontestutils.NewReq(hco)
@@ -609,7 +609,7 @@ var _ = Describe("imageStream tests", func() {
 			Expect(imageStreamNames).To(ContainElement("test-image-stream"))
 
 			hco := commontestutils.NewHco()
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 			By("apply the ImageStream CRs", func() {
 				req := commontestutils.NewReq(hco)
@@ -652,8 +652,8 @@ var _ = Describe("imageStream tests", func() {
 			const customNS = "custom-ns"
 			It("should create imagestream in a custom namespace", func() {
 				hco := commontestutils.NewHco()
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-				hco.Spec.CommonBootImageNamespace = ptr.To(customNS)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.CommonBootImageNamespace = ptr.To(customNS)
 
 				cli := commontestutils.InitClient([]client.Object{hco})
 				handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -676,7 +676,7 @@ var _ = Describe("imageStream tests", func() {
 			It("should delete an imagestream from one namespace, and create it in another one", func() {
 				By("create imagestream in the default namespace")
 				hco := commontestutils.NewHco()
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 				cli := commontestutils.InitClient([]client.Object{hco})
 				handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
 				Expect(err).ToNot(HaveOccurred())
@@ -699,8 +699,8 @@ var _ = Describe("imageStream tests", func() {
 
 				By("replace the image stream with a new one in the custom namespace")
 				hco = commontestutils.NewHco()
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-				hco.Spec.CommonBootImageNamespace = ptr.To(customNS)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.CommonBootImageNamespace = ptr.To(customNS)
 				Expect(objectreferencesv1.SetObjectReference(&hco.Status.RelatedObjects, *ref)).To(Succeed())
 
 				req = commontestutils.NewReq(hco)
@@ -722,8 +722,8 @@ var _ = Describe("imageStream tests", func() {
 			It("should remove an imagestream from a custom namespace, and create it in the default one", func() {
 				By("create imagestream in a custom namespace")
 				hco := commontestutils.NewHco()
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-				hco.Spec.CommonBootImageNamespace = ptr.To(customNS)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.CommonBootImageNamespace = ptr.To(customNS)
 
 				cli := commontestutils.InitClient([]client.Object{hco})
 				handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -747,7 +747,7 @@ var _ = Describe("imageStream tests", func() {
 
 				By("replace the image stream with a new one in the default namespace")
 				hco = commontestutils.NewHco()
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 				Expect(objectreferencesv1.SetObjectReference(&hco.Status.RelatedObjects, *ref)).To(Succeed())
 
 				req = commontestutils.NewReq(hco)
@@ -769,8 +769,8 @@ var _ = Describe("imageStream tests", func() {
 			It("should remove an imagestream from a custom namespace, and create it in the new custom namespace", func() {
 				By("create imagestream in a custom namespace")
 				hco := commontestutils.NewHco()
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-				hco.Spec.CommonBootImageNamespace = ptr.To(customNS)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.CommonBootImageNamespace = ptr.To(customNS)
 
 				cli := commontestutils.InitClient([]client.Object{hco})
 				handlers, err := GetImageStreamHandlers(testLogger, cli, schemeForTest, hco, dir)
@@ -794,8 +794,8 @@ var _ = Describe("imageStream tests", func() {
 
 				By("replace the image stream with a new one in another custom namespace")
 				hco = commontestutils.NewHco()
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-				hco.Spec.CommonBootImageNamespace = ptr.To(customNS + "1")
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.CommonBootImageNamespace = ptr.To(customNS + "1")
 				Expect(objectreferencesv1.SetObjectReference(&hco.Status.RelatedObjects, *ref)).To(Succeed())
 
 				req = commontestutils.NewReq(hco)

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -26,9 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/controller-lifecycle-operator-sdk/api"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/aie"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
@@ -117,11 +117,6 @@ const (
 const (
 	// Allow running IBM Z Secure Execution VMs
 	kvSecureExecution = "SecureExecution"
-)
-
-const (
-	highBurstProfileBurst = 400
-	highBurstProfileQPS   = 200
 )
 
 var (
@@ -233,7 +228,7 @@ type rateLimits struct {
 	Burst int     `json:"burst"`
 }
 
-func (h *kubevirtHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *kubevirtHooks) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -288,30 +283,38 @@ func (*kubevirtHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exi
 	return false, false, nil
 }
 
-func NewKubeVirt(hc *hcov1beta1.HyperConverged, opts ...string) (*kubevirtcorev1.KubeVirt, error) {
+func NewKubeVirt(hc *hcov1.HyperConverged, opts ...string) (*kubevirtcorev1.KubeVirt, error) {
 	config, err := getKVConfig(hc)
 	if err != nil {
 		return nil, err
 	}
 
-	kvCertConfig := hcoCertConfig2KvCertificateRotateStrategy(hc.Spec.CertConfig)
+	kvCertConfig := hcoCertConfig2KvCertificateRotateStrategy(hc.Spec.Security.CertConfig)
 
 	controlPlaneHighlyAvailable := nodeinfo.IsControlPlaneHighlyAvailable()
 	controlPlaneNodeExists := nodeinfo.IsControlPlaneNodeExists()
 	infraHighlyAvailable := nodeinfo.IsInfrastructureHighlyAvailable()
 
 	uninstallStrategy := kubevirtcorev1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist
-	if hc.Spec.UninstallStrategy == hcov1.HyperConvergedUninstallStrategyRemoveWorkloads {
+	if hc.Spec.Deployment.UninstallStrategy == hcov1.HyperConvergedUninstallStrategyRemoveWorkloads {
 		uninstallStrategy = kubevirtcorev1.KubeVirtUninstallStrategyRemoveWorkloads
 	}
 
+	var infra, workload *api.NodePlacement
+	if np := hc.Spec.Deployment.NodePlacements; np != nil {
+		infra = np.Infra
+		workload = np.Workload
+	}
+	kvInfra := hcoConfig2KvConfig(infra, infraHighlyAvailable, controlPlaneHighlyAvailable, controlPlaneNodeExists)
+	kvWorkloads := hcoConfig2KvConfig(workload, true, true, true)
+
 	spec := kubevirtcorev1.KubeVirtSpec{
 		UninstallStrategy:           uninstallStrategy,
-		Infra:                       hcoConfig2KvConfig(hc.Spec.Infra, infraHighlyAvailable, controlPlaneHighlyAvailable, controlPlaneNodeExists),
-		Workloads:                   hcoConfig2KvConfig(hc.Spec.Workloads, true, true, true),
+		Infra:                       kvInfra,
+		Workloads:                   kvWorkloads,
 		Configuration:               *config,
 		CertificateRotationStrategy: *kvCertConfig,
-		WorkloadUpdateStrategy:      hcWorkloadUpdateStrategyToKv(&hc.Spec.WorkloadUpdateStrategy),
+		WorkloadUpdateStrategy:      hcWorkloadUpdateStrategyToKv(&hc.Spec.Virtualization.WorkloadUpdateStrategy),
 		ProductName:                 hcoutil.HyperConvergedCluster,
 		ProductVersion:              os.Getenv(hcoutil.HcoKvIoVersionName),
 		ProductComponent:            string(hcoutil.AppComponentCompute),
@@ -336,71 +339,54 @@ func isAnnotationStateMeetingRequirements(requiredAnnotations, actualAnnotations
 	return isRequired == exists
 }
 
-func setAnnotationsToReqState(hc *hcov1beta1.HyperConverged, kv *kubevirtcorev1.KubeVirt) {
+func setAnnotationsToReqState(hc *hcov1.HyperConverged, kv *kubevirtcorev1.KubeVirt) {
 	if kv.Annotations == nil {
 		kv.Annotations = map[string]string{}
 	}
 
-	if hc.Spec.FeatureGates.AlignCPUs != nil && *hc.Spec.FeatureGates.AlignCPUs {
+	if hc.Spec.FeatureGates.IsEnabled("alignCPUs") {
 		kv.Annotations[kubevirtcorev1.EmulatorThreadCompleteToEvenParity] = ""
 	} else {
 		delete(kv.Annotations, kubevirtcorev1.EmulatorThreadCompleteToEvenParity)
 	}
 }
 
-func getHcoAnnotationTuning(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.ReloadableComponentConfiguration, error) {
-	if annotation, ok := hc.Annotations[common.TuningPolicyAnnotationName]; ok {
-
-		var rates rateLimits
-		err := json.Unmarshal([]byte(annotation), &rates)
-		if err != nil {
-			return nil, err
-		}
-
-		if rates.QPS <= 0 {
-			return nil, fmt.Errorf("qps parameter not found in annotation")
-		}
-		if rates.Burst <= 0 {
-			return nil, fmt.Errorf("burst parameter not found in annotation")
-		}
-		return &kubevirtcorev1.ReloadableComponentConfiguration{
-			RestClient: &kubevirtcorev1.RESTClientConfiguration{
-				RateLimiter: &kubevirtcorev1.RateLimiter{
-					TokenBucketRateLimiter: &kubevirtcorev1.TokenBucketRateLimiter{
-						QPS:   rates.QPS,
-						Burst: rates.Burst,
-					},
-				},
-			},
-		}, nil
+func getHcoAnnotationTuning(hc *hcov1.HyperConverged) (*kubevirtcorev1.ReloadableComponentConfiguration, error) {
+	annotation, ok := hc.Annotations[common.TuningPolicyAnnotationName]
+	if !ok {
+		return nil, fmt.Errorf("tuning policy set but annotation not present or wrong")
 	}
 
-	return nil, fmt.Errorf("tuning policy set but annotation not present or wrong")
-}
-
-func getHcoHighBurstProfileTuningValues(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.ReloadableComponentConfiguration, error) {
-	if _, ok := hc.Annotations[common.TuningPolicyAnnotationName]; ok {
-		return nil, fmt.Errorf("highBurst profile is enabled and the annotation " + common.TuningPolicyAnnotationName + " is present")
+	var rates rateLimits
+	err := json.Unmarshal([]byte(annotation), &rates)
+	if err != nil {
+		return nil, err
 	}
+
+	if rates.QPS <= 0 {
+		return nil, fmt.Errorf("qps parameter not found in annotation")
+	}
+	if rates.Burst <= 0 {
+		return nil, fmt.Errorf("burst parameter not found in annotation")
+	}
+
 	return &kubevirtcorev1.ReloadableComponentConfiguration{
 		RestClient: &kubevirtcorev1.RESTClientConfiguration{
 			RateLimiter: &kubevirtcorev1.RateLimiter{
 				TokenBucketRateLimiter: &kubevirtcorev1.TokenBucketRateLimiter{
-					QPS:   highBurstProfileQPS,
-					Burst: highBurstProfileBurst,
+					QPS:   rates.QPS,
+					Burst: rates.Burst,
 				},
 			},
 		},
 	}, nil
 }
 
-func hcoTuning2Kv(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.ReloadableComponentConfiguration, error) {
-	switch hc.Spec.TuningPolicy {
-	case hcov1.HyperConvergedAnnotationTuningPolicy:
+func hcoTuning2Kv(hc *hcov1.HyperConverged) (*kubevirtcorev1.ReloadableComponentConfiguration, error) {
+	if hc.Spec.Virtualization.TuningPolicy == hcov1.HyperConvergedAnnotationTuningPolicy {
 		return getHcoAnnotationTuning(hc)
-	case hcov1beta1.HyperConvergedHighBurstProfile: //nolint SA1019
-		return getHcoHighBurstProfileTuningValues(hc)
 	}
+
 	return nil, nil
 }
 
@@ -428,15 +414,15 @@ func hcWorkloadUpdateStrategyToKv(hcObject *hcov1.HyperConvergedWorkloadUpdateSt
 	return kvObject
 }
 
-func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfiguration, error) {
+func getKVConfig(hc *hcov1.HyperConverged) (*kubevirtcorev1.KubeVirtConfiguration, error) {
 	devConfig := getKVDevConfig(hc)
 
-	kvLiveMigration, err := hcLiveMigrationToKv(hc.Spec.LiveMigrationConfig)
+	kvLiveMigration, err := hcLiveMigrationToKv(hc.Spec.Virtualization.LiveMigrationConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	obsoleteCPUs := getObsoleteCPUConfig(hc.Spec.ObsoleteCPUs)
+	obsoleteCPUs := getObsoleteCPUConfig(hc.Spec.Virtualization.ObsoleteCPUModels)
 
 	rateLimiter, err := hcoTuning2Kv(hc)
 	if err != nil {
@@ -445,7 +431,7 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 
 	seccompConfig := getKVSeccompConfig()
 
-	networkBindings := getNetworkBindings(hc.Spec.NetworkBinding)
+	networkBindings := getNetworkBindings(hc.Spec.Networking)
 
 	config := &kubevirtcorev1.KubeVirtConfiguration{
 		DeveloperConfiguration: devConfig,
@@ -454,76 +440,84 @@ func getKVConfig(hc *hcov1beta1.HyperConverged) (*kubevirtcorev1.KubeVirtConfigu
 			Binding:          networkBindings,
 		},
 		MigrationConfiguration:             kvLiveMigration,
-		PermittedHostDevices:               toKvPermittedHostDevices(hc.Spec.PermittedHostDevices),
+		PermittedHostDevices:               toKvPermittedHostDevices(hc.Spec.Virtualization.PermittedHostDevices),
 		MediatedDevicesConfiguration:       toKvMediatedDevicesConfiguration(hc),
 		ObsoleteCPUModels:                  obsoleteCPUs,
-		TLSConfiguration:                   hcTLSSecurityProfileToKv(tlssecprofile.GetTLSSecurityProfile(hc.Spec.TLSSecurityProfile)),
+		TLSConfiguration:                   hcTLSSecurityProfileToKv(tlssecprofile.GetTLSSecurityProfile(hc.Spec.Security.TLSSecurityProfile)),
 		APIConfiguration:                   rateLimiter,
 		WebhookConfiguration:               rateLimiter,
 		ControllerConfiguration:            rateLimiter,
 		HandlerConfiguration:               rateLimiter,
 		SeccompConfiguration:               seccompConfig,
-		EvictionStrategy:                   hc.Spec.EvictionStrategy,
-		KSMConfiguration:                   hc.Spec.KSMConfiguration,
-		ChangedBlockTrackingLabelSelectors: hc.Spec.ChangedBlockTrackingLabelSelectors,
+		EvictionStrategy:                   hc.Spec.Virtualization.EvictionStrategy,
+		KSMConfiguration:                   hc.Spec.Virtualization.KSMConfiguration,
+		ChangedBlockTrackingLabelSelectors: hc.Spec.Virtualization.ChangedBlockTrackingLabelSelectors,
 		VMRolloutStrategy:                  ptr.To(kubevirtcorev1.VMRolloutStrategyLiveUpdate),
-		LiveUpdateConfiguration:            hc.Spec.LiveUpdateConfiguration,
+		LiveUpdateConfiguration:            hc.Spec.Virtualization.LiveUpdateConfiguration,
 		ArchitectureConfiguration:          getArchConfiguration(),
 	}
 
-	if smbiosConfig, ok := os.LookupEnv(smbiosEnvName); ok {
-		if smbiosConfig = strings.TrimSpace(smbiosConfig); smbiosConfig != "" {
-			config.SMBIOSConfig = &kubevirtcorev1.SMBiosConfiguration{}
-			err = yaml.NewYAMLOrJSONDecoder(strings.NewReader(smbiosConfig), 1024).Decode(config.SMBIOSConfig)
-			if err != nil {
-				return nil, err
-			}
+	smbiosConfig, err := getSMBConfig()
+	if err != nil {
+		return nil, err
+	}
+	config.SMBIOSConfig = smbiosConfig
+
+	hcoVmOptionsToKV(hc.Spec.Virtualization.VirtualMachineOptions, config)
+
+	if hc.Spec.Storage != nil {
+		config.VMStateStorageClass = ptr.Deref(hc.Spec.Storage.VMStateStorageClass, "")
+	}
+
+	if hc.Spec.Virtualization.AutoCPULimitNamespaceLabelSelector != nil {
+		config.AutoCPULimitNamespaceLabelSelector = hc.Spec.Virtualization.AutoCPULimitNamespaceLabelSelector.DeepCopy()
+	}
+
+	if hc.Spec.WorkloadSources.InstancetypeConfig != nil {
+		config.Instancetype = hc.Spec.WorkloadSources.InstancetypeConfig.DeepCopy()
+	}
+
+	if hc.Spec.WorkloadSources.CommonInstancetypesDeployment != nil {
+		config.CommonInstancetypesDeployment = hc.Spec.WorkloadSources.CommonInstancetypesDeployment.DeepCopy()
+	}
+
+	copyHypervisors(hc.Spec.Virtualization.Hypervisors, config)
+
+	config.RoleAggregationStrategy = hc.Spec.Virtualization.RoleAggregationStrategy
+
+	return config, nil
+}
+
+func copyHypervisors(hvs []kubevirtcorev1.HypervisorConfiguration, config *kubevirtcorev1.KubeVirtConfiguration) {
+	if len(hvs) == 0 {
+		return
+	}
+
+	config.Hypervisors = make([]kubevirtcorev1.HypervisorConfiguration, len(hvs))
+
+	for i := range hvs {
+		config.Hypervisors[i] = *(hvs[i].DeepCopy())
+	}
+}
+
+func hcoVmOptionsToKV(vmOpts *hcov1.VirtualMachineOptions, config *kubevirtcorev1.KubeVirtConfiguration) {
+	if vmOpts == nil {
+		return
+	}
+	config.CPUModel = ptr.Deref(vmOpts.DefaultCPUModel, "")
+
+	if disableFPR, disableSCL := ptr.Deref(vmOpts.DisableFreePageReporting, false), ptr.Deref(vmOpts.DisableSerialConsoleLog, false); disableFPR || disableSCL {
+		config.VirtualMachineOptions = &kubevirtcorev1.VirtualMachineOptions{}
+		if disableFPR {
+			config.VirtualMachineOptions.DisableFreePageReporting = &kubevirtcorev1.DisableFreePageReporting{}
 		}
-	}
 
-	if hc.Spec.DefaultCPUModel != nil {
-		config.CPUModel = *hc.Spec.DefaultCPUModel
-	}
-
-	if hc.Spec.DefaultRuntimeClass != nil {
-		config.DefaultRuntimeClass = *hc.Spec.DefaultRuntimeClass
-	}
-
-	if hc.Spec.VMStateStorageClass != nil {
-		config.VMStateStorageClass = *hc.Spec.VMStateStorageClass
-	}
-
-	if hc.Spec.VirtualMachineOptions != nil && hc.Spec.VirtualMachineOptions.DisableFreePageReporting != nil && *hc.Spec.VirtualMachineOptions.DisableFreePageReporting {
-		config.VirtualMachineOptions = &kubevirtcorev1.VirtualMachineOptions{DisableFreePageReporting: &kubevirtcorev1.DisableFreePageReporting{}}
-	}
-
-	if hc.Spec.VirtualMachineOptions != nil && hc.Spec.VirtualMachineOptions.DisableSerialConsoleLog != nil && *hc.Spec.VirtualMachineOptions.DisableSerialConsoleLog {
-		if config.VirtualMachineOptions == nil {
-			config.VirtualMachineOptions = &kubevirtcorev1.VirtualMachineOptions{DisableSerialConsoleLog: &kubevirtcorev1.DisableSerialConsoleLog{}}
-		} else {
+		if disableSCL {
 			config.VirtualMachineOptions.DisableSerialConsoleLog = &kubevirtcorev1.DisableSerialConsoleLog{}
 		}
 	}
 
-	if hc.Spec.ResourceRequirements != nil {
-		config.AutoCPULimitNamespaceLabelSelector = hc.Spec.ResourceRequirements.AutoCPULimitNamespaceLabelSelector.DeepCopy()
-	}
-
-	if hc.Spec.InstancetypeConfig != nil {
-		config.Instancetype = hc.Spec.InstancetypeConfig.DeepCopy()
-	}
-
-	if hc.Spec.CommonInstancetypesDeployment != nil {
-		config.CommonInstancetypesDeployment = hc.Spec.CommonInstancetypesDeployment.DeepCopy()
-	}
-
-	for _, hv := range hc.Spec.Hypervisors {
-		config.Hypervisors = append(config.Hypervisors, *hv.DeepCopy())
-	}
-
-	config.RoleAggregationStrategy = hc.Spec.RoleAggregationStrategy
-
-	return config, nil
+	config.DefaultRuntimeClass = ptr.Deref(vmOpts.DefaultRuntimeClass, "")
 }
 
 var (
@@ -596,35 +590,37 @@ func getS390xArchConfig() *kubevirtcorev1.ArchSpecificConfiguration {
 	}
 }
 
-func getNetworkBindings(hcoNetworkBindings map[string]kubevirtcorev1.InterfaceBindingPlugin) map[string]kubevirtcorev1.InterfaceBindingPlugin {
-	networkBindings := maps.Clone(hcoNetworkBindings)
+func getNetworkBindings(networkingCfg *hcov1.NetworkingConfig) map[string]kubevirtcorev1.InterfaceBindingPlugin {
+	var networkBindings map[string]kubevirtcorev1.InterfaceBindingPlugin
+	if networkingCfg != nil {
+		networkBindings = maps.Clone(networkingCfg.NetworkBinding)
+	}
 
 	if networkBindings == nil {
 		networkBindings = make(map[string]kubevirtcorev1.InterfaceBindingPlugin)
 	}
 
 	networkBindings[primaryUDNNetworkBindingName] = primaryUserDefinedNetworkBinding()
+
 	return networkBindings
 }
 
-func getObsoleteCPUConfig(hcObsoleteCPUConf *hcov1beta1.HyperConvergedObsoleteCPUs) map[string]bool {
+func getObsoleteCPUConfig(hcObsoleteCPUModels []string) map[string]bool {
 	obsoleteCPUModels := make(map[string]bool)
 	for _, cpu := range hardcodedObsoleteCPUModels {
 		obsoleteCPUModels[cpu] = true
 	}
 
-	if hcObsoleteCPUConf != nil {
-		for _, cpu := range hcObsoleteCPUConf.CPUModels {
-			obsoleteCPUModels[cpu] = true
-		}
+	for _, cpu := range hcObsoleteCPUModels {
+		obsoleteCPUModels[cpu] = true
 	}
 
 	return obsoleteCPUModels
 }
 
-func toKvMediatedDevicesConfiguration(hc *hcov1beta1.HyperConverged) *kubevirtcorev1.MediatedDevicesConfiguration {
-	mdevsConfig := hc.Spec.MediatedDevicesConfiguration
-	disabled := ptr.Deref(hc.Spec.FeatureGates.DisableMDevConfiguration, false)
+func toKvMediatedDevicesConfiguration(hc *hcov1.HyperConverged) *kubevirtcorev1.MediatedDevicesConfiguration {
+	mdevsConfig := hc.Spec.Virtualization.MediatedDevicesConfiguration
+	disabled := hc.Spec.FeatureGates.IsEnabled("disableMDevConfiguration")
 
 	if mdevsConfig == nil && !disabled {
 		return nil
@@ -636,8 +632,6 @@ func toKvMediatedDevicesConfiguration(hc *hcov1beta1.HyperConverged) *kubevirtco
 		var mediatedDeviceTypes []string
 		if len(mdevsConfig.MediatedDeviceTypes) > 0 {
 			mediatedDeviceTypes = mdevsConfig.MediatedDeviceTypes
-		} else if len(mdevsConfig.MediatedDevicesTypes) > 0 { //nolint SA1019
-			mediatedDeviceTypes = mdevsConfig.MediatedDevicesTypes //nolint SA1019
 		}
 
 		kvMdev.MediatedDeviceTypes = mediatedDeviceTypes
@@ -651,7 +645,7 @@ func toKvMediatedDevicesConfiguration(hc *hcov1beta1.HyperConverged) *kubevirtco
 	return kvMdev
 }
 
-func toKvNodeMediatedDevicesConfiguration(hcoNodeMdevTypesConf []hcov1beta1.NodeMediatedDeviceTypesConfig) []kubevirtcorev1.NodeMediatedDeviceTypesConfig {
+func toKvNodeMediatedDevicesConfiguration(hcoNodeMdevTypesConf []hcov1.NodeMediatedDeviceTypesConfig) []kubevirtcorev1.NodeMediatedDeviceTypesConfig {
 	if len(hcoNodeMdevTypesConf) > 0 {
 		nodeMdevTypesConf := make([]kubevirtcorev1.NodeMediatedDeviceTypesConfig, 0, len(hcoNodeMdevTypesConf))
 		for _, hcoNodeMdevTypeConf := range hcoNodeMdevTypesConf {
@@ -659,8 +653,6 @@ func toKvNodeMediatedDevicesConfiguration(hcoNodeMdevTypesConf []hcov1beta1.Node
 			var mediatedDeviceTypes []string
 			if len(hcoNodeMdevTypeConf.MediatedDeviceTypes) > 0 {
 				mediatedDeviceTypes = hcoNodeMdevTypeConf.MediatedDeviceTypes
-			} else if len(hcoNodeMdevTypeConf.MediatedDevicesTypes) > 0 { //nolint SA1019
-				mediatedDeviceTypes = hcoNodeMdevTypeConf.MediatedDevicesTypes //nolint SA1019
 			}
 
 			nodeMdevTypesConf = append(nodeMdevTypesConf, kubevirtcorev1.NodeMediatedDeviceTypesConfig{
@@ -812,30 +804,29 @@ func hcTLSSecurityProfileToKv(profile *openshiftconfigv1.TLSSecurityProfile) *ku
 	}
 }
 
-func getKVDevConfig(hc *hcov1beta1.HyperConverged) *kubevirtcorev1.DeveloperConfiguration {
+func getKVDevConfig(hc *hcov1.HyperConverged) *kubevirtcorev1.DeveloperConfiguration {
 	devConf := &kubevirtcorev1.DeveloperConfiguration{
 		DiskVerification: &kubevirtcorev1.DiskVerification{
 			MemoryLimit: &kvDiskVerificationMemoryLimit,
 		},
 	}
 
-	if hc.Spec.HigherWorkloadDensity != nil {
-		devConf.MemoryOvercommit = hc.Spec.HigherWorkloadDensity.MemoryOvercommitPercentage
+	if hc.Spec.Virtualization.HigherWorkloadDensity != nil {
+		devConf.MemoryOvercommit = hc.Spec.Virtualization.HigherWorkloadDensity.MemoryOvercommitPercentage
 	}
 
-	fgs := getKvFeatureGateList(hc.Spec, hc.Annotations)
+	fgs := getKvFeatureGateList(hc)
 	if len(fgs) > 0 {
 		devConf.FeatureGates = fgs
 	}
 	if useKVMEmulation {
 		devConf.UseEmulation = useKVMEmulation
 	}
-	if lv := hc.Spec.LogVerbosityConfig; lv != nil && lv.Kubevirt != nil {
+	if lv := hc.Spec.Deployment.LogVerbosityConfig; lv != nil && lv.Kubevirt != nil {
 		devConf.LogVerbosity = lv.Kubevirt.DeepCopy()
 	}
-	if hc.Spec.ResourceRequirements != nil && hc.Spec.ResourceRequirements.VmiCPUAllocationRatio != nil {
-		devConf.CPUAllocationRatio = *hc.Spec.ResourceRequirements.VmiCPUAllocationRatio
-	}
+
+	devConf.CPUAllocationRatio = ptr.Deref(hc.Spec.Virtualization.VmiCPUAllocationRatio, 0)
 
 	return devConf
 }
@@ -869,8 +860,8 @@ func NewKubeVirtWithNameOnly() *kubevirtcorev1.KubeVirt {
 }
 
 func hcoConfig2KvConfig(
-	hcoConfig hcov1beta1.HyperConvergedConfig, infraHighlyAvailable, controlPlaneHighlyAvailable, controlPlaneNodeExists bool) *kubevirtcorev1.ComponentConfig {
-	if hcoConfig.NodePlacement == nil && controlPlaneHighlyAvailable {
+	nodePlacement *api.NodePlacement, infraHighlyAvailable, controlPlaneHighlyAvailable, controlPlaneNodeExists bool) *kubevirtcorev1.ComponentConfig {
+	if nodePlacement == nil && controlPlaneHighlyAvailable {
 		return nil
 	}
 
@@ -879,7 +870,7 @@ func hcoConfig2KvConfig(
 	// In case there are no control plane / master nodes in the cluster, we're setting
 	// an empty struct for NodePlacement so that kubevirt control plane pods won't have
 	// any affinity rules, and they could get scheduled onto worker nodes.
-	if hcoConfig.NodePlacement == nil && !controlPlaneNodeExists {
+	if nodePlacement == nil && !controlPlaneNodeExists {
 		kvConfig.NodePlacement = &kubevirtcorev1.NodePlacement{}
 		if !infraHighlyAvailable {
 			// if there is only one worker node and no control plane nodes,
@@ -893,65 +884,68 @@ func hcoConfig2KvConfig(
 		kvConfig.Replicas = ptr.To[uint8](1)
 	}
 
-	if hcoConfig.NodePlacement != nil {
-		kvConfig.NodePlacement = &kubevirtcorev1.NodePlacement{}
-
-		if hcoConfig.NodePlacement.Affinity != nil {
-			kvConfig.NodePlacement.Affinity = &corev1.Affinity{}
-			hcoConfig.NodePlacement.Affinity.DeepCopyInto(kvConfig.NodePlacement.Affinity)
-		}
-
-		if hcoConfig.NodePlacement.NodeSelector != nil {
-			kvConfig.NodePlacement.NodeSelector = maps.Clone(hcoConfig.NodePlacement.NodeSelector)
-		}
-
-		for _, hcoTolr := range hcoConfig.NodePlacement.Tolerations {
-			kvTolr := corev1.Toleration{}
-			hcoTolr.DeepCopyInto(&kvTolr)
-			kvConfig.NodePlacement.Tolerations = append(kvConfig.NodePlacement.Tolerations, kvTolr)
-		}
+	if nodePlacement == nil {
+		return kvConfig
 	}
+
+	kvConfig.NodePlacement = &kubevirtcorev1.NodePlacement{}
+
+	if nodePlacement.Affinity != nil {
+		kvConfig.NodePlacement.Affinity = &corev1.Affinity{}
+		nodePlacement.Affinity.DeepCopyInto(kvConfig.NodePlacement.Affinity)
+	}
+
+	if nodePlacement.NodeSelector != nil {
+		kvConfig.NodePlacement.NodeSelector = maps.Clone(nodePlacement.NodeSelector)
+	}
+
+	for _, hcoTolr := range nodePlacement.Tolerations {
+		kvTolr := corev1.Toleration{}
+		hcoTolr.DeepCopyInto(&kvTolr)
+		kvConfig.NodePlacement.Tolerations = append(kvConfig.NodePlacement.Tolerations, kvTolr)
+	}
+
 	return kvConfig
 }
 
-func getFeatureGateChecks(spec hcov1beta1.HyperConvergedSpec, annotations map[string]string) []string {
-	featureGates := &spec.FeatureGates
+func getFeatureGateChecks(hc *hcov1.HyperConverged) []string {
+	featureGates := &hc.Spec.FeatureGates
 	fgs := make([]string, 0, 2)
 
-	if ptr.Deref(featureGates.DownwardMetrics, false) {
+	if featureGates.IsEnabled("downwardMetrics") {
 		fgs = append(fgs, kvDownwardMetrics)
 	}
-	if ptr.Deref(featureGates.PersistentReservation, false) {
+	if featureGates.IsEnabled("persistentReservation") {
 		fgs = append(fgs, kvPersistentReservation)
 	}
-	if ptr.Deref(featureGates.AlignCPUs, false) {
+	if featureGates.IsEnabled("alignCPUs") {
 		fgs = append(fgs, kvAlignCPUs)
 	}
-	if ptr.Deref(featureGates.VideoConfig, true) {
+	if featureGates.IsEnabled("videoConfig") {
 		fgs = append(fgs, kvVideoConfig)
 	}
 
-	if ptr.Deref(featureGates.ObjectGraph, false) {
+	if featureGates.IsEnabled("objectGraph") {
 		fgs = append(fgs, kvObjectGraph)
 	}
 
-	if ptr.Deref(featureGates.DecentralizedLiveMigration, true) {
+	if featureGates.IsEnabled("decentralizedLiveMigration") {
 		fgs = append(fgs, kvDecentralizedLiveMigration)
 	}
 
 	// Add the appropriate volume hotplug featuregate based on DeclarativeHotplugVolumes setting
-	if ptr.Deref(featureGates.DeclarativeHotplugVolumes, false) {
+	if featureGates.IsEnabled("declarativeHotplugVolumes") {
 		fgs = append(fgs, kvDeclarativeHotplugVolumesGate)
 	} else {
 		// Default behavior: use the original HotplugVolumes featuregate
 		fgs = append(fgs, kvHotplugVolumesGate)
 	}
 
-	if annotations[deployPasstNetworkBindingAnn] == "true" {
+	if hc.Annotations[deployPasstNetworkBindingAnn] == "true" {
 		fgs = append(fgs, kvPasstBinding)
 	}
 
-	if annotations[aie.DeployAIEAnnotation] == "true" {
+	if hc.Annotations[aie.DeployAIEAnnotation] == "true" {
 		fgs = append(fgs, kvPCINUMAAwareTopology)
 	}
 
@@ -959,20 +953,20 @@ func getFeatureGateChecks(spec hcov1beta1.HyperConvergedSpec, annotations map[st
 		fgs = append(fgs, kvSecureExecution)
 	}
 
-	if ptr.Deref(featureGates.IncrementalBackup, false) {
+	if featureGates.IsEnabled("incrementalBackup") {
 		fgs = append(fgs, kvIncrementalBackup)
 		fgs = append(fgs, kvUtilityVolumes)
 	}
 
-	if len(spec.Hypervisors) > 0 {
+	if len(hc.Spec.Virtualization.Hypervisors) > 0 {
 		fgs = append(fgs, kvConfigurableHypervisor)
 	}
 
-	if spec.RoleAggregationStrategy != nil {
+	if hc.Spec.Virtualization.RoleAggregationStrategy != nil {
 		fgs = append(fgs, kvOptOutRoleAggregation)
 	}
 
-	if ptr.Deref(featureGates.ContainerPathVolumes, false) {
+	if featureGates.IsEnabled("containerPathVolumes") {
 		fgs = append(fgs, kvContainerPathVolumes)
 	}
 
@@ -986,7 +980,7 @@ func NewKvPriorityClassHandler(Client client.Client, Scheme *runtime.Scheme) *op
 
 type kvPriorityClassHooks struct{}
 
-func (kvPriorityClassHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (kvPriorityClassHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return NewKubeVirtPriorityClass(), nil
 }
 func (kvPriorityClassHooks) GetEmptyCr() client.Object { return &schedulingv1.PriorityClass{} }
@@ -1094,8 +1088,8 @@ func getMandatoryKvFeatureGates(isKVMEmulation bool) []string {
 }
 
 // get list of feature gates or KV FG list
-func getKvFeatureGateList(spec hcov1beta1.HyperConvergedSpec, annotations map[string]string) []string {
-	checks := getFeatureGateChecks(spec, annotations)
+func getKvFeatureGateList(hc *hcov1.HyperConverged) []string {
+	checks := getFeatureGateChecks(hc)
 	res := make([]string, 0, len(checks)+len(mandatoryKvFeatureGates))
 	res = append(res, mandatoryKvFeatureGates...)
 	res = append(res, checks...)
@@ -1140,4 +1134,27 @@ func getLabelPatch(dest, src map[string]string) ([]byte, error) {
 	}
 
 	return json.Marshal(patches)
+}
+
+var (
+	smbiosCfg  *kubevirtcorev1.SMBiosConfiguration
+	smbiosOnce = &sync.Once{}
+)
+
+func getSMBConfig() (*kubevirtcorev1.SMBiosConfiguration, error) {
+	var err error
+	smbiosOnce.Do(func() {
+		smbiosConfig := strings.TrimSpace(os.Getenv(smbiosEnvName))
+		if smbiosConfig == "" {
+			return
+		}
+
+		smbiosCfg = &kubevirtcorev1.SMBiosConfiguration{}
+		err = yaml.NewYAMLOrJSONDecoder(strings.NewReader(smbiosConfig), 1024).Decode(smbiosCfg)
+		if err != nil {
+			smbiosCfg = nil
+		}
+	})
+
+	return smbiosCfg, err
 }

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
@@ -129,7 +129,7 @@ func NewKvUIPluginCRHandler(Client client.Client, Scheme *runtime.Scheme) operan
 	return newConsolePluginHandler(Client, Scheme, NewKVConsolePlugin())
 }
 
-func NewKvUIPluginDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
+func NewKvUIPluginDeployment(hc *hcov1.HyperConverged) *appsv1.Deployment {
 	// The env var was validated prior to handler creation
 	kvUIPluginImage, _ := os.LookupEnv(hcoutil.KVUIPluginImageEnvV)
 	deployment := getKvUIDeployment(hc, kvUIPluginDeploymentName, kvUIPluginImage,
@@ -163,13 +163,13 @@ func NewKvUIPluginDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
 	return deployment
 }
 
-func NewKvUIProxyDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
+func NewKvUIProxyDeployment(hc *hcov1.HyperConverged) *appsv1.Deployment {
 	// The env var was validated prior to handler creation
 	kvUIProxyImage, _ := os.LookupEnv(hcoutil.KVUIProxyImageEnvV)
 	deployment := getKvUIDeployment(hc, kvUIProxyDeploymentName, kvUIProxyImage, kvUIProxyServingCertName,
 		kvUIProxyServingCertPath, hcoutil.UIProxyServerPort, hcoutil.AppComponentUIProxy)
 
-	ciphers, minTLSVersion := tlssecprofile.GetCipherSuitesAndMinTLSVersionInGolangFormat(hc.Spec.TLSSecurityProfile)
+	ciphers, minTLSVersion := tlssecprofile.GetCipherSuitesAndMinTLSVersionInGolangFormat(hc.Spec.Security.TLSSecurityProfile)
 
 	var args []string
 	if minTLSVersion < tls.VersionTLS13 && len(ciphers) > 0 {
@@ -191,7 +191,7 @@ func NewKvUIProxyDeployment(hc *hcov1beta1.HyperConverged) *appsv1.Deployment {
 	return deployment
 }
 
-func getKvUIDeployment(hc *hcov1beta1.HyperConverged, deploymentName string, image string,
+func getKvUIDeployment(hc *hcov1.HyperConverged, deploymentName string, image string,
 	servingCertName string, servingCertPath string, port int32, componentName hcoutil.AppComponent) *appsv1.Deployment {
 	labels := operands.GetLabels(componentName)
 	infrastructureHighlyAvailable := nodeinfo.IsInfrastructureHighlyAvailable()
@@ -272,25 +272,20 @@ func getKvUIDeployment(hc *hcov1beta1.HyperConverged, deploymentName string, ima
 		},
 	}
 
-	if hc.Spec.Infra.NodePlacement != nil {
-		if hc.Spec.Infra.NodePlacement.NodeSelector != nil {
-			deployment.Spec.Template.Spec.NodeSelector = maps.Clone(hc.Spec.Infra.NodePlacement.NodeSelector)
+	if np := hc.Spec.Deployment.NodePlacements; np != nil && np.Infra != nil {
+		if np.Infra.NodeSelector != nil {
+			deployment.Spec.Template.Spec.NodeSelector = maps.Clone(np.Infra.NodeSelector)
 		} else {
 			deployment.Spec.Template.Spec.NodeSelector = nil
 		}
 
-		if hc.Spec.Infra.NodePlacement.Affinity != nil {
-			deployment.Spec.Template.Spec.Affinity = hc.Spec.Infra.NodePlacement.Affinity.DeepCopy()
+		if np.Infra.Affinity != nil {
+			deployment.Spec.Template.Spec.Affinity = np.Infra.Affinity.DeepCopy()
 		} else {
 			deployment.Spec.Template.Spec.Affinity = affinity
 		}
 
-		if hc.Spec.Infra.NodePlacement.Tolerations != nil {
-			deployment.Spec.Template.Spec.Tolerations = make([]corev1.Toleration, len(hc.Spec.Infra.NodePlacement.Tolerations))
-			copy(deployment.Spec.Template.Spec.Tolerations, hc.Spec.Infra.NodePlacement.Tolerations)
-		} else {
-			deployment.Spec.Template.Spec.Tolerations = nil
-		}
+		deployment.Spec.Template.Spec.Tolerations = slices.Clone(np.Infra.Tolerations)
 	} else {
 		deployment.Spec.Template.Spec.NodeSelector = nil
 		deployment.Spec.Template.Spec.Affinity = affinity
@@ -381,8 +376,8 @@ type nginxConfTemplateData struct {
 	SSLCiphers   string
 }
 
-func getNginxConfig(hc *hcov1beta1.HyperConverged) (string, error) {
-	ciphers, minTLS := tlssecprofile.GetCipherSuitesAndMinTLSVersion(hc.Spec.TLSSecurityProfile)
+func getNginxConfig(hc *hcov1.HyperConverged) (string, error) {
+	ciphers, minTLS := tlssecprofile.GetCipherSuitesAndMinTLSVersion(hc.Spec.Security.TLSSecurityProfile)
 	data := nginxConfTemplateData{
 		Port:         hcoutil.UIPluginServerPort,
 		SSLProtocols: nginxSSLProtocolsFromMinTLS(minTLS),
@@ -400,7 +395,7 @@ func getNginxConfig(hc *hcov1beta1.HyperConverged) (string, error) {
 	return out.String(), nil
 }
 
-func NewKVUINginxCM(hc *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {
+func NewKVUINginxCM(hc *hcov1.HyperConverged) (*corev1.ConfigMap, error) {
 	nginxConf, err := getNginxConfig(hc)
 	if err != nil {
 		return nil, err
@@ -551,7 +546,7 @@ type consolePluginHooks struct {
 	required *consolev1.ConsolePlugin
 }
 
-func (h consolePluginHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h consolePluginHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.required.DeepCopy(), nil
 }
 

--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -26,7 +26,7 @@ import (
 
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
@@ -37,7 +37,7 @@ import (
 
 var _ = Describe("Kubevirt Console Plugin", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 	)
 
@@ -271,7 +271,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 	Context("Kubevirt Console Plugin and UI Proxy Deployments", func() {
 		DescribeTable("should create if not present", func(appComponent hcoutil.AppComponent,
-			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+			deploymentManifestor func(*hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 			expectedResource := deploymentManifestor(hco)
 
 			cl := commontestutils.InitClient([]client.Object{})
@@ -302,7 +302,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		)
 
 		DescribeTable("should find deployment if present", func(appComponent hcoutil.AppComponent,
-			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+			deploymentManifestor func(*hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 			expectedResource := deploymentManifestor(hco)
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
@@ -331,7 +331,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		)
 
 		DescribeTable("should reconcile deployment to default if changed - (updatable fields)", func(appComponent hcoutil.AppComponent,
-			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+			deploymentManifestor func(*hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 			expectedResource := deploymentManifestor(hco)
 			outdatedResource := deploymentManifestor(hco)
 
@@ -378,7 +378,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		)
 
 		DescribeTable("should reconcile deployment to default if changed - (immutable fields)", func(appComponent hcoutil.AppComponent,
-			deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+			deploymentManifestor func(*hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 			expectedResource := deploymentManifestor(hco)
 			outdatedResource := deploymentManifestor(hco)
 
@@ -425,7 +425,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 		)
 
 		Context("Kubevirt UI configuration config maps", func() {
-			var hco *hcov1beta1.HyperConverged
+			var hco *hcov1.HyperConverged
 			var req *common.HcoRequest
 
 			BeforeEach(func() {
@@ -519,8 +519,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 		Context("KubeVirt UI Nginx ConfigMap (NewKVUINginxCM)", func() {
 			It("should create nginx ConfigMap with default TLS when TLSSecurityProfile is nil", func() {
-				hco := commontestutils.NewHco()
-				Expect(hco.Spec.TLSSecurityProfile).To(BeNil())
+				Expect(hco.Spec.Security.TLSSecurityProfile).To(BeNil())
 				cm, err := NewKVUINginxCM(hco)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cm).ToNot(BeNil())
@@ -535,8 +534,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			})
 
 			It("should create nginx ConfigMap with Modern TLS profile", func() {
-				hco := commontestutils.NewHco()
-				hco.Spec.TLSSecurityProfile = &openshiftconfigv1.TLSSecurityProfile{
+				hco.Spec.Security.TLSSecurityProfile = &openshiftconfigv1.TLSSecurityProfile{
 					Type: openshiftconfigv1.TLSProfileModernType,
 				}
 				cm, err := NewKVUINginxCM(hco)
@@ -550,8 +548,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			})
 
 			It("should create nginx ConfigMap with Intermediate TLS profile", func() {
-				hco := commontestutils.NewHco()
-				hco.Spec.TLSSecurityProfile = &openshiftconfigv1.TLSSecurityProfile{
+				hco.Spec.Security.TLSSecurityProfile = &openshiftconfigv1.TLSSecurityProfile{
 					Type: openshiftconfigv1.TLSProfileIntermediateType,
 				}
 				cm, err := NewKVUINginxCM(hco)
@@ -567,8 +564,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			})
 
 			It("should create nginx ConfigMap with Custom TLS profile", func() {
-				hco := commontestutils.NewHco()
-				hco.Spec.TLSSecurityProfile = &openshiftconfigv1.TLSSecurityProfile{
+				hco.Spec.Security.TLSSecurityProfile = &openshiftconfigv1.TLSSecurityProfile{
 					Type: openshiftconfigv1.TLSProfileCustomType,
 					Custom: &openshiftconfigv1.CustomTLSProfile{
 						TLSProfileSpec: openshiftconfigv1.TLSProfileSpec{
@@ -588,7 +584,6 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			})
 
 			It("should not emit empty ssl_protocols or ssl_ciphers directives", func() {
-				hco := commontestutils.NewHco()
 				cm, err := NewKVUINginxCM(hco)
 				Expect(err).ToNot(HaveOccurred())
 				nginxConf := cm.Data["nginx.conf"]
@@ -600,11 +595,10 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 		Context("Node Placement", func() {
 			DescribeTable("should add node placement if missing", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+				deploymentManifestor func(*hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				existingResource := deploymentManifestor(hco)
 
-				hco.Spec.Workloads.NodePlacement = commontestutils.NewNodePlacement()
-				hco.Spec.Infra.NodePlacement = commontestutils.NewOtherNodePlacement()
+				commontestutils.SetNodeCustomPlacement(hco, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := handlerFunc(cl, commontestutils.GetScheme())
@@ -627,19 +621,19 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				Expect(existingResource.Spec.Template.Spec.Affinity).To(BeNil())
 				Expect(existingResource.Spec.Template.Spec.Tolerations).To(BeEmpty())
 
-				Expect(foundResource.Spec.Template.Spec.NodeSelector).To(BeEquivalentTo(hco.Spec.Infra.NodePlacement.NodeSelector))
-				Expect(foundResource.Spec.Template.Spec.Affinity).To(BeEquivalentTo(hco.Spec.Infra.NodePlacement.Affinity))
-				Expect(foundResource.Spec.Template.Spec.Tolerations).To(BeEquivalentTo(hco.Spec.Infra.NodePlacement.Tolerations))
+				infra := hco.Spec.Deployment.NodePlacements.Infra
+				Expect(foundResource.Spec.Template.Spec.NodeSelector).To(BeEquivalentTo(infra.NodeSelector))
+				Expect(foundResource.Spec.Template.Spec.Affinity).To(BeEquivalentTo(infra.Affinity))
+				Expect(foundResource.Spec.Template.Spec.Tolerations).To(BeEquivalentTo(infra.Tolerations))
 			},
 				Entry("plugin deployment", hcoutil.AppComponentUIPlugin, NewKvUIPluginDeployment, NewKvUIPluginDeploymentHandler),
 				Entry("proxy deployment", hcoutil.AppComponentUIProxy, NewKvUIProxyDeployment, NewKvUIProxyDeploymentHandler),
 			)
 
 			DescribeTable("should remove node placement if missing in HCO CR", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+				deploymentManifestor func(*hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				hcoNodePlacement := commontestutils.NewHco()
-				hcoNodePlacement.Spec.Workloads.NodePlacement = commontestutils.NewNodePlacement()
-				hcoNodePlacement.Spec.Infra.NodePlacement = commontestutils.NewOtherNodePlacement()
+				commontestutils.SetNodeCustomPlacement(hcoNodePlacement, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
 
 				existingResource := deploymentManifestor(hcoNodePlacement)
 
@@ -673,18 +667,17 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("should modify node placement according to HCO CR", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
-
-				hco.Spec.Workloads.NodePlacement = commontestutils.NewNodePlacement()
-				hco.Spec.Infra.NodePlacement = commontestutils.NewOtherNodePlacement()
+				deploymentManifestor func(*hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+				commontestutils.SetNodeCustomPlacement(hco, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
 
 				existingResource := deploymentManifestor(hco)
 
 				// now, modify HCO's node placement
-				hco.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, v1.Toleration{
+				infra := hco.Spec.Deployment.NodePlacements.Infra
+				infra.Tolerations = append(infra.Tolerations, v1.Toleration{
 					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: ptr.To[int64](34),
 				})
-				hco.Spec.Infra.NodePlacement.NodeSelector["key3"] = "something entirely else"
+				infra.NodeSelector["key3"] = "something entirely else"
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := handlerFunc(cl, commontestutils.GetScheme())
@@ -718,17 +711,15 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("should overwrite node placement if directly set on Kubevirt Console Plugin Deployment", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(*hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
-
-				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewOtherNodePlacement()}
+				deploymentManifestor func(*hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+				commontestutils.SetNodeCustomPlacement(hco, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
 				existingResource := deploymentManifestor(hco)
 
 				// mock a reconciliation triggered by a change in the deployment
 				req.HCOTriggered = false
 
 				// now, modify deployment Kubevirt Console Plugin Deployment node placement
-				existingResource.Spec.Template.Spec.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, v1.Toleration{
+				existingResource.Spec.Template.Spec.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, v1.Toleration{
 					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: ptr.To[int64](34),
 				})
 				existingResource.Spec.Template.Spec.NodeSelector["key3"] = "BADvalue3"
@@ -762,11 +753,14 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("apply only NodeSelector if missing", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+				deploymentManifestor func(converged *hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				existingResource := deploymentManifestor(hco)
 
-				hco.Spec.Infra.NodePlacement = &sdkapi.NodePlacement{}
-				hco.Spec.Infra.NodePlacement.NodeSelector = commontestutils.NewNodePlacement().NodeSelector
+				hco.Spec.Deployment.NodePlacements = &hcov1.NodePlacements{
+					Infra: &sdkapi.NodePlacement{
+						NodeSelector: commontestutils.NewNodePlacement().NodeSelector,
+					},
+				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := handlerFunc(cl, commontestutils.GetScheme())
@@ -786,18 +780,21 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				).To(Succeed())
 
 				Expect(existingResource.Spec.Template.Spec.NodeSelector).To(BeEmpty())
-				Expect(foundResource.Spec.Template.Spec.NodeSelector).To(BeEquivalentTo(hco.Spec.Infra.NodePlacement.NodeSelector))
+				Expect(foundResource.Spec.Template.Spec.NodeSelector).To(BeEquivalentTo(hco.Spec.Deployment.NodePlacements.Infra.NodeSelector))
 			},
 				Entry("plugin deployment", hcoutil.AppComponentUIPlugin, NewKvUIPluginDeployment, NewKvUIPluginDeploymentHandler),
 				Entry("proxy deployment", hcoutil.AppComponentUIProxy, NewKvUIProxyDeployment, NewKvUIProxyDeploymentHandler),
 			)
 
 			DescribeTable("apply only Affinity if missing", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+				deploymentManifestor func(converged *hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				existingResource := deploymentManifestor(hco)
 
-				hco.Spec.Infra.NodePlacement = &sdkapi.NodePlacement{}
-				hco.Spec.Infra.NodePlacement.Affinity = commontestutils.NewNodePlacement().Affinity
+				hco.Spec.Deployment.NodePlacements = &hcov1.NodePlacements{
+					Infra: &sdkapi.NodePlacement{
+						Affinity: commontestutils.NewNodePlacement().Affinity,
+					},
+				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := handlerFunc(cl, commontestutils.GetScheme())
@@ -817,18 +814,21 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				).To(Succeed())
 
 				Expect(existingResource.Spec.Template.Spec.Affinity).To(BeNil())
-				Expect(foundResource.Spec.Template.Spec.Affinity).To(BeEquivalentTo(hco.Spec.Infra.NodePlacement.Affinity))
+				Expect(foundResource.Spec.Template.Spec.Affinity).To(BeEquivalentTo(hco.Spec.Deployment.NodePlacements.Infra.Affinity))
 			},
 				Entry("plugin deployment", hcoutil.AppComponentUIPlugin, NewKvUIPluginDeployment, NewKvUIPluginDeploymentHandler),
 				Entry("proxy deployment", hcoutil.AppComponentUIProxy, NewKvUIProxyDeployment, NewKvUIProxyDeploymentHandler),
 			)
 
 			DescribeTable("apply only Tolerations if missing", func(appComponent hcoutil.AppComponent,
-				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+				deploymentManifestor func(converged *hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 				existingResource := deploymentManifestor(hco)
 
-				hco.Spec.Infra.NodePlacement = &sdkapi.NodePlacement{}
-				hco.Spec.Infra.NodePlacement.Tolerations = commontestutils.NewNodePlacement().Tolerations
+				hco.Spec.Deployment.NodePlacements = &hcov1.NodePlacements{
+					Infra: &sdkapi.NodePlacement{
+						Tolerations: commontestutils.NewNodePlacement().Tolerations,
+					},
+				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := handlerFunc(cl, commontestutils.GetScheme())
@@ -848,14 +848,14 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				).To(Succeed())
 
 				Expect(existingResource.Spec.Template.Spec.Tolerations).To(BeEmpty())
-				Expect(foundResource.Spec.Template.Spec.Tolerations).To(BeEquivalentTo(hco.Spec.Infra.NodePlacement.Tolerations))
+				Expect(foundResource.Spec.Template.Spec.Tolerations).To(BeEquivalentTo(hco.Spec.Deployment.NodePlacements.Infra.Tolerations))
 			},
 				Entry("plugin deployment", hcoutil.AppComponentUIPlugin, NewKvUIPluginDeployment, NewKvUIPluginDeploymentHandler),
 				Entry("proxy deployment", hcoutil.AppComponentUIProxy, NewKvUIProxyDeployment, NewKvUIProxyDeploymentHandler),
 			)
 
 			DescribeTable("apply PodAntiAffinity and two replicas if HighlyAvailable", func(ctx context.Context, appComponent hcoutil.AppComponent,
-				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+				deploymentManifestor func(converged *hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 
 				originalNodeInfoFunc := nodeinfo.IsInfrastructureHighlyAvailable
 				nodeinfo.IsInfrastructureHighlyAvailable = func() bool {
@@ -868,7 +868,9 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 				existingResource := deploymentManifestor(hco)
 
-				hco.Spec.Infra.NodePlacement = nil
+				hco.Spec.Deployment.NodePlacements = &hcov1.NodePlacements{
+					Infra: nil,
+				}
 				existingResource.Spec.Template.Spec.Affinity = nil
 				existingResource.Spec.Replicas = ptr.To(int32(1))
 
@@ -901,7 +903,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			)
 
 			DescribeTable("use one replica on SNO", func(ctx context.Context, appComponent hcoutil.AppComponent,
-				deploymentManifestor func(converged *hcov1beta1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
+				deploymentManifestor func(converged *hcov1.HyperConverged) *appsv1.Deployment, handlerFunc func(cli client.Client, Scheme *runtime.Scheme) operands.Operand) {
 
 				commontestutils.SNONodeInfoMock()
 				DeferCleanup(func() {
@@ -1320,7 +1322,7 @@ func expectedPodAntiAffinity(appComponent hcoutil.AppComponent) *v1.Affinity {
 	}
 }
 
-func newExpectedDeployment(_ *hcov1beta1.HyperConverged) *appsv1.Deployment {
+func newExpectedDeployment(_ *hcov1.HyperConverged) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -25,7 +25,7 @@ import (
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/aie"
@@ -50,7 +50,7 @@ var _ = Describe("KubeVirt Operand", func() {
 
 	Context("KubeVirt Priority Classes", func() {
 
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
@@ -260,7 +260,7 @@ var _ = Describe("KubeVirt Operand", func() {
 	})
 
 	Context("KubeVirt", func() {
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
@@ -282,6 +282,9 @@ Version: 1.2.3`)).To(Succeed())
 			restArchConfig()
 
 			DeferCleanup(func() {
+				// reset smbios once
+				smbiosOnce = &sync.Once{}
+
 				Expect(os.Unsetenv(smbiosEnvName)).To(Succeed())
 				Expect(os.Unsetenv(machineTypeEnvName)).To(Succeed())
 				Expect(os.Unsetenv(amd64MachineTypeEnvName)).To(Succeed())
@@ -295,14 +298,12 @@ Version: 1.2.3`)).To(Succeed())
 
 		It("should create if not present", func() {
 			mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
-			hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-				DownwardMetrics: ptr.To(true),
-			}
+			hco.Spec.FeatureGates.Enable("downwardMetrics")
 			bindingPlugins := map[string]kubevirtcorev1.InterfaceBindingPlugin{
 				"binding1": {SidecarImage: "image1", NetworkAttachmentDefinition: "nad1"},
 				"l2bridge": {Migration: &kubevirtcorev1.InterfaceBindingMigration{}, DomainAttachmentType: "managedTap"},
 			}
-			hco.Spec.NetworkBinding = bindingPlugins
+			hco.Spec.Networking = &hcov1.NetworkingConfig{NetworkBinding: bindingPlugins}
 
 			expectedResource, err := NewKubeVirt(hco, commontestutils.Namespace)
 			Expect(err).ToNot(HaveOccurred())
@@ -470,9 +471,7 @@ Version: 1.2.3`)).To(Succeed())
 
 		It("should force mandatory configurations", func() {
 			mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
-			hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-				DownwardMetrics: ptr.To(true),
-			}
+			hco.Spec.FeatureGates.Enable("downwardMetrics")
 
 			os.Setenv(smbiosEnvName,
 				`Family: smbios family
@@ -621,9 +620,7 @@ Version: 1.2.3`)
 		})
 
 		It("should fail if the SMBIOS is wrongly formatted mandatory configurations", func() {
-			hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-				WithHostPassthroughCPU: ptr.To(true),
-			}
+			hco.Spec.FeatureGates.Enable("withHostPassthroughCPU")
 
 			_ = os.Setenv(smbiosEnvName, "WRONG YAML")
 
@@ -632,7 +629,7 @@ Version: 1.2.3`)
 		})
 
 		It("should fail if the Spec.LiveMigrationConfig.BandwidthPerMigration is wrongly formatted", func() {
-			hco.Spec.LiveMigrationConfig.BandwidthPerMigration = ptr.To("Wrong Format")
+			hco.Spec.Virtualization.LiveMigrationConfig.BandwidthPerMigration = ptr.To("Wrong Format")
 
 			_, err := NewKubeVirt(hco, commontestutils.Namespace)
 			Expect(err).To(HaveOccurred())
@@ -667,7 +664,7 @@ Version: 1.2.3`)
 			It("should set BlockUninstallIfWorkloadsExist if missing HCO CR", func() {
 				expectedResource, err := NewKubeVirt(hco, commontestutils.Namespace)
 				Expect(err).ToNot(HaveOccurred())
-				hco.Spec.UninstallStrategy = ""
+				hco.Spec.Deployment.UninstallStrategy = ""
 
 				cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -689,7 +686,7 @@ Version: 1.2.3`)
 				expectedResource, err := NewKubeVirt(hco, commontestutils.Namespace)
 				Expect(err).ToNot(HaveOccurred())
 				uninstallStrategy := hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
-				hco.Spec.UninstallStrategy = uninstallStrategy
+				hco.Spec.Deployment.UninstallStrategy = uninstallStrategy
 
 				cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -711,7 +708,7 @@ Version: 1.2.3`)
 				expectedResource, err := NewKubeVirt(hco, commontestutils.Namespace)
 				Expect(err).ToNot(HaveOccurred())
 				uninstallStrategy := hcov1.HyperConvergedUninstallStrategyRemoveWorkloads
-				hco.Spec.UninstallStrategy = uninstallStrategy
+				hco.Spec.Deployment.UninstallStrategy = uninstallStrategy
 
 				cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -744,14 +741,14 @@ Version: 1.2.3`)
 				network                           = "testNetwork"
 			)
 
-			hco.Spec.LiveMigrationConfig.BandwidthPerMigration = ptr.To(bandwidthPerMigration)
-			hco.Spec.LiveMigrationConfig.CompletionTimeoutPerGiB = ptr.To(completionTimeoutPerGiB)
-			hco.Spec.LiveMigrationConfig.ParallelOutboundMigrationsPerNode = ptr.To(parallelOutboundMigrationsPerNode)
-			hco.Spec.LiveMigrationConfig.ParallelMigrationsPerCluster = ptr.To(parallelMigrationsPerCluster)
-			hco.Spec.LiveMigrationConfig.ProgressTimeout = ptr.To(progressTimeout)
-			hco.Spec.LiveMigrationConfig.Network = ptr.To(network)
-			hco.Spec.LiveMigrationConfig.AllowAutoConverge = ptr.To(true)
-			hco.Spec.LiveMigrationConfig.AllowPostCopy = ptr.To(true)
+			hco.Spec.Virtualization.LiveMigrationConfig.BandwidthPerMigration = ptr.To(bandwidthPerMigration)
+			hco.Spec.Virtualization.LiveMigrationConfig.CompletionTimeoutPerGiB = ptr.To(completionTimeoutPerGiB)
+			hco.Spec.Virtualization.LiveMigrationConfig.ParallelOutboundMigrationsPerNode = ptr.To(parallelOutboundMigrationsPerNode)
+			hco.Spec.Virtualization.LiveMigrationConfig.ParallelMigrationsPerCluster = ptr.To(parallelMigrationsPerCluster)
+			hco.Spec.Virtualization.LiveMigrationConfig.ProgressTimeout = ptr.To(progressTimeout)
+			hco.Spec.Virtualization.LiveMigrationConfig.Network = ptr.To(network)
+			hco.Spec.Virtualization.LiveMigrationConfig.AllowAutoConverge = ptr.To(true)
+			hco.Spec.Virtualization.LiveMigrationConfig.AllowPostCopy = ptr.To(true)
 
 			cl := commontestutils.InitClient([]client.Object{hco, existKv})
 			handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -792,7 +789,7 @@ Version: 1.2.3`)
 
 		Context("test mediated device configuration", func() {
 			It("should not propagate the mediated devices configuration, if not set in HCO", func() {
-				hco.Spec.MediatedDevicesConfiguration = nil
+				hco.Spec.Virtualization.MediatedDevicesConfiguration = nil
 
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
@@ -801,8 +798,8 @@ Version: 1.2.3`)
 			})
 
 			It("should propagate the mediated devices configuration, only with the Enabled field, if not set in HCO, and the FG is true", func() {
-				hco.Spec.MediatedDevicesConfiguration = nil
-				hco.Spec.FeatureGates.DisableMDevConfiguration = ptr.To(true)
+				hco.Spec.Virtualization.MediatedDevicesConfiguration = nil
+				hco.Spec.FeatureGates.Enable("disableMDevConfiguration")
 
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
@@ -811,42 +808,11 @@ Version: 1.2.3`)
 				Expect(kv.Spec.Configuration.MediatedDevicesConfiguration.Enabled).To(HaveValue(BeFalse()))
 			})
 
-			It("should propagate the mediated devices configuration from the HC with deprecated APIs", func() {
-				existKv, err := NewKubeVirt(hco)
-				Expect(err).ToNot(HaveOccurred())
-
-				hco.Spec.MediatedDevicesConfiguration = &hcov1beta1.MediatedDevicesConfiguration{
-					MediatedDevicesTypes: []string{"nvidia-222", "nvidia-230"}, //nolint SA1019
-				}
-
-				cl := commontestutils.InitClient([]client.Object{hco, existKv})
-				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
-				res := handler.Ensure(req)
-
-				Expect(res.UpgradeDone).To(BeFalse())
-				Expect(res.Updated).To(BeTrue())
-				Expect(res.Err).ToNot(HaveOccurred())
-
-				foundResource := &kubevirtcorev1.KubeVirt{}
-				Expect(
-					cl.Get(context.TODO(),
-						types.NamespacedName{Name: existKv.Name, Namespace: existKv.Namespace},
-						foundResource),
-				).ToNot(HaveOccurred())
-
-				mdevConf := foundResource.Spec.Configuration.MediatedDevicesConfiguration
-				Expect(mdevConf).ToNot(BeNil())
-				Expect(mdevConf.MediatedDeviceTypes).To(HaveLen(2))
-				Expect(mdevConf.MediatedDeviceTypes).To(ContainElements("nvidia-222", "nvidia-230"))
-				Expect(mdevConf.MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
-
-			})
-
 			It("should propagate the mediated devices configuration from the HC - mediatedDeviceTypes", func() {
 				existKv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.MediatedDevicesConfiguration = &hcov1beta1.MediatedDevicesConfiguration{
+				hco.Spec.Virtualization.MediatedDevicesConfiguration = &hcov1.MediatedDevicesConfiguration{
 					MediatedDeviceTypes: []string{"nvidia-222", "nvidia-230"},
 				}
 
@@ -873,68 +839,13 @@ Version: 1.2.3`)
 
 			})
 
-			It("should propagate the mediated devices configuration from the HC with node selectors with deprecated APIs", func() {
-				existKv, err := NewKubeVirt(hco)
-				Expect(err).ToNot(HaveOccurred())
-
-				hco.Spec.MediatedDevicesConfiguration = &hcov1beta1.MediatedDevicesConfiguration{
-					MediatedDevicesTypes: []string{"nvidia-222", "nvidia-230"}, //nolint SA1019
-					NodeMediatedDeviceTypes: []hcov1beta1.NodeMediatedDeviceTypesConfig{
-						{
-							NodeSelector: map[string]string{
-								"testLabel1": "true",
-							},
-							MediatedDevicesTypes: []string{ //nolint SA1019
-								"nvidia-223",
-							},
-						},
-						{
-							NodeSelector: map[string]string{
-								"testLabel2": "true",
-							},
-							MediatedDevicesTypes: []string{ //nolint SA1019
-								"nvidia-229",
-							},
-						},
-					},
-				}
-
-				cl := commontestutils.InitClient([]client.Object{hco, existKv})
-				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
-				res := handler.Ensure(req)
-
-				Expect(res.UpgradeDone).To(BeFalse())
-				Expect(res.Updated).To(BeTrue())
-				Expect(res.Err).ToNot(HaveOccurred())
-
-				foundResource := &kubevirtcorev1.KubeVirt{}
-				Expect(
-					cl.Get(context.TODO(),
-						types.NamespacedName{Name: existKv.Name, Namespace: existKv.Namespace},
-						foundResource),
-				).ToNot(HaveOccurred())
-
-				mdevConf := foundResource.Spec.Configuration.MediatedDevicesConfiguration
-				Expect(mdevConf).ToNot(BeNil())
-				Expect(mdevConf.MediatedDeviceTypes).To(HaveLen(2))
-				Expect(mdevConf.MediatedDeviceTypes).To(ContainElements("nvidia-222", "nvidia-230"))
-				Expect(mdevConf.MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
-				Expect(mdevConf.NodeMediatedDeviceTypes).To(HaveLen(2))
-				Expect(mdevConf.NodeMediatedDeviceTypes[0].MediatedDeviceTypes).To(ContainElements("nvidia-223"))
-				Expect(mdevConf.NodeMediatedDeviceTypes[0].NodeSelector).To(HaveKeyWithValue("testLabel1", "true"))
-				Expect(mdevConf.NodeMediatedDeviceTypes[0].MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
-				Expect(mdevConf.NodeMediatedDeviceTypes[1].MediatedDeviceTypes).To(ContainElements("nvidia-229"))
-				Expect(mdevConf.NodeMediatedDeviceTypes[1].NodeSelector).To(HaveKeyWithValue("testLabel2", "true"))
-				Expect(mdevConf.NodeMediatedDeviceTypes[1].MediatedDevicesTypes).To(BeEmpty()) //nolint SA1019
-
-			})
 			It("should propagate the mediated devices configuration from the HC with node selectors - mediatedDeviceTypes", func() {
 				existKv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.MediatedDevicesConfiguration = &hcov1beta1.MediatedDevicesConfiguration{
+				hco.Spec.Virtualization.MediatedDevicesConfiguration = &hcov1.MediatedDevicesConfiguration{
 					MediatedDeviceTypes: []string{"nvidia-222", "nvidia-230"},
-					NodeMediatedDeviceTypes: []hcov1beta1.NodeMediatedDeviceTypesConfig{
+					NodeMediatedDeviceTypes: []hcov1.NodeMediatedDeviceTypesConfig{
 						{
 							NodeSelector: map[string]string{
 								"testLabel1": "true",
@@ -991,7 +902,7 @@ Version: 1.2.3`)
 					MediatedDeviceTypes: []string{"nvidia-222", "nvidia-230"},
 				}
 
-				hco.Spec.MediatedDevicesConfiguration = &hcov1beta1.MediatedDevicesConfiguration{
+				hco.Spec.Virtualization.MediatedDevicesConfiguration = &hcov1.MediatedDevicesConfiguration{
 					MediatedDeviceTypes: []string{"nvidia-181", "nvidia-191", "nvidia-224"},
 				}
 
@@ -1033,59 +944,11 @@ Version: 1.2.3`)
 				Expect(mdc.MediatedDeviceTypes).To(ContainElements("nvidia-181", "nvidia-191", "nvidia-224"))
 			})
 
-			It("should update the permitted host devices configuration from the HC migrating to mediatedDeviceTypes", func() {
-				existKv, err := NewKubeVirt(hco)
-				Expect(err).ToNot(HaveOccurred())
-
-				existKv.Spec.Configuration.MediatedDevicesConfiguration = &kubevirtcorev1.MediatedDevicesConfiguration{
-					MediatedDevicesTypes: []string{"nvidia-222", "nvidia-230"}, //nolint SA1019
-				}
-
-				hco.Spec.MediatedDevicesConfiguration = &hcov1beta1.MediatedDevicesConfiguration{
-					MediatedDevicesTypes: []string{"nvidia-181", "nvidia-191", "nvidia-224"}, //nolint SA1019
-				}
-
-				cl := commontestutils.InitClient([]client.Object{hco, existKv})
-
-				By("Check before reconciling", func() {
-					foundResource := &kubevirtcorev1.KubeVirt{}
-					Expect(
-						cl.Get(context.TODO(),
-							types.NamespacedName{Name: existKv.Name, Namespace: existKv.Namespace},
-							foundResource),
-					).To(Succeed())
-
-					mdc := foundResource.Spec.Configuration.MediatedDevicesConfiguration
-					Expect(mdc).ToNot(BeNil())
-					Expect(mdc.MediatedDevicesTypes).To(HaveLen(2))                                  //nolint SA1019
-					Expect(mdc.MediatedDevicesTypes).To(ContainElements("nvidia-222", "nvidia-230")) //nolint SA1019
-
-				})
-
-				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
-				res := handler.Ensure(req)
-
-				Expect(res.UpgradeDone).To(BeFalse())
-				Expect(res.Updated).To(BeTrue())
-				Expect(res.Err).ToNot(HaveOccurred())
-
-				foundResource := &kubevirtcorev1.KubeVirt{}
-				Expect(
-					cl.Get(context.TODO(),
-						types.NamespacedName{Name: existKv.Name, Namespace: existKv.Namespace},
-						foundResource),
-				).ToNot(HaveOccurred())
-
-				By("Check after reconcile")
-				mdc := foundResource.Spec.Configuration.MediatedDevicesConfiguration
-				Expect(mdc).ToNot(BeNil())
-				Expect(mdc.MediatedDeviceTypes).To(HaveLen(3))
-				Expect(mdc.MediatedDeviceTypes).To(ContainElements("nvidia-181", "nvidia-191", "nvidia-224"))
-			})
-
 			It("should set the enabled field to false, if the DisableMDevConfiguration FG is enabled", func() {
-				hco.Spec.FeatureGates.DisableMDevConfiguration = ptr.To(true)
-				hco.Spec.MediatedDevicesConfiguration = &hcov1beta1.MediatedDevicesConfiguration{
+				hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+					{Name: "disableMDevConfiguration"},
+				}
+				hco.Spec.Virtualization.MediatedDevicesConfiguration = &hcov1.MediatedDevicesConfiguration{
 					MediatedDeviceTypes: []string{"nvidia-222", "nvidia-230"},
 				}
 
@@ -1097,8 +960,10 @@ Version: 1.2.3`)
 			})
 
 			It("should not set the enabled field, if the DisableMDevConfiguration FG is disabled", func() {
-				hco.Spec.FeatureGates.DisableMDevConfiguration = ptr.To(false)
-				hco.Spec.MediatedDevicesConfiguration = &hcov1beta1.MediatedDevicesConfiguration{
+				hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+					{Name: "disableMDevConfiguration", State: ptr.To(featuregates.Disabled)},
+				}
+				hco.Spec.Virtualization.MediatedDevicesConfiguration = &hcov1.MediatedDevicesConfiguration{
 					MediatedDeviceTypes: []string{"nvidia-222", "nvidia-230"},
 				}
 
@@ -1109,9 +974,9 @@ Version: 1.2.3`)
 				Expect(kv.Spec.Configuration.MediatedDevicesConfiguration.Enabled).To(BeNil())
 			})
 
-			It("should not set the enabled field, if the DisableMDevConfiguration FG is nil", func() {
-				hco.Spec.FeatureGates.DisableMDevConfiguration = nil
-				hco.Spec.MediatedDevicesConfiguration = &hcov1beta1.MediatedDevicesConfiguration{
+			It("should not set the enabled field, if the DisableMDevConfiguration FG is not defined", func() {
+				hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{}
+				hco.Spec.Virtualization.MediatedDevicesConfiguration = &hcov1.MediatedDevicesConfiguration{
 					MediatedDeviceTypes: []string{"nvidia-222", "nvidia-230"},
 				}
 
@@ -1128,7 +993,7 @@ Version: 1.2.3`)
 				existKv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.PermittedHostDevices = &hcov1.PermittedHostDevices{
+				hco.Spec.Virtualization.PermittedHostDevices = &hcov1.PermittedHostDevices{
 					PciHostDevices: []hcov1.PciHostDevice{
 						{
 							PCIDeviceSelector:        "vendor1",
@@ -1411,7 +1276,7 @@ Version: 1.2.3`)
 					},
 				}
 
-				hco.Spec.PermittedHostDevices = &hcov1.PermittedHostDevices{
+				hco.Spec.Virtualization.PermittedHostDevices = &hcov1.PermittedHostDevices{
 					PciHostDevices: []hcov1.PciHostDevice{
 						{
 							PCIDeviceSelector:        "vendor1",
@@ -1702,8 +1567,10 @@ Version: 1.2.3`)
 				existKv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				testCPUModel := "testValue"
-				hco.Spec.DefaultCPUModel = ptr.To(testCPUModel)
+				const testCPUModel = "testValue"
+				hco.Spec.Virtualization.VirtualMachineOptions = &hcov1.VirtualMachineOptions{
+					DefaultCPUModel: ptr.To(testCPUModel),
+				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existKv})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -1721,7 +1588,6 @@ Version: 1.2.3`)
 				).ToNot(HaveOccurred())
 
 				kvCPUModel := foundResource.Spec.Configuration.CPUModel
-				Expect(kvCPUModel).ToNot(BeEmpty())
 				Expect(kvCPUModel).To(Equal(testCPUModel))
 
 			})
@@ -1730,7 +1596,7 @@ Version: 1.2.3`)
 				existKv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.DefaultCPUModel = nil
+				hco.Spec.Virtualization.VirtualMachineOptions = &hcov1.VirtualMachineOptions{DefaultCPUModel: nil}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existKv})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -1763,7 +1629,9 @@ Version: 1.2.3`)
 
 				existKv.Spec.Configuration.CPUModel = oldKVCPUmodel
 
-				hco.Spec.DefaultCPUModel = ptr.To(testCPUModel)
+				hco.Spec.Virtualization.VirtualMachineOptions = &hcov1.VirtualMachineOptions{
+					DefaultCPUModel: ptr.To(testCPUModel),
+				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existKv})
 
@@ -1821,9 +1689,7 @@ Version: 1.2.3`)
 			It("should add node placement if missing in KubeVirt", func() {
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
-
-				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				commontestutils.SetNodePlacement(hco)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -1843,23 +1709,24 @@ Version: 1.2.3`)
 				Expect(existingResource.Spec.Infra).To(BeNil())
 				Expect(existingResource.Spec.Workloads).To(BeNil())
 
+				expectedNP := commontestutils.NewNodePlacement()
 				Expect(foundResource.Spec.Infra).ToNot(BeNil())
 				Expect(foundResource.Spec.Infra.NodePlacement).ToNot(BeNil())
 				Expect(foundResource.Spec.Infra.NodePlacement.Affinity).ToNot(BeNil())
-				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key1"]).To(Equal("value1"))
-				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector["key2"]).To(Equal("value2"))
+				Expect(foundResource.Spec.Infra.NodePlacement.NodeSelector).To(Equal(expectedNP.NodeSelector))
+				Expect(foundResource.Spec.Infra.NodePlacement.Tolerations).To(Equal(expectedNP.Tolerations))
 
 				Expect(foundResource.Spec.Workloads).ToNot(BeNil())
 				Expect(foundResource.Spec.Workloads.NodePlacement).ToNot(BeNil())
-				Expect(foundResource.Spec.Workloads.NodePlacement.Tolerations).To(Equal(hco.Spec.Workloads.NodePlacement.Tolerations))
+				Expect(foundResource.Spec.Workloads.NodePlacement.NodeSelector).To(Equal(expectedNP.NodeSelector))
+				Expect(foundResource.Spec.Workloads.NodePlacement.Tolerations).To(Equal(expectedNP.Tolerations))
 
 				Expect(req.Conditions).To(BeEmpty())
 			})
 
 			It("should remove node placement if missing in HCO CR", func() {
 				hcoNodePlacement := commontestutils.NewHco()
-				hcoNodePlacement.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hcoNodePlacement.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				commontestutils.SetNodePlacement(hcoNodePlacement)
 				existingResource, err := NewKubeVirt(hcoNodePlacement)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1888,17 +1755,16 @@ Version: 1.2.3`)
 			})
 
 			It("should modify node placement according to HCO CR", func() {
-				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				commontestutils.SetNodePlacement(hco)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				// now, modify HCO's node placement
-				hco.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+				hco.Spec.Deployment.NodePlacements.Infra.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, corev1.Toleration{
 					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
 
-				hco.Spec.Workloads.NodePlacement.NodeSelector["key1"] = "something else"
+				hco.Spec.Deployment.NodePlacements.Workload.NodeSelector["key1"] = "something else"
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -1934,8 +1800,7 @@ Version: 1.2.3`)
 			})
 
 			It("should overwrite node placement if directly set on KV CR", func() {
-				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				commontestutils.SetNodePlacement(hco)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1943,10 +1808,10 @@ Version: 1.2.3`)
 				req.HCOTriggered = false
 
 				// now, modify KV's node placement
-				existingResource.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+				existingResource.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, corev1.Toleration{
 					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
-				existingResource.Spec.Workloads.NodePlacement.Tolerations = append(hco.Spec.Workloads.NodePlacement.Tolerations, corev1.Toleration{
+				existingResource.Spec.Workloads.NodePlacement.Tolerations = append(hco.Spec.Deployment.NodePlacements.Workload.Tolerations, corev1.Toleration{
 					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
 
@@ -1996,7 +1861,7 @@ Version: 1.2.3`)
 			Context("test feature gates in NewKubeVirt", func() {
 				DescribeTable("featureGates in NewKubeVirt",
 					func(
-						modifyHC func(hc *hcov1beta1.HyperConverged),
+						modifyHC func(hc *hcov1.HyperConverged),
 						matcher gomegatypes.GomegaMatcher,
 						additionalKvAssertions ...func(virt *kubevirtcorev1.KubeVirt),
 					) {
@@ -2012,91 +1877,83 @@ Version: 1.2.3`)
 						}
 					},
 					Entry("should not add the feature gates if FeatureGates field is empty",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{}
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{}
 						},
-						And(HaveLen(basicNumFgOnOpenshift), ContainElements(hardCodeKvFgs), ContainElements(sspConditionKvFgs)),
+						And(
+							HaveLen(basicNumFgOnOpenshift),
+							ContainElements(hardCodeKvFgs),
+							ContainElements(sspConditionKvFgs),
+							Not(ContainElement(kvPersistentReservation)),
+							Not(ContainElement(kvDownwardMetrics)),
+							ContainElement(kvDecentralizedLiveMigration),
+							Not(ContainElement(kvAlignCPUs)),
+							And(ContainElement(kvHotplugVolumesGate), Not(ContainElement(kvDeclarativeHotplugVolumesGate))),
+							Not(ContainElement(kvObjectGraph)),
+							And(Not(ContainElement(kvIncrementalBackup)), Not(ContainElement(kvUtilityVolumes))),
+							Not(ContainElement(kvContainerPathVolumes)),
+							ContainElement(kvVideoConfig),
+						),
+						func(kv *kubevirtcorev1.KubeVirt) {
+							Expect(kv.Annotations).ToNot(HaveKey(kubevirtcorev1.EmulatorThreadCompleteToEvenParity))
+						},
 					),
 					// PersistentReservation
 					Entry("should add the PersistentReservation feature gate if PersistentReservation is true in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								PersistentReservation: ptr.To(true),
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "persistentReservation", State: ptr.To(featuregates.Enabled)},
 							}
 						},
 						ContainElement(kvPersistentReservation),
 					),
-					Entry("should not add the PersistentReservation feature gate if PersistentReservation is not set in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								PersistentReservation: nil,
-							}
-						},
-						Not(ContainElement(kvPersistentReservation)),
-					),
 					Entry("should not add the PersistentReservation feature gate if PersistentReservation is false in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								PersistentReservation: ptr.To(false),
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "persistentReservation", State: ptr.To(featuregates.Disabled)},
 							}
 						},
 						Not(ContainElement(kvPersistentReservation)),
 					),
 					// DownwardMetrics
 					Entry("should add the DownwardMetrics feature gate if DownwardMetrics is true in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								DownwardMetrics: ptr.To(true),
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "downwardMetrics", State: ptr.To(featuregates.Enabled)},
 							}
 						},
 						ContainElement(kvDownwardMetrics),
 					),
-					Entry("should not add the DownwardMetrics feature gate if DownwardMetrics is not set in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								DownwardMetrics: nil,
-							}
-						},
-						Not(ContainElement(kvDownwardMetrics)),
-					),
 					Entry("should not add the DownwardMetrics feature gate if DownwardMetrics is false in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								DownwardMetrics: ptr.To(false),
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "downwardMetrics", State: ptr.To(featuregates.Disabled)},
 							}
 						},
 						Not(ContainElement(kvDownwardMetrics)),
 					),
 					// DecentralizedLiveMigration
 					Entry("should add the DecentralizedLiveMigration feature gate if DecentralizedLiveMigration is true in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								DecentralizedLiveMigration: ptr.To(true),
-							}
-						},
-						ContainElement(kvDecentralizedLiveMigration),
-					),
-					Entry("should add the DecentralizedLiveMigration feature gate if DecentralizedLiveMigration is not set in HyperConverged CR (default true)",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								DecentralizedLiveMigration: nil,
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "decentralizedLiveMigration", State: ptr.To(featuregates.Enabled)},
 							}
 						},
 						ContainElement(kvDecentralizedLiveMigration),
 					),
 					Entry("should not add the DecentralizedLiveMigration feature gate if DecentralizedLiveMigration is false in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								DecentralizedLiveMigration: ptr.To(false),
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "decentralizedLiveMigration", State: ptr.To(featuregates.Disabled)},
 							}
 						},
 						Not(ContainElement(kvDecentralizedLiveMigration)),
 					),
 					// AlignCPUs
 					Entry("should add the AlignCPUs feature gate if DownwardMetrics is true in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								AlignCPUs: ptr.To(true),
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "alignCPUs", State: ptr.To(featuregates.Enabled)},
 							}
 						},
 						ContainElement(kvAlignCPUs),
@@ -2105,20 +1962,9 @@ Version: 1.2.3`)
 						},
 					),
 					Entry("should not add the AlignCPUs feature gate if DownwardMetrics is false in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								AlignCPUs: ptr.To(false),
-							}
-						},
-						Not(ContainElement(kvAlignCPUs)),
-						func(kv *kubevirtcorev1.KubeVirt) {
-							Expect(kv.Annotations).ToNot(HaveKey(kubevirtcorev1.EmulatorThreadCompleteToEvenParity))
-						},
-					),
-					Entry("should not add the AlignCPUs feature gate if DownwardMetrics is not set in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								AlignCPUs: nil,
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "alignCPUs", State: ptr.To(featuregates.Disabled)},
 							}
 						},
 						Not(ContainElement(kvAlignCPUs)),
@@ -2128,174 +1974,124 @@ Version: 1.2.3`)
 					),
 					// PasstBinding
 					Entry("should add the PasstBinding FG to Kubevirt CR if PasstNetworkBinding is true in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
+						func(hc *hcov1.HyperConverged) {
 							hc.Annotations[deployPasstNetworkBindingAnn] = "true"
 						},
 						ContainElement(kvPasstBinding),
 					),
 					Entry("should not add the Passt Network Binding to Kubevirt CR if PasstNetworkBinding is false in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
+						func(hc *hcov1.HyperConverged) {
 							hc.Annotations[deployPasstNetworkBindingAnn] = "false"
 						},
 						Not(ContainElement(kvPasstBinding)),
 					),
 					Entry("should not add the Passt Network Binding to Kubevirt CR if PasstNetworkBinding is not set in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
+						func(hc *hcov1.HyperConverged) {
 							delete(hc.Annotations, deployPasstNetworkBindingAnn)
 						},
 						Not(ContainElement(kvPasstBinding)),
 					),
 					// PCINUMAAwareTopology
 					Entry("should add the PCINUMAAwareTopology FG to KubeVirt CR if deployAIE annotation is true",
-						func(hc *hcov1beta1.HyperConverged) {
+						func(hc *hcov1.HyperConverged) {
 							hc.Annotations[aie.DeployAIEAnnotation] = "true"
 						},
 						ContainElement(kvPCINUMAAwareTopology),
 					),
 					Entry("should not add the PCINUMAAwareTopology FG to KubeVirt CR if deployAIE annotation is false",
-						func(hc *hcov1beta1.HyperConverged) {
+						func(hc *hcov1.HyperConverged) {
 							hc.Annotations[aie.DeployAIEAnnotation] = "false"
 						},
 						Not(ContainElement(kvPCINUMAAwareTopology)),
 					),
 					Entry("should not add the PCINUMAAwareTopology FG to KubeVirt CR if deployAIE annotation is not set",
-						func(hc *hcov1beta1.HyperConverged) {
+						func(hc *hcov1.HyperConverged) {
 							delete(hc.Annotations, aie.DeployAIEAnnotation)
 						},
 						Not(ContainElement(kvPCINUMAAwareTopology)),
 					),
 					Entry("should add the DeclarativeHotplugVolumes feature gate if DeclarativeHotplugVolumes is true in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								DeclarativeHotplugVolumes: ptr.To(true),
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "declarativeHotplugVolumes", State: ptr.To(featuregates.Enabled)},
 							}
 						},
 						And(ContainElement(kvDeclarativeHotplugVolumesGate), Not(ContainElement(kvHotplugVolumesGate))),
 					),
 					Entry("should add the HotplugVolumes feature gate if DeclarativeHotplugVolumes is false in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								DeclarativeHotplugVolumes: ptr.To(false),
-							}
-						},
-						And(ContainElement(kvHotplugVolumesGate), Not(ContainElement(kvDeclarativeHotplugVolumesGate))),
-					),
-					Entry("should add the HotplugVolumes feature gate if DeclarativeHotplugVolumes is not set in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								DeclarativeHotplugVolumes: nil,
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "declarativeHotplugVolumes", State: ptr.To(featuregates.Disabled)},
 							}
 						},
 						And(ContainElement(kvHotplugVolumesGate), Not(ContainElement(kvDeclarativeHotplugVolumesGate))),
 					),
 					Entry("should add the ObjectGraph feature gate if ObjectGraph is true in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								ObjectGraph: ptr.To(true),
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "objectGraph", State: ptr.To(featuregates.Enabled)},
 							}
 						},
 						And(ContainElement(kvObjectGraph)),
 					),
 					Entry("should not add the ObjectGraph feature gate if ObjectGraph is false in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								ObjectGraph: ptr.To(false),
-							}
-						},
-						Not(ContainElement(kvObjectGraph)),
-					),
-					Entry("should not add the ObjectGraph feature gate if ObjectGraph is not set in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								ObjectGraph: nil,
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "objectGraph", State: ptr.To(featuregates.Disabled)},
 							}
 						},
 						Not(ContainElement(kvObjectGraph)),
 					),
 					Entry("should add both IncrementalBackup and UtilityVolumes feature gates if IncrementalBackup is true in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								IncrementalBackup: ptr.To(true),
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "incrementalBackup", State: ptr.To(featuregates.Enabled)},
 							}
 						},
 						ContainElements(kvIncrementalBackup, kvUtilityVolumes),
 					),
 					Entry("should not add IncrementalBackup or UtilityVolumes feature gates if IncrementalBackup is false in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								IncrementalBackup: ptr.To(false),
-							}
-						},
-						And(Not(ContainElement(kvIncrementalBackup)), Not(ContainElement(kvUtilityVolumes))),
-					),
-					Entry("should not add IncrementalBackup or UtilityVolumes feature gates if IncrementalBackup is not set in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								IncrementalBackup: nil,
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "incrementalBackup", State: ptr.To(featuregates.Disabled)},
 							}
 						},
 						And(Not(ContainElement(kvIncrementalBackup)), Not(ContainElement(kvUtilityVolumes))),
 					),
 					// ContainerPathVolumes
 					Entry("should add the ContainerPathVolumes feature gate if ContainerPathVolumes is true in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								ContainerPathVolumes: ptr.To(true),
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "containerPathVolumes", State: ptr.To(featuregates.Enabled)},
 							}
 						},
 						ContainElement(kvContainerPathVolumes),
 					),
-					Entry("should not add the ContainerPathVolumes feature gate if ContainerPathVolumes is not set in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								ContainerPathVolumes: nil,
+					Entry("should not add the ContainerPathVolumes feature gate if ContainerPathVolumes is false in HyperConverged CR",
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "containerPathVolumes", State: ptr.To(featuregates.Disabled)},
 							}
 						},
 						Not(ContainElement(kvContainerPathVolumes)),
 					),
-					Entry("should not add the ContainerPathVolumes feature gate if ContainerPathVolumes is false in HyperConverged CR",
-						func(hc *hcov1beta1.HyperConverged) {
-							hc.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-								ContainerPathVolumes: ptr.To(false),
+					Entry("should add the VideoConfig if feature gate VideoConfig is true in HyperConverged CR",
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "videoConfig", State: ptr.To(featuregates.Enabled)},
 							}
 						},
-						Not(ContainElement(kvContainerPathVolumes)),
+						ContainElement(kvVideoConfig),
+					),
+					Entry("should not add the VideoConfig if feature gate VideoConfig is set to false in HyperConverged CR",
+						func(hc *hcov1.HyperConverged) {
+							hc.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+								{Name: "videoConfig", State: ptr.To(featuregates.Disabled)},
+							}
+						},
+						Not(ContainElement(kvVideoConfig)),
 					),
 				)
-
-				It("should add the VideoConfig if feature gate VideoConfig is true in HyperConverged CR", func() {
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						VideoConfig: ptr.To(true),
-					}
-
-					existingResource, err := NewKubeVirt(hco)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
-					Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvVideoConfig))
-				})
-
-				It("should add the VideoConfig if feature gate VideoConfig is not in HyperConverged CR", func() {
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						VideoConfig: nil,
-					}
-
-					existingResource, err := NewKubeVirt(hco)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
-					Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvVideoConfig))
-				})
-
-				It("should not add the VideoConfig if feature gate VideoConfig is set to false in HyperConverged CR", func() {
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						VideoConfig: ptr.To(false),
-					}
-
-					existingResource, err := NewKubeVirt(hco)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(existingResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
-					Expect(existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvVideoConfig))
-				})
-
 			})
 
 			Context("test feature gates in KV handler", func() {
@@ -2303,9 +2099,9 @@ Version: 1.2.3`)
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						DownwardMetrics:       ptr.To(true),
-						PersistentReservation: ptr.To(true),
+					hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+						{Name: "downwardMetrics", State: ptr.To(featuregates.Enabled)},
+						{Name: "persistentReservation", State: ptr.To(featuregates.Enabled)},
 					}
 
 					cl := commontestutils.InitClient([]client.Object{hco, existingResource})
@@ -2334,9 +2130,9 @@ Version: 1.2.3`)
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						WithHostPassthroughCPU: ptr.To(false),
-						ObjectGraph:            ptr.To(false),
+					hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+						{Name: "withHostPassthroughCPU", State: ptr.To(featuregates.Disabled)},
+						{Name: "objectGraph", State: ptr.To(featuregates.Disabled)},
 					}
 
 					cl := commontestutils.InitClient([]client.Object{hco, existingResource})
@@ -2354,18 +2150,18 @@ Version: 1.2.3`)
 							foundResource),
 					).ToNot(HaveOccurred())
 
-					By("KV CR should contain the HC enabled managed feature gates", func() {
-						mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
-						Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-						fgList := getKvFeatureGateList(hco.Spec, nil)
-						Expect(fgList).To(HaveLen(basicNumFgOnOpenshift))
-						Expect(fgList).To(ContainElements(hardCodeKvFgs))
-						Expect(fgList).To(ContainElements(sspConditionKvFgs))
-					})
+					By("KV CR should contain the HC enabled managed feature gates")
+					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
+					Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
+
+					fgList := foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates
+					Expect(fgList).To(HaveLen(basicNumFgOnOpenshift))
+					Expect(fgList).To(ContainElements(hardCodeKvFgs))
+					Expect(fgList).To(ContainElements(sspConditionKvFgs))
 				})
 
 				It("should not add feature gates if they are not exist", func() {
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{}
+					hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{}
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
@@ -2384,26 +2180,24 @@ Version: 1.2.3`)
 							foundResource),
 					).ToNot(HaveOccurred())
 
-					By("KV CR should contain the HC enabled managed feature gates", func() {
-						mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
-						Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-						fgList := getKvFeatureGateList(hco.Spec, nil)
-						Expect(fgList).To(HaveLen(len(getKvFeatureGateList(hco.Spec, nil))))
-						Expect(fgList).To(ContainElements(hardCodeKvFgs))
-						Expect(fgList).To(ContainElements(sspConditionKvFgs))
-					})
+					By("KV CR should contain the HC enabled managed feature gates")
+					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
+					Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
+					fgList := foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates
+					Expect(fgList).To(ContainElements(hardCodeKvFgs))
+					Expect(fgList).To(ContainElements(sspConditionKvFgs))
 				})
 
 				It("should keep FG if already exist", func() {
 					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(true)
 
 					// Set up HCO with PersistentReservation enabled first
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						PersistentReservation: ptr.To(true),
+					hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+						{Name: "persistentReservation", State: ptr.To(featuregates.Enabled)},
 					}
 
 					// Get the expected featuregates for this configuration
-					fgs := getKvFeatureGateList(hco.Spec, nil)
+					fgs := getKvFeatureGateList(hco)
 					existingResource, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 					existingResource.Spec.Configuration.DeveloperConfiguration.FeatureGates = fgs
@@ -2426,7 +2220,6 @@ Version: 1.2.3`)
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration).NotTo(BeNil())
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).
 						To(ContainElements(kvPersistentReservation))
-
 				})
 
 				It("should remove FG if it disabled in HC CR", func() {
@@ -2437,8 +2230,8 @@ Version: 1.2.3`)
 						FeatureGates: []string{kvPersistentReservation},
 					}
 
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-						PersistentReservation: ptr.To(false),
+					hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+						{Name: "persistentReservation", State: ptr.To(featuregates.Disabled)},
 					}
 
 					cl := commontestutils.InitClient([]client.Object{hco, existingResource})
@@ -2457,7 +2250,6 @@ Version: 1.2.3`)
 					).ToNot(HaveOccurred())
 
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(getKvFeatureGateList(hco.Spec, nil))))
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(hardCodeKvFgs))
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(sspConditionKvFgs))
 				})
@@ -2470,7 +2262,7 @@ Version: 1.2.3`)
 						FeatureGates: []string{kvPersistentReservation},
 					}
 
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{}
+					hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{}
 
 					cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 					handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -2488,7 +2280,6 @@ Version: 1.2.3`)
 					).ToNot(HaveOccurred())
 
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(getKvFeatureGateList(hco.Spec, nil))))
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(hardCodeKvFgs))
 					Expect(foundResource.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(sspConditionKvFgs))
 				})
@@ -2501,7 +2292,7 @@ Version: 1.2.3`)
 						FeatureGates: []string{kvPersistentReservation},
 					}
 
-					hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{}
+					hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{}
 
 					cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 					handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -2531,7 +2322,7 @@ Version: 1.2.3`)
 					DeferCleanup(func() {
 						commontestutils.ResetNodeInfoMocks()
 					})
-					fgList := getKvFeatureGateList(hco.Spec, nil)
+					fgList := getKvFeatureGateList(hco)
 
 					Expect(fgList).To(ContainElement(kvSecureExecution))
 				})
@@ -2539,10 +2330,10 @@ Version: 1.2.3`)
 
 			Context("Test getKvFeatureGateList", func() {
 				DescribeTable("Should return featureGate slice",
-					func(isKVMEmulation bool, fgs *hcov1beta1.HyperConvergedFeatureGates, expectedLength int, expectedFgs [][]string) {
+					func(isKVMEmulation bool, fgs *featuregates.HyperConvergedFeatureGates, expectedLength int, expectedFgs [][]string) {
 						mandatoryKvFeatureGates = getMandatoryKvFeatureGates(isKVMEmulation)
-						hcoForFg := &hcov1beta1.HyperConverged{Spec: hcov1beta1.HyperConvergedSpec{FeatureGates: *fgs}}
-						fgList := getKvFeatureGateList(hcoForFg.Spec, nil)
+						hcoForFg := &hcov1.HyperConverged{Spec: hcov1.HyperConvergedSpec{FeatureGates: *fgs}}
+						fgList := getKvFeatureGateList(hcoForFg)
 						Expect(fgList).To(HaveLen(expectedLength))
 						for _, expected := range expectedFgs {
 							Expect(fgList).To(ContainElements(expected))
@@ -2550,37 +2341,25 @@ Version: 1.2.3`)
 					},
 					Entry("When not using kvm-emulation and FG is empty",
 						false,
-						&hcov1beta1.HyperConvergedFeatureGates{},
+						&featuregates.HyperConvergedFeatureGates{},
 						basicNumFgOnOpenshift,
 						[][]string{hardCodeKvFgs, sspConditionKvFgs},
 					),
 					Entry("When using kvm-emulation and FG is empty",
 						true,
-						&hcov1beta1.HyperConvergedFeatureGates{},
-						defaultFeatureGateCount,
-						[][]string{hardCodeKvFgs},
-					),
-					Entry("When not using kvm-emulation and all FGs are disabled",
-						false,
-						&hcov1beta1.HyperConvergedFeatureGates{WithHostPassthroughCPU: ptr.To(false)},
-						basicNumFgOnOpenshift,
-						[][]string{hardCodeKvFgs, sspConditionKvFgs},
-					),
-					Entry("When using kvm-emulation all FGs are disabled",
-						true,
-						&hcov1beta1.HyperConvergedFeatureGates{WithHostPassthroughCPU: ptr.To(false)},
+						&featuregates.HyperConvergedFeatureGates{},
 						defaultFeatureGateCount,
 						[][]string{hardCodeKvFgs},
 					),
 					Entry("When not using kvm-emulation and all FGs are enabled",
 						false,
-						&hcov1beta1.HyperConvergedFeatureGates{DownwardMetrics: ptr.To(true)},
+						&featuregates.HyperConvergedFeatureGates{{Name: "downwardMetrics", State: ptr.To(featuregates.Enabled)}},
 						basicNumFgOnOpenshift+1,
 						[][]string{hardCodeKvFgs, sspConditionKvFgs, {kvDownwardMetrics}},
 					),
 					Entry("When using kvm-emulation all FGs are enabled",
 						true,
-						&hcov1beta1.HyperConvergedFeatureGates{DownwardMetrics: ptr.To(true)},
+						&featuregates.HyperConvergedFeatureGates{{Name: "downwardMetrics", State: ptr.To(featuregates.Enabled)}},
 						defaultFeatureGateCount+1, // +1 for DownwardMetrics
 						[][]string{hardCodeKvFgs, {kvDownwardMetrics}},
 					))
@@ -2605,9 +2384,7 @@ Version: 1.2.3`)
 		Context("Obsolete CPU Models", func() {
 			Context("test Obsolete CPU Models in NewKubeVirt", func() {
 				It("should add obsolete CPU Models if exists in HC CR", func() {
-					hco.Spec.ObsoleteCPUs = &hcov1beta1.HyperConvergedObsoleteCPUs{
-						CPUModels: []string{"aaa", "bbb", "ccc"},
-					}
+					hco.Spec.Virtualization.ObsoleteCPUModels = []string{"aaa", "bbb", "ccc"}
 
 					kv, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
@@ -2627,9 +2404,7 @@ Version: 1.2.3`)
 					existingKV, err := NewKubeVirt(hco)
 					Expect(err).ToNot(HaveOccurred())
 
-					hco.Spec.ObsoleteCPUs = &hcov1beta1.HyperConvergedObsoleteCPUs{
-						CPUModels: []string{"aaa", "bbb", "ccc"},
-					}
+					hco.Spec.Virtualization.ObsoleteCPUModels = []string{"aaa", "bbb", "ccc"}
 
 					cl := commontestutils.InitClient([]client.Object{hco, existingKV})
 					handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -2667,9 +2442,7 @@ Version: 1.2.3`)
 						"shouldBeRemoved": true,
 					}
 
-					hco.Spec.ObsoleteCPUs = &hcov1beta1.HyperConvergedObsoleteCPUs{
-						CPUModels: []string{"shouldStay", "shouldBeTrue", "newOne"},
-					}
+					hco.Spec.Virtualization.ObsoleteCPUModels = []string{"shouldStay", "shouldBeTrue", "newOne"}
 
 					cl := commontestutils.InitClient([]client.Object{hco, existingKV})
 					handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -2686,17 +2459,16 @@ Version: 1.2.3`)
 							foundKV),
 					).ToNot(HaveOccurred())
 
-					By("KV CR should contain the HC obsolete CPU models", func() {
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("shouldStay", true))
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("shouldBeTrue", true))
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("newOne", true))
-						for _, cpu := range hardcodedObsoleteCPUModels {
-							Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
-						}
+					By("KV CR should contain the HC obsolete CPU models")
+					Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveLen(3 + len(hardcodedObsoleteCPUModels)))
+					Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("shouldStay", true))
+					Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("shouldBeTrue", true))
+					Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).To(HaveKeyWithValue("newOne", true))
+					for _, cpu := range hardcodedObsoleteCPUModels {
+						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels[cpu]).To(BeTrue())
+					}
 
-						Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).ToNot(HaveKey("shouldBeRemoved"))
-					})
+					Expect(foundKV.Spec.Configuration.ObsoleteCPUModels).ToNot(HaveKey("shouldBeRemoved"))
 				})
 
 				It("Should remove obsolete CPU model if they are not set in HC CR", func() {
@@ -2738,7 +2510,7 @@ Version: 1.2.3`)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.CertConfig = hcov1.HyperConvergedCertConfig{
+				hco.Spec.Security.CertConfig = hcov1.HyperConvergedCertConfig{
 					CA: hcov1.CertRotateConfigCA{
 						Duration:    &metav1.Duration{Duration: 24 * time.Hour},
 						RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
@@ -2804,7 +2576,7 @@ Version: 1.2.3`)
 
 			It("should modify certificate rotation strategy according to HCO CR", func() {
 
-				hco.Spec.CertConfig = hcov1.HyperConvergedCertConfig{
+				hco.Spec.Security.CertConfig = hcov1.HyperConvergedCertConfig{
 					CA: hcov1.CertRotateConfigCA{
 						Duration:    &metav1.Duration{Duration: 24 * time.Hour},
 						RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
@@ -2818,10 +2590,10 @@ Version: 1.2.3`)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Modify HCO's cert configuration")
-				hco.Spec.CertConfig.CA.Duration.Duration *= 2
-				hco.Spec.CertConfig.CA.RenewBefore.Duration *= 2
-				hco.Spec.CertConfig.Server.Duration.Duration *= 2
-				hco.Spec.CertConfig.Server.RenewBefore.Duration *= 2
+				hco.Spec.Security.CertConfig.CA.Duration.Duration *= 2
+				hco.Spec.Security.CertConfig.CA.RenewBefore.Duration *= 2
+				hco.Spec.Security.CertConfig.Server.Duration.Duration *= 2
+				hco.Spec.Security.CertConfig.Server.RenewBefore.Duration *= 2
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -2856,7 +2628,7 @@ Version: 1.2.3`)
 
 			It("should overwrite certificate rotation strategy if directly set on KV CR", func() {
 
-				hco.Spec.CertConfig = hcov1.HyperConvergedCertConfig{
+				hco.Spec.Security.CertConfig = hcov1.HyperConvergedCertConfig{
 					CA: hcov1.CertRotateConfigCA{
 						Duration:    &metav1.Duration{Duration: 24 * time.Hour},
 						RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
@@ -2925,7 +2697,7 @@ Version: 1.2.3`)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.WorkloadUpdateStrategy = hcov1.HyperConvergedWorkloadUpdateStrategy{
+				hco.Spec.Virtualization.WorkloadUpdateStrategy = hcov1.HyperConvergedWorkloadUpdateStrategy{
 					WorkloadUpdateMethods: []string{"aaa", "bbb"},
 					BatchEvictionInterval: &metav1.Duration{Duration: time.Minute * 1},
 					BatchEvictionSize:     ptr.To(defaultBatchEvictionSize),
@@ -2992,9 +2764,9 @@ Version: 1.2.3`)
 				Expect(err).ToNot(HaveOccurred())
 
 				const modifiedBatchEvictionSize = 5
-				hco.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []string{"aaa", "bbb", "ccc"}
-				hco.Spec.WorkloadUpdateStrategy.BatchEvictionInterval = &metav1.Duration{Duration: time.Minute * 3}
-				hco.Spec.WorkloadUpdateStrategy.BatchEvictionSize = ptr.To(modifiedBatchEvictionSize)
+				hco.Spec.Virtualization.WorkloadUpdateStrategy.WorkloadUpdateMethods = []string{"aaa", "bbb", "ccc"}
+				hco.Spec.Virtualization.WorkloadUpdateStrategy.BatchEvictionInterval = &metav1.Duration{Duration: time.Minute * 3}
+				hco.Spec.Virtualization.WorkloadUpdateStrategy.BatchEvictionSize = ptr.To(modifiedBatchEvictionSize)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingKv})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -3028,7 +2800,7 @@ Version: 1.2.3`)
 					hcoModifiedBatchEvictionSize = 5
 					kvModifiedBatchEvictionSize  = 7
 				)
-				hco.Spec.WorkloadUpdateStrategy = hcov1.HyperConvergedWorkloadUpdateStrategy{
+				hco.Spec.Virtualization.WorkloadUpdateStrategy = hcov1.HyperConvergedWorkloadUpdateStrategy{
 					WorkloadUpdateMethods: []string{"LiveMigrate"},
 					BatchEvictionInterval: &metav1.Duration{Duration: time.Minute * 5},
 					BatchEvictionSize:     ptr.To(hcoModifiedBatchEvictionSize),
@@ -3091,9 +2863,8 @@ Version: 1.2.3`)
 			})
 
 			Context("Custom Infra placement, default Workloads placement", func() {
-
 				BeforeEach(func() {
-					hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+					commontestutils.SetNodeCustomPlacement(hco, commontestutils.NewNodePlacement(), nil)
 				})
 
 				It("should set replica=1 on SNO", func() {
@@ -3132,7 +2903,7 @@ Version: 1.2.3`)
 			Context("Custom Workloads placement, default Infra placement", func() {
 
 				BeforeEach(func() {
-					hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+					commontestutils.SetNodeCustomPlacement(hco, nil, commontestutils.NewNodePlacement())
 				})
 
 				It("should set replica=1 on SNO", func() {
@@ -3208,8 +2979,7 @@ Version: 1.2.3`)
 			Context("Custom Infra and Workloads placement", func() {
 
 				BeforeEach(func() {
-					hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-					hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+					commontestutils.SetNodePlacement(hco)
 				})
 
 				It("should set replica=1 on SNO", func() {
@@ -3254,7 +3024,7 @@ Version: 1.2.3`)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.EvictionStrategy = ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrate)
+				hco.Spec.Virtualization.EvictionStrategy = ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrate)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -3279,12 +3049,12 @@ Version: 1.2.3`)
 
 			It("should modify eviction strategy according to HCO CR", func() {
 
-				hco.Spec.EvictionStrategy = ptr.To(kubevirtcorev1.EvictionStrategyNone)
+				hco.Spec.Virtualization.EvictionStrategy = ptr.To(kubevirtcorev1.EvictionStrategyNone)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Modify HCO's eviction strategy configuration")
-				hco.Spec.EvictionStrategy = ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrateIfPossible)
+				hco.Spec.Virtualization.EvictionStrategy = ptr.To(kubevirtcorev1.EvictionStrategyLiveMigrateIfPossible)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -3314,7 +3084,7 @@ Version: 1.2.3`)
 
 		Context("Hypervisors", func() {
 			It("should propagate kvm hypervisor to KubeVirt CR and add ConfigurableHypervisor feature gate", func() {
-				hco.Spec.Hypervisors = []kubevirtcorev1.HypervisorConfiguration{
+				hco.Spec.Virtualization.Hypervisors = []kubevirtcorev1.HypervisorConfiguration{
 					{Name: kubevirtcorev1.KvmHypervisorName},
 				}
 				kv, err := NewKubeVirt(hco)
@@ -3326,7 +3096,7 @@ Version: 1.2.3`)
 			})
 
 			It("should propagate hyperv-direct hypervisor to KubeVirt CR and add ConfigurableHypervisor feature gate", func() {
-				hco.Spec.Hypervisors = []kubevirtcorev1.HypervisorConfiguration{
+				hco.Spec.Virtualization.Hypervisors = []kubevirtcorev1.HypervisorConfiguration{
 					{Name: kubevirtcorev1.HyperVDirectHypervisorName},
 				}
 				kv, err := NewKubeVirt(hco)
@@ -3338,7 +3108,7 @@ Version: 1.2.3`)
 			})
 
 			It("should not set Hypervisors or ConfigurableHypervisor FG when not set in HCO", func() {
-				hco.Spec.Hypervisors = nil
+				hco.Spec.Virtualization.Hypervisors = nil
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -3349,7 +3119,7 @@ Version: 1.2.3`)
 
 		Context("RoleAggregationStrategy", func() {
 			It("should propagate Manual to KubeVirt CR and add OptOutRoleAggregation feature gate", func() {
-				hco.Spec.RoleAggregationStrategy = ptr.To(kubevirtcorev1.RoleAggregationStrategyManual)
+				hco.Spec.Virtualization.RoleAggregationStrategy = ptr.To(kubevirtcorev1.RoleAggregationStrategyManual)
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -3358,7 +3128,7 @@ Version: 1.2.3`)
 			})
 
 			It("should propagate AggregateToDefault to KubeVirt CR and add OptOutRoleAggregation feature gate", func() {
-				hco.Spec.RoleAggregationStrategy = ptr.To(kubevirtcorev1.RoleAggregationStrategyAggregateToDefault)
+				hco.Spec.Virtualization.RoleAggregationStrategy = ptr.To(kubevirtcorev1.RoleAggregationStrategyAggregateToDefault)
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -3367,7 +3137,7 @@ Version: 1.2.3`)
 			})
 
 			It("should not set RoleAggregationStrategy or OptOutRoleAggregation FG when not set in HCO", func() {
-				hco.Spec.RoleAggregationStrategy = nil
+				hco.Spec.Virtualization.RoleAggregationStrategy = nil
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -3382,7 +3152,7 @@ Version: 1.2.3`)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Modify HCO's VM state storage class configuration")
-				hco.Spec.VMStateStorageClass = ptr.To("rook-cephfs")
+				hco.Spec.Storage = &hcov1.StorageConfig{VMStateStorageClass: ptr.To("rook-cephfs")}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -3411,10 +3181,8 @@ Version: 1.2.3`)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					AutoCPULimitNamespaceLabelSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"someLabel": "true"},
-					},
+				hco.Spec.Virtualization.AutoCPULimitNamespaceLabelSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"someLabel": "true"},
 				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
@@ -3449,8 +3217,8 @@ Version: 1.2.3`)
 				Expect(kv.Spec.Configuration.VirtualMachineOptions).To(BeNil())
 			})
 
-			DescribeTable("Should set VirtualMachineOptions according to HCO CR options", func(hcoVMOptions *hcov1beta1.VirtualMachineOptions, kvVMOptions *kubevirtcorev1.VirtualMachineOptions) {
-				hco.Spec.VirtualMachineOptions = hcoVMOptions
+			DescribeTable("Should set VirtualMachineOptions according to HCO CR options", func(hcoVMOptions *hcov1.VirtualMachineOptions, kvVMOptions *kubevirtcorev1.VirtualMachineOptions) {
+				hco.Spec.Virtualization.VirtualMachineOptions = hcoVMOptions
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(kv.Spec.Configuration).ToNot(BeNil())
@@ -3461,45 +3229,45 @@ Version: 1.2.3`)
 					nil,
 				),
 				Entry("disableFreePageReporting only, false",
-					&hcov1beta1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(false)},
+					&hcov1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(false)},
 					nil,
 				),
 				Entry("disableFreePageReporting only, true",
-					&hcov1beta1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(true)},
+					&hcov1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(true)},
 					&kubevirtcorev1.VirtualMachineOptions{DisableFreePageReporting: &kubevirtcorev1.DisableFreePageReporting{}},
 				),
 				Entry("disableSerialConsoleLog only, false",
-					&hcov1beta1.VirtualMachineOptions{DisableSerialConsoleLog: ptr.To(false)},
+					&hcov1.VirtualMachineOptions{DisableSerialConsoleLog: ptr.To(false)},
 					nil,
 				),
 				Entry("disableSerialConsoleLog only, true",
-					&hcov1beta1.VirtualMachineOptions{DisableSerialConsoleLog: ptr.To(true)},
+					&hcov1.VirtualMachineOptions{DisableSerialConsoleLog: ptr.To(true)},
 					&kubevirtcorev1.VirtualMachineOptions{DisableSerialConsoleLog: &kubevirtcorev1.DisableSerialConsoleLog{}},
 				),
 				Entry("disableFreePageReporting false, disableSerialConsoleLog false",
-					&hcov1beta1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(false), DisableSerialConsoleLog: ptr.To(false)},
+					&hcov1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(false), DisableSerialConsoleLog: ptr.To(false)},
 					nil,
 				),
 				Entry("disableFreePageReporting true, disableSerialConsoleLog false",
-					&hcov1beta1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(true), DisableSerialConsoleLog: ptr.To(false)},
+					&hcov1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(true), DisableSerialConsoleLog: ptr.To(false)},
 					&kubevirtcorev1.VirtualMachineOptions{DisableFreePageReporting: &kubevirtcorev1.DisableFreePageReporting{}},
 				),
 				Entry("disableFreePageReporting false, disableSerialConsoleLog true",
-					&hcov1beta1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(false), DisableSerialConsoleLog: ptr.To(true)},
+					&hcov1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(false), DisableSerialConsoleLog: ptr.To(true)},
 					&kubevirtcorev1.VirtualMachineOptions{DisableSerialConsoleLog: &kubevirtcorev1.DisableSerialConsoleLog{}},
 				),
 				Entry("disableFreePageReporting true, disableSerialConsoleLog true",
-					&hcov1beta1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(true), DisableSerialConsoleLog: ptr.To(true)},
+					&hcov1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(true), DisableSerialConsoleLog: ptr.To(true)},
 					&kubevirtcorev1.VirtualMachineOptions{DisableFreePageReporting: &kubevirtcorev1.DisableFreePageReporting{}, DisableSerialConsoleLog: &kubevirtcorev1.DisableSerialConsoleLog{}},
 				),
 			)
 
-			DescribeTable("should modify disableFreePageReporting according to HCO CR", func(virtualMachineOptions *hcov1beta1.VirtualMachineOptions, updated, expectDisableFreePageReporting bool) {
+			DescribeTable("should modify disableFreePageReporting according to HCO CR", func(virtualMachineOptions *hcov1.VirtualMachineOptions, updated, expectDisableFreePageReporting bool) {
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Modify HCO's virtual machine options configuration")
-				hco.Spec.VirtualMachineOptions = virtualMachineOptions
+				hco.Spec.Virtualization.VirtualMachineOptions = virtualMachineOptions
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -3527,17 +3295,17 @@ Version: 1.2.3`)
 				}
 
 			},
-				Entry("with virtualMachineOptions containing disableFreePageReporting false", &hcov1beta1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(false)}, false, false),
-				Entry("with virtualMachineOptions containing disableFreePageReporting true", &hcov1beta1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(true)}, true, true),
-				Entry("with empty virtualMachineOptions", &hcov1beta1.VirtualMachineOptions{}, false, false),
+				Entry("with virtualMachineOptions containing disableFreePageReporting false", &hcov1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(false)}, false, false),
+				Entry("with virtualMachineOptions containing disableFreePageReporting true", &hcov1.VirtualMachineOptions{DisableFreePageReporting: ptr.To(true)}, true, true),
+				Entry("with empty virtualMachineOptions", &hcov1.VirtualMachineOptions{}, false, false),
 			)
 
-			DescribeTable("should modify disableSerialConsoleLog according to HCO CR", func(virtualMachineOptions *hcov1beta1.VirtualMachineOptions, updated, expectDisableSerialConsoleLog bool) {
+			DescribeTable("should modify disableSerialConsoleLog according to HCO CR", func(virtualMachineOptions *hcov1.VirtualMachineOptions, updated, expectDisableSerialConsoleLog bool) {
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Modify HCO's virtual machine options configuration")
-				hco.Spec.VirtualMachineOptions = virtualMachineOptions
+				hco.Spec.Virtualization.VirtualMachineOptions = virtualMachineOptions
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -3564,9 +3332,9 @@ Version: 1.2.3`)
 					Expect(foundResource.Spec.Configuration.VirtualMachineOptions).To(BeNil())
 				}
 			},
-				Entry("with virtualMachineOptions containing disableSerialConsoleLog false", &hcov1beta1.VirtualMachineOptions{DisableSerialConsoleLog: ptr.To(false)}, false, false),
-				Entry("with virtualMachineOptions containing disableSerialConsoleLog true", &hcov1beta1.VirtualMachineOptions{DisableSerialConsoleLog: ptr.To(true)}, true, true),
-				Entry("with empty virtualMachineOptions", &hcov1beta1.VirtualMachineOptions{}, false, false),
+				Entry("with virtualMachineOptions containing disableSerialConsoleLog false", &hcov1.VirtualMachineOptions{DisableSerialConsoleLog: ptr.To(false)}, false, false),
+				Entry("with virtualMachineOptions containing disableSerialConsoleLog true", &hcov1.VirtualMachineOptions{DisableSerialConsoleLog: ptr.To(true)}, true, true),
+				Entry("with empty virtualMachineOptions", &hcov1.VirtualMachineOptions{}, false, false),
 			)
 
 		})
@@ -3578,9 +3346,7 @@ Version: 1.2.3`)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					VmiCPUAllocationRatio: ptr.To(expectedCPUAllocationRatio),
-				}
+				hco.Spec.Virtualization.VmiCPUAllocationRatio = ptr.To(expectedCPUAllocationRatio)
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -3605,9 +3371,7 @@ Version: 1.2.3`)
 				const initialCPUAllocationRatio = 16
 
 				hcoResourceRequirements := commontestutils.NewHco()
-				hcoResourceRequirements.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					VmiCPUAllocationRatio: ptr.To(initialCPUAllocationRatio),
-				}
+				hcoResourceRequirements.Spec.Virtualization.VmiCPUAllocationRatio = ptr.To(initialCPUAllocationRatio)
 
 				existingResource, err := NewKubeVirt(hcoResourceRequirements)
 				Expect(err).ToNot(HaveOccurred())
@@ -3631,7 +3395,7 @@ Version: 1.2.3`)
 				).ToNot(HaveOccurred())
 
 				Expect(foundResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(foundResource.Spec.Configuration.DeveloperConfiguration.CPUAllocationRatio).To(Equal(0))
+				Expect(foundResource.Spec.Configuration.DeveloperConfiguration.CPUAllocationRatio).To(Equal(10))
 			})
 
 			It("should modify CPUAllocationRatio according to HCO CR", func() {
@@ -3641,16 +3405,12 @@ Version: 1.2.3`)
 				)
 				hcoResourceRequirements := commontestutils.NewHco()
 
-				hcoResourceRequirements.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					VmiCPUAllocationRatio: ptr.To(initialCPUAllocationRatio),
-				}
+				hcoResourceRequirements.Spec.Virtualization.VmiCPUAllocationRatio = ptr.To(initialCPUAllocationRatio)
 
 				existingResource, err := NewKubeVirt(hcoResourceRequirements)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.ResourceRequirements = &hcov1beta1.OperandResourceRequirements{
-					VmiCPUAllocationRatio: ptr.To(expectedCPUAllocationRatio),
-				}
+				hco.Spec.Virtualization.VmiCPUAllocationRatio = ptr.To(expectedCPUAllocationRatio)
 
 				Expect(existingResource.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
 				Expect(existingResource.Spec.Configuration.DeveloperConfiguration.CPUAllocationRatio).To(Equal(initialCPUAllocationRatio))
@@ -3681,7 +3441,7 @@ Version: 1.2.3`)
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.KSMConfiguration = &kubevirtcorev1.KSMConfiguration{
+				hco.Spec.Virtualization.KSMConfiguration = &kubevirtcorev1.KSMConfiguration{
 					NodeLabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"someLabel": "true"},
 					},
@@ -3714,7 +3474,7 @@ Version: 1.2.3`)
 
 		Context("ChangedBlockTrackingLabelSelectors", func() {
 			It("should set the label selectors according to HCO CR", func() {
-				hco.Spec.ChangedBlockTrackingLabelSelectors = &kubevirtcorev1.ChangedBlockTrackingSelectors{
+				hco.Spec.Virtualization.ChangedBlockTrackingLabelSelectors = &kubevirtcorev1.ChangedBlockTrackingSelectors{
 					NamespaceLabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"cbt": "true"},
 					},
@@ -3807,7 +3567,7 @@ Version: 1.2.3`)
 
 		Context("Tune KubeVirt rateLimiters", func() {
 
-			var hco *hcov1beta1.HyperConverged
+			var hco *hcov1.HyperConverged
 
 			BeforeEach(func() {
 				hco = commontestutils.NewHco()
@@ -3816,7 +3576,7 @@ Version: 1.2.3`)
 			It("Should be empty by default", func() {
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(hco.Spec.TuningPolicy).To(BeEmpty())
+				Expect(hco.Spec.Virtualization.TuningPolicy).To(BeEmpty())
 				Expect(kv.Spec.Configuration.APIConfiguration).To(BeNil())
 				Expect(kv.Spec.Configuration.ControllerConfiguration).To(BeNil())
 				Expect(kv.Spec.Configuration.WebhookConfiguration).To(BeNil())
@@ -3826,7 +3586,7 @@ Version: 1.2.3`)
 
 			Context("with annotations", func() {
 				It("Should return error if annotation is not present", func() {
-					hco.Spec.TuningPolicy = hcov1.HyperConvergedAnnotationTuningPolicy
+					hco.Spec.Virtualization.TuningPolicy = hcov1.HyperConvergedAnnotationTuningPolicy
 
 					kv, err := NewKubeVirt(hco)
 					Expect(err).To(MatchError("tuning policy set but annotation not present or wrong"))
@@ -3836,7 +3596,7 @@ Version: 1.2.3`)
 				})
 				It("Should return error if the annotation is present but the parameters are wrong", func() {
 
-					hco.Spec.TuningPolicy = hcov1.HyperConvergedAnnotationTuningPolicy
+					hco.Spec.Virtualization.TuningPolicy = hcov1.HyperConvergedAnnotationTuningPolicy
 					hco.Annotations = make(map[string]string, 1)
 					//burst is missing
 					hco.Annotations[common.TuningPolicyAnnotationName] = `{"qps": 100}`
@@ -3848,7 +3608,7 @@ Version: 1.2.3`)
 				})
 
 				It("Should return error if the json annotation is corrupted", func() {
-					hco.Spec.TuningPolicy = hcov1.HyperConvergedAnnotationTuningPolicy
+					hco.Spec.Virtualization.TuningPolicy = hcov1.HyperConvergedAnnotationTuningPolicy
 					hco.Annotations = make(map[string]string, 1)
 					// qps field is missing a "
 					hco.Annotations[common.TuningPolicyAnnotationName] = `{"qps: 100, "burst": 200}`
@@ -3860,7 +3620,7 @@ Version: 1.2.3`)
 				})
 
 				It("Should create the fields and populate them when requested", func() {
-					hco.Spec.TuningPolicy = hcov1.HyperConvergedAnnotationTuningPolicy
+					hco.Spec.Virtualization.TuningPolicy = hcov1.HyperConvergedAnnotationTuningPolicy
 					hco.Annotations = make(map[string]string, 1)
 					hco.Annotations[common.TuningPolicyAnnotationName] = `{"qps": 100, "burst": 200}`
 
@@ -3879,40 +3639,6 @@ Version: 1.2.3`)
 				})
 
 			})
-
-			Context("with highBurst profile", func() {
-
-				It("Should return error if the json annotation tuningPolicy is present", func() {
-					hco.Spec.TuningPolicy = hcov1beta1.HyperConvergedHighBurstProfile //nolint SA1019
-					hco.Annotations = make(map[string]string, 1)
-					hco.Annotations[common.TuningPolicyAnnotationName] = `{"qps": 100, "burst": 200}`
-
-					kv, err := NewKubeVirt(hco)
-
-					Expect(err).To(HaveOccurred())
-					Expect(kv).To(BeNil())
-				})
-
-				It("Should create the fields and populate them using the highBurst profile values", func() {
-					hco.Spec.TuningPolicy = hcov1beta1.HyperConvergedHighBurstProfile //nolint SA1019
-					kv, err := NewKubeVirt(hco)
-					const expectedQPS = float32(200)
-					const expectedBurst = 400
-
-					Expect(kv).ToNot(BeNil())
-					Expect(err).ToNot(HaveOccurred())
-					Expect(kv.Spec.Configuration.APIConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.QPS).To(Equal(expectedQPS))
-					Expect(kv.Spec.Configuration.APIConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.Burst).To(Equal(expectedBurst))
-					Expect(kv.Spec.Configuration.ControllerConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.QPS).To(Equal(expectedQPS))
-					Expect(kv.Spec.Configuration.ControllerConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.Burst).To(Equal(expectedBurst))
-					Expect(kv.Spec.Configuration.WebhookConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.QPS).To(Equal(expectedQPS))
-					Expect(kv.Spec.Configuration.WebhookConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.Burst).To(Equal(expectedBurst))
-					Expect(kv.Spec.Configuration.HandlerConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.QPS).To(Equal(expectedQPS))
-					Expect(kv.Spec.Configuration.HandlerConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.Burst).To(Equal(expectedBurst))
-
-				})
-			})
-
 		})
 
 		Context("jsonpath Annotation", func() {
@@ -4114,7 +3840,7 @@ Version: 1.2.3`)
 				).ToNot(HaveOccurred())
 
 				Expect(kv.Spec.Configuration.DeveloperConfiguration).ToNot(BeNil())
-				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(getKvFeatureGateList(hco.Spec, nil))))
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(HaveLen(len(getKvFeatureGateList(hco))))
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElements(hardCodeKvFgs))
 				Expect(kv.Spec.Configuration.CPURequest).To(BeNil())
 
@@ -4158,7 +3884,7 @@ Version: 1.2.3`)
 					VirtAPI:        456,
 					VirtController: 789,
 				}
-				hco.Spec.LogVerbosityConfig = &hcov1.LogVerbosityConfiguration{Kubevirt: &logVerbosity}
+				hco.Spec.Deployment.LogVerbosityConfig = &hcov1.LogVerbosityConfiguration{Kubevirt: &logVerbosity}
 				devConfig := getKVDevConfig(hco)
 
 				Expect(devConfig).ToNot(BeNil())
@@ -4166,7 +3892,7 @@ Version: 1.2.3`)
 			})
 
 			DescribeTable("Should not be defined for KubevirtCR if not defined in HCO CR", func(logConfig *hcov1.LogVerbosityConfiguration) {
-				hco.Spec.LogVerbosityConfig = logConfig
+				hco.Spec.Deployment.LogVerbosityConfig = logConfig
 				devConfig := getKVDevConfig(hco)
 
 				Expect(devConfig).ToNot(BeNil())
@@ -4182,7 +3908,7 @@ Version: 1.2.3`)
 
 			It("Should be defined for KubevirtCR if defined in HCO CR", func() {
 				const runtimeClass = "myCustomRuntimeClass"
-				hco.Spec.DefaultRuntimeClass = ptr.To(runtimeClass)
+				hco.Spec.Virtualization.VirtualMachineOptions = &hcov1.VirtualMachineOptions{DefaultRuntimeClass: ptr.To(runtimeClass)}
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -4190,7 +3916,7 @@ Version: 1.2.3`)
 			})
 
 			DescribeTable("Should be empty on KubevirtCR if not defined in HCO CR", func(runtimeClass *string) {
-				hco.Spec.DefaultRuntimeClass = runtimeClass
+				hco.Spec.Virtualization.VirtualMachineOptions = &hcov1.VirtualMachineOptions{DefaultRuntimeClass: runtimeClass}
 				kv, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -4221,7 +3947,7 @@ Version: 1.2.3`)
 					existingResource.Annotations[kubevirtcorev1.EmulatorThreadCompleteToEvenParity] = ""
 				}
 
-				hco.Spec.FeatureGates.AlignCPUs = ptr.To(true)
+				hco.Spec.FeatureGates.Enable("alignCPUs")
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -4245,7 +3971,7 @@ Version: 1.2.3`)
 				Entry("FG present, annotation is missing in KubeVirt", true, false),
 			)
 
-			DescribeTable("AlignCPUs is disabled in HCO", func(alignCPUsValue *bool, isAlignCPUsFGEnabledOnKV, isAnnotationPresentOnKV bool) {
+			DescribeTable("AlignCPUs is disabled in HCO", func(alignCPUsValue *featuregates.State, isAlignCPUsFGEnabledOnKV, isAnnotationPresentOnKV bool) {
 				existingResource, err := NewKubeVirt(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -4263,7 +3989,11 @@ Version: 1.2.3`)
 					existingResource.Annotations[kubevirtcorev1.EmulatorThreadCompleteToEvenParity] = ""
 				}
 
-				hco.Spec.FeatureGates.AlignCPUs = alignCPUsValue
+				if alignCPUsValue != nil {
+					hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+						{Name: "alignCPUs", State: alignCPUsValue},
+					}
+				}
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -4285,10 +4015,10 @@ Version: 1.2.3`)
 				Entry("implicitly disabled, FG and annotation are present in KubeVirt", nil, true, true),
 				Entry("implicitly disabled, FG missing, annotation is present in KubeVirt", nil, false, true),
 				Entry("implicitly disabled, FG present, annotation is missing in KubeVirt", nil, true, false),
-				Entry("explicitly disabled, FG and annotation are missing in KubeVirt", ptr.To(false), false, false),
-				Entry("explicitly disabled, FG and annotation are present in KubeVirt", ptr.To(false), true, true),
-				Entry("explicitly disabled, FG missing, annotation is present in KubeVirt", ptr.To(false), false, true),
-				Entry("explicitly disabled, FG present, annotation is missing in KubeVirt", ptr.To(false), true, false),
+				Entry("explicitly disabled, FG and annotation are missing in KubeVirt", ptr.To(featuregates.Disabled), false, false),
+				Entry("explicitly disabled, FG and annotation are present in KubeVirt", ptr.To(featuregates.Disabled), true, true),
+				Entry("explicitly disabled, FG missing, annotation is present in KubeVirt", ptr.To(featuregates.Disabled), false, true),
+				Entry("explicitly disabled, FG present, annotation is missing in KubeVirt", ptr.To(featuregates.Disabled), true, false),
 			)
 		})
 
@@ -4296,7 +4026,7 @@ Version: 1.2.3`)
 			It("should convert ratio to corresponding percentage when overcommit ratio is set", func() {
 				const expectedPercentage int = 125
 
-				hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+				hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 					MemoryOvercommitPercentage: expectedPercentage,
 				}
 				devConfig := getKVDevConfig(hco)
@@ -4305,60 +4035,66 @@ Version: 1.2.3`)
 		})
 
 		Context("InstancetypeConfig", func() {
-			DescribeTable("should", func(spec hcov1beta1.HyperConvergedSpec, expectedConfig *kubevirtcorev1.InstancetypeConfiguration) {
+			DescribeTable("should", func(spec hcov1.HyperConvergedSpec, expectedConfig *kubevirtcorev1.InstancetypeConfiguration) {
 				hco.Spec = spec
 				config, err := getKVConfig(hco)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(config.Instancetype).To(Equal(expectedConfig))
 			},
 				Entry("pass to KubeVirt when provided",
-					hcov1beta1.HyperConvergedSpec{
-						InstancetypeConfig: &kubevirtcorev1.InstancetypeConfiguration{
-							ReferencePolicy: ptr.To(kubevirtcorev1.Reference),
+					hcov1.HyperConvergedSpec{
+						WorkloadSources: hcov1.WorkloadSourcesConfig{
+							InstancetypeConfig: &kubevirtcorev1.InstancetypeConfiguration{
+								ReferencePolicy: ptr.To(kubevirtcorev1.Reference),
+							},
 						},
 					},
 					&kubevirtcorev1.InstancetypeConfiguration{
 						ReferencePolicy: ptr.To(kubevirtcorev1.Reference),
 					},
 				),
-				Entry("not pass to KubeVirt when nil", hcov1beta1.HyperConvergedSpec{}, nil),
+				Entry("not pass to KubeVirt when nil", hcov1.HyperConvergedSpec{}, nil),
 			)
 		})
 
 		Context("CommonInstancetypesDeployment", func() {
-			DescribeTable("should", func(spec hcov1beta1.HyperConvergedSpec, expectedConfig *kubevirtcorev1.CommonInstancetypesDeployment) {
+			DescribeTable("should", func(spec hcov1.HyperConvergedSpec, expectedConfig *kubevirtcorev1.CommonInstancetypesDeployment) {
 				hco.Spec = spec
 				config, err := getKVConfig(hco)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(config.CommonInstancetypesDeployment).To(Equal(expectedConfig))
 			},
 				Entry("pass to KubeVirt when provided",
-					hcov1beta1.HyperConvergedSpec{
-						CommonInstancetypesDeployment: &kubevirtcorev1.CommonInstancetypesDeployment{
-							Enabled: ptr.To(false),
+					hcov1.HyperConvergedSpec{
+						WorkloadSources: hcov1.WorkloadSourcesConfig{
+							CommonInstancetypesDeployment: &kubevirtcorev1.CommonInstancetypesDeployment{
+								Enabled: ptr.To(false),
+							},
 						},
 					},
 					&kubevirtcorev1.CommonInstancetypesDeployment{
 						Enabled: ptr.To(false),
 					},
 				),
-				Entry("not pass to KubeVirt when nil", hcov1beta1.HyperConvergedSpec{}, nil),
+				Entry("not pass to KubeVirt when nil", hcov1.HyperConvergedSpec{}, nil),
 			)
 		})
 
 		Context("LiveUpdateConfiguration", func() {
-			DescribeTable("should", func(spec hcov1beta1.HyperConvergedSpec, expectedConfig *kubevirtcorev1.LiveUpdateConfiguration) {
+			DescribeTable("should", func(spec hcov1.HyperConvergedSpec, expectedConfig *kubevirtcorev1.LiveUpdateConfiguration) {
 				hco.Spec = spec
 				config, err := getKVConfig(hco)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(config.LiveUpdateConfiguration).To(Equal(expectedConfig))
 			},
 				Entry("pass to KubeVirt when provided",
-					hcov1beta1.HyperConvergedSpec{
-						LiveUpdateConfiguration: &kubevirtcorev1.LiveUpdateConfiguration{
-							MaxHotplugRatio: uint32(3),
-							MaxCpuSockets:   ptr.To(uint32(2)),
-							MaxGuest:        resource.NewQuantity(int64(3), resource.BinarySI),
+					hcov1.HyperConvergedSpec{
+						Virtualization: hcov1.VirtualizationConfig{
+							LiveUpdateConfiguration: &kubevirtcorev1.LiveUpdateConfiguration{
+								MaxHotplugRatio: uint32(3),
+								MaxCpuSockets:   ptr.To(uint32(2)),
+								MaxGuest:        resource.NewQuantity(int64(3), resource.BinarySI),
+							},
 						},
 					},
 					&kubevirtcorev1.LiveUpdateConfiguration{
@@ -4368,16 +4104,18 @@ Version: 1.2.3`)
 					},
 				),
 				Entry("pass to KubeVirt when provided",
-					hcov1beta1.HyperConvergedSpec{
-						LiveUpdateConfiguration: &kubevirtcorev1.LiveUpdateConfiguration{
-							MaxHotplugRatio: uint32(4),
+					hcov1.HyperConvergedSpec{
+						Virtualization: hcov1.VirtualizationConfig{
+							LiveUpdateConfiguration: &kubevirtcorev1.LiveUpdateConfiguration{
+								MaxHotplugRatio: uint32(4),
+							},
 						},
 					},
 					&kubevirtcorev1.LiveUpdateConfiguration{
 						MaxHotplugRatio: uint32(4),
 					},
 				),
-				Entry("not pass to KubeVirt when nil", hcov1beta1.HyperConvergedSpec{}, nil),
+				Entry("not pass to KubeVirt when nil", hcov1.HyperConvergedSpec{}, nil),
 			)
 		})
 
@@ -4598,7 +4336,7 @@ Version: 1.2.3`)
 
 	Context("TLSSecurityProfile", func() {
 
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
@@ -4666,7 +4404,7 @@ Version: 1.2.3`)
 				Expect(existingResource.Spec.Configuration.TLSConfiguration.Ciphers).To(Equal(kvIntermediateCiphers))
 
 				// now, modify HCO's TLSSecurityProfile
-				hco.Spec.TLSSecurityProfile = hcoTLSSecurityProfile
+				hco.Spec.Security.TLSSecurityProfile = hcoTLSSecurityProfile
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -4721,7 +4459,7 @@ Version: 1.2.3`)
 		)
 
 		It("should overwrite TLSSecurityProfile if directly set on Kubevirt CR", func() {
-			hco.Spec.TLSSecurityProfile = intermediateTLSSecurityProfile
+			hco.Spec.Security.TLSSecurityProfile = intermediateTLSSecurityProfile
 			existingResource, err := NewKubeVirt(hco)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -4758,7 +4496,7 @@ Version: 1.2.3`)
 	Context("Quantity", func() {
 		It("should add a quantity type if missing", func() {
 			hco := commontestutils.NewHco()
-			hco.Spec.LiveMigrationConfig.BandwidthPerMigration = ptr.To("1.5")
+			hco.Spec.Virtualization.LiveMigrationConfig.BandwidthPerMigration = ptr.To("1.5")
 
 			kv, err := NewKubeVirt(hco)
 			Expect(err).ToNot(HaveOccurred())

--- a/controllers/handlers/migration.go
+++ b/controllers/handlers/migration.go
@@ -13,7 +13,7 @@ import (
 
 	migrationv1alpha1 "kubevirt.io/kubevirt-migration-operator/api/v1alpha1"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/reformatobj"
@@ -30,7 +30,7 @@ type migrationHooks struct {
 	cache *migrationv1alpha1.MigController
 }
 
-func (h *migrationHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *migrationHooks) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -89,16 +89,16 @@ func (*migrationHooks) UpdateCR(req *common.HcoRequest, Client client.Client, ex
 	return false, false, nil
 }
 
-func NewMigController(hc *hcov1beta1.HyperConverged) (*migrationv1alpha1.MigController, error) {
+func NewMigController(hc *hcov1.HyperConverged) (*migrationv1alpha1.MigController, error) {
 	spec := migrationv1alpha1.MigControllerSpec{
 		ImagePullPolicy: corev1.PullIfNotPresent,
 	}
 
-	if hc.Spec.Infra.NodePlacement != nil {
-		hc.Spec.Infra.NodePlacement.DeepCopyInto(&spec.Infra)
+	if np := hc.Spec.Deployment.NodePlacements; np != nil && np.Infra != nil {
+		np.Infra.DeepCopyInto(&spec.Infra)
 	}
 
-	spec.TLSSecurityProfile = openshift2MigrationSecProfile(tlssecprofile.GetTLSSecurityProfile(hc.Spec.TLSSecurityProfile))
+	spec.TLSSecurityProfile = openshift2MigrationSecProfile(tlssecprofile.GetTLSSecurityProfile(hc.Spec.Security.TLSSecurityProfile))
 
 	migController := NewMigControllerWithNameOnly()
 	migController.Spec = spec

--- a/controllers/handlers/migration_test.go
+++ b/controllers/handlers/migration_test.go
@@ -14,7 +14,7 @@ import (
 	"kubevirt.io/controller-lifecycle-operator-sdk/api"
 	migrationv1alpha1 "kubevirt.io/kubevirt-migration-operator/api/v1alpha1"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -22,7 +22,7 @@ import (
 
 var _ = Describe("Migration tests", func() {
 	var (
-		hco *v1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 
@@ -72,7 +72,7 @@ var _ = Describe("Migration tests", func() {
 		})
 
 		It("should get node placement configurations from the HyperConverged CR", func() {
-			hco.Spec.Infra.NodePlacement = &testNodePlacement
+			commontestutils.SetNodeCustomPlacement(hco, &testNodePlacement, nil)
 
 			migController, err := NewMigController(hco)
 			Expect(err).ToNot(HaveOccurred())
@@ -233,7 +233,7 @@ var _ = Describe("Migration tests", func() {
 			Expect(existingResource.Spec.TLSSecurityProfile).To(Equal(openshift2MigrationSecProfile(intermediateTLSSecurityProfile)))
 
 			// now, modify HCO's TLSSecurityProfile
-			hco.Spec.TLSSecurityProfile = modernTLSSecurityProfile
+			hco.Spec.Security.TLSSecurityProfile = modernTLSSecurityProfile
 
 			cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 			handler := NewMigControllerHandler(cl, commontestutils.GetScheme())
@@ -255,7 +255,7 @@ var _ = Describe("Migration tests", func() {
 		})
 
 		It("should overwrite TLSSecurityProfile if directly set on MigController CR", func() {
-			hco.Spec.TLSSecurityProfile = intermediateTLSSecurityProfile
+			hco.Spec.Security.TLSSecurityProfile = intermediateTLSSecurityProfile
 			existingResource, err := NewMigController(hco)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -280,7 +280,7 @@ var _ = Describe("Migration tests", func() {
 					foundResource),
 			).ToNot(HaveOccurred())
 
-			Expect(foundResource.Spec.TLSSecurityProfile).To(Equal(openshift2MigrationSecProfile(hco.Spec.TLSSecurityProfile)))
+			Expect(foundResource.Spec.TLSSecurityProfile).To(Equal(openshift2MigrationSecProfile(hco.Spec.Security.TLSSecurityProfile)))
 			Expect(foundResource.Spec.TLSSecurityProfile).ToNot(Equal(existingResource.Spec.TLSSecurityProfile))
 
 			Expect(req.Conditions).To(BeEmpty())

--- a/controllers/handlers/networkAddons.go
+++ b/controllers/handlers/networkAddons.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	networkaddonsshared "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
@@ -18,7 +19,6 @@ import (
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
@@ -27,7 +27,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-var defaultHco = components.GetOperatorCR()
+var defaultHcoCertCfg = components.GetOperatorV1CR().Spec.Security.CertConfig
 
 func NewCnaHandler(Client client.Client, Scheme *runtime.Scheme) *operands.GenericOperand {
 	return operands.NewGenericOperand(Client, Scheme, "NetworkAddonsConfig", &cnaHooks{}, false)
@@ -38,7 +38,7 @@ type cnaHooks struct {
 	cache *networkaddonsv1.NetworkAddonsConfig
 }
 
-func (h *cnaHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *cnaHooks) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -138,7 +138,7 @@ func setDeployOvsAnnotation(req *common.HcoRequest, found *networkaddonsv1.Netwo
 	}
 }
 
-func NewNetworkAddons(hc *hcov1beta1.HyperConverged) (*networkaddonsv1.NetworkAddonsConfig, error) {
+func NewNetworkAddons(hc *hcov1.HyperConverged) (*networkaddonsv1.NetworkAddonsConfig, error) {
 	ipam := &networkaddonsshared.KubevirtIpamController{}
 	if util.GetClusterInfo().IsOpenshift() {
 		ipam.DefaultNetworkNADNamespace = "openshift-ovn-kubernetes"
@@ -147,16 +147,16 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged) (*networkaddonsv1.NetworkAd
 	cnaoSpec := networkaddonsshared.NetworkAddonsConfigSpec{
 		Multus:                 &networkaddonsshared.Multus{},
 		LinuxBridge:            &networkaddonsshared.LinuxBridge{},
-		KubeMacPool:            hcoKubeMacPool2CnaoKubeMacPool(hc.Spec.KubeMacPoolConfiguration),
+		KubeMacPool:            hcoKubeMacPool2CnaoKubeMacPool(hc.Spec.Networking),
 		KubevirtIpamController: ipam,
 	}
 
-	nameServerIP, err := getKSDNameServerIP(hc.Spec.KubeSecondaryDNSNameServerIP)
+	nameServerIP, err := getKSDNameServerIP(hc.Spec.Networking)
 	if err != nil {
 		return nil, err
 	}
 
-	if hc.Spec.FeatureGates.DeployKubeSecondaryDNS != nil && *hc.Spec.FeatureGates.DeployKubeSecondaryDNS {
+	if hc.Spec.FeatureGates.IsEnabled("deployKubeSecondaryDNS") {
 		baseDomain := util.GetClusterInfo().GetBaseDomain()
 		cnaoSpec.KubeSecondaryDNS = &networkaddonsshared.KubeSecondaryDNS{
 			Domain:       baseDomain,
@@ -165,17 +165,21 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged) (*networkaddonsv1.NetworkAd
 	}
 
 	cnaoSpec.Ovs = hcoAnnotation2CnaoSpec(hc.Annotations)
-	cnaoInfra := hcoConfig2CnaoPlacement(hc.Spec.Infra.NodePlacement)
-	cnaoWorkloads := hcoConfig2CnaoPlacement(hc.Spec.Workloads.NodePlacement)
-	if cnaoInfra != nil || cnaoWorkloads != nil {
-		cnaoSpec.PlacementConfiguration = &networkaddonsshared.PlacementConfiguration{
-			Infra:     cnaoInfra,
-			Workloads: cnaoWorkloads,
+
+	if np := hc.Spec.Deployment.NodePlacements; np != nil {
+		cnaoInfra := hcoConfig2CnaoPlacement(np.Infra)
+		cnaoWorkloads := hcoConfig2CnaoPlacement(np.Workload)
+		if cnaoInfra != nil || cnaoWorkloads != nil {
+			cnaoSpec.PlacementConfiguration = &networkaddonsshared.PlacementConfiguration{
+				Infra:     cnaoInfra,
+				Workloads: cnaoWorkloads,
+			}
 		}
 	}
-	cnaoSpec.SelfSignConfiguration = hcoCertConfig2CnaoSelfSignedConfig(&hc.Spec.CertConfig)
 
-	cnaoSpec.TLSSecurityProfile = tlssecprofile.GetTLSSecurityProfile(hc.Spec.TLSSecurityProfile)
+	cnaoSpec.SelfSignConfiguration = hcoCertConfig2CnaoSelfSignedConfig(&hc.Spec.Security.CertConfig)
+
+	cnaoSpec.TLSSecurityProfile = tlssecprofile.GetTLSSecurityProfile(hc.Spec.Security.TLSSecurityProfile)
 
 	cna := NewNetworkAddonsWithNameOnly()
 	cna.Spec = cnaoSpec
@@ -187,13 +191,14 @@ func NewNetworkAddons(hc *hcov1beta1.HyperConverged) (*networkaddonsv1.NetworkAd
 	return reformatobj.ReformatObj(cna)
 }
 
-func getKSDNameServerIP(nameServerIPPtr *string) (string, error) {
-	var nameServerIP string
-	if nameServerIPPtr != nil {
-		nameServerIP = *nameServerIPPtr
-		if nameServerIP != "" && !net.IsIPv4String(nameServerIP) {
-			return "", errors.New("kubeSecondaryDNSNameServerIP isn't a valid IPv4")
-		}
+func getKSDNameServerIP(nt *hcov1.NetworkingConfig) (string, error) {
+	if nt == nil {
+		return "", nil
+	}
+
+	nameServerIP := ptr.Deref(nt.KubeSecondaryDNSNameServerIP, "")
+	if nameServerIP != "" && !net.IsIPv4String(nameServerIP) {
+		return "", errors.New("kubeSecondaryDNSNameServerIP isn't a valid IPv4")
 	}
 
 	return nameServerIP, nil
@@ -245,26 +250,22 @@ func hcoAnnotation2CnaoSpec(hcoAnnotations map[string]string) *networkaddonsshar
 	return nil
 }
 
-func hcoKubeMacPool2CnaoKubeMacPool(hcoKubeMacPool *hcov1.KubeMacPoolConfig) *networkaddonsshared.KubeMacPool {
+func hcoKubeMacPool2CnaoKubeMacPool(nt *hcov1.NetworkingConfig) *networkaddonsshared.KubeMacPool {
 	kubeMacPool := &networkaddonsshared.KubeMacPool{}
 
-	if hcoKubeMacPool != nil {
-		if hcoKubeMacPool.RangeStart != nil {
-			kubeMacPool.RangeStart = *hcoKubeMacPool.RangeStart
-		}
-		if hcoKubeMacPool.RangeEnd != nil {
-			kubeMacPool.RangeEnd = *hcoKubeMacPool.RangeEnd
-		}
+	if nt != nil && nt.KubeMacPoolConfiguration != nil {
+		kubeMacPool.RangeStart = ptr.Deref(nt.KubeMacPoolConfiguration.RangeStart, "")
+		kubeMacPool.RangeEnd = ptr.Deref(nt.KubeMacPoolConfiguration.RangeEnd, "")
 	}
 
 	return kubeMacPool
 }
 
 func hcoCertConfig2CnaoSelfSignedConfig(hcoCertConfig *hcov1.HyperConvergedCertConfig) *networkaddonsshared.SelfSignConfiguration {
-	caRotateInterval := defaultHco.Spec.CertConfig.CA.Duration.Duration.String()
-	caOverlapInterval := defaultHco.Spec.CertConfig.CA.RenewBefore.Duration.String()
-	certRotateInterval := defaultHco.Spec.CertConfig.Server.Duration.Duration.String()
-	certOverlapInterval := defaultHco.Spec.CertConfig.Server.RenewBefore.Duration.String()
+	caRotateInterval := defaultHcoCertCfg.CA.Duration.Duration.String()
+	caOverlapInterval := defaultHcoCertCfg.CA.RenewBefore.Duration.String()
+	certRotateInterval := defaultHcoCertCfg.Server.Duration.Duration.String()
+	certOverlapInterval := defaultHcoCertCfg.Server.RenewBefore.Duration.String()
 	if hcoCertConfig.CA.Duration != nil {
 		caRotateInterval = hcoCertConfig.CA.Duration.Duration.String()
 	}

--- a/controllers/handlers/networkAddons_test.go
+++ b/controllers/handlers/networkAddons_test.go
@@ -22,7 +22,7 @@ import (
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -31,7 +31,7 @@ import (
 var _ = Describe("CNA Operand", func() {
 
 	Context("NetworkAddonsConfig", func() {
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
@@ -198,8 +198,7 @@ var _ = Describe("CNA Operand", func() {
 			existingResource, err := NewNetworkAddons(hco)
 			Expect(err).ToNot(HaveOccurred())
 
-			hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-			hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+			commontestutils.SetNodePlacement(hco)
 
 			cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 			handler := NewCnaHandler(cl, commontestutils.GetScheme())
@@ -223,7 +222,7 @@ var _ = Describe("CNA Operand", func() {
 			Expect(placementConfig.Infra.NodeSelector["key2"]).To(Equal("value2"))
 
 			Expect(placementConfig.Workloads).ToNot(BeNil())
-			Expect(placementConfig.Workloads.Tolerations).To(Equal(hco.Spec.Workloads.NodePlacement.Tolerations))
+			Expect(placementConfig.Workloads.Tolerations).To(Equal(hco.Spec.Deployment.NodePlacements.Workload.Tolerations))
 
 			Expect(req.Conditions).To(BeEmpty())
 		})
@@ -231,8 +230,7 @@ var _ = Describe("CNA Operand", func() {
 		It("should remove node placement if missing in HCO CR", func() {
 
 			hcoNodePlacement := commontestutils.NewHco()
-			hcoNodePlacement.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-			hcoNodePlacement.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+			commontestutils.SetNodePlacement(hcoNodePlacement)
 			existingResource, err := NewNetworkAddons(hcoNodePlacement)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -258,17 +256,16 @@ var _ = Describe("CNA Operand", func() {
 
 		It("should modify node placement according to HCO CR", func() {
 
-			hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-			hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+			commontestutils.SetNodePlacement(hco)
 			existingResource, err := NewNetworkAddons(hco)
 			Expect(err).ToNot(HaveOccurred())
 
 			// now, modify HCO's node placement
-			hco.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+			hco.Spec.Deployment.NodePlacements.Infra.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, corev1.Toleration{
 				Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 			})
 
-			hco.Spec.Workloads.NodePlacement.NodeSelector["key1"] = "something else"
+			hco.Spec.Deployment.NodePlacements.Workload.NodeSelector["key1"] = "something else"
 
 			cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 			handler := NewCnaHandler(cl, commontestutils.GetScheme())
@@ -296,8 +293,7 @@ var _ = Describe("CNA Operand", func() {
 		})
 
 		It("should overwrite node placement if directly set on CNAO CR", func() {
-			hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-			hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+			commontestutils.SetNodePlacement(hco)
 			existingResource, err := NewNetworkAddons(hco)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -305,10 +301,10 @@ var _ = Describe("CNA Operand", func() {
 			req.HCOTriggered = false
 
 			// now, modify CNAO node placement
-			existingResource.Spec.PlacementConfiguration.Infra.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+			existingResource.Spec.PlacementConfiguration.Infra.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, corev1.Toleration{
 				Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 			})
-			existingResource.Spec.PlacementConfiguration.Workloads.Tolerations = append(hco.Spec.Workloads.NodePlacement.Tolerations, corev1.Toleration{
+			existingResource.Spec.PlacementConfiguration.Workloads.Tolerations = append(hco.Spec.Deployment.NodePlacements.Workload.Tolerations, corev1.Toleration{
 				Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 			})
 
@@ -347,7 +343,7 @@ var _ = Describe("CNA Operand", func() {
 			existingResource, err := NewNetworkAddons(hco)
 			Expect(err).ToNot(HaveOccurred())
 
-			hco.Spec.CertConfig = hcov1.HyperConvergedCertConfig{
+			hco.Spec.Security.CertConfig = hcov1.HyperConvergedCertConfig{
 				CA: hcov1.CertRotateConfigCA{
 					Duration:    &metav1.Duration{Duration: 24 * time.Hour},
 					RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
@@ -413,7 +409,7 @@ var _ = Describe("CNA Operand", func() {
 
 		It("should modify self signed configuration according to HCO CR", func() {
 
-			hco.Spec.CertConfig = hcov1.HyperConvergedCertConfig{
+			hco.Spec.Security.CertConfig = hcov1.HyperConvergedCertConfig{
 				CA: hcov1.CertRotateConfigCA{
 					Duration:    &metav1.Duration{Duration: 24 * time.Hour},
 					RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
@@ -427,10 +423,10 @@ var _ = Describe("CNA Operand", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Modify HCO's cert configuration")
-			hco.Spec.CertConfig.CA.Duration.Duration *= 2
-			hco.Spec.CertConfig.CA.RenewBefore.Duration *= 2
-			hco.Spec.CertConfig.Server.Duration.Duration *= 2
-			hco.Spec.CertConfig.Server.RenewBefore.Duration *= 2
+			hco.Spec.Security.CertConfig.CA.Duration.Duration *= 2
+			hco.Spec.Security.CertConfig.CA.RenewBefore.Duration *= 2
+			hco.Spec.Security.CertConfig.Server.Duration.Duration *= 2
+			hco.Spec.Security.CertConfig.Server.RenewBefore.Duration *= 2
 
 			cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 			handler := NewCnaHandler(cl, commontestutils.GetScheme())
@@ -465,7 +461,7 @@ var _ = Describe("CNA Operand", func() {
 
 		It("should overwrite self signed configuration if directly set on CNAO CR", func() {
 
-			hco.Spec.CertConfig = hcov1.HyperConvergedCertConfig{
+			hco.Spec.Security.CertConfig = hcov1.HyperConvergedCertConfig{
 				CA: hcov1.CertRotateConfigCA{
 					Duration:    &metav1.Duration{Duration: 24 * time.Hour},
 					RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
@@ -592,7 +588,7 @@ var _ = Describe("CNA Operand", func() {
 		type ksdAnnotationParams struct {
 			ksdExists          bool
 			setFeatureGate     bool
-			featureGateValue   bool
+			featureGateValue   featuregates.State
 			ksdDeployExpected  bool
 			expectedBaseDomain string
 		}
@@ -606,8 +602,13 @@ var _ = Describe("CNA Operand", func() {
 
 			const kubeSecondaryDNSNameServerIP = "127.0.0.1"
 			if o.setFeatureGate {
-				hco.Spec.FeatureGates.DeployKubeSecondaryDNS = ptr.To(o.featureGateValue)
-				hco.Spec.KubeSecondaryDNSNameServerIP = ptr.To(kubeSecondaryDNSNameServerIP)
+				hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+					{Name: "deployKubeSecondaryDNS", State: ptr.To(o.featureGateValue)},
+				}
+
+				hco.Spec.Networking = &hcov1.NetworkingConfig{
+					KubeSecondaryDNSNameServerIP: ptr.To(kubeSecondaryDNSNameServerIP),
+				}
 			}
 
 			cl := commontestutils.InitClient([]client.Object{hco, existingCNAO})
@@ -639,21 +640,21 @@ var _ = Describe("CNA Operand", func() {
 				Entry("should have KSD if feature gate is set to true", ksdAnnotationParams{
 					ksdExists:          false,
 					setFeatureGate:     true,
-					featureGateValue:   true,
+					featureGateValue:   featuregates.Enabled,
 					ksdDeployExpected:  true,
 					expectedBaseDomain: "",
 				}),
 				Entry("should not have KSD if feature gate is set to false", ksdAnnotationParams{
 					ksdExists:          true,
 					setFeatureGate:     true,
-					featureGateValue:   false,
+					featureGateValue:   featuregates.Disabled,
 					ksdDeployExpected:  false,
 					expectedBaseDomain: "",
 				}),
 				Entry("should not have KSD if feature gate does not exist", ksdAnnotationParams{
 					ksdExists:          true,
 					setFeatureGate:     false,
-					featureGateValue:   false,
+					featureGateValue:   featuregates.Disabled,
 					ksdDeployExpected:  false,
 					expectedBaseDomain: "",
 				}),
@@ -677,21 +678,21 @@ var _ = Describe("CNA Operand", func() {
 				Entry("should have KSD if feature gate is set to true", ksdAnnotationParams{
 					ksdExists:          false,
 					setFeatureGate:     true,
-					featureGateValue:   true,
+					featureGateValue:   featuregates.Enabled,
 					ksdDeployExpected:  true,
 					expectedBaseDomain: commontestutils.BaseDomain,
 				}),
 				Entry("should not have KSD if feature gate is set to false", ksdAnnotationParams{
 					ksdExists:          true,
 					setFeatureGate:     true,
-					featureGateValue:   false,
+					featureGateValue:   featuregates.Disabled,
 					ksdDeployExpected:  false,
 					expectedBaseDomain: "",
 				}),
 				Entry("should not have KSD if feature gate does not exist", ksdAnnotationParams{
 					ksdExists:          true,
 					setFeatureGate:     false,
-					featureGateValue:   false,
+					featureGateValue:   featuregates.Disabled,
 					ksdDeployExpected:  false,
 					expectedBaseDomain: "",
 				}),
@@ -1019,7 +1020,7 @@ var _ = Describe("CNA Operand", func() {
 
 		Context("KubeMacPoolConfiguration", func() {
 			It("should create KubeMacPool with empty config when KubeMacPoolConfiguration is nil", func() {
-				hco.Spec.KubeMacPoolConfiguration = nil
+				hco.Spec.Networking = &hcov1.NetworkingConfig{KubeMacPoolConfiguration: nil}
 
 				expectedResource, err := NewNetworkAddons(hco)
 				Expect(err).ToNot(HaveOccurred())
@@ -1029,7 +1030,7 @@ var _ = Describe("CNA Operand", func() {
 			})
 
 			It("should create KubeMacPool with empty config when KubeMacPoolConfiguration is empty", func() {
-				hco.Spec.KubeMacPoolConfiguration = &hcov1.KubeMacPoolConfig{}
+				hco.Spec.Networking = &hcov1.NetworkingConfig{KubeMacPoolConfiguration: &hcov1.KubeMacPoolConfig{}}
 
 				expectedResource, err := NewNetworkAddons(hco)
 				Expect(err).ToNot(HaveOccurred())
@@ -1039,9 +1040,11 @@ var _ = Describe("CNA Operand", func() {
 			})
 
 			It("should create KubeMacPool with both RangeStart and RangeEnd when both are specified", func() {
-				hco.Spec.KubeMacPoolConfiguration = &hcov1.KubeMacPoolConfig{
-					RangeStart: ptr.To("02:00:00:00:00:00"),
-					RangeEnd:   ptr.To("FD:FF:FF:FF:FF:FF"),
+				hco.Spec.Networking = &hcov1.NetworkingConfig{
+					KubeMacPoolConfiguration: &hcov1.KubeMacPoolConfig{
+						RangeStart: ptr.To("02:00:00:00:00:00"),
+						RangeEnd:   ptr.To("FD:FF:FF:FF:FF:FF"),
+					},
 				}
 
 				expectedResource, err := NewNetworkAddons(hco)
@@ -1099,7 +1102,7 @@ var _ = Describe("CNA Operand", func() {
 				Expect(existingResource.Spec.TLSSecurityProfile).To(Equal(intermediateTLSSecurityProfile))
 
 				// now, modify HCO's TLSSecurityProfile
-				hco.Spec.TLSSecurityProfile = modernTLSSecurityProfile
+				hco.Spec.Security.TLSSecurityProfile = modernTLSSecurityProfile
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewCnaHandler(cl, commontestutils.GetScheme())
@@ -1121,7 +1124,7 @@ var _ = Describe("CNA Operand", func() {
 			})
 
 			It("should overwrite TLSSecurityProfile if directly set on CNAO CR", func() {
-				hco.Spec.TLSSecurityProfile = intermediateTLSSecurityProfile
+				hco.Spec.Security.TLSSecurityProfile = intermediateTLSSecurityProfile
 				existingResource, err := NewNetworkAddons(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1146,7 +1149,7 @@ var _ = Describe("CNA Operand", func() {
 						foundResource),
 				).To(Succeed())
 
-				Expect(foundResource.Spec.TLSSecurityProfile).To(Equal(hco.Spec.TLSSecurityProfile))
+				Expect(foundResource.Spec.TLSSecurityProfile).To(Equal(hco.Spec.Security.TLSSecurityProfile))
 				Expect(foundResource.Spec.TLSSecurityProfile).ToNot(Equal(existingResource.Spec.TLSSecurityProfile))
 
 				Expect(req.Conditions).To(BeEmpty())

--- a/controllers/handlers/quickStart.go
+++ b/controllers/handlers/quickStart.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -37,7 +37,7 @@ type qsHooks struct {
 	required *consolev1.ConsoleQuickStart
 }
 
-func (h qsHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h qsHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.required.DeepCopy(), nil
 }
 
@@ -71,7 +71,7 @@ func (h qsHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exists r
 	return false, false, nil
 }
 
-func GetQuickStartHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, _ *hcov1beta1.HyperConverged, dir fs.FS) ([]operands.Operand, error) {
+func GetQuickStartHandlers(logger log.Logger, Client client.Client, Scheme *runtime.Scheme, _ *hcov1.HyperConverged, dir fs.FS) ([]operands.Operand, error) {
 	err := util.ValidateManifestDir(QuickStartDefaultManifestLocation, dir)
 	if err != nil {
 		return nil, errors.Unwrap(err) // if not wrapped, then it's not an error that stops processing, and it return nil

--- a/controllers/handlers/ssp.go
+++ b/controllers/handlers/ssp.go
@@ -13,7 +13,6 @@ import (
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	goldenimages "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/golden-images"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
@@ -67,7 +66,7 @@ type sspHooks struct {
 	dictStatuses []hcov1.DataImportCronTemplateStatus
 }
 
-func (h *sspHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *sspHooks) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -132,12 +131,8 @@ func (h *sspHooks) updateDICTsInHCStatus(req *common.HcoRequest) {
 	goldenimages.CheckDataImportCronTemplates(req.Instance)
 }
 
-func NewSSP(hc *hcov1beta1.HyperConverged) (*sspv1beta3.SSP, []hcov1.DataImportCronTemplateStatus, error) {
-	templatesNamespace := defaultCommonTemplatesNamespace
-
-	if hc.Spec.CommonTemplatesNamespace != nil {
-		templatesNamespace = *hc.Spec.CommonTemplatesNamespace
-	}
+func NewSSP(hc *hcov1.HyperConverged) (*sspv1beta3.SSP, []hcov1.DataImportCronTemplateStatus, error) {
+	templatesNamespace := ptr.Deref(hc.Spec.WorkloadSources.CommonTemplatesNamespace, defaultCommonTemplatesNamespace)
 
 	goldenimages.ApplyDataImportSchedule(hc)
 
@@ -168,22 +163,22 @@ func NewSSP(hc *hcov1beta1.HyperConverged) (*sspv1beta3.SSP, []hcov1.DataImportC
 
 		Cluster: cluster,
 
-		EnableMultipleArchitectures: hc.Spec.FeatureGates.EnableMultiArchBootImageImport,
+		EnableMultipleArchitectures: ptr.To(hc.Spec.FeatureGates.IsEnabled(goldenimages.EnableMultiArchFeatureGate)),
 
 		// NodeLabeller field is explicitly initialized to its zero-value,
 		// in order to future-proof from bugs if SSP changes it to pointer-type,
 		// causing nil pointers dereferences at the DeepCopyInto() below.
-		TLSSecurityProfile: tlssecprofile.GetTLSSecurityProfile(hc.Spec.TLSSecurityProfile),
+		TLSSecurityProfile: tlssecprofile.GetTLSSecurityProfile(hc.Spec.Security.TLSSecurityProfile),
 	}
 
-	if hc.Spec.DeployVMConsoleProxy != nil {
+	if hc.Spec.Deployment.DeployVMConsoleProxy != nil {
 		spec.TokenGenerationService = &sspv1beta3.TokenGenerationService{
-			Enabled: *hc.Spec.DeployVMConsoleProxy,
+			Enabled: *hc.Spec.Deployment.DeployVMConsoleProxy,
 		}
 	}
 
-	if hc.Spec.Infra.NodePlacement != nil {
-		spec.TemplateValidator.Placement = hc.Spec.Infra.NodePlacement.DeepCopy()
+	if np := hc.Spec.Deployment.NodePlacements; np != nil && np.Infra != nil {
+		spec.TemplateValidator.Placement = np.Infra.DeepCopy()
 	}
 
 	ssp := NewSSPWithNameOnly()

--- a/controllers/handlers/ssp_test.go
+++ b/controllers/handlers/ssp_test.go
@@ -22,7 +22,7 @@ import (
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	goldenimages "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/golden-images"
@@ -45,7 +45,7 @@ var _ = Describe("SSP Operands", func() {
 
 	Context("SSP", func() {
 		var (
-			hco *hcov1beta1.HyperConverged
+			hco *hcov1.HyperConverged
 			req *common.HcoRequest
 		)
 
@@ -99,7 +99,7 @@ var _ = Describe("SSP Operands", func() {
 
 		It("should reconcile to default", func() {
 			const cTNamespace = "nonDefault"
-			hco.Spec.CommonTemplatesNamespace = ptr.To(cTNamespace)
+			hco.Spec.WorkloadSources.CommonTemplatesNamespace = ptr.To(cTNamespace)
 			expectedResource, _, err := NewSSP(hco)
 			Expect(err).ToNot(HaveOccurred())
 			existingResource := expectedResource.DeepCopy()
@@ -199,7 +199,7 @@ var _ = Describe("SSP Operands", func() {
 		})
 
 		It("should create ssp with deployVmConsoleProxy feature gate enabled", func() {
-			hco.Spec.DeployVMConsoleProxy = ptr.To(true)
+			hco.Spec.Deployment.DeployVMConsoleProxy = ptr.To(true)
 
 			expectedResource, _, err := NewSSP(hco)
 			Expect(err).ToNot(HaveOccurred())
@@ -208,16 +208,17 @@ var _ = Describe("SSP Operands", func() {
 			Expect(expectedResource.Spec.TokenGenerationService.Enabled).To(BeTrue())
 		})
 
-		DescribeTable("should copy the HC's EnableMultiArchBootImageImport feature gate, to SSP's EnableMultipleArchitectures field", func(hcFG *bool, matcher gomegatypes.GomegaMatcher) {
-			hco.Spec.FeatureGates.EnableMultiArchBootImageImport = hcFG
+		DescribeTable("should copy the HC's EnableMultiArchBootImageImport feature gate, to SSP's EnableMultipleArchitectures field", func(hcFG *featuregates.State, matcher gomegatypes.GomegaMatcher) {
+			hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+				{Name: goldenimages.EnableMultiArchFeatureGate, State: hcFG},
+			}
 
 			ssp, _, err := NewSSP(hco)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ssp.Spec.EnableMultipleArchitectures).To(matcher)
 		},
-			Entry("when HC's EnableMultiArchBootImageImport is nil", nil, BeNil()),
-			Entry("when HC's EnableMultiArchBootImageImport is false", ptr.To(false), HaveValue(BeFalse())),
-			Entry("when HC's EnableMultiArchBootImageImport is true", ptr.To(true), HaveValue(BeTrue())),
+			Entry("when HC's EnableMultiArchBootImageImport is false", ptr.To(featuregates.Disabled), HaveValue(BeFalse())),
+			Entry("when HC's EnableMultiArchBootImageImport is true", ptr.To(featuregates.Enabled), HaveValue(BeTrue())),
 		)
 
 		Context("SSP's Cluster filed", func() {
@@ -295,8 +296,7 @@ var _ = Describe("SSP Operands", func() {
 				existingResource, _, err := NewSSP(hco)
 				Expect(err).ToNot(HaveOccurred())
 
-				hco.Spec.Workloads.NodePlacement = commontestutils.NewNodePlacement()
-				hco.Spec.Infra.NodePlacement = commontestutils.NewOtherNodePlacement()
+				commontestutils.SetNodeCustomPlacement(hco, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewSspHandler(cl, commontestutils.GetScheme())
@@ -314,17 +314,15 @@ var _ = Describe("SSP Operands", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 
-				Expect(existingResource.Spec.TemplateValidator.Placement).To(BeNil())
-				// TODO: replace BeEquivalentTo with BeEqual once SSP will consume kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4
-				Expect(*foundResource.Spec.TemplateValidator.Placement).To(BeEquivalentTo(*hco.Spec.Infra.NodePlacement))
+				Expect(foundResource.Spec.TemplateValidator.Placement).To(HaveValue(Equal(*hco.Spec.Deployment.NodePlacements.Infra)))
 				Expect(req.Conditions).To(BeEmpty())
 			})
 
 			It("should remove node placement if missing in HCO CR", func() {
 
 				hcoNodePlacement := commontestutils.NewHco()
-				hcoNodePlacement.Spec.Workloads.NodePlacement = commontestutils.NewNodePlacement()
-				hcoNodePlacement.Spec.Infra.NodePlacement = commontestutils.NewOtherNodePlacement()
+				commontestutils.SetNodeCustomPlacement(hcoNodePlacement, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
+
 				existingResource, _, err := NewSSP(hcoNodePlacement)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -351,21 +349,20 @@ var _ = Describe("SSP Operands", func() {
 
 			It("should modify node placement according to HCO CR", func() {
 
-				hco.Spec.Workloads.NodePlacement = commontestutils.NewNodePlacement()
-				hco.Spec.Infra.NodePlacement = commontestutils.NewOtherNodePlacement()
+				commontestutils.SetNodeCustomPlacement(hco, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
 				existingResource, _, err := NewSSP(hco)
 				Expect(err).ToNot(HaveOccurred())
 
 				// now, modify HCO's node placement
-				hco.Spec.Workloads.NodePlacement.Tolerations = append(hco.Spec.Workloads.NodePlacement.Tolerations, corev1.Toleration{
+				hco.Spec.Deployment.NodePlacements.Workload.Tolerations = append(hco.Spec.Deployment.NodePlacements.Workload.Tolerations, corev1.Toleration{
 					Key: "key12", Operator: "operator12", Value: "value12", Effect: "effect12", TolerationSeconds: ptr.To[int64](12),
 				})
-				hco.Spec.Workloads.NodePlacement.NodeSelector["key1"] = "something else"
+				hco.Spec.Deployment.NodePlacements.Workload.NodeSelector["key1"] = "something else"
 
-				hco.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+				hco.Spec.Deployment.NodePlacements.Infra.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, corev1.Toleration{
 					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: ptr.To[int64](34),
 				})
-				hco.Spec.Infra.NodePlacement.NodeSelector["key3"] = "something entirely else"
+				hco.Spec.Deployment.NodePlacements.Infra.NodeSelector["key3"] = "something entirely else"
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewSspHandler(cl, commontestutils.GetScheme())
@@ -395,8 +392,7 @@ var _ = Describe("SSP Operands", func() {
 			})
 
 			It("should overwrite node placement if directly set on SSP CR", func() {
-				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewOtherNodePlacement()}
+				commontestutils.SetNodeCustomPlacement(hco, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
 				existingResource, _, err := NewSSP(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -404,7 +400,7 @@ var _ = Describe("SSP Operands", func() {
 				req.HCOTriggered = false
 
 				// and modify TemplateValidator node placement
-				existingResource.Spec.TemplateValidator.Placement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+				existingResource.Spec.TemplateValidator.Placement.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, corev1.Toleration{
 					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: ptr.To(int64(34)),
 				})
 				existingResource.Spec.TemplateValidator.Placement.NodeSelector["key3"] = "BADvalue3"
@@ -588,14 +584,14 @@ var _ = Describe("SSP Operands", func() {
 				Expect(hook.cache).To(BeNil())
 
 				origFunc := goldenimages.GetDataImportCronTemplates
-				goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+				goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 					return []hcov1.DataImportCronTemplateStatus{makeDICT(1)}, nil
 				}
 				DeferCleanup(func() {
 					goldenimages.GetDataImportCronTemplates = origFunc
 				})
 
-				hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+				hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 				firstCR, err := hook.GetFullCr(hco)
 				Expect(err).ToNot(HaveOccurred())
@@ -653,11 +649,11 @@ var _ = Describe("SSP Operands", func() {
 							goldenimages.MultiArchDICTAnnotation: "noarch1,noarch2",
 						}
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
 
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 						cli := commontestutils.InitClient([]client.Object{hco})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -696,12 +692,12 @@ var _ = Describe("SSP Operands", func() {
 						}
 						customDICT.Status.OriginalSupportedArchitectures = "arch2,arch3"
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
 
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
-						hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
 
 						cli := commontestutils.InitClient([]client.Object{hco})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -757,12 +753,12 @@ var _ = Describe("SSP Operands", func() {
 							OriginalSupportedArchitectures: "noarch1,noarch2",
 						}
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
 
-						hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 						cli := commontestutils.InitClient([]client.Object{hco})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -801,17 +797,17 @@ var _ = Describe("SSP Operands", func() {
 							goldenimages.MultiArchDICTAnnotation: "noarch1,noarch2",
 						}
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
 						ssp, _, err := NewSSP(hco)
 						Expect(err).ToNot(HaveOccurred())
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 						cli := commontestutils.InitClient([]client.Object{hco, ssp})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -856,18 +852,18 @@ var _ = Describe("SSP Operands", func() {
 							OriginalSupportedArchitectures: "arch2,arch3",
 						}
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
 						ssp, _, err := NewSSP(hco)
 						Expect(err).ToNot(HaveOccurred())
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
-						hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 						cli := commontestutils.InitClient([]client.Object{hco, ssp})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -925,18 +921,18 @@ var _ = Describe("SSP Operands", func() {
 							OriginalSupportedArchitectures: "noarch1,noarch2",
 						}
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
 						ssp, _, err := NewSSP(hco)
 						Expect(err).ToNot(HaveOccurred())
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
-						hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 						cli := commontestutils.InitClient([]client.Object{hco, ssp})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -979,11 +975,11 @@ var _ = Describe("SSP Operands", func() {
 						customDICT := makeDICT(2)
 						customDICT.Annotations = map[string]string{}
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
 
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 						cli := commontestutils.InitClient([]client.Object{hco})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -1022,12 +1018,12 @@ var _ = Describe("SSP Operands", func() {
 						}
 						customDICT.Status.OriginalSupportedArchitectures = "arch2,arch3"
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
 
-						hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 						cli := commontestutils.InitClient([]client.Object{hco})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -1060,12 +1056,12 @@ var _ = Describe("SSP Operands", func() {
 						customDICT := makeDICT(2)
 						customDICT.Annotations = map[string]string{}
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
 
-						hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 						cli := commontestutils.InitClient([]client.Object{hco})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -1102,15 +1098,15 @@ var _ = Describe("SSP Operands", func() {
 						customDICT := makeDICT(2)
 						customDICT.Annotations = map[string]string{}
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 						ssp, _, err := NewSSP(hco)
 						Expect(err).ToNot(HaveOccurred())
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
 
@@ -1153,18 +1149,18 @@ var _ = Describe("SSP Operands", func() {
 						customDICT.Annotations = map[string]string{}
 						customDICT.Status.OriginalSupportedArchitectures = "arch2,arch3"
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
 						ssp, _, err := NewSSP(hco)
 						Expect(err).ToNot(HaveOccurred())
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
-						hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 						cli := commontestutils.InitClient([]client.Object{hco, ssp})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -1201,18 +1197,18 @@ var _ = Describe("SSP Operands", func() {
 						customDICT := makeDICT(2)
 						customDICT.Annotations = map[string]string{}
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
 						ssp, _, err := NewSSP(hco)
 						Expect(err).ToNot(HaveOccurred())
 
-						goldenimages.GetDataImportCronTemplates = func(_ *hcov1beta1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
+						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT, customDICT}, nil
 						}
-						hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
-						hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+						hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
+						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 
 						cli := commontestutils.InitClient([]client.Object{hco, ssp})
 						handler := NewSspHandler(cli, commontestutils.GetScheme())
@@ -1254,7 +1250,7 @@ var _ = Describe("SSP Operands", func() {
 				Expect(existingResource.Spec.TLSSecurityProfile).To(Equal(intermediateTLSSecurityProfile))
 
 				// now, modify HCO's TLSSecurityProfile
-				hco.Spec.TLSSecurityProfile = modernTLSSecurityProfile
+				hco.Spec.Security.TLSSecurityProfile = modernTLSSecurityProfile
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := NewSspHandler(cl, commontestutils.GetScheme())
@@ -1276,7 +1272,7 @@ var _ = Describe("SSP Operands", func() {
 			})
 
 			It("should overwrite TLSSecurityProfile if directly set on SSP CR", func() {
-				hco.Spec.TLSSecurityProfile = intermediateTLSSecurityProfile
+				hco.Spec.Security.TLSSecurityProfile = intermediateTLSSecurityProfile
 				existingResource, _, err := NewSSP(hco)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1301,7 +1297,7 @@ var _ = Describe("SSP Operands", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 
-				Expect(foundResource.Spec.TLSSecurityProfile).To(Equal(hco.Spec.TLSSecurityProfile))
+				Expect(foundResource.Spec.TLSSecurityProfile).To(Equal(hco.Spec.Security.TLSSecurityProfile))
 				Expect(foundResource.Spec.TLSSecurityProfile).ToNot(Equal(existingResource.Spec.TLSSecurityProfile))
 
 				Expect(req.Conditions).To(BeEmpty())

--- a/controllers/handlers/virtio_win_ConfigMap_test.go
+++ b/controllers/handlers/virtio_win_ConfigMap_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -23,7 +23,7 @@ import (
 var _ = Describe("VirtioWin", func() {
 	Context("Virtio-Win ConfigMap", func() {
 
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
@@ -191,7 +191,7 @@ var _ = Describe("VirtioWin", func() {
 	})
 
 	Context("ConfigMap Reader Role", func() {
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
@@ -242,7 +242,7 @@ var _ = Describe("VirtioWin", func() {
 	})
 
 	Context("ConfigMap Reader Role Binding", func() {
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {

--- a/controllers/handlers/wasp-agent/daemonset.go
+++ b/controllers/handlers/wasp-agent/daemonset.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -43,7 +43,7 @@ func NewWaspAgentDaemonSetHandler(Client client.Client, Scheme *runtime.Scheme) 
 	return operands.NewConditionalHandler(
 		operands.NewDaemonSetHandler(Client, Scheme, newWaspAgentDaemonSet),
 		shouldDeployWaspAgent,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return NewWaspAgentWithNameOnly()
 		},
 	)
@@ -59,7 +59,7 @@ func NewWaspAgentWithNameOnly() *appsv1.DaemonSet {
 	}
 }
 
-func newWaspAgentDaemonSet(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
+func newWaspAgentDaemonSet(hc *hcov1.HyperConverged) *appsv1.DaemonSet {
 	waspImage, _ := os.LookupEnv(hcoutil.WaspAgentImageEnvV)
 
 	podLabels := operands.GetLabels(AppComponentWaspAgent)
@@ -146,18 +146,18 @@ func newWaspAgentDaemonSet(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet {
 	ds := NewWaspAgentWithNameOnly()
 	ds.Spec = spec
 
-	if hc.Spec.Infra.NodePlacement != nil {
-		if hc.Spec.Infra.NodePlacement.NodeSelector != nil {
-			ds.Spec.Template.Spec.NodeSelector = maps.Clone(hc.Spec.Infra.NodePlacement.NodeSelector)
+	if np := hc.Spec.Deployment.NodePlacements; np != nil && np.Infra != nil {
+		if np.Infra.NodeSelector != nil {
+			ds.Spec.Template.Spec.NodeSelector = maps.Clone(np.Infra.NodeSelector)
 		}
 
-		if hc.Spec.Infra.NodePlacement.Affinity != nil {
-			ds.Spec.Template.Spec.Affinity = hc.Spec.Infra.NodePlacement.Affinity.DeepCopy()
+		if np.Infra.Affinity != nil {
+			ds.Spec.Template.Spec.Affinity = np.Infra.Affinity.DeepCopy()
 		}
 
-		if hc.Spec.Infra.NodePlacement.Tolerations != nil {
-			ds.Spec.Template.Spec.Tolerations = make([]corev1.Toleration, len(hc.Spec.Infra.NodePlacement.Tolerations))
-			copy(ds.Spec.Template.Spec.Tolerations, hc.Spec.Infra.NodePlacement.Tolerations)
+		if np.Infra.Tolerations != nil {
+			ds.Spec.Template.Spec.Tolerations = make([]corev1.Toleration, len(np.Infra.Tolerations))
+			copy(ds.Spec.Template.Spec.Tolerations, np.Infra.Tolerations)
 		}
 	} else {
 		affinity := getPodAntiAffinity(ds.Labels[hcoutil.AppLabelComponent], nodeinfo.IsInfrastructureHighlyAvailable())
@@ -185,7 +185,7 @@ func createDaemonSetEnvVar() []corev1.EnvVar {
 	}
 }
 
-func shouldDeployWaspAgent(hc *hcov1beta1.HyperConverged) bool {
+func shouldDeployWaspAgent(hc *hcov1.HyperConverged) bool {
 	val := strings.TrimSpace(hc.Annotations[AutopilotSwapAnnotation])
 	if val == AutopilotFullOptInAnnotationValue {
 		return false
@@ -196,7 +196,7 @@ func shouldDeployWaspAgent(hc *hcov1beta1.HyperConverged) bool {
 		}
 	}
 
-	overcommitPercentage := hc.Spec.HigherWorkloadDensity.MemoryOvercommitPercentage
+	overcommitPercentage := hc.Spec.Virtualization.HigherWorkloadDensity.MemoryOvercommitPercentage
 	return overcommitPercentage > NoOverCommitPercentage
 }
 

--- a/controllers/handlers/wasp-agent/daemonset_test.go
+++ b/controllers/handlers/wasp-agent/daemonset_test.go
@@ -14,14 +14,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 )
 
 var _ = Describe("Wasp Agent DaemonSet", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		ds  client.Client
 	)
@@ -34,7 +33,7 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 
 	Context("Wasp DaemonSet deployment", func() {
 		It("should not create if overcommit percent is less or equal to 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
 			ds = commontestutils.InitClient([]client.Object{hco})
@@ -53,7 +52,7 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 			Expect(foundDs.Items).To(BeEmpty())
 		})
 		It("should delete DaemonSet when percentage is set to 100 and below", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
 			scc := newWaspAgentDaemonSet(hco)
@@ -74,7 +73,7 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 			Expect(foundDs.Items).To(BeEmpty())
 		})
 		It("should create Deamonset when percentage is set to higher than 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			ds = commontestutils.InitClient([]client.Object{hco})
@@ -95,7 +94,7 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 		})
 
 		It("should not create DaemonSet when autopilot swap annotation is set even with overcommit > 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			hco.Annotations[AutopilotSwapAnnotation] = AutopilotSwapAnnotationValue
@@ -116,7 +115,7 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 		})
 
 		It("should not create DaemonSet when autopilot full opt-in annotation is set even with overcommit > 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			hco.Annotations[AutopilotSwapAnnotation] = AutopilotFullOptInAnnotationValue
@@ -137,7 +136,7 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 		})
 
 		It("should delete DaemonSet when autopilot full opt-in annotation is added", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			existingDs := newWaspAgentDaemonSet(hco)
@@ -160,7 +159,7 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 		})
 
 		It("should delete DaemonSet when autopilot swap annotation is added", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			existingDs := newWaspAgentDaemonSet(hco)
@@ -183,7 +182,7 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 		})
 
 		It("should not create DaemonSet when autopilot swap value is embedded in a comma-separated list", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			// introducing whitespaces to verify the consistency with autopilot implementation
@@ -207,7 +206,7 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 	})
 	Context("Wasp agent DaemonSet update", func() {
 		It("should update DaemonSet fields if not matched to the requirements", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			originalDs := newWaspAgentDaemonSet(hco)
@@ -242,7 +241,7 @@ var _ = Describe("Wasp Agent DaemonSet", func() {
 		})
 
 		It("should reconcile labels if they are missing while preserving user labels", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			ds := newWaspAgentDaemonSet(hco)

--- a/controllers/handlers/wasp-agent/rbac.go
+++ b/controllers/handlers/wasp-agent/rbac.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -15,7 +15,7 @@ func NewWaspAgentClusterRoleBindingHandler(cli client.Client, Scheme *runtime.Sc
 	return operands.NewConditionalHandler(
 		operands.NewClusterRoleBindingHandler(cli, Scheme, newWaspAgentClusterRoleBinding()),
 		shouldDeployWaspAgent,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return newWaspAgentClusterRoleBindingWithNameOnly()
 		},
 	)
@@ -58,7 +58,7 @@ func NewWaspAgentClusterRoleHandler(Client client.Client, Scheme *runtime.Scheme
 	return operands.NewConditionalHandler(
 		operands.NewClusterRoleHandler(Client, Scheme, newWaspAgentClusterRole()),
 		shouldDeployWaspAgent,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return newWaspAgentClusterRoleWithNameOnly()
 		},
 	)

--- a/controllers/handlers/wasp-agent/rbac_test.go
+++ b/controllers/handlers/wasp-agent/rbac_test.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -18,7 +17,7 @@ import (
 
 var _ = Describe("Wasp agent Cluster Role", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)
@@ -47,7 +46,7 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 
 	Context("Cluster role deployment", func() {
 		It("should not create if overcommit percent is less or equal to 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
 			cr := newWaspAgentClusterRole()
@@ -69,7 +68,7 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 			Expect(foundCRs.Items).To(BeEmpty())
 		})
 		It("should delete cluster role when percentage is set to 100 and below", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
 			cr := newWaspAgentClusterRole()
@@ -91,7 +90,7 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 			Expect(foundCRs.Items).To(BeEmpty())
 		})
 		It("should create cluster role when percentage is set to higher than 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 
@@ -111,7 +110,7 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 		})
 
 		It("should not create cluster role when autopilot swap annotation is set even with overcommit > 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			hco.Annotations[AutopilotSwapAnnotation] = AutopilotSwapAnnotationValue
@@ -136,7 +135,7 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 	})
 	Context("Wasp agent cluster role update", func() {
 		It("should reconcile labels if they are missing while preserving user labels", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			cr := newWaspAgentClusterRole()
@@ -166,7 +165,7 @@ var _ = Describe("Wasp agent Cluster Role", func() {
 
 var _ = Describe("Wasp agent Cluster Role Binding", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)
@@ -191,7 +190,7 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 	})
 	Context("Cluster role binding deployment", func() {
 		It("should not create if overcommit percent is less or equal to 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
 			crb := newWaspAgentClusterRoleBinding()
@@ -213,7 +212,7 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 			Expect(foundCRBs.Items).To(BeEmpty())
 		})
 		It("should delete cluster role binding when percentage is set to 100 and below", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
 			crb := newWaspAgentClusterRoleBinding()
@@ -235,7 +234,7 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 			Expect(foundCRBs.Items).To(BeEmpty())
 		})
 		It("should create cluster role binding when percentage is set to higher than 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 
@@ -255,7 +254,7 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 		})
 
 		It("should not create cluster role binding when autopilot swap annotation is set even with overcommit > 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			hco.Annotations[AutopilotSwapAnnotation] = AutopilotSwapAnnotationValue
@@ -280,7 +279,7 @@ var _ = Describe("Wasp agent Cluster Role Binding", func() {
 	})
 	Context("Wasp agent cluster role binding update", func() {
 		It("should reconcile labels if they are missing while preserving user labels", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			crb := newWaspAgentClusterRoleBinding()

--- a/controllers/handlers/wasp-agent/scc.go
+++ b/controllers/handlers/wasp-agent/scc.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -19,7 +19,7 @@ func NewWaspAgentSCCHandler(Client client.Client, Scheme *runtime.Scheme) operan
 	return operands.NewConditionalHandler(
 		operands.NewSecurityContextConstraintsHandler(Client, Scheme, newWaspAgentSCC()),
 		shouldDeployWaspAgent,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return NewWaspAgentSCCWithNameOnly()
 		},
 	)

--- a/controllers/handlers/wasp-agent/scc_test.go
+++ b/controllers/handlers/wasp-agent/scc_test.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -19,7 +18,7 @@ import (
 
 var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)
@@ -59,7 +58,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 
 	Context("SecurityContextConstraints deployment", func() {
 		It("should not create if overcommit percent is less or equal to 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
 			cl = commontestutils.InitClient([]client.Object{hco})
@@ -79,7 +78,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 		})
 
 		It("should delete SecurityContextConstraints when percentage is set to 100 and below", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
 			scc := newWaspAgentSCC()
@@ -101,7 +100,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 		})
 
 		It("should create SecurityContextConstraints when percentage is set to higher than 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			cl = commontestutils.InitClient([]client.Object{hco})
@@ -122,7 +121,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 		})
 
 		It("should not create SCC when autopilot swap annotation is set even with overcommit > 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			hco.Annotations[AutopilotSwapAnnotation] = AutopilotSwapAnnotationValue
@@ -143,7 +142,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 		})
 
 		It("should delete SCC when autopilot swap annotation is added", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			scc := newWaspAgentSCC()
@@ -168,7 +167,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 
 	Context("SecurityContextConstraints update", func() {
 		It("should update SecurityContextConstraints fields if not matched to the requirements", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			scc := newWaspAgentSCC()
@@ -195,7 +194,7 @@ var _ = Describe("Wasp Agent SecurityContextConstraints", func() {
 		})
 
 		It("should reconcile labels if they are missing while preserving user labels", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			scc := newWaspAgentSCC()

--- a/controllers/handlers/wasp-agent/service_account.go
+++ b/controllers/handlers/wasp-agent/service_account.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -15,7 +15,7 @@ func NewWaspAgentServiceAccountHandler(Client client.Client, Scheme *runtime.Sch
 	return operands.NewConditionalHandler(
 		operands.NewServiceAccountHandler(Client, Scheme, newWaspAgentServiceAccount),
 		shouldDeployWaspAgent,
-		func(hc *hcov1beta1.HyperConverged) client.Object {
+		func(hc *hcov1.HyperConverged) client.Object {
 			return newWaspAgentServiceAccount()
 		},
 	)

--- a/controllers/handlers/wasp-agent/service_account_test.go
+++ b/controllers/handlers/wasp-agent/service_account_test.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -18,7 +17,7 @@ import (
 
 var _ = Describe("Wasp Agent Service Account", func() {
 	var (
-		hco *hcov1beta1.HyperConverged
+		hco *hcov1.HyperConverged
 		req *common.HcoRequest
 		cl  client.Client
 	)
@@ -41,7 +40,7 @@ var _ = Describe("Wasp Agent Service Account", func() {
 
 	Context("Wasp agent service account deployment", func() {
 		It("should not create if overcommit percent is less or equal to 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
 			cl = commontestutils.InitClient([]client.Object{hco})
@@ -62,7 +61,7 @@ var _ = Describe("Wasp Agent Service Account", func() {
 		})
 
 		It("should delete service account when percentage is set to 100 and below", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 100,
 			}
 			sa := newWaspAgentServiceAccount()
@@ -86,7 +85,7 @@ var _ = Describe("Wasp Agent Service Account", func() {
 		})
 
 		It("should create service account when percentage is set to higher than 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 
@@ -106,7 +105,7 @@ var _ = Describe("Wasp Agent Service Account", func() {
 		})
 
 		It("should not create service account when autopilot swap annotation is set even with overcommit > 100", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			hco.Annotations[AutopilotSwapAnnotation] = AutopilotSwapAnnotationValue
@@ -127,7 +126,7 @@ var _ = Describe("Wasp Agent Service Account", func() {
 		})
 
 		It("should delete service account when autopilot swap annotation is added", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			sa := newWaspAgentServiceAccount()
@@ -151,7 +150,7 @@ var _ = Describe("Wasp Agent Service Account", func() {
 	})
 	Context("Wasp agent service account update", func() {
 		It("should reconcile labels if they are missing while preserving user labels", func() {
-			hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+			hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 				MemoryOvercommitPercentage: 150,
 			}
 			sa := newWaspAgentServiceAccount()

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -158,7 +158,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, ci hcoutil.ClusterInfo, in
 	// Watch for changes to primary resource HyperConverged
 	err = c.Watch(
 		source.Kind(
-			mgr.GetCache(), client.Object(&hcov1beta1.HyperConverged{}),
+			mgr.GetCache(), client.Object(&hcov1.HyperConverged{}),
 			&operatorhandler.InstrumentedEnqueueRequestForObject[client.Object]{},
 			predicate.Or[client.Object](predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{},
 				predicate.ResourceVersionChangedPredicate{}),
@@ -346,7 +346,7 @@ func (r *ReconcileHyperConverged) Reconcile(ctx context.Context, request reconci
 
 	// update the HyperConverged's TLS Security Profile cache, to be used in the
 	// server's TLS configurations.
-	tlssecprofile.SetHyperConvergedTLSSecurityProfile(instance.Spec.TLSSecurityProfile)
+	tlssecprofile.SetHyperConvergedTLSSecurityProfile(instance.Spec.Security.TLSSecurityProfile)
 
 	if err = r.monitoringReconciler.UpdateRelatedObjects(hcoRequest); err != nil {
 		logger.Error(err, "Failed to update the PrometheusRule as a related object")
@@ -392,7 +392,7 @@ func (r *ReconcileHyperConverged) doReconcile(req *common.HcoRequest) (reconcile
 	updateStatus(req)
 
 	metrics.SetHCOMetricMemoryOvercommitPercentage(
-		getMemoryOvercommitPercentage(req.Instance.Spec.HigherWorkloadDensity),
+		getMemoryOvercommitPercentage(req.Instance.Spec.Virtualization.HigherWorkloadDensity),
 	)
 
 	// in-memory conditions should start off empty. It will only ever hold
@@ -501,8 +501,8 @@ func updateStatus(req *common.HcoRequest) {
 }
 
 // getHyperConverged gets the HyperConverged resource from the Kubernetes API.
-func (r *ReconcileHyperConverged) getHyperConverged(req *common.HcoRequest) (*hcov1beta1.HyperConverged, error) {
-	instance := &hcov1beta1.HyperConverged{}
+func (r *ReconcileHyperConverged) getHyperConverged(req *common.HcoRequest) (*hcov1.HyperConverged, error) {
+	instance := &hcov1.HyperConverged{}
 	err := r.client.Get(req.Ctx, req.NamespacedName, instance)
 
 	// Green path first
@@ -536,7 +536,7 @@ func (r *ReconcileHyperConverged) updateHyperConverged(request *common.HcoReques
 	// In addition, metadata and spec changes are removed by status update, but since status update done first, we need
 	// to store metadata and spec and recover it after status update
 
-	var spec hcov1beta1.HyperConvergedSpec
+	var spec hcov1.HyperConvergedSpec
 	var meta metav1.ObjectMeta
 	if request.Dirty {
 		request.Instance.Spec.DeepCopyInto(&spec)
@@ -1144,9 +1144,29 @@ func (r *ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (b
 		return false, err
 	}
 
-	tmpInstance, err := upgradepatch.ApplyUpgradePatch(req.Logger, req.Instance, knownHcoSV)
+	// Temporary workaround, until  upgradepatch.ApplyUpgradePatch moves to v1; TODO: restore when done
+	v1Beta1Instance := &hcov1beta1.HyperConverged{}
+	err = v1Beta1Instance.ConvertFrom(req.Instance)
 	if err != nil {
 		return false, err
+	}
+
+	tmpInstance, err := upgradepatch.ApplyUpgradePatch(req.Logger, v1Beta1Instance, knownHcoSV)
+	if err != nil {
+		return false, err
+	}
+
+	if !reflect.DeepEqual(tmpInstance.Spec, v1Beta1Instance.Spec) {
+		req.Logger.Info("updating HCO spec as a result of upgrade patches")
+		tmpInstance.Spec.DeepCopyInto(&v1Beta1Instance.Spec)
+		err = v1Beta1Instance.ConvertTo(req.Instance)
+		if err != nil {
+			return false, err
+		}
+		// End of workaround
+
+		modified = true
+		req.Dirty = true
 	}
 
 	for _, p := range upgradepatch.GetObjectsToBeRemoved() {
@@ -1154,13 +1174,6 @@ func (r *ReconcileHyperConverged) applyUpgradePatches(req *common.HcoRequest) (b
 		if err != nil {
 			return removed, err
 		}
-	}
-
-	if !reflect.DeepEqual(tmpInstance.Spec, req.Instance.Spec) {
-		req.Logger.Info("updating HCO spec as a result of upgrade patches")
-		tmpInstance.Spec.DeepCopyInto(&req.Instance.Spec)
-		modified = true
-		req.Dirty = true
 	}
 
 	return modified, nil

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -33,7 +33,7 @@ import (
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
@@ -126,7 +126,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the HCO
-				foundResource := &hcov1beta1.HyperConverged{}
+				foundResource := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -144,9 +144,9 @@ var _ = Describe("HyperconvergedController", func() {
 			It("should create all managed resources", func() {
 
 				hco := commontestutils.NewHco()
-				hco.Spec.FeatureGates = hcov1beta1.HyperConvergedFeatureGates{
-					DownwardMetrics: ptr.To(true),
-					VideoConfig:     ptr.To(true),
+				hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{
+					{Name: "downwardMetrics"},
+					{Name: "videoConfig"},
 				}
 
 				ci := hcoutil.GetClusterInfo()
@@ -164,7 +164,7 @@ var _ = Describe("HyperconvergedController", func() {
 				verifyHyperConvergedCRExistsMetricTrue()
 
 				// Get the HCO
-				foundResource := &hcov1beta1.HyperConverged{}
+				foundResource := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -242,7 +242,7 @@ var _ = Describe("HyperconvergedController", func() {
 				verifyHyperConvergedCRExistsMetricTrue()
 
 				// Get the HCO
-				foundResource = &hcov1beta1.HyperConverged{}
+				foundResource = &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -298,7 +298,7 @@ var _ = Describe("HyperconvergedController", func() {
 				verifyHyperConvergedCRExistsMetricTrue()
 
 				// Get the HCO
-				foundResource := &hcov1beta1.HyperConverged{}
+				foundResource := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
@@ -338,7 +338,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the HCO
-				foundResource := &hcov1beta1.HyperConverged{}
+				foundResource := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
@@ -396,7 +396,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the latest objects
-				latestHCO := &hcov1beta1.HyperConverged{}
+				latestHCO := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
@@ -428,7 +428,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the latest objects
-				HCO := &hcov1beta1.HyperConverged{}
+				HCO := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
@@ -452,7 +452,7 @@ var _ = Describe("HyperconvergedController", func() {
 					cl.Status().Update(context.TODO(), HCO),
 				).ToNot(HaveOccurred())
 
-				HCO = &hcov1beta1.HyperConverged{}
+				HCO = &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
@@ -522,7 +522,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the latest objects
-				latestHCO := &hcov1beta1.HyperConverged{}
+				latestHCO := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
@@ -544,7 +544,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 			It("should set different template namespace to ssp CR", func() {
 				expected := getBasicDeployment()
-				expected.hco.Spec.CommonTemplatesNamespace = &expected.hco.Namespace
+				expected.hco.Spec.WorkloadSources.CommonTemplatesNamespace = &expected.hco.Namespace
 
 				cl := expected.initClient()
 				r := initReconciler(cl, nil)
@@ -576,7 +576,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(res).To(Equal(reconcile.Result{}))
 
 				// Get the HCO
-				foundResource := &hcov1beta1.HyperConverged{}
+				foundResource := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
@@ -619,17 +619,16 @@ var _ = Describe("HyperconvergedController", func() {
 
 			It("should increment counter when out-of-band change overwritten", func() {
 				hco := commontestutils.NewHco()
-				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				commontestutils.SetNodePlacement(hco)
 				existingResource, err := handlers.NewKubeVirt(hco, namespace)
 				Expect(err).ToNot(HaveOccurred())
 				existingResource.APIVersion, existingResource.Kind = kubevirtcorev1.KubeVirtGroupVersionKind.ToAPIVersionAndKind() // necessary for metrics
 
 				// now, modify KV's node placement
-				existingResource.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+				existingResource.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, corev1.Toleration{
 					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
-				existingResource.Spec.Workloads.NodePlacement.Tolerations = append(hco.Spec.Workloads.NodePlacement.Tolerations, corev1.Toleration{
+				existingResource.Spec.Workloads.NodePlacement.Tolerations = append(hco.Spec.Deployment.NodePlacements.Workload.Tolerations, corev1.Toleration{
 					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
 
@@ -675,17 +674,17 @@ var _ = Describe("HyperconvergedController", func() {
 
 			It("should not increment counter when CR was changed by HCO", func() {
 				hco := commontestutils.NewHco()
-				hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
-				hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				commontestutils.SetNodePlacement(hco)
+
 				existingResource, err := handlers.NewKubeVirt(hco, namespace)
 				Expect(err).ToNot(HaveOccurred())
 				existingResource.Kind = kubevirtcorev1.KubeVirtGroupVersionKind.Kind // necessary for metrics
 
 				// now, modify KV's node placement
-				existingResource.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Infra.NodePlacement.Tolerations, corev1.Toleration{
+				existingResource.Spec.Infra.NodePlacement.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, corev1.Toleration{
 					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
-				existingResource.Spec.Workloads.NodePlacement.Tolerations = append(hco.Spec.Workloads.NodePlacement.Tolerations, corev1.Toleration{
+				existingResource.Spec.Workloads.NodePlacement.Tolerations = append(hco.Spec.Deployment.NodePlacements.Workload.Tolerations, corev1.Toleration{
 					Key: "key3", Operator: "operator3", Value: "value3", Effect: "effect3", TolerationSeconds: ptr.To[int64](3),
 				})
 
@@ -805,7 +804,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{}))
 
-				foundResource := &hcov1beta1.HyperConverged{}
+				foundResource := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
@@ -831,7 +830,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res.IsZero()).To(BeTrue())
 
-				foundResource = &hcov1beta1.HyperConverged{}
+				foundResource = &hcov1.HyperConverged{}
 				err = cl.Get(context.TODO(),
 					types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
 					foundResource)
@@ -848,7 +847,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{}))
 
-				foundResource := &hcov1beta1.HyperConverged{}
+				foundResource := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
@@ -876,7 +875,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
 
 				// Get the HCO
-				foundResource := &hcov1beta1.HyperConverged{}
+				foundResource := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -918,7 +917,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(res.IsZero()).To(BeTrue())
 
 				// Get the HCO
-				foundHyperConverged := &hcov1beta1.HyperConverged{}
+				foundHyperConverged := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
 						types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -949,7 +948,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 			It("Should update memory overcommit metrics according to the CR", func() {
 				expected := getBasicDeployment()
-				expected.hco.Spec.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
+				expected.hco.Spec.Virtualization.HigherWorkloadDensity = &hcov1.HigherWorkloadDensityConfiguration{
 					MemoryOvercommitPercentage: 42,
 				}
 
@@ -1000,7 +999,7 @@ var _ = Describe("HyperconvergedController", func() {
 				}
 
 				expected := getBasicDeployment()
-				Expect(expected.hco.Spec.TLSSecurityProfile).To(BeNil())
+				Expect(expected.hco.Spec.Security.TLSSecurityProfile).To(BeNil())
 
 				resources := expected.toArray()
 				resources = append(resources, apiServer)
@@ -1015,14 +1014,14 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{}))
 
-				foundResource := &hcov1beta1.HyperConverged{}
+				foundResource := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
 						foundResource),
 				).ToNot(HaveOccurred())
 				checkAvailability(foundResource, metav1.ConditionTrue)
-				Expect(foundResource.Spec.TLSSecurityProfile).To(BeNil(), "TLSSecurityProfile on HCO CR should still be nil")
+				Expect(foundResource.Spec.Security.TLSSecurityProfile).To(BeNil(), "TLSSecurityProfile on HCO CR should still be nil")
 
 				By("Verify that Kubevirt was properly configured with initialTLSSecurityProfile")
 				kv := handlers.NewKubeVirtWithNameOnly()
@@ -1078,7 +1077,7 @@ var _ = Describe("HyperconvergedController", func() {
 				// Update ApiServer CR
 				apiServer.Spec.TLSSecurityProfile = customTLSSecurityProfile
 				Expect(cl.Update(ctx, apiServer)).To(Succeed())
-				Expect(tlssecprofile.GetTLSSecurityProfile(expected.hco.Spec.TLSSecurityProfile)).To(Equal(initialTLSSecurityProfile), "should still return the cached value (initial value)")
+				Expect(tlssecprofile.GetTLSSecurityProfile(expected.hco.Spec.Security.TLSSecurityProfile)).To(Equal(initialTLSSecurityProfile), "should still return the cached value (initial value)")
 
 				// this is done in the apiserver controller
 				modified, err := tlssecprofile.Refresh(ctx, cl)
@@ -1098,9 +1097,9 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 				checkAvailability(foundResource, metav1.ConditionTrue)
-				Expect(foundResource.Spec.TLSSecurityProfile).To(BeNil(), "TLSSecurityProfile on HCO CR should still be nil")
+				Expect(foundResource.Spec.Security.TLSSecurityProfile).To(BeNil(), "TLSSecurityProfile on HCO CR should still be nil")
 
-				Expect(tlssecprofile.GetTLSSecurityProfile(expected.hco.Spec.TLSSecurityProfile)).To(Equal(customTLSSecurityProfile), "should return the up-to-date value")
+				Expect(tlssecprofile.GetTLSSecurityProfile(expected.hco.Spec.Security.TLSSecurityProfile)).To(Equal(customTLSSecurityProfile), "should return the up-to-date value")
 
 				By("Verify that Kubevirt was properly updated with customTLSSecurityProfile")
 				kv = handlers.NewKubeVirtWithNameOnly()
@@ -1165,7 +1164,7 @@ var _ = Describe("HyperconvergedController", func() {
 				}
 
 				expected := getBasicDeployment()
-				Expect(expected.hco.Spec.TLSSecurityProfile).To(BeNil())
+				Expect(expected.hco.Spec.Security.TLSSecurityProfile).To(BeNil())
 
 				resources := expected.toArray()
 				resources = append(resources, apiServer)
@@ -1180,14 +1179,14 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{}))
 
-				foundHCO := &hcov1beta1.HyperConverged{}
+				foundHCO := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(ctx,
 						types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
 						foundHCO),
 				).ToNot(HaveOccurred())
 
-				Expect(foundHCO.Spec.TLSSecurityProfile).To(BeNil(), "TLSSecurityProfile on HCO CR should still be nil")
+				Expect(foundHCO.Spec.Security.TLSSecurityProfile).To(BeNil(), "TLSSecurityProfile on HCO CR should still be nil")
 
 				By("Verify that Kubevirt was properly configured with initialTLSSecurityProfile")
 				kv := handlers.NewKubeVirtWithNameOnly()
@@ -1241,7 +1240,7 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(ssp.Spec.TLSSecurityProfile).To(Equal(initialTLSSecurityProfile))
 
 				By("Update HyperConverged CR with customTLSSecurityProfile")
-				foundHCO.Spec.TLSSecurityProfile = customTLSSecurityProfile
+				foundHCO.Spec.Security.TLSSecurityProfile = customTLSSecurityProfile
 				Expect(cl.Update(ctx, foundHCO)).To(Succeed())
 
 				// Reconcile again to make sure all the CRs get updated with the new TLS security profile
@@ -1255,7 +1254,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundHCO),
 				).ToNot(HaveOccurred())
 				checkAvailability(foundHCO, metav1.ConditionTrue)
-				Expect(foundHCO.Spec.TLSSecurityProfile).To(Equal(customTLSSecurityProfile), "TLSSecurityProfile on HCO CR should be updated")
+				Expect(foundHCO.Spec.Security.TLSSecurityProfile).To(Equal(customTLSSecurityProfile), "TLSSecurityProfile on HCO CR should be updated")
 
 				By("Verify that Kubevirt was properly updated with customTLSSecurityProfile")
 				kv = handlers.NewKubeVirtWithNameOnly()
@@ -1795,7 +1794,7 @@ var _ = Describe("HyperconvergedController", func() {
 				cl := expected.initClient()
 				rsc := schema.GroupResource{Group: hcoutil.APIVersionGroup, Resource: "hyperconvergeds.hco.kubevirt.io"}
 				cl.InitiateUpdateErrors(func(obj client.Object) error {
-					if _, ok := obj.(*hcov1beta1.HyperConverged); ok {
+					if _, ok := obj.(*hcov1.HyperConverged); ok {
 						return apierrors.NewConflict(rsc, "hco", errors.New("test error"))
 					}
 					return nil
@@ -1829,7 +1828,7 @@ var _ = Describe("HyperconvergedController", func() {
 		Context("Detection of a tainted configuration", func() {
 			var (
 				hcoNamespace *corev1.Namespace
-				hco          *hcov1beta1.HyperConverged
+				hco          *hcov1.HyperConverged
 			)
 			BeforeEach(func() {
 				hcoNamespace = commontestutils.NewHcoNamespace()
@@ -1861,7 +1860,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
 					})
 
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -1916,7 +1915,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(res.IsZero()).To(BeTrue())
 
 					// Get the HCO
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -1966,7 +1965,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(res.RequeueAfter).To(BeZero())
 					})
 
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2016,7 +2015,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
 					})
 
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2075,7 +2074,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(res.RequeueAfter).To(BeZero())
 
 					// Get the HCO
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2118,7 +2117,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(res.RequeueAfter).To(BeZero())
 					})
 
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2167,7 +2166,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
 					})
 
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2222,7 +2221,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(res.RequeueAfter).To(BeZero())
 
 					// Get the HCO
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2257,7 +2256,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
 					})
 
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2301,7 +2300,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
 					})
 
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2354,7 +2353,7 @@ var _ = Describe("HyperconvergedController", func() {
 					Expect(res.RequeueAfter).To(BeZero())
 
 					// Get the HCO
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2389,7 +2388,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
 					})
 
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2466,7 +2465,7 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
 					})
 
-					foundResource := &hcov1beta1.HyperConverged{}
+					foundResource := &hcov1.HyperConverged{}
 					Expect(
 						cl.Get(context.TODO(),
 							types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -2565,7 +2564,7 @@ func verifyHyperConvergedCRExistsMetricFalse() {
 	ExpectWithOffset(1, hcExists).To(BeFalse())
 }
 
-func verifySystemHealthStatusHealthy(hco *hcov1beta1.HyperConverged) {
+func verifySystemHealthStatusHealthy(hco *hcov1.HyperConverged) {
 	ExpectWithOffset(1, hco.Status.SystemHealthStatus).To(Equal(systemHealthStatusHealthy))
 
 	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus()
@@ -2573,7 +2572,7 @@ func verifySystemHealthStatusHealthy(hco *hcov1beta1.HyperConverged) {
 	ExpectWithOffset(1, systemHealthStatusMetric).To(Equal(metrics.SystemHealthStatusHealthy))
 }
 
-func verifySystemHealthStatusError(hco *hcov1beta1.HyperConverged) {
+func verifySystemHealthStatusError(hco *hcov1.HyperConverged) {
 	ExpectWithOffset(1, hco.Status.SystemHealthStatus).To(Equal(systemHealthStatusError))
 
 	systemHealthStatusMetric, err := metrics.GetHCOMetricSystemHealthStatus()

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -33,7 +33,6 @@ import (
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/alerts"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
@@ -118,7 +117,7 @@ func validateOperatorCondition(r *ReconcileHyperConverged, status metav1.Conditi
 
 type BasicExpected struct {
 	namespace            *corev1.Namespace
-	hco                  *hcov1beta1.HyperConverged
+	hco                  *hcov1.HyperConverged
 	pc                   *schedulingv1.PriorityClass
 	kv                   *kubevirtcorev1.KubeVirt
 	cdi                  *cdiv1beta1.CDI
@@ -180,13 +179,13 @@ func getBasicDeployment() *BasicExpected {
 
 	res := &BasicExpected{}
 
-	hco := &hcov1beta1.HyperConverged{
+	hco := &hcov1.HyperConverged{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels:    map[string]string{hcoutil.AppLabel: name},
 		},
-		Spec: hcov1beta1.HyperConvergedSpec{},
+		Spec: hcov1.HyperConvergedSpec{},
 		Status: hcov1.HyperConvergedStatus{
 			Conditions: []metav1.Condition{
 				{
@@ -206,7 +205,7 @@ func getBasicDeployment() *BasicExpected {
 	}
 	res.hco = hco
 
-	components.GetOperatorCR().Spec.DeepCopyInto(&res.hco.Spec)
+	components.GetOperatorV1CR().Spec.DeepCopyInto(&res.hco.Spec)
 
 	res.namespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -327,7 +326,7 @@ func getBasicDeployment() *BasicExpected {
 }
 
 // returns the HCO after reconcile, and the returned requeue
-func doReconcile(cl client.Client, hco *hcov1beta1.HyperConverged, old *ReconcileHyperConverged) (*hcov1beta1.HyperConverged, *ReconcileHyperConverged, bool) {
+func doReconcile(cl client.Client, hco *hcov1.HyperConverged, old *ReconcileHyperConverged) (*hcov1.HyperConverged, *ReconcileHyperConverged, bool) {
 	r := initReconciler(cl, old)
 
 	r.firstLoop = false
@@ -336,7 +335,7 @@ func doReconcile(cl client.Client, hco *hcov1beta1.HyperConverged, old *Reconcil
 	res, err := r.Reconcile(context.TODO(), request)
 	Expect(err).ToNot(HaveOccurred())
 
-	foundResource := &hcov1beta1.HyperConverged{}
+	foundResource := &hcov1.HyperConverged{}
 	Expect(
 		cl.Get(context.TODO(),
 			types.NamespacedName{Name: hco.Name, Namespace: hco.Namespace},
@@ -380,7 +379,7 @@ func getGenericProgressingConditions() []conditionsv1.Condition {
 	}
 }
 
-func checkAvailability(hco *hcov1beta1.HyperConverged, expected metav1.ConditionStatus) {
+func checkAvailability(hco *hcov1.HyperConverged, expected metav1.ConditionStatus) {
 	found := false
 	for _, cond := range hco.Status.Conditions {
 		if cond.Type == hcov1.ConditionAvailable {

--- a/controllers/hyperconverged/upgrade_test.go
+++ b/controllers/hyperconverged/upgrade_test.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/reqresolver"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/metrics"
@@ -227,7 +226,7 @@ var _ = Describe("Upgrade Mode", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(Equal(requeueAfter))
 
-		foundHC := &hcov1beta1.HyperConverged{}
+		foundHC := &hcov1.HyperConverged{}
 		Expect(
 			cl.Get(context.TODO(),
 				types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
@@ -247,7 +246,7 @@ var _ = Describe("Upgrade Mode", func() {
 	DescribeTable(
 		"be tolerant parsing parse version",
 		func(testHcoVersion string, acceptableVersion bool, errorMessage string) {
-			foundResource := &hcov1beta1.HyperConverged{}
+			foundResource := &hcov1.HyperConverged{}
 			UpdateVersion(&expected.hco.Status, hcoVersionName, testHcoVersion)
 
 			cl := expected.initClient()
@@ -568,7 +567,7 @@ var _ = Describe("Upgrade Mode", func() {
 
 		It("should drop spec.livemigrationconfig.bandwidthpermigration if == 64Mi when upgrading from < 1.5.0", func() {
 			UpdateVersion(&expected.hco.Status, hcoVersionName, "1.4.99")
-			expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = ptr.To(badBandwidthPerMigration)
+			expected.hco.Spec.Virtualization.LiveMigrationConfig.BandwidthPerMigration = ptr.To(badBandwidthPerMigration)
 
 			cl := expected.initClient()
 			_, reconciler, requeue := doReconcile(cl, expected.hco, nil)
@@ -577,31 +576,31 @@ var _ = Describe("Upgrade Mode", func() {
 			Expect(requeue).To(BeTrue())
 			_, _, requeue = doReconcile(cl, expected.hco, reconciler)
 			Expect(requeue).To(BeFalse())
-			Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).To(BeNil())
+			Expect(foundResource.Spec.Virtualization.LiveMigrationConfig.BandwidthPerMigration).To(BeNil())
 		})
 
 		It("should preserve spec.livemigrationconfig.bandwidthpermigration if != 64Mi when upgrading from < 1.5.0", func() {
 			UpdateVersion(&expected.hco.Status, hcoVersionName, "1.4.99")
-			expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = ptr.To(customBandwidthPerMigration)
+			expected.hco.Spec.Virtualization.LiveMigrationConfig.BandwidthPerMigration = ptr.To(customBandwidthPerMigration)
 
 			cl := expected.initClient()
 			_, reconciler, requeue := doReconcile(cl, expected.hco, nil)
 			Expect(requeue).To(BeTrue())
 			foundResource, _, requeue := doReconcile(cl, expected.hco, reconciler)
 			Expect(requeue).To(BeFalse())
-			Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).To(HaveValue(Equal(customBandwidthPerMigration)))
+			Expect(foundResource.Spec.Virtualization.LiveMigrationConfig.BandwidthPerMigration).To(HaveValue(Equal(customBandwidthPerMigration)))
 		})
 
 		It("should preserve spec.livemigrationconfig.bandwidthpermigration even if == 64Mi when upgrading from >= 1.5.1", func() {
 			UpdateVersion(&expected.hco.Status, hcoVersionName, "1.5.1")
-			expected.hco.Spec.LiveMigrationConfig.BandwidthPerMigration = ptr.To(badBandwidthPerMigration)
+			expected.hco.Spec.Virtualization.LiveMigrationConfig.BandwidthPerMigration = ptr.To(badBandwidthPerMigration)
 
 			cl := expected.initClient()
 			_, reconciler, requeue := doReconcile(cl, expected.hco, nil)
 			Expect(requeue).To(BeTrue())
 			foundResource, _, requeue := doReconcile(cl, expected.hco, reconciler)
 			Expect(requeue).To(BeFalse())
-			Expect(foundResource.Spec.LiveMigrationConfig.BandwidthPerMigration).To(HaveValue(Equal(badBandwidthPerMigration)))
+			Expect(foundResource.Spec.Virtualization.LiveMigrationConfig.BandwidthPerMigration).To(HaveValue(Equal(badBandwidthPerMigration)))
 		})
 	})
 

--- a/controllers/nodes/nodes_controller_test.go
+++ b/controllers/nodes/nodes_controller_test.go
@@ -55,7 +55,7 @@ var _ = Describe("NodesController", func() {
 					return true, nil
 				}
 
-				hco := commontestutils.NewHcoV1()
+				hco := commontestutils.NewHco()
 				resources := []client.Object{hco}
 				cl := commontestutils.InitClient(resources)
 
@@ -97,7 +97,7 @@ var _ = Describe("NodesController", func() {
 					return false, nil
 				}
 
-				hco := commontestutils.NewHcoV1()
+				hco := commontestutils.NewHco()
 				resources := []client.Object{hco}
 				cl := commontestutils.InitClient(resources)
 
@@ -119,7 +119,7 @@ var _ = Describe("NodesController", func() {
 					return false, errors.New("fake error")
 				}
 
-				hco := commontestutils.NewHcoV1()
+				hco := commontestutils.NewHco()
 				resources := []client.Object{hco}
 				cl := commontestutils.InitClient(resources)
 
@@ -148,7 +148,7 @@ var _ = Describe("NodesController", func() {
 					},
 				}
 
-				hco := commontestutils.NewHcoV1()
+				hco := commontestutils.NewHco()
 				resources := []client.Object{hco, workerNode}
 				cl := commontestutils.InitClient(resources)
 
@@ -192,7 +192,7 @@ var _ = Describe("NodesController", func() {
 					},
 				}
 
-				hco := commontestutils.NewHcoV1()
+				hco := commontestutils.NewHco()
 				resources := []client.Object{hco, cpNode}
 				cl := commontestutils.InitClient(resources)
 
@@ -233,7 +233,7 @@ var _ = Describe("NodesController", func() {
 					},
 				}
 
-				hco := commontestutils.NewHcoV1()
+				hco := commontestutils.NewHco()
 				resources := []client.Object{hco, workerNode}
 				cl := commontestutils.InitClient(resources)
 
@@ -265,7 +265,7 @@ var _ = Describe("NodesController", func() {
 			})
 
 			It("Should handle missing node gracefully", func() {
-				hco := commontestutils.NewHcoV1()
+				hco := commontestutils.NewHco()
 				resources := []client.Object{hco}
 				cl := commontestutils.InitClient(resources)
 
@@ -301,7 +301,7 @@ var _ = Describe("NodesController", func() {
 					},
 				}
 
-				hco := commontestutils.NewHcoV1()
+				hco := commontestutils.NewHco()
 				resources := []client.Object{hco, workerNode}
 				cl := commontestutils.InitClient(resources)
 

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -14,7 +14,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers"
 	aie "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/aie"
@@ -124,7 +123,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 // FirstUseInitiation is a lazy init function
 // The k8s client is not available when calling to NewOperandHandler.
 // Initial operations that need to read/write from the cluster can only be done when the client is already working.
-func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.ClusterInfo, hc *hcov1beta1.HyperConverged, pwdFS fs.FS) {
+func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.ClusterInfo, hc *hcov1.HyperConverged, pwdFS fs.FS) {
 	h.objects = make([]client.Object, 0)
 
 	if !ci.IsOpenshift() {
@@ -148,7 +147,7 @@ func (h *OperandHandler) GetImageStreamNames() []string {
 	return handlers.GetImageStreamNames()
 }
 
-func (h *OperandHandler) addOperandObject(handler operands.Operand, hc *hcov1beta1.HyperConverged) {
+func (h *OperandHandler) addOperandObject(handler operands.Operand, hc *hcov1.HyperConverged) {
 	var (
 		obj client.Object
 		err error
@@ -167,7 +166,7 @@ func (h *OperandHandler) addOperandObject(handler operands.Operand, hc *hcov1bet
 	}
 }
 
-func (h *OperandHandler) addOperands(scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged, getHandlers operands.GetHandlers, dir fs.FS) {
+func (h *OperandHandler) addOperands(scheme *runtime.Scheme, hc *hcov1.HyperConverged, getHandlers operands.GetHandlers, dir fs.FS) {
 	handlers, err := getHandlers(logger, h.client, scheme, hc, dir)
 	if err != nil {
 		logger.Error(err, "can't create handler")

--- a/controllers/operandhandler/operandHandler_test.go
+++ b/controllers/operandhandler/operandHandler_test.go
@@ -495,7 +495,7 @@ var _ = Describe("Test operandHandler", func() {
 		It("should delete the ImageStream resource if the FG is not set, and emit event", func() {
 			hcoNamespace := commontestutils.NewHcoNamespace()
 			hco := commontestutils.NewHco()
-			hco.Spec.EnableCommonBootImageImport = ptr.To(true)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
 			eventEmitter := commontestutils.NewEventEmitterMock()
 			ci := commontestutils.ClusterInfoMock{}
 			cli := commontestutils.InitClient([]client.Object{hcoNamespace, hco, commontestutils.GetCSV()})
@@ -522,7 +522,7 @@ var _ = Describe("Test operandHandler", func() {
 
 			By("Run again, this time when the FG is false")
 			eventEmitter.Reset()
-			hco.Spec.EnableCommonBootImageImport = ptr.To(false)
+			hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(false)
 			req = commontestutils.NewReq(hco)
 			Expect(handler.Ensure(req)).To(Succeed())
 

--- a/controllers/operands/cmHandler.go
+++ b/controllers/operands/cmHandler.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -24,7 +24,7 @@ func NewEditableCmHandler(Client client.Client, Scheme *runtime.Scheme, required
 	return NewGenericOperand(Client, Scheme, "ConfigMap", &cmHooks{required: required, editable: true, managedKeys: managedKeys}, false)
 }
 
-type newDynamicConfigMapFunc func(*hcov1beta1.HyperConverged) (*corev1.ConfigMap, error)
+type newDynamicConfigMapFunc func(*hcov1.HyperConverged) (*corev1.ConfigMap, error)
 
 func NewDynamicCmHandler(Client client.Client, Scheme *runtime.Scheme, makeCM newDynamicConfigMapFunc) *GenericOperand {
 	return NewGenericOperand(Client, Scheme, "ConfigMap", &dynamicCmHooks{makeCM: makeCM}, false)
@@ -36,7 +36,7 @@ type cmHooks struct {
 	managedKeys []string
 }
 
-func (h cmHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h cmHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.required.DeepCopy(), nil
 }
 
@@ -113,7 +113,7 @@ func (h *dynamicCmHooks) Reset() {
 	h.cache = nil
 }
 
-func (h *dynamicCmHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *dynamicCmHooks) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	h.Lock()
 	defer h.Unlock()
 

--- a/controllers/operands/conditionalHandler.go
+++ b/controllers/operands/conditionalHandler.go
@@ -6,13 +6,13 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-type ConditionFunc func(hc *v1beta1.HyperConverged) bool
-type GetCRWithNameFunc func(hc *v1beta1.HyperConverged) client.Object
+type ConditionFunc func(hc *hcov1.HyperConverged) bool
+type GetCRWithNameFunc func(hc *hcov1.HyperConverged) client.Object
 
 // ConditionalHandler is an operand handler that only deploy the operand CR if a given shouldDeploy function returns true.
 // If not, it makes sure the CR is deleted.
@@ -85,6 +85,6 @@ func (ch *ConditionalHandler) ensureDeleted(req *common.HcoRequest) *EnsureResul
 	return res.SetUpgradeDone(req.ComponentUpgradeInProgress)
 }
 
-func (ch *ConditionalHandler) GetFullCr(hc *v1beta1.HyperConverged) (client.Object, error) {
+func (ch *ConditionalHandler) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	return ch.operand.GetFullCr(hc)
 }

--- a/controllers/operands/daemonSetHandler.go
+++ b/controllers/operands/daemonSetHandler.go
@@ -9,12 +9,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-type newDaemonSetFunc func(hc *hcov1beta1.HyperConverged) *appsv1.DaemonSet
+type newDaemonSetFunc func(hc *hcov1.HyperConverged) *appsv1.DaemonSet
 
 func NewDaemonSetHandler(Client client.Client, Scheme *runtime.Scheme, newCrFunc newDaemonSetFunc) *GenericOperand {
 	return NewGenericOperand(Client, Scheme, "DaemonSet", &daemonSetHooks{newCrFunc: newCrFunc}, true)
@@ -26,7 +26,7 @@ type daemonSetHooks struct {
 	cache     *appsv1.DaemonSet
 }
 
-func (h *daemonSetHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *daemonSetHooks) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	h.Lock()
 	defer h.Unlock()
 

--- a/controllers/operands/deploymentHandler.go
+++ b/controllers/operands/deploymentHandler.go
@@ -9,13 +9,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
-type newDeploymentFunc func(hc *hcov1beta1.HyperConverged) *appsv1.Deployment
+type newDeploymentFunc func(hc *hcov1.HyperConverged) *appsv1.Deployment
 
 func NewDeploymentHandler(cli client.Client, Scheme *runtime.Scheme, deploymentGenerator newDeploymentFunc) *GenericOperand {
 	return NewGenericOperand(cli, Scheme, "Deployment", newDeploymentHooks(deploymentGenerator), false)
@@ -40,7 +39,7 @@ func (h *deploymentHooks) Reset() {
 	h.cache = nil
 }
 
-func (h *deploymentHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *deploymentHooks) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	h.Lock()
 	defer h.Unlock()
 

--- a/controllers/operands/deploymentHandler_test.go
+++ b/controllers/operands/deploymentHandler_test.go
@@ -11,14 +11,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 )
 
 var _ = Describe("Deployment Handler", func() {
 	Context("update or recreate the Deployment as required", func() {
-		var hco *hcov1beta1.HyperConverged
+		var hco *hcov1.HyperConverged
 		var req *common.HcoRequest
 		var expectedDeployment *appsv1.Deployment
 
@@ -177,7 +177,7 @@ var _ = Describe("Deployment Handler", func() {
 
 })
 
-func NewExpectedDeployment(_ *hcov1beta1.HyperConverged) *appsv1.Deployment {
+func NewExpectedDeployment(_ *hcov1.HyperConverged) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",

--- a/controllers/operands/generic_operand.go
+++ b/controllers/operands/generic_operand.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -208,7 +207,7 @@ func (h *GenericOperand) Reset() {
 	}
 }
 
-func (h *GenericOperand) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *GenericOperand) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	return h.hooks.GetFullCr(hc)
 }
 

--- a/controllers/operands/network_policy.go
+++ b/controllers/operands/network_policy.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -27,7 +27,7 @@ func newNetworkPolicyHook(required *networkingv1.NetworkPolicy) *networkPolicyHo
 	}
 }
 
-func (nph *networkPolicyHook) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (nph *networkPolicyHook) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return nph.required.DeepCopy(), nil
 }
 

--- a/controllers/operands/operand.go
+++ b/controllers/operands/operand.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 )
 
@@ -27,7 +26,7 @@ type Operand interface {
 
 type CRGetter interface {
 	// GetFullCr Generate the required resource, with all the required fields)
-	GetFullCr(*hcov1beta1.HyperConverged) (client.Object, error)
+	GetFullCr(*hcov1.HyperConverged) (client.Object, error)
 }
 
 // HCOResourceHooks Set of resource handler hooks, to be implement in each handler
@@ -55,8 +54,8 @@ type Reseter interface {
 	Reset()
 }
 
-type GetHandler func(log.Logger, client.Client, *runtime.Scheme, *hcov1beta1.HyperConverged) (Operand, error)
-type GetHandlers func(log.Logger, client.Client, *runtime.Scheme, *hcov1beta1.HyperConverged, fs.FS) ([]Operand, error)
+type GetHandler func(log.Logger, client.Client, *runtime.Scheme, *hcov1.HyperConverged) (Operand, error)
+type GetHandlers func(log.Logger, client.Client, *runtime.Scheme, *hcov1.HyperConverged, fs.FS) ([]Operand, error)
 
 func handleOperandDegradedCond(req *common.HcoRequest, component string, condition metav1.Condition) bool {
 	if condition.Status == metav1.ConditionTrue {
@@ -151,7 +150,7 @@ func applyAnnotationPatch(obj runtime.Object, annotation string) error {
 	return json.Unmarshal(patchedBytes, obj)
 }
 
-func ApplyPatchToSpec(hc *hcov1beta1.HyperConverged, annotationName string, obj runtime.Object) error {
+func ApplyPatchToSpec(hc *hcov1.HyperConverged, annotationName string, obj runtime.Object) error {
 	if jsonpathAnnotation, ok := hc.Annotations[annotationName]; ok {
 		if err := applyAnnotationPatch(obj, jsonpathAnnotation); err != nil {
 			return fmt.Errorf("invalid jsonPatch in the %s annotation: %v", annotationName, err)

--- a/controllers/operands/rbac.go
+++ b/controllers/operands/rbac.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -24,7 +24,7 @@ type roleHooks struct {
 	required *rbacv1.Role
 }
 
-func (h *roleHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *roleHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.required.DeepCopy(), nil
 }
 func (h *roleHooks) GetEmptyCr() client.Object {
@@ -68,7 +68,7 @@ type clusterRoleHooks struct {
 	required *rbacv1.ClusterRole
 }
 
-func (h *clusterRoleHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h *clusterRoleHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.required.DeepCopy(), nil
 }
 
@@ -124,7 +124,7 @@ type roleBindingHooks struct {
 	required *rbacv1.RoleBinding
 }
 
-func (h roleBindingHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h roleBindingHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.required.DeepCopy(), nil
 }
 func (h roleBindingHooks) GetEmptyCr() client.Object {
@@ -167,8 +167,8 @@ type clusterRoleBindingHooks struct {
 	required *rbacv1.ClusterRoleBinding
 }
 
-func (h clusterRoleBindingHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
-	return h.required, nil
+func (h clusterRoleBindingHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
+	return h.required.DeepCopy(), nil
 }
 
 func (h clusterRoleBindingHooks) GetEmptyCr() client.Object { return &rbacv1.ClusterRoleBinding{} }

--- a/controllers/operands/securityContextConstraintsHandler.go
+++ b/controllers/operands/securityContextConstraintsHandler.go
@@ -4,12 +4,11 @@ import (
 	"errors"
 	"reflect"
 
+	securityv1 "github.com/openshift/api/security/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	securityv1 "github.com/openshift/api/security/v1"
-
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -22,7 +21,7 @@ type securityContextConstraintsHooks struct {
 	scc *securityv1.SecurityContextConstraints
 }
 
-func (h securityContextConstraintsHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h securityContextConstraintsHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.scc.DeepCopy(), nil
 }
 

--- a/controllers/operands/serviceAccountHandler.go
+++ b/controllers/operands/serviceAccountHandler.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -22,7 +22,7 @@ type serviceAccountHooks struct {
 	newCrFunc newSvcAccountFunc
 }
 
-func (h serviceAccountHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h serviceAccountHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.newCrFunc(), nil
 }
 

--- a/controllers/operands/serviceHandler.go
+++ b/controllers/operands/serviceHandler.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -29,7 +29,7 @@ type serviceHooks struct {
 	svc *corev1.Service
 }
 
-func (h serviceHooks) GetFullCr(_ *hcov1beta1.HyperConverged) (client.Object, error) {
+func (h serviceHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
 	return h.svc.DeepCopy(), nil
 }
 

--- a/pkg/monitoring/hyperconverged/collectors/operator_collectors.go
+++ b/pkg/monitoring/hyperconverged/collectors/operator_collectors.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	goldenimages "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/golden-images"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 )
 
@@ -45,8 +45,8 @@ func getMultiArchBootImagesStatusCallback(cli client.Client, operatorNamespace s
 			return []operatormetrics.CollectorResult{}
 		}
 
-		hc := hcov1beta1.HyperConverged{}
-		key := client.ObjectKey{Name: hcov1beta1.HyperConvergedName, Namespace: operatorNamespace}
+		hc := hcov1.HyperConverged{}
+		key := client.ObjectKey{Name: hcov1.HyperConvergedName, Namespace: operatorNamespace}
 		if err := cli.Get(context.TODO(), key, &hc); err != nil {
 			if !errors.IsNotFound(err) {
 				logger.Error(err, "can't read HyperConverged CR")
@@ -62,7 +62,7 @@ func getMultiArchBootImagesStatusCallback(cli client.Client, operatorNamespace s
 
 		// Set the metric based on the FeatureGate value
 		value := multiArchBootImagesFeatureDisabled
-		if ptr.Deref(hc.Spec.FeatureGates.EnableMultiArchBootImageImport, false) {
+		if hc.Spec.FeatureGates.IsEnabled(goldenimages.EnableMultiArchFeatureGate) {
 			value = multiArchBootImagesFeatureEnabled
 		}
 

--- a/pkg/monitoring/hyperconverged/collectors/operator_collectors_test.go
+++ b/pkg/monitoring/hyperconverged/collectors/operator_collectors_test.go
@@ -4,17 +4,17 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	goldenimages "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/golden-images"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 )
 
 var _ = Describe("HyperConverged Collectors", func() {
-	var hco *hcov1beta1.HyperConverged
+	var hco *hcov1.HyperConverged
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
@@ -55,7 +55,7 @@ var _ = Describe("HyperConverged Collectors", func() {
 				})
 
 				It("should be set and enabled, if multi-arch dict enabled", func() {
-					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+					hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
 
 					cli := commontestutils.InitClient([]client.Object{hco})
 					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
@@ -64,7 +64,7 @@ var _ = Describe("HyperConverged Collectors", func() {
 				})
 
 				It("should be set and disabled, if multi-arch dict disabled", func() {
-					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(false)
+					hco.Spec.FeatureGates.Disable(goldenimages.EnableMultiArchFeatureGate)
 
 					cli := commontestutils.InitClient([]client.Object{hco})
 					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
@@ -73,7 +73,7 @@ var _ = Describe("HyperConverged Collectors", func() {
 				})
 
 				It("should be set and disabled, if multi-arch dict is not set", func() {
-					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = nil
+					hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{}
 
 					cli := commontestutils.InitClient([]client.Object{hco})
 					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
@@ -88,7 +88,7 @@ var _ = Describe("HyperConverged Collectors", func() {
 				})
 
 				It("should not be set, if multi-arch dict enabled", func() {
-					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+					hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
 
 					cli := commontestutils.InitClient([]client.Object{hco})
 					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
@@ -97,7 +97,7 @@ var _ = Describe("HyperConverged Collectors", func() {
 				})
 
 				It("should not be set, if multi-arch dict disabled", func() {
-					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(false)
+					hco.Spec.FeatureGates.Disable(goldenimages.EnableMultiArchFeatureGate)
 
 					cli := commontestutils.InitClient([]client.Object{hco})
 					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
@@ -135,7 +135,7 @@ var _ = Describe("HyperConverged Collectors", func() {
 				})
 
 				It("should not be set, if multi-arch dict enabled", func() {
-					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+					hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
 
 					cli := commontestutils.InitClient([]client.Object{hco})
 					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
@@ -144,7 +144,7 @@ var _ = Describe("HyperConverged Collectors", func() {
 				})
 
 				It("should not be set, if multi-arch dict disabled", func() {
-					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(false)
+					hco.Spec.FeatureGates.Disable(goldenimages.EnableMultiArchFeatureGate)
 
 					cli := commontestutils.InitClient([]client.Object{hco})
 					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
@@ -154,7 +154,7 @@ var _ = Describe("HyperConverged Collectors", func() {
 				})
 
 				It("should not be set, if multi-arch dict is not set", func() {
-					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = nil
+					hco.Spec.FeatureGates = featuregates.HyperConvergedFeatureGates{}
 
 					cli := commontestutils.InitClient([]client.Object{hco})
 					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
@@ -170,7 +170,7 @@ var _ = Describe("HyperConverged Collectors", func() {
 				})
 
 				It("should not be set, if multi-arch dict enabled", func() {
-					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(true)
+					hco.Spec.FeatureGates.Enable(goldenimages.EnableMultiArchFeatureGate)
 
 					cli := commontestutils.InitClient([]client.Object{hco})
 					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)
@@ -180,7 +180,7 @@ var _ = Describe("HyperConverged Collectors", func() {
 				})
 
 				It("should not be set, if multi-arch dict disabled", func() {
-					hco.Spec.FeatureGates.EnableMultiArchBootImageImport = ptr.To(false)
+					hco.Spec.FeatureGates.Disable(goldenimages.EnableMultiArchFeatureGate)
 
 					cli := commontestutils.InitClient([]client.Object{hco})
 					isSet, isEnabled := isMultiArchBootImagesFeatureEnabled(cli)

--- a/pkg/webhooks/setup.go
+++ b/pkg/webhooks/setup.go
@@ -28,7 +28,7 @@ func SetupWebhookWithManager(mgr ctrl.Manager, isOpenshift bool) error {
 	decoder := admission.NewDecoder(mgr.GetScheme())
 
 	v1Beta1WHHandler := validator.NewWebhookV1Beta1Handler(logger, mgr.GetClient(), decoder, operatorNsEnv, isOpenshift)
-	v1WHHandler := validator.NewWebhookHandler(logger, mgr.GetClient(), decoder, operatorNsEnv, isOpenshift, v1Beta1WHHandler)
+	v1WHHandler := validator.NewWebhookHandler(logger, mgr.GetClient(), decoder, operatorNsEnv, isOpenshift)
 	nsMutator := mutator.NewNsMutator(mgr.GetClient(), decoder, operatorNsEnv)
 	v1HCMutator := mutator.NewHyperConvergedMutator(mgr.GetClient(), decoder)
 	v1Beta1HCMutator := mutator.NewHyperConvergedV1Beta1Mutator(mgr.GetClient(), decoder)

--- a/pkg/webhooks/validator/v1beta1_validator.go
+++ b/pkg/webhooks/validator/v1beta1_validator.go
@@ -12,21 +12,15 @@ import (
 
 	"github.com/go-logr/logr"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
-	xsync "golang.org/x/sync/errgroup"
 	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
-	kubevirtcorev1 "kubevirt.io/api/core/v1"
-	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
-
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -115,7 +109,7 @@ func (wh *WebhookV1Beta1Handler) Handle(ctx context.Context, req admission.Reque
 	return admission.Allowed("")
 }
 
-func (wh *WebhookV1Beta1Handler) ValidateCreate(ctx context.Context, logger logr.Logger, dryrun bool, hc *v1beta1.HyperConverged) error {
+func (wh *WebhookV1Beta1Handler) ValidateCreate(_ context.Context, logger logr.Logger, dryrun bool, hc *v1beta1.HyperConverged) error {
 	logger.Info("Validating create", "name", hc.Name, "namespace:", hc.Namespace)
 
 	if err := wh.validateCertConfig(hc); err != nil {
@@ -146,19 +140,24 @@ func (wh *WebhookV1Beta1Handler) ValidateCreate(ctx context.Context, logger logr
 		return err
 	}
 
-	if _, err := handlers.NewKubeVirt(hc); err != nil {
+	v1hc := &hcov1.HyperConverged{}
+	if err := hc.ConvertTo(v1hc); err != nil {
 		return err
 	}
 
-	if _, err := handlers.NewCDI(hc); err != nil {
+	if _, err := handlers.NewKubeVirt(v1hc); err != nil {
 		return err
 	}
 
-	if _, err := handlers.NewNetworkAddons(hc); err != nil {
+	if _, err := handlers.NewCDI(v1hc); err != nil {
 		return err
 	}
 
-	if _, _, err := handlers.NewSSP(hc); err != nil {
+	if _, err := handlers.NewNetworkAddons(v1hc); err != nil {
+		return err
+	}
+
+	if _, _, err := handlers.NewSSP(v1hc); err != nil {
 		return err
 	}
 
@@ -167,32 +166,6 @@ func (wh *WebhookV1Beta1Handler) ValidateCreate(ctx context.Context, logger logr
 	}
 
 	return nil
-}
-
-func (wh *WebhookV1Beta1Handler) getOperands(ctx context.Context, requested *v1beta1.HyperConverged) (*kubevirtcorev1.KubeVirt, *cdiv1beta1.CDI, *networkaddonsv1.NetworkAddonsConfig, error) {
-	if err := wh.validateCertConfig(requested); err != nil {
-		return nil, nil, nil, err
-	}
-
-	kv := handlers.NewKubeVirtWithNameOnly()
-	err := wh.cli.Get(ctx, client.ObjectKeyFromObject(kv), kv)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	cdi := handlers.NewCDIWithNameOnly()
-	err = wh.cli.Get(ctx, client.ObjectKeyFromObject(cdi), cdi)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	cna := handlers.NewNetworkAddonsWithNameOnly()
-	err = wh.cli.Get(ctx, client.ObjectKeyFromObject(cna), cna)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	return kv, cdi, cna, nil
 }
 
 // ValidateUpdate is the ValidateUpdate webhook implementation. It calls all the resources in parallel, to dry-run the
@@ -230,55 +203,16 @@ func (wh *WebhookV1Beta1Handler) ValidateUpdate(ctx context.Context, logger logr
 		return nil
 	}
 
-	kv, cdi, cna, err := wh.getOperands(ctx, requested)
-	if err != nil {
+	if err := wh.validateCertConfig(requested); err != nil {
 		return err
 	}
 
-	toCtx, cancel := context.WithTimeout(ctx, updateDryRunTimeOut)
-	defer cancel()
-
-	eg, egCtx := xsync.WithContext(toCtx)
-	opts := &client.UpdateOptions{DryRun: []string{metav1.DryRunAll}}
-
-	resources := []client.Object{
-		kv,
-		cdi,
-		cna,
+	v1hc := &hcov1.HyperConverged{}
+	if err := requested.ConvertTo(v1hc); err != nil {
+		return err
 	}
 
-	if wh.isOpenshift {
-		origGetControlPlaneArchitectures := nodeinfo.GetControlPlaneArchitectures
-		origGetWorkloadsArchitectures := nodeinfo.GetWorkloadsArchitectures
-		defer func() {
-			nodeinfo.GetControlPlaneArchitectures = origGetControlPlaneArchitectures
-			nodeinfo.GetWorkloadsArchitectures = origGetWorkloadsArchitectures
-		}()
-
-		nodeinfo.GetControlPlaneArchitectures = func() []string {
-			return requested.Status.NodeInfo.ControlPlaneArchitectures
-		}
-		nodeinfo.GetWorkloadsArchitectures = func() []string {
-			return requested.Status.NodeInfo.WorkloadsArchitectures
-		}
-
-		ssp, _, err := handlers.NewSSP(requested)
-		if err != nil {
-			return err
-		}
-		resources = append(resources, ssp)
-	}
-
-	for _, obj := range resources {
-		func(o client.Object) {
-			eg.Go(func() error {
-				return wh.updateOperatorCr(egCtx, logger, requested, o, opts)
-			})
-		}(obj)
-	}
-
-	err = eg.Wait()
-	if err != nil {
+	if err := checkOperands(ctx, wh.cli, logger, v1hc, wh.isOpenshift); err != nil {
 		return err
 	}
 
@@ -286,52 +220,6 @@ func (wh *WebhookV1Beta1Handler) ValidateUpdate(ctx context.Context, logger logr
 		tlssecprofile.SetHyperConvergedTLSSecurityProfile(requested.Spec.TLSSecurityProfile)
 	}
 
-	return nil
-}
-
-func (wh *WebhookV1Beta1Handler) updateOperatorCr(ctx context.Context, logger logr.Logger, hc *v1beta1.HyperConverged, exists client.Object, opts *client.UpdateOptions) error {
-	err := hcoutil.GetRuntimeObject(ctx, wh.cli, exists)
-	if err != nil {
-		logger.Error(err, "failed to get object from kubernetes", "kind", exists.GetObjectKind())
-		return err
-	}
-
-	switch existing := exists.(type) {
-	case *kubevirtcorev1.KubeVirt:
-		required, err := handlers.NewKubeVirt(hc)
-		if err != nil {
-			return err
-		}
-		required.Spec.DeepCopyInto(&existing.Spec)
-
-	case *cdiv1beta1.CDI:
-		required, err := handlers.NewCDI(hc)
-		if err != nil {
-			return err
-		}
-		required.Spec.DeepCopyInto(&existing.Spec)
-
-	case *networkaddonsv1.NetworkAddonsConfig:
-		required, err := handlers.NewNetworkAddons(hc)
-		if err != nil {
-			return err
-		}
-		required.Spec.DeepCopyInto(&existing.Spec)
-
-	case *sspv1beta3.SSP:
-		required, _, err := handlers.NewSSP(hc)
-		if err != nil {
-			return err
-		}
-		required.Spec.DeepCopyInto(&existing.Spec)
-	}
-
-	if err = wh.cli.Update(ctx, exists, opts); err != nil {
-		logger.Error(err, "failed to dry-run update the object", "kind", exists.GetObjectKind())
-		return err
-	}
-
-	logger.Info("dry-run update the object passed", "kind", exists.GetObjectKind())
 	return nil
 }
 

--- a/pkg/webhooks/validator/v1beta1_validator_test.go
+++ b/pkg/webhooks/validator/v1beta1_validator_test.go
@@ -99,16 +99,19 @@ const (
 
 var _ = Describe("v1beta1 webhooks validator", func() {
 	getFakeClient := func(hco *v1beta1.HyperConverged) *commontestutils.HcoTestClient {
-		kv, err := handlers.NewKubeVirt(hco)
+		v1hc := &hcov1.HyperConverged{}
+		Expect(hco.ConvertTo(v1hc)).To(Succeed())
+
+		kv, err := handlers.NewKubeVirt(v1hc)
 		Expect(err).ToNot(HaveOccurred())
 
-		cdi, err := handlers.NewCDI(hco)
+		cdi, err := handlers.NewCDI(v1hc)
 		Expect(err).ToNot(HaveOccurred())
 
-		cna, err := handlers.NewNetworkAddons(hco)
+		cna, err := handlers.NewNetworkAddons(v1hc)
 		Expect(err).ToNot(HaveOccurred())
 
-		ssp, _, err := handlers.NewSSP(hco)
+		ssp, _, err := handlers.NewSSP(v1hc)
 		Expect(err).ToNot(HaveOccurred())
 
 		return commontestutils.InitClient([]client.Object{hco, kv, cdi, cna, ssp})
@@ -136,9 +139,11 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 	Context("Check create validation webhook", func() {
 		var cr *v1beta1.HyperConverged
 		var dryRun bool
+
 		BeforeEach(func() {
+			cr = &v1beta1.HyperConverged{}
 			Expect(os.Setenv("OPERATOR_NAMESPACE", HcoValidNamespace)).To(Succeed())
-			cr = commontestutils.NewHco()
+			Expect(cr.ConvertFrom(commontestutils.NewHco())).To(Succeed())
 			dryRun = false
 		})
 
@@ -802,7 +807,9 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 		var dryRun bool
 
 		BeforeEach(func() {
-			hco = commontestutils.NewHco()
+			hco = &v1beta1.HyperConverged{}
+			Expect(hco.ConvertFrom(commontestutils.NewHco())).To(Succeed())
+
 			hco.Spec.Infra = v1beta1.HyperConvergedConfig{
 				NodePlacement: newHyperConvergedConfig(),
 			}
@@ -883,8 +890,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 
 		It("should return error if CDI CR is missing", func(ctx context.Context) {
 			cli := getFakeClient(hco)
-			cdi, err := handlers.NewCDI(hco)
-			Expect(err).ToNot(HaveOccurred())
+			cdi := handlers.NewCDIWithNameOnly()
 			Expect(cli.Delete(ctx, cdi)).To(Succeed())
 
 			wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)
@@ -895,7 +901,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 			// just do some change to force update
 			newHco.Spec.Infra.NodePlacement.NodeSelector["key3"] = "value3"
 
-			err = wh.ValidateUpdate(ctx, GinkgoLogr, dryRun, newHco, hco)
+			err := wh.ValidateUpdate(ctx, GinkgoLogr, dryRun, newHco, hco)
 			Expect(err).To(MatchError(apierrors.IsNotFound, "not found error"))
 			Expect(err).To(MatchError(ContainSubstring("cdis.cdi.kubevirt.io")))
 		})
@@ -930,8 +936,8 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 
 		It("should return error if NetworkAddons CR is missing", func(ctx context.Context) {
 			cli := getFakeClient(hco)
-			cna, err := handlers.NewNetworkAddons(hco)
-			Expect(err).ToNot(HaveOccurred())
+
+			cna := handlers.NewNetworkAddonsWithNameOnly()
 			Expect(cli.Delete(ctx, cna)).To(Succeed())
 			wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)
 
@@ -940,7 +946,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 			// just do some change to force update
 			newHco.Spec.Infra.NodePlacement.NodeSelector["key3"] = "value3"
 
-			err = wh.ValidateUpdate(ctx, GinkgoLogr, dryRun, newHco, hco)
+			err := wh.ValidateUpdate(ctx, GinkgoLogr, dryRun, newHco, hco)
 			Expect(err).To(MatchError(apierrors.IsNotFound, "not found error"))
 			Expect(err).To(MatchError(ContainSubstring("networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io")))
 		})
@@ -1072,14 +1078,20 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 
 		Context("plain-k8s tests", func() {
 			It("should return error in plain-k8s if KV CR is missing", func(ctx context.Context) {
-				hco := &v1beta1.HyperConverged{}
-				cli := getFakeClient(hco)
-				kv, err := handlers.NewKubeVirt(hco)
-				Expect(err).ToNot(HaveOccurred())
+				oldHC := &v1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      hco.Name,
+						Namespace: hco.Namespace,
+					},
+				}
+				cli := getFakeClient(oldHC)
+				kv := handlers.NewKubeVirtWithNameOnly()
 				Expect(cli.Delete(ctx, kv)).To(Succeed())
 				wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, false)
 
-				newHco := commontestutils.NewHco()
+				newHco := &v1beta1.HyperConverged{}
+				Expect(newHco.ConvertFrom(commontestutils.NewHco())).To(Succeed())
+
 				newHco.Spec.Infra = v1beta1.HyperConvergedConfig{
 					NodePlacement: newHyperConvergedConfig(),
 				}
@@ -1088,18 +1100,12 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 				}
 
 				Expect(
-					wh.ValidateUpdate(ctx, GinkgoLogr, dryRun, newHco, hco),
+					wh.ValidateUpdate(ctx, GinkgoLogr, dryRun, newHco, oldHC),
 				).To(MatchError(apierrors.IsNotFound, "not found error"))
 			})
 		})
 
 		Context("Check LiveMigrationConfiguration", func() {
-			var hco *v1beta1.HyperConverged
-
-			BeforeEach(func() {
-				hco = commontestutils.NewHco()
-			})
-
 			It("should ignore if there is no change in live migration", func(ctx context.Context) {
 				cli := getFakeClient(hco)
 
@@ -1150,12 +1156,6 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 		})
 
 		Context("Check CertRotation", func() {
-			var hco *v1beta1.HyperConverged
-
-			BeforeEach(func() {
-				hco = commontestutils.NewHco()
-			})
-
 			It("should ignore if there is no change in cert config", func(ctx context.Context) {
 				cli := getFakeClient(hco)
 
@@ -1345,12 +1345,6 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 		})
 
 		Context("validate tlsSecurityProfiles", func() {
-			var hco *v1beta1.HyperConverged
-
-			BeforeEach(func() {
-				hco = commontestutils.NewHco()
-			})
-
 			updateTLSSecurityProfile := func(ctx context.Context, minTLSVersion openshiftconfigv1.TLSProtocolVersion, ciphers []string) error {
 				cli := getFakeClient(hco)
 
@@ -1775,8 +1769,9 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 	Context("unsupported annotation", func() {
 		var hco *v1beta1.HyperConverged
 		BeforeEach(func() {
+			hco = &v1beta1.HyperConverged{}
 			Expect(os.Setenv("OPERATOR_NAMESPACE", HcoValidNamespace)).To(Succeed())
-			hco = commontestutils.NewHco()
+			Expect(hco.ConvertFrom(commontestutils.NewHco())).To(Succeed())
 		})
 
 		DescribeTable("should accept if annotation is valid",
@@ -1784,7 +1779,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 				cli := getFakeClient(hco)
 				wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)
 
-				dryRun := false
+				const dryRun = false
 
 				newHco := &v1beta1.HyperConverged{}
 				hco.DeepCopyInto(newHco)
@@ -1838,7 +1833,9 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 
 		BeforeEach(func() {
 			Expect(os.Setenv("OPERATOR_NAMESPACE", HcoValidNamespace)).To(Succeed())
-			cr = commontestutils.NewHco()
+			cr = &v1beta1.HyperConverged{}
+			Expect(cr.ConvertFrom(commontestutils.NewHco())).To(Succeed())
+
 			origSetHyperConvergedProfile := tlssecprofile.SetHyperConvergedTLSSecurityProfile
 
 			tlssecprofile.SetHyperConvergedTLSSecurityProfile = func(hcoTLSSecurityProfile *openshiftconfigv1.TLSSecurityProfile) {
@@ -1988,7 +1985,9 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 
 		BeforeEach(func() {
 			Expect(os.Setenv("OPERATOR_NAMESPACE", HcoValidNamespace)).To(Succeed())
-			cr = commontestutils.NewHco()
+			cr = &v1beta1.HyperConverged{}
+			Expect(cr.ConvertFrom(commontestutils.NewHco())).To(Succeed())
+
 			cr.Spec.MediatedDevicesConfiguration = nil
 			newCr = cr.DeepCopy()
 		})

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -22,6 +22,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
+	kubevirtcorev1 "kubevirt.io/api/core/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
+
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	hcov1fg "github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
@@ -58,22 +63,20 @@ func (v *ValidationWarning) Warnings() []string {
 }
 
 type WebhookHandler struct {
-	logger         logr.Logger
-	cli            client.Client
-	namespace      string
-	isOpenshift    bool
-	decoder        admission.Decoder
-	v1beta1Handler *WebhookV1Beta1Handler
+	logger      logr.Logger
+	cli         client.Client
+	namespace   string
+	isOpenshift bool
+	decoder     admission.Decoder
 }
 
-func NewWebhookHandler(logger logr.Logger, cli client.Client, decoder admission.Decoder, namespace string, isOpenshift bool, v1beta1Handler *WebhookV1Beta1Handler) *WebhookHandler {
+func NewWebhookHandler(logger logr.Logger, cli client.Client, decoder admission.Decoder, namespace string, isOpenshift bool) *WebhookHandler {
 	return &WebhookHandler{
-		logger:         logger.WithName(validatorV1Name),
-		cli:            cli,
-		namespace:      namespace,
-		isOpenshift:    isOpenshift,
-		decoder:        decoder,
-		v1beta1Handler: v1beta1Handler,
+		logger:      logger.WithName(validatorV1Name),
+		cli:         cli,
+		namespace:   namespace,
+		isOpenshift: isOpenshift,
+		decoder:     decoder,
 	}
 }
 
@@ -87,75 +90,40 @@ func (wh *WebhookHandler) Handle(ctx context.Context, req admission.Request) adm
 	}
 
 	// Get the object in the request
-	v1obj := &hcov1.HyperConverged{}
+	obj := &hcov1.HyperConverged{}
 
 	dryRun := req.DryRun != nil && *req.DryRun
 
 	switch req.Operation {
 	case admissionv1.Create:
-		if err = wh.decoder.Decode(req, v1obj); err != nil {
+		if err = wh.decoder.Decode(req, obj); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		return wh.validateCreate(logger, dryRun, v1obj)
+		return wh.validateCreate(logger, dryRun, obj)
 
 	case admissionv1.Update:
-		v1OldObj := &hcov1.HyperConverged{}
-		if err = wh.decoder.DecodeRaw(req.Object, v1obj); err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
-		}
-		if err = wh.decoder.DecodeRaw(req.OldObject, v1OldObj); err != nil {
+		if err = wh.decoder.DecodeRaw(req.Object, obj); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		obj := &hcov1beta1.HyperConverged{}
-		err = obj.ConvertFrom(v1obj)
-		if err != nil {
-			return admission.Errored(http.StatusInternalServerError, err)
+		oldObj := &hcov1.HyperConverged{}
+		if err = wh.decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		oldObj := &hcov1beta1.HyperConverged{}
-		err = oldObj.ConvertFrom(v1OldObj)
-		if err != nil {
-			return admission.Errored(http.StatusInternalServerError, err)
-		}
-
-		err = wh.v1beta1Handler.ValidateUpdate(ctx, logger, dryRun, obj, oldObj)
+		return wh.validateUpdate(ctx, logger, dryRun, obj, oldObj)
 
 	case admissionv1.Delete:
-		if err = wh.decoder.DecodeRaw(req.OldObject, v1obj); err != nil {
+		if err = wh.decoder.DecodeRaw(req.OldObject, obj); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		obj := &hcov1beta1.HyperConverged{}
-		err = obj.ConvertFrom(v1obj)
-		if err != nil {
-			return admission.Errored(http.StatusInternalServerError, err)
-		}
-
-		err = wh.v1beta1Handler.ValidateDelete(ctx, logger, dryRun, obj)
+		return wh.validateDelete(ctx, logger, dryRun, obj)
 
 	default:
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("unknown operation request %q", req.Operation))
 	}
-
-	// Check the error message first.
-	if err != nil {
-		var apiStatus apierrors.APIStatus
-		if errors.As(err, &apiStatus) {
-			return validationResponseFromStatus(false, apiStatus.Status())
-		}
-
-		var vw *ValidationWarning
-		if errors.As(err, &vw) {
-			return admission.Allowed("").WithWarnings(vw.Warnings()...)
-		}
-
-		return admission.Denied(err.Error())
-	}
-
-	// Return allowed if everything succeeded.
-	return admission.Allowed("")
 }
 
 func (wh *WebhookHandler) validateCreate(logger logr.Logger, dryrun bool, hc *hcov1.HyperConverged) admission.Response {
@@ -165,13 +133,7 @@ func (wh *WebhookHandler) validateCreate(logger logr.Logger, dryrun bool, hc *hc
 		return errToResponse(err)
 	}
 
-	v1beta1HC := &hcov1beta1.HyperConverged{}
-	err := v1beta1HC.ConvertFrom(hc)
-	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
-
-	err = wh.validateCreateComponents(v1beta1HC)
+	err := wh.validateCreateComponents(hc)
 	if err != nil {
 		return errToResponse(err)
 	}
@@ -196,20 +158,7 @@ func (wh *WebhookHandler) validateUpdate(ctx context.Context, logger logr.Logger
 		return errToResponse(err)
 	}
 
-	v1beta1Req := &hcov1beta1.HyperConverged{}
-	err := v1beta1Req.ConvertFrom(requested)
-	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
-
-	v1beta1Old := &hcov1beta1.HyperConverged{}
-	err = v1beta1Old.ConvertFrom(exists)
-	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
-
-	err = wh.dryRunUpdateComponents(ctx, logger, v1beta1Req, requested)
-	if err != nil {
+	if err := checkOperands(ctx, wh.cli, logger, requested, wh.isOpenshift); err != nil {
 		return errToResponse(err)
 	}
 
@@ -218,6 +167,28 @@ func (wh *WebhookHandler) validateUpdate(ctx context.Context, logger logr.Logger
 	}
 
 	return admission.Allowed("")
+}
+
+func (wh *WebhookHandler) validateDelete(ctx context.Context, logger logr.Logger, dryrun bool, hc *hcov1.HyperConverged) admission.Response {
+	logger.Info("Validating delete", "name", hc.Name, "namespace", hc.Namespace)
+
+	var err error
+	for _, obj := range []client.Object{
+		handlers.NewKubeVirtWithNameOnly(),
+		handlers.NewCDIWithNameOnly(),
+	} {
+		_, err = hcoutil.EnsureDeleted(ctx, wh.cli, obj, hc.Name, logger, true, false, true)
+		if err != nil {
+			logger.Error(err, "Delete validation failed", "GVK", obj.GetObjectKind().GroupVersionKind())
+			break
+		}
+	}
+
+	if err == nil && !dryrun {
+		tlssecprofile.SetHyperConvergedTLSSecurityProfile(nil)
+	}
+
+	return errToResponse(err)
 }
 
 func (wh *WebhookHandler) validateHyperConverged(hc *hcov1.HyperConverged) error {
@@ -268,75 +239,24 @@ func (wh *WebhookHandler) validateUpdateHyperConverged(hc, oldHC *hcov1.HyperCon
 	return nil
 }
 
-func (wh *WebhookHandler) validateCreateComponents(v1beta1HC *hcov1beta1.HyperConverged) error {
-	if _, err := handlers.NewKubeVirt(v1beta1HC); err != nil {
+func (wh *WebhookHandler) validateCreateComponents(hc *hcov1.HyperConverged) error {
+	if _, err := handlers.NewKubeVirt(hc); err != nil {
 		return err
 	}
 
-	if _, err := handlers.NewCDI(v1beta1HC); err != nil {
+	if _, err := handlers.NewCDI(hc); err != nil {
 		return err
 	}
 
-	if _, err := handlers.NewNetworkAddons(v1beta1HC); err != nil {
+	if _, err := handlers.NewNetworkAddons(hc); err != nil {
 		return err
 	}
 
-	if _, _, err := handlers.NewSSP(v1beta1HC); err != nil {
+	if _, _, err := handlers.NewSSP(hc); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func (wh *WebhookHandler) dryRunUpdateComponents(ctx context.Context, logger logr.Logger, v1beta1Req *hcov1beta1.HyperConverged, requested *hcov1.HyperConverged) error {
-	kv, cdi, cna, err := wh.v1beta1Handler.getOperands(ctx, v1beta1Req)
-	if err != nil {
-		return err
-	}
-
-	toCtx, cancel := context.WithTimeout(ctx, updateDryRunTimeOut)
-	defer cancel()
-
-	eg, egCtx := xsync.WithContext(toCtx)
-	opts := &client.UpdateOptions{DryRun: []string{metav1.DryRunAll}}
-
-	resources := []client.Object{
-		kv,
-		cdi,
-		cna,
-	}
-
-	if wh.isOpenshift {
-		origGetControlPlaneArchitectures := nodeinfo.GetControlPlaneArchitectures
-		origGetWorkloadsArchitectures := nodeinfo.GetWorkloadsArchitectures
-		defer func() {
-			nodeinfo.GetControlPlaneArchitectures = origGetControlPlaneArchitectures
-			nodeinfo.GetWorkloadsArchitectures = origGetWorkloadsArchitectures
-		}()
-
-		nodeinfo.GetControlPlaneArchitectures = func() []string {
-			return requested.Status.NodeInfo.ControlPlaneArchitectures
-		}
-		nodeinfo.GetWorkloadsArchitectures = func() []string {
-			return requested.Status.NodeInfo.WorkloadsArchitectures
-		}
-
-		ssp, _, err := handlers.NewSSP(v1beta1Req)
-		if err != nil {
-			return err
-		}
-		resources = append(resources, ssp)
-	}
-
-	for _, obj := range resources {
-		func(o client.Object) {
-			eg.Go(func() error {
-				return wh.v1beta1Handler.updateOperatorCr(egCtx, logger, v1beta1Req, o, opts)
-			})
-		}(obj)
-	}
-
-	return eg.Wait()
 }
 
 func (wh *WebhookHandler) validateCertConfig(hc *hcov1.HyperConverged) error {
@@ -540,22 +460,22 @@ func validateAffinity(affinity *corev1.Affinity) error {
 }
 
 func errToResponse(err error) admission.Response {
-	if err != nil {
-		var apiStatus apierrors.APIStatus
-		if errors.As(err, &apiStatus) {
-			return validationResponseFromStatus(false, apiStatus.Status())
-		}
-
-		var vw *ValidationWarning
-		if errors.As(err, &vw) {
-			return admission.Allowed("").WithWarnings(vw.Warnings()...)
-		}
-
-		return admission.Denied(err.Error())
+	if err == nil {
+		// Return allowed if everything succeeded.
+		return admission.Allowed("")
 	}
 
-	// Return allowed if everything succeeded.
-	return admission.Allowed("")
+	var apiStatus apierrors.APIStatus
+	if errors.As(err, &apiStatus) {
+		return validationResponseFromStatus(false, apiStatus.Status())
+	}
+
+	var vw *ValidationWarning
+	if errors.As(err, &vw) {
+		return admission.Allowed("").WithWarnings(vw.Warnings()...)
+	}
+
+	return admission.Denied(err.Error())
 }
 
 func v1FGsToMap(fgs hcov1fg.HyperConvergedFeatureGates) map[string]bool {
@@ -565,4 +485,116 @@ func v1FGsToMap(fgs hcov1fg.HyperConvergedFeatureGates) map[string]bool {
 	}
 
 	return m
+}
+
+func checkOperands(ctx context.Context, cli client.Client, logger logr.Logger, requested *hcov1.HyperConverged, isOpenshift bool) error {
+	resources, err := getOperands(ctx, cli, isOpenshift)
+	if err != nil {
+		return err
+	}
+
+	toCtx, cancel := context.WithTimeout(ctx, updateDryRunTimeOut)
+	defer cancel()
+
+	eg, egCtx := xsync.WithContext(toCtx)
+	opts := &client.UpdateOptions{DryRun: []string{metav1.DryRunAll}}
+
+	for _, obj := range resources {
+		func(o client.Object) {
+			eg.Go(func() error {
+				return updateOperatorCr(egCtx, cli, logger, requested, o, opts)
+			})
+		}(obj)
+	}
+
+	return eg.Wait()
+}
+
+func getOperands(ctx context.Context, cli client.Client, isOpenshift bool) ([]client.Object, error) {
+	kv := handlers.NewKubeVirtWithNameOnly()
+	err := cli.Get(ctx, client.ObjectKeyFromObject(kv), kv)
+	if err != nil {
+		return nil, err
+	}
+
+	cdi := handlers.NewCDIWithNameOnly()
+	err = cli.Get(ctx, client.ObjectKeyFromObject(cdi), cdi)
+	if err != nil {
+		return nil, err
+	}
+
+	cna := handlers.NewNetworkAddonsWithNameOnly()
+	err = cli.Get(ctx, client.ObjectKeyFromObject(cna), cna)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]client.Object, 0, 4)
+	resources = append(resources, kv, cdi, cna)
+
+	if isOpenshift {
+		ssp := handlers.NewSSPWithNameOnly()
+		err = cli.Get(ctx, client.ObjectKeyFromObject(ssp), ssp)
+		if err != nil {
+			return nil, err
+		}
+
+		resources = append(resources, ssp)
+	}
+
+	return resources, nil
+}
+
+func updateOperatorCr(ctx context.Context, cli client.Client, logger logr.Logger, hc *hcov1.HyperConverged, exists client.Object, opts *client.UpdateOptions) error {
+	switch existing := exists.(type) {
+	case *kubevirtcorev1.KubeVirt:
+		required, err := handlers.NewKubeVirt(hc)
+		if err != nil {
+			return err
+		}
+		required.Spec.DeepCopyInto(&existing.Spec)
+
+	case *cdiv1beta1.CDI:
+		required, err := handlers.NewCDI(hc)
+		if err != nil {
+			return err
+		}
+		required.Spec.DeepCopyInto(&existing.Spec)
+
+	case *networkaddonsv1.NetworkAddonsConfig:
+		required, err := handlers.NewNetworkAddons(hc)
+		if err != nil {
+			return err
+		}
+		required.Spec.DeepCopyInto(&existing.Spec)
+
+	case *sspv1beta3.SSP:
+		origGetControlPlaneArchitectures := nodeinfo.GetControlPlaneArchitectures
+		origGetWorkloadsArchitectures := nodeinfo.GetWorkloadsArchitectures
+		defer func() {
+			nodeinfo.GetControlPlaneArchitectures = origGetControlPlaneArchitectures
+			nodeinfo.GetWorkloadsArchitectures = origGetWorkloadsArchitectures
+		}()
+
+		nodeinfo.GetControlPlaneArchitectures = func() []string {
+			return hc.Status.NodeInfo.ControlPlaneArchitectures
+		}
+		nodeinfo.GetWorkloadsArchitectures = func() []string {
+			return hc.Status.NodeInfo.WorkloadsArchitectures
+		}
+
+		required, _, err := handlers.NewSSP(hc)
+		if err != nil {
+			return err
+		}
+		required.Spec.DeepCopyInto(&existing.Spec)
+	}
+
+	if err := cli.Update(ctx, exists, opts); err != nil {
+		logger.Error(err, "failed to dry-run update the object", "kind", exists.GetObjectKind())
+		return err
+	}
+
+	logger.Info("dry-run update the object passed", "kind", exists.GetObjectKind())
+	return nil
 }

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -50,19 +50,16 @@ var _ = Describe("v1 webhooks validator", func() {
 	getFakeClient := func(hco *hcov1.HyperConverged) *commontestutils.HcoTestClient {
 		GinkgoHelper()
 
-		v1beta1HC := &hcov1beta1.HyperConverged{}
-		Expect(v1beta1HC.ConvertFrom(hco)).To(Succeed())
-
-		kv, err := handlers.NewKubeVirt(v1beta1HC)
+		kv, err := handlers.NewKubeVirt(hco)
 		Expect(err).ToNot(HaveOccurred())
 
-		cdi, err := handlers.NewCDI(v1beta1HC)
+		cdi, err := handlers.NewCDI(hco)
 		Expect(err).ToNot(HaveOccurred())
 
-		cna, err := handlers.NewNetworkAddons(v1beta1HC)
+		cna, err := handlers.NewNetworkAddons(hco)
 		Expect(err).ToNot(HaveOccurred())
 
-		ssp, _, err := handlers.NewSSP(v1beta1HC)
+		ssp, _, err := handlers.NewSSP(hco)
 		Expect(err).ToNot(HaveOccurred())
 
 		return commontestutils.InitClient([]client.Object{hco, kv, cdi, cna, ssp})
@@ -74,22 +71,19 @@ var _ = Describe("v1 webhooks validator", func() {
 	decoder := admission.NewDecoder(s)
 
 	var (
-		cr        *hcov1.HyperConverged
-		dryRun    bool
-		wh        *WebhookHandler
-		v1beta1WH *WebhookV1Beta1Handler
-		cli       client.Client
+		cr     *hcov1.HyperConverged
+		dryRun bool
+		wh     *WebhookHandler
+		cli    client.Client
 	)
 
 	JustBeforeEach(func() {
-		v1beta1WH = NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)
-		wh = NewWebhookHandler(GinkgoLogr, cli, decoder, HcoValidNamespace, true, v1beta1WH)
+		wh = NewWebhookHandler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)
 	})
 
 	BeforeEach(func() {
 		Expect(os.Setenv("OPERATOR_NAMESPACE", HcoValidNamespace)).To(Succeed())
-		cr = &hcov1.HyperConverged{}
-		Expect(commontestutils.NewHco().ConvertTo(cr)).To(Succeed())
+		cr = commontestutils.NewHco()
 		dryRun = false
 	})
 
@@ -792,7 +786,7 @@ var _ = Describe("v1 webhooks validator", func() {
 		})
 
 		It("should return error if CDI CR is missing", func(ctx context.Context) {
-			cdi, err := handlers.NewCDI(v1beta1CR)
+			cdi, err := handlers.NewCDI(cr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cli.Delete(ctx, cdi)).To(Succeed())
 
@@ -835,7 +829,7 @@ var _ = Describe("v1 webhooks validator", func() {
 		})
 
 		It("should return error if NetworkAddons CR is missing", func(ctx context.Context) {
-			cna, err := handlers.NewNetworkAddons(v1beta1CR)
+			cna, err := handlers.NewNetworkAddons(cr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cli.Delete(ctx, cna)).To(Succeed())
 

--- a/tests/func-tests/tuningpolicy_test.go
+++ b/tests/func-tests/tuningpolicy_test.go
@@ -12,7 +12,6 @@ import (
 	kvv1 "kubevirt.io/api/core/v1"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
@@ -50,22 +49,6 @@ var _ = Describe("Check that the TuningPolicy annotation is configuring the KV o
 		expected := kvv1.TokenBucketRateLimiter{
 			Burst: 200,
 			QPS:   100,
-		}
-
-		checkTuningPolicy(ctx, cli, expected)
-	})
-
-	It("should update KV with the highBurst tuningPolicy", func(ctx context.Context) {
-		hc := tests.GetHCO(ctx, cli)
-
-		delete(hc.Annotations, common.TuningPolicyAnnotationName)
-		hc.Spec.TuningPolicy = hcov1beta1.HyperConvergedHighBurstProfile //nolint SA1019
-
-		tests.UpdateHCORetry(ctx, cli, hc)
-
-		expected := kvv1.TokenBucketRateLimiter{
-			Burst: 400,
-			QPS:   200,
 		}
 
 		checkTuningPolicy(ctx, cli, expected)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies the internal implementation of the hyperconverged controller to use the v1 API version.

However, since this controller is the main controller, and it actually split to several other packages, and since some other packages like the validation webhook are also depend on the hyperconverged controller, this PR modifies many other packages.

** Notes to the reviewer**:
The scope of this PR is very large. There is no real option to limit its size, without breaking the compilation or the tests.

**Jira Ticket**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-86219
```

**Release note**:
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HyperConverged CR now targets stable v1; new helpers to configure infra/workload node placements.

* **Improvements**
  * Feature-gate model modernized (e.g., multi-arch boot images).
  * Spec fields reorganized into nested sections (Security, Deployment, Virtualization, Storage, WorkloadSources).
  * TLS/certificate, logging, storage, and placement settings read from new nested paths.
  * Webhook validation updated to operate on v1 objects.

* **Breaking Changes**
  * Existing HyperConverged CRs must be migrated to v1 field paths/nesting before upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->