### PR TITLE
Fix a potential race condition in the validating webhook

### DIFF
--- a/controllers/handlers/ssp.go
+++ b/controllers/handlers/ssp.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"reflect"
+	"slices"
 	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (h *sspHooks) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
 	defer h.Unlock()
 
 	if h.cache == nil {
-		ssp, dictStatus, err := NewSSP(hc)
+		ssp, dictStatus, err := NewSSP(hc, false)
 		if err != nil {
 			return nil, err
 		}
@@ -131,7 +132,7 @@ func (h *sspHooks) updateDICTsInHCStatus(req *common.HcoRequest) {
 	goldenimages.CheckDataImportCronTemplates(req.Instance)
 }
 
-func NewSSP(hc *hcov1.HyperConverged) (*sspv1beta3.SSP, []hcov1.DataImportCronTemplateStatus, error) {
+func NewSSP(hc *hcov1.HyperConverged, useNodeInfoFromStatus bool) (*sspv1beta3.SSP, []hcov1.DataImportCronTemplateStatus, error) {
 	templatesNamespace := ptr.Deref(hc.Spec.WorkloadSources.CommonTemplatesNamespace, defaultCommonTemplatesNamespace)
 
 	goldenimages.ApplyDataImportSchedule(hc)
@@ -141,8 +142,21 @@ func NewSSP(hc *hcov1.HyperConverged) (*sspv1beta3.SSP, []hcov1.DataImportCronTe
 		return nil, nil, err
 	}
 
-	cpArches := nodeinfo.GetControlPlaneArchitectures()
-	wlArches := nodeinfo.GetWorkloadsArchitectures()
+	var (
+		cpArches []string
+		wlArches []string
+	)
+
+	if useNodeInfoFromStatus {
+		// The webhook pod does not run the node controller, and so the node-info is never
+		// up-to-date. But the same info is copying to the HyperConverged CR status by the
+		// operator, and that is good enough for the webhook.
+		cpArches = slices.Clone(hc.Status.NodeInfo.ControlPlaneArchitectures)
+		wlArches = slices.Clone(hc.Status.NodeInfo.WorkloadsArchitectures)
+	} else {
+		cpArches = nodeinfo.GetControlPlaneArchitectures()
+		wlArches = nodeinfo.GetWorkloadsArchitectures()
+	}
 
 	var cluster *sspv1beta3.Cluster
 	if len(cpArches) > 0 || len(wlArches) > 0 {

--- a/controllers/handlers/ssp_test.go
+++ b/controllers/handlers/ssp_test.go
@@ -55,7 +55,7 @@ var _ = Describe("SSP Operands", func() {
 		})
 
 		It("should create if not present", func() {
-			expectedResource, _, err := NewSSP(hco)
+			expectedResource, _, err := NewSSP(hco, false)
 			Expect(err).ToNot(HaveOccurred())
 			cl := commontestutils.InitClient([]client.Object{})
 			handler := NewSspHandler(cl, commontestutils.GetScheme())
@@ -78,7 +78,7 @@ var _ = Describe("SSP Operands", func() {
 		})
 
 		It("should find if present", func() {
-			expectedResource, _, err := NewSSP(hco)
+			expectedResource, _, err := NewSSP(hco, false)
 			Expect(err).ToNot(HaveOccurred())
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
 			handler := NewSspHandler(cl, commontestutils.GetScheme())
@@ -100,7 +100,7 @@ var _ = Describe("SSP Operands", func() {
 		It("should reconcile to default", func() {
 			const cTNamespace = "nonDefault"
 			hco.Spec.WorkloadSources.CommonTemplatesNamespace = ptr.To(cTNamespace)
-			expectedResource, _, err := NewSSP(hco)
+			expectedResource, _, err := NewSSP(hco, false)
 			Expect(err).ToNot(HaveOccurred())
 			existingResource := expectedResource.DeepCopy()
 
@@ -139,7 +139,7 @@ var _ = Describe("SSP Operands", func() {
 		It("should reconcile managed labels to default without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource, _, err := NewSSP(hco)
+			outdatedResource, _, err := NewSSP(hco, false)
 			Expect(err).ToNot(HaveOccurred())
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
@@ -171,7 +171,7 @@ var _ = Describe("SSP Operands", func() {
 		It("should reconcile managed labels to default on label deletion without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource, _, err := NewSSP(hco)
+			outdatedResource, _, err := NewSSP(hco, false)
 			Expect(err).ToNot(HaveOccurred())
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
@@ -201,7 +201,7 @@ var _ = Describe("SSP Operands", func() {
 		It("should create ssp with deployVmConsoleProxy feature gate enabled", func() {
 			hco.Spec.Deployment.DeployVMConsoleProxy = ptr.To(true)
 
-			expectedResource, _, err := NewSSP(hco)
+			expectedResource, _, err := NewSSP(hco, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(expectedResource.Spec.TokenGenerationService).ToNot(BeNil())
@@ -213,7 +213,7 @@ var _ = Describe("SSP Operands", func() {
 				{Name: goldenimages.EnableMultiArchFeatureGate, State: hcFG},
 			}
 
-			ssp, _, err := NewSSP(hco)
+			ssp, _, err := NewSSP(hco, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ssp.Spec.EnableMultipleArchitectures).To(matcher)
 		},
@@ -222,78 +222,137 @@ var _ = Describe("SSP Operands", func() {
 		)
 
 		Context("SSP's Cluster filed", func() {
-			It("should set Cluster field to the HC's Cluster field", func() {
-				nodeinfo.GetControlPlaneArchitectures = func() []string {
-					return []string{"cparch1", "cparch2"}
-				}
+			Context("when useNodeInfoFromStatus is false (operator mode)", func() {
+				It("should set Cluster field to the HC's Cluster field", func() {
+					nodeinfo.GetControlPlaneArchitectures = func() []string {
+						return []string{"cparch1", "cparch2"}
+					}
 
-				nodeinfo.GetWorkloadsArchitectures = func() []string {
-					return []string{"wlarch1", "wlarch2", "wlarch3"}
-				}
+					nodeinfo.GetWorkloadsArchitectures = func() []string {
+						return []string{"wlarch1", "wlarch2", "wlarch3"}
+					}
 
-				ssp, _, err := NewSSP(hco)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ssp.Spec.Cluster).ToNot(BeNil())
-				Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(HaveLen(2))
-				Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(ConsistOf("cparch1", "cparch2"))
-				Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(HaveLen(3))
-				Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(ConsistOf("wlarch1", "wlarch2", "wlarch3"))
+					ssp, _, err := NewSSP(hco, false)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ssp.Spec.Cluster).ToNot(BeNil())
+					Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(HaveLen(2))
+					Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(ConsistOf("cparch1", "cparch2"))
+					Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(HaveLen(3))
+					Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(ConsistOf("wlarch1", "wlarch2", "wlarch3"))
 
+				})
+
+				It("should not set Cluster.ControlPlaneArchitectures field if there are no cp nodes", func() {
+					nodeinfo.GetControlPlaneArchitectures = func() []string {
+						return nil
+					}
+
+					nodeinfo.GetWorkloadsArchitectures = func() []string {
+						return []string{"wlarch1", "wlarch2", "wlarch3"}
+					}
+
+					ssp, _, err := NewSSP(hco, false)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ssp.Spec.Cluster).ToNot(BeNil())
+					Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(BeNil())
+					Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(HaveLen(3))
+					Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(ConsistOf("wlarch1", "wlarch2", "wlarch3"))
+				})
+
+				It("should not set Cluster.WorkloadArchitectures field if there are no wl nodes", func() {
+					nodeinfo.GetControlPlaneArchitectures = func() []string {
+						return []string{"cparch1", "cparch2"}
+					}
+
+					nodeinfo.GetWorkloadsArchitectures = func() []string {
+						return nil
+					}
+
+					ssp, _, err := NewSSP(hco, false)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ssp.Spec.Cluster).ToNot(BeNil())
+					Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(HaveLen(2))
+					Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(ConsistOf("cparch1", "cparch2"))
+					Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(BeNil())
+				})
+
+				It("should not set Cluster field if there are no nodes", func() { // should never happen, but just in case
+					nodeinfo.GetControlPlaneArchitectures = func() []string {
+						return nil
+					}
+
+					nodeinfo.GetWorkloadsArchitectures = func() []string {
+						return nil
+					}
+
+					ssp, _, err := NewSSP(hco, false)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ssp.Spec.Cluster).To(BeNil())
+				})
 			})
 
-			It("should not set Cluster.ControlPlaneArchitectures field if there are no cp nodes", func() {
-				nodeinfo.GetControlPlaneArchitectures = func() []string {
-					return nil
-				}
+			Context("when useNodeInfoFromStatus is true (webhook mode)", func() {
+				It("should set Cluster field to the HC's Cluster field", func() {
+					hco.Status.NodeInfo = hcov1.NodeInfoStatus{
+						ControlPlaneArchitectures: []string{"cparch1", "cparch2"},
+						WorkloadsArchitectures:    []string{"wlarch1", "wlarch2", "wlarch3"},
+					}
 
-				nodeinfo.GetWorkloadsArchitectures = func() []string {
-					return []string{"wlarch1", "wlarch2", "wlarch3"}
-				}
+					ssp, _, err := NewSSP(hco, true)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ssp.Spec.Cluster).ToNot(BeNil())
+					Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(HaveLen(2))
+					Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(ConsistOf("cparch1", "cparch2"))
+					Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(HaveLen(3))
+					Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(ConsistOf("wlarch1", "wlarch2", "wlarch3"))
 
-				ssp, _, err := NewSSP(hco)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ssp.Spec.Cluster).ToNot(BeNil())
-				Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(BeNil())
-				Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(HaveLen(3))
-				Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(ConsistOf("wlarch1", "wlarch2", "wlarch3"))
-			})
+				})
 
-			It("should not set Cluster.WorkloadArchitectures field if there are no wl nodes", func() {
-				nodeinfo.GetControlPlaneArchitectures = func() []string {
-					return []string{"cparch1", "cparch2"}
-				}
+				It("should not set Cluster.ControlPlaneArchitectures field if there are no cp nodes", func() {
+					hco.Status.NodeInfo = hcov1.NodeInfoStatus{
+						ControlPlaneArchitectures: nil,
+						WorkloadsArchitectures:    []string{"wlarch1", "wlarch2", "wlarch3"},
+					}
 
-				nodeinfo.GetWorkloadsArchitectures = func() []string {
-					return nil
-				}
+					ssp, _, err := NewSSP(hco, true)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ssp.Spec.Cluster).ToNot(BeNil())
+					Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(BeNil())
+					Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(HaveLen(3))
+					Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(ConsistOf("wlarch1", "wlarch2", "wlarch3"))
+				})
 
-				ssp, _, err := NewSSP(hco)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ssp.Spec.Cluster).ToNot(BeNil())
-				Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(HaveLen(2))
-				Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(ConsistOf("cparch1", "cparch2"))
-				Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(BeNil())
-			})
+				It("should not set Cluster.WorkloadArchitectures field if there are no wl nodes", func() {
+					hco.Status.NodeInfo = hcov1.NodeInfoStatus{
+						ControlPlaneArchitectures: []string{"cparch1", "cparch2"},
+						WorkloadsArchitectures:    nil,
+					}
 
-			It("should not set Cluster field if there are no nodes", func() { // should never happen, but just in case
-				nodeinfo.GetControlPlaneArchitectures = func() []string {
-					return nil
-				}
+					ssp, _, err := NewSSP(hco, true)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ssp.Spec.Cluster).ToNot(BeNil())
+					Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(HaveLen(2))
+					Expect(ssp.Spec.Cluster.ControlPlaneArchitectures).To(ConsistOf("cparch1", "cparch2"))
+					Expect(ssp.Spec.Cluster.WorkloadArchitectures).To(BeNil())
+				})
 
-				nodeinfo.GetWorkloadsArchitectures = func() []string {
-					return nil
-				}
+				It("should not set Cluster field if there are no nodes", func() { // should never happen, but just in case
+					hco.Status.NodeInfo = hcov1.NodeInfoStatus{
+						ControlPlaneArchitectures: nil,
+						WorkloadsArchitectures:    nil,
+					}
 
-				ssp, _, err := NewSSP(hco)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ssp.Spec.Cluster).To(BeNil())
+					ssp, _, err := NewSSP(hco, true)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ssp.Spec.Cluster).To(BeNil())
+				})
 			})
 		})
 
 		Context("Node placement", func() {
 
 			It("should add node placement if missing", func() {
-				existingResource, _, err := NewSSP(hco)
+				existingResource, _, err := NewSSP(hco, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				commontestutils.SetNodeCustomPlacement(hco, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
@@ -323,7 +382,7 @@ var _ = Describe("SSP Operands", func() {
 				hcoNodePlacement := commontestutils.NewHco()
 				commontestutils.SetNodeCustomPlacement(hcoNodePlacement, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
 
-				existingResource, _, err := NewSSP(hcoNodePlacement)
+				existingResource, _, err := NewSSP(hcoNodePlacement, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
@@ -350,7 +409,7 @@ var _ = Describe("SSP Operands", func() {
 			It("should modify node placement according to HCO CR", func() {
 
 				commontestutils.SetNodeCustomPlacement(hco, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
-				existingResource, _, err := NewSSP(hco)
+				existingResource, _, err := NewSSP(hco, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				// now, modify HCO's node placement
@@ -393,7 +452,7 @@ var _ = Describe("SSP Operands", func() {
 
 			It("should overwrite node placement if directly set on SSP CR", func() {
 				commontestutils.SetNodeCustomPlacement(hco, commontestutils.NewOtherNodePlacement(), commontestutils.NewNodePlacement())
-				existingResource, _, err := NewSSP(hco)
+				existingResource, _, err := NewSSP(hco, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				// mock a reconciliation triggered by a change in NewKubeVirtNodeLabellerBundle CR
@@ -440,7 +499,7 @@ var _ = Describe("SSP Operands", func() {
 					}
 				]`}
 
-				ssp, _, err := NewSSP(hco)
+				ssp, _, err := NewSSP(hco, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ssp).ToNot(BeNil())
 				Expect(ssp.Spec.TemplateValidator.Replicas).ToNot(BeNil())
@@ -456,7 +515,7 @@ var _ = Describe("SSP Operands", func() {
 					}
 				]`}
 
-				_, _, err := NewSSP(hco)
+				_, _, err := NewSSP(hco, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -512,7 +571,7 @@ var _ = Describe("SSP Operands", func() {
 			})
 
 			It("Ensure func should update SSP object with changes from the annotation", func() {
-				existsSsp, _, err := NewSSP(hco)
+				existsSsp, _, err := NewSSP(hco, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				hco.Annotations = map[string]string{common.JSONPatchSSPAnnotationName: `[
@@ -545,7 +604,7 @@ var _ = Describe("SSP Operands", func() {
 			})
 
 			It("Ensure func should fail to update SSP object with wrong jsonPatch", func() {
-				existsSsp, _, err := NewSSP(hco)
+				existsSsp, _, err := NewSSP(hco, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				hco.Annotations = map[string]string{common.JSONPatchSSPAnnotationName: `[
@@ -801,7 +860,7 @@ var _ = Describe("SSP Operands", func() {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
-						ssp, _, err := NewSSP(hco)
+						ssp, _, err := NewSSP(hco, false)
 						Expect(err).ToNot(HaveOccurred())
 
 						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
@@ -856,7 +915,7 @@ var _ = Describe("SSP Operands", func() {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
-						ssp, _, err := NewSSP(hco)
+						ssp, _, err := NewSSP(hco, false)
 						Expect(err).ToNot(HaveOccurred())
 
 						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
@@ -925,7 +984,7 @@ var _ = Describe("SSP Operands", func() {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
-						ssp, _, err := NewSSP(hco)
+						ssp, _, err := NewSSP(hco, false)
 						Expect(err).ToNot(HaveOccurred())
 
 						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
@@ -1103,7 +1162,7 @@ var _ = Describe("SSP Operands", func() {
 						}
 
 						hco.Spec.WorkloadSources.EnableCommonBootImageImport = ptr.To(true)
-						ssp, _, err := NewSSP(hco)
+						ssp, _, err := NewSSP(hco, false)
 						Expect(err).ToNot(HaveOccurred())
 
 						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
@@ -1153,7 +1212,7 @@ var _ = Describe("SSP Operands", func() {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
-						ssp, _, err := NewSSP(hco)
+						ssp, _, err := NewSSP(hco, false)
 						Expect(err).ToNot(HaveOccurred())
 
 						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
@@ -1201,7 +1260,7 @@ var _ = Describe("SSP Operands", func() {
 							return []hcov1.DataImportCronTemplateStatus{commonDICT}, nil
 						}
 
-						ssp, _, err := NewSSP(hco)
+						ssp, _, err := NewSSP(hco, false)
 						Expect(err).ToNot(HaveOccurred())
 
 						goldenimages.GetDataImportCronTemplates = func(_ *hcov1.HyperConverged) ([]hcov1.DataImportCronTemplateStatus, error) {
@@ -1245,7 +1304,7 @@ var _ = Describe("SSP Operands", func() {
 			}
 
 			It("should modify TLSSecurityProfile on SSP CR according to ApiServer or HCO CR", func() {
-				existingResource, _, err := NewSSP(hco)
+				existingResource, _, err := NewSSP(hco, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(existingResource.Spec.TLSSecurityProfile).To(Equal(intermediateTLSSecurityProfile))
 
@@ -1273,7 +1332,7 @@ var _ = Describe("SSP Operands", func() {
 
 			It("should overwrite TLSSecurityProfile if directly set on SSP CR", func() {
 				hco.Spec.Security.TLSSecurityProfile = intermediateTLSSecurityProfile
-				existingResource, _, err := NewSSP(hco)
+				existingResource, _, err := NewSSP(hco, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				// mock a reconciliation triggered by a change in CDI CR

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -258,7 +258,7 @@ func getBasicDeployment() *BasicExpected {
 	expectedCNA.Status.Conditions = getGenericCompletedConditions()
 	res.cna = expectedCNA
 
-	expectedSSP, _, err := handlers.NewSSP(hco)
+	expectedSSP, _, err := handlers.NewSSP(hco, false)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	expectedSSP.Status.Conditions = getGenericCompletedConditions()
 	res.ssp = expectedSSP

--- a/pkg/webhooks/validator/v1beta1_validator.go
+++ b/pkg/webhooks/validator/v1beta1_validator.go
@@ -157,7 +157,7 @@ func (wh *WebhookV1Beta1Handler) ValidateCreate(_ context.Context, logger logr.L
 		return err
 	}
 
-	if _, _, err := handlers.NewSSP(v1hc); err != nil {
+	if _, _, err := handlers.NewSSP(v1hc, true); err != nil {
 		return err
 	}
 

--- a/pkg/webhooks/validator/v1beta1_validator_test.go
+++ b/pkg/webhooks/validator/v1beta1_validator_test.go
@@ -111,7 +111,7 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 		cna, err := handlers.NewNetworkAddons(v1hc)
 		Expect(err).ToNot(HaveOccurred())
 
-		ssp, _, err := handlers.NewSSP(v1hc)
+		ssp, _, err := handlers.NewSSP(v1hc, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		return commontestutils.InitClient([]client.Object{hco, kv, cdi, cna, ssp})

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -33,7 +33,6 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/featuregatedetails"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/featuregates"
-	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -252,7 +251,7 @@ func (wh *WebhookHandler) validateCreateComponents(hc *hcov1.HyperConverged) err
 		return err
 	}
 
-	if _, _, err := handlers.NewSSP(hc); err != nil {
+	if _, _, err := handlers.NewSSP(hc, true); err != nil {
 		return err
 	}
 
@@ -569,21 +568,7 @@ func updateOperatorCr(ctx context.Context, cli client.Client, logger logr.Logger
 		required.Spec.DeepCopyInto(&existing.Spec)
 
 	case *sspv1beta3.SSP:
-		origGetControlPlaneArchitectures := nodeinfo.GetControlPlaneArchitectures
-		origGetWorkloadsArchitectures := nodeinfo.GetWorkloadsArchitectures
-		defer func() {
-			nodeinfo.GetControlPlaneArchitectures = origGetControlPlaneArchitectures
-			nodeinfo.GetWorkloadsArchitectures = origGetWorkloadsArchitectures
-		}()
-
-		nodeinfo.GetControlPlaneArchitectures = func() []string {
-			return hc.Status.NodeInfo.ControlPlaneArchitectures
-		}
-		nodeinfo.GetWorkloadsArchitectures = func() []string {
-			return hc.Status.NodeInfo.WorkloadsArchitectures
-		}
-
-		required, _, err := handlers.NewSSP(hc)
+		required, _, err := handlers.NewSSP(hc, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -59,7 +59,7 @@ var _ = Describe("v1 webhooks validator", func() {
 		cna, err := handlers.NewNetworkAddons(hco)
 		Expect(err).ToNot(HaveOccurred())
 
-		ssp, _, err := handlers.NewSSP(hco)
+		ssp, _, err := handlers.NewSSP(hco, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		return commontestutils.InitClient([]client.Object{hco, kv, cdi, cna, ssp})


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a followup of #4237, to fix the [comment about potential race condition in the validating webhook](https://github.com/kubevirt/hyperconverged-cluster-operator/pull/4237#discussion_r3234415246), where we overriding the nodeIngo methods, to get the node information from the HyperConverged CR status.

Instead, this PR changes the NewSSP method to allow it reading from the status, explicitly.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required". 
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

Fixes #4238 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Allow node architecture info to be sourced from cluster status or defaults; webhook validation now uses the status-aware construction and removes the prior special-case workaround.

* **Tests**
  * Updated handler and webhook tests and fixtures to align with the refined architecture selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubevirt/hyperconverged-cluster-operator/pull/4251)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->