### PR TITLE
Remove LiveUpdateNADRef FG

### DIFF
--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -107,9 +107,6 @@ const (
 
 	// Enable the installation of the KubeVirt seccomp profile
 	kvKubevirtSeccompProfile = "KubevirtSeccompProfile"
-
-	// Enable updating NAD reference on a running VM
-	kvLiveUpdateNADRef = "LiveUpdateNADRef"
 )
 
 // KubeVirt architecture dependant feature gates.
@@ -132,7 +129,6 @@ var (
 		kvHostDevicesGate,
 		kvVMExportGate,
 		kvKubevirtSeccompProfile,
-		kvLiveUpdateNADRef,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -217,7 +217,6 @@ var _ = Describe("HyperconvergedController", func() {
 					"KubevirtSeccompProfile",
 					"VideoConfig",
 					"DecentralizedLiveMigration",
-					"LiveUpdateNADRef",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}


### PR DESCRIPTION
The LiveUpdateNADRef feature gate was enabled by default in HCO as the feature was beta in KubeVirt 1.8 and GA in KubeVirt 1.9.

Now that the feature has reached GA through PR [1] and the feature gate protection has been removed upstream in KubeVirt, there is no point to set it anymore.

This PR modifies HCO to stop adding the LiveUpdateNADRef feature gate to the KubeVirt CR.

[1] https://github.com/kubevirt/kubevirt/pull/17049

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removes LiveUpdateNadRef feature gate
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated KubeVirt feature gate defaults: removed one legacy gate and added/adjusted defaults to include KubevirtSeccompProfile and VideoConfig, changing the default enabled gate set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubevirt/hyperconverged-cluster-operator/pull/4248)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->