### PR TITLE
Fix the nightly build: update HCO version

### DIFF
--- a/deploy/kustomize/deploy_kustomize.sh
+++ b/deploy/kustomize/deploy_kustomize.sh
@@ -4,8 +4,8 @@ set -x
 
 # Setup Environment Variables
 HCO_VERSION="${HCO_VERSION:-}"
-HCO_CHANNEL="${HCO_CHANNEL:-candidate-v1.18}"
-HCO_INDEX_IMAGE="${HCO_INDEX_IMAGE:-quay.io/kubevirt/hyperconverged-cluster-index:1.18.0-unstable}"
+HCO_CHANNEL="${HCO_CHANNEL:-candidate-v1.19}"
+HCO_INDEX_IMAGE="${HCO_INDEX_IMAGE:-quay.io/kubevirt/hyperconverged-cluster-index:1.19.0-unstable}"
 MARKETPLACE_MODE="${MARKETPLACE_MODE:-true}"
 PRIVATE_REPO="${PRIVATE_REPO:-false}"
 QUAY_USERNAME="${QUAY_USERNAME:-}"

--- a/deploy/kustomize/kvm_emulation/kustomization.yaml
+++ b/deploy/kustomize/kvm_emulation/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
   - ../base
 
-patchesStrategicMerge:
-  - subscription.patch.yaml
+patches:
+  - path: subscription.patch.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
[Openshift nightly build](https://prow.ci.openshift.org/job-history/test-platform-results/logs/periodic-ci-kubevirt-hyperconverged-cluster-operator-main-hco-e2e-deploy-nightly-main-aws) is broken since 2026-04-29.

This is because we [bumped HCO to v1.19](#4198)

This PR fixes the issue by bumping HCO in the deploy/kustomize/deploy_kustomize.sh script, to match the current version.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration defaults to support newer infrastructure component versions.
  * Modernized deployment configuration syntax for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubevirt/hyperconverged-cluster-operator/pull/4252)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->