### PR TITLE
Fix patches in script files

### DIFF
--- a/hack/consecutive-upgrades-test.sh
+++ b/hack/consecutive-upgrades-test.sh
@@ -218,7 +218,7 @@ END
 CSV=$( ${CMD} get csv -o name -n ${HCO_NAMESPACE} | grep "kubevirt-hyperconverged-operator")
 
 # Patch the default CPU model to ensure a successful live migration
-${CMD} patch hco kubevirt-hyperconverged -n ${HCO_NAMESPACE} --type=json -p='[{"op": "add", "path": "/spec/defaultCPUModel", "value": "Westmere"}]'
+${CMD} patch hco kubevirt-hyperconverged -n ${HCO_NAMESPACE} --type=merge -p='{"spec":{"virtualization":{"virtualMachineOptions":{"defaultCPUModel":"Westmere"}}}}'
 
 Msg "operator conditions before upgrade"
 source ./hack/check_operator_condition.sh
@@ -243,7 +243,7 @@ Msg "make sure that we don't have outdated VMs"
 ${CMD} get vmim -n ${VMS_NAMESPACE} -o yaml
 
 INFRASTRUCTURETOPOLOGY=$(${CMD} get infrastructure.config.openshift.io cluster -o json | jq -j '.status.infrastructureTopology')
-UPDATE_METHODS=$(${CMD} get hco ${HCO_RESOURCE_NAME} -n ${HCO_NAMESPACE} -o jsonpath='{.spec .workloadUpdateStrategy .workloadUpdateMethods}')
+UPDATE_METHODS=$(${CMD} get hco ${HCO_RESOURCE_NAME} -n ${HCO_NAMESPACE} -o jsonpath='{.spec.virtualization.workloadUpdateStrategy.workloadUpdateMethods}')
 
 if [[ "${INFRASTRUCTURETOPOLOGY}" == "SingleReplica" ]]; then
   echo "Skipping the check on SNO clusters"

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -36,8 +36,9 @@ ${TEST_OUT_PATH}/func-tests.test -ginkgo.v -ginkgo.junit-report="${TEST_OUT_PATH
 sleep 60
 
 # Check the webhook, to see if it allow updating of the HyperConverged CR
-./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged -p '{\"spec\":{\"infra\":{\"nodePlacement\":{\"tolerations\":[{\"effect\":\"NoSchedule\",\"key\":\"key\",\"operator\":\"Equal\",\"value\":\"value\"}]}}}}' --type=merge"
-./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged -p '{\"spec\":{\"workloads\":{\"nodePlacement\":{\"tolerations\":[{\"effect\":\"NoSchedule\",\"key\":\"key\",\"operator\":\"Equal\",\"value\":\"value\"}]}}}}' --type=merge"
+NODE_PLACEMENT_PATCH='{"spec":{"deployment":{"nodePlacements":{"infra":{"tolerations":[{"effect":"NoSchedule","key":"key","operator":"Equal","value":"value"}]},"workload":{"tolerations":[{"effect":"NoSchedule","key":"key","operator":"Equal","value":"value"}]}}}}}'
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch hco -n ${INSTALLED_NAMESPACE} kubevirt-hyperconverged -p '${NODE_PLACEMENT_PATCH}' --type=merge"
+
 # Read the HyperConverged CR
 ${KUBECTL_BINARY} get hco -n "${INSTALLED_NAMESPACE}" kubevirt-hyperconverged -o yaml
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In two places, we are patching v1 HyperConverged CR with v1beta1 content. This PR moves the patches to v1, to match the CR.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted pre-upgrade test patching to set the default virtual CPU model and corrected how upgrade update methods are read.
  * Consolidated node placement patching in test scripts to apply unified placement/toleration settings across deployment tiers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubevirt/hyperconverged-cluster-operator/pull/4245)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->