### PR TITLE
Move func tests to v1

### DIFF
--- a/tests/func-tests/aaq_test.go
+++ b/tests/func-tests/aaq_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	setAAQFGPatchTemplate = `[{"op": "replace", "path": "/spec/enableApplicationAwareQuota", "value": %t}]`
+	setAAQFGPatchTemplate = `{"spec":{"deployment":{"applicationAwareConfig":{"enable": %t}}}}`
 )
 
 var _ = Describe("Test AAQ", Label("AAQ"), Serial, Ordered, func() {
@@ -34,17 +34,17 @@ var _ = Describe("Test AAQ", Label("AAQ"), Serial, Ordered, func() {
 	BeforeEach(func(ctx context.Context) {
 		k8scli = tests.GetControllerRuntimeClient()
 
-		disableAAQFeatureGate(ctx, k8scli)
+		disableAAQ(ctx, k8scli)
 	})
 
 	AfterAll(func(ctx context.Context) {
-		disableAAQFeatureGate(ctx, k8scli)
+		disableAAQ(ctx, k8scli)
 	})
 
 	When("set the applicationAwareConfig exists", func() {
 		It("should create the AAQ CR and all the pods", func(ctx context.Context) {
 
-			enableAAQFeatureGate(ctx, k8scli)
+			enableAAQ(ctx, k8scli)
 
 			By("check the AAQ CR")
 			Eventually(func(g Gomega, ctx context.Context) bool {
@@ -93,14 +93,14 @@ func getAAQ(ctx context.Context, cli client.Client) (*aaqv1alpha1.AAQ, error) {
 	return aaq, err
 }
 
-func enableAAQFeatureGate(ctx context.Context, cli client.Client) {
+func enableAAQ(ctx context.Context, cli client.Client) {
 	By("enable the AAQ FG")
-	setAAQFeatureGate(ctx, cli, true)
+	setAAQEnablement(ctx, cli, true)
 }
 
-func disableAAQFeatureGate(ctx context.Context, cli client.Client) {
+func disableAAQ(ctx context.Context, cli client.Client) {
 	By("disable the AAQ FG")
-	setAAQFeatureGate(ctx, cli, false)
+	setAAQEnablement(ctx, cli, false)
 
 	By("make sure the AAQ CR was removed")
 	Eventually(func(ctx context.Context) error {
@@ -113,10 +113,10 @@ func disableAAQFeatureGate(ctx context.Context, cli client.Client) {
 		Should(MatchError(errors.IsNotFound, "not found error"))
 }
 
-func setAAQFeatureGate(ctx context.Context, cli client.Client, fgState bool) {
-	patchBytes := []byte(fmt.Sprintf(setAAQFGPatchTemplate, fgState))
+func setAAQEnablement(ctx context.Context, cli client.Client, shouldEnable bool) {
+	patchBytes := fmt.Appendf(nil, setAAQFGPatchTemplate, shouldEnable)
 
-	Eventually(tests.PatchHCO).
+	Eventually(tests.PatchMergeHCO).
 		WithArguments(ctx, cli, patchBytes).
 		WithTimeout(10 * time.Second).
 		WithPolling(100 * time.Millisecond).

--- a/tests/func-tests/aie_test.go
+++ b/tests/func-tests/aie_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Test AIE", Label("AIE"), Serial, Ordered, func() {
 			Expect(cli.Update(ctx, cm)).To(Succeed())
 
 			By("triggering a reconcile by touching the HCO CR")
-			patchBytes := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":"true"}}}`, deployAIEAnnotationKey))
+			patchBytes := fmt.Appendf(nil, `{"metadata":{"annotations":{"%s":"true"}}}`, deployAIEAnnotationKey)
 			Eventually(tests.PatchMergeHCO).
 				WithArguments(ctx, cli, patchBytes).
 				WithTimeout(10 * time.Second).
@@ -248,7 +248,7 @@ func validateAIEDeleted(ctx context.Context, cli client.Client, tryGetResource a
 
 func enableAIEAnnotation(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
-	patchBytes := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":"true"}}}`, deployAIEAnnotationKey))
+	patchBytes := fmt.Appendf(nil, `{"metadata":{"annotations":{"%s":"true"}}}`, deployAIEAnnotationKey)
 
 	Eventually(tests.PatchMergeHCO).
 		WithArguments(ctx, cli, patchBytes).
@@ -261,7 +261,7 @@ func enableAIEAnnotation(ctx context.Context, cli client.Client) {
 
 func disableAIEAnnotation(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
-	patchBytes := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":null}}}`, deployAIEAnnotationKey))
+	patchBytes := fmt.Appendf(nil, `{"metadata":{"annotations":{"%s":null}}}`, deployAIEAnnotationKey)
 
 	Eventually(tests.PatchMergeHCO).
 		WithArguments(ctx, cli, patchBytes).

--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -39,7 +39,7 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 		Expect(err).ToNot(HaveOccurred())
 
 		s := scheme.Scheme
-		Expect(consolev1.AddToScheme(s)).To(Succeed())
+		Expect(consolev1.Install(s)).To(Succeed())
 		cli, err = client.New(cfg, client.Options{Scheme: s})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -102,7 +102,7 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 
 			if len(ingress.Spec.ComponentRoutes) > 0 {
 				GinkgoWriter.Println("restoring the custom routes after the test")
-				cleanupPatch := []byte(fmt.Sprintf(`[{"op": "replace", "path": "/spec/componentRoutes", "value": %v}]`, existingRoutes))
+				cleanupPatch := fmt.Appendf(nil, `[{"op": "replace", "path": "/spec/componentRoutes", "value": %v}]`, existingRoutes)
 				Expect(cli.Patch(ctx, ingress, client.RawPatch(types.JSONPatchType, cleanupPatch))).To(Succeed())
 			}
 		})
@@ -119,7 +119,7 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 			By("customize the virt-downloads route, to set another host")
 			baseDomain := ingress.Spec.Domain
 			newCLIDLHost := "virt-dl." + baseDomain
-			patch := []byte(fmt.Sprintf(`[{"op": "add", "path": "/spec/componentRoutes", "value": [{"name": "virt-downloads", "hostname": %q, "namespace": %q}]}]`, newCLIDLHost, tests.InstallNamespace))
+			patch := fmt.Appendf(nil, `[{"op": "add", "path": "/spec/componentRoutes", "value": [{"name": "virt-downloads", "hostname": %q, "namespace": %q}]}]`, newCLIDLHost, tests.InstallNamespace)
 			Expect(cli.Patch(ctx, ingress, client.RawPatch(types.JSONPatchType, patch))).To(Succeed())
 
 			customTransport := http.DefaultTransport.(*http.Transport).Clone()

--- a/tests/func-tests/cluster_eviction_strategy_test.go
+++ b/tests/func-tests/cluster_eviction_strategy_test.go
@@ -37,7 +37,9 @@ var _ = Describe("Cluster level evictionStrategy default value", Label("eviction
 		Expect(err).ToNot(HaveOccurred())
 
 		tests.BeforeEach(ctx)
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+
 		initialEvictionStrategy = hc.Spec.Virtualization.EvictionStrategy
 	})
 
@@ -59,7 +61,8 @@ var _ = Describe("Cluster level evictionStrategy default value", Label("eviction
 		Expect(tests.PatchHCO(ctx, cli, rmEvictionStrategyPatch)).To(Succeed())
 
 		Eventually(func(g Gomega, ctx context.Context) {
-			hc := tests.GetHCO(ctx, cli)
+			hc, err := tests.GetHCO(ctx, cli)
+			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(hc).NotTo(BeNil())
 			g.Expect(hc.Spec.Virtualization.EvictionStrategy).To(HaveValue(Equal(expectedValue)))
 		}).WithContext(ctx).WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())

--- a/tests/func-tests/cluster_eviction_strategy_test.go
+++ b/tests/func-tests/cluster_eviction_strategy_test.go
@@ -2,20 +2,22 @@ package tests_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "kubevirt.io/api/core/v1"
+	kvv1 "kubevirt.io/api/core/v1"
 
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 	"github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/libnode"
 )
 
 var (
-	rmEvictionStrategyPatch = []byte(`[{"op": "remove", "path": "/spec/evictionStrategy"}]`)
+	rmEvictionStrategyPatch  = []byte(`[{"op": "remove", "path": "/spec/virtualization/evictionStrategy"}]`)
+	setEvictionStrategyPatch = `[{"op": "replace", "path": "/spec/virtualization/evictionStrategy", "value": "%s"}]`
 )
 
 var _ = Describe("Cluster level evictionStrategy default value", Label("evictionStrategy"), func() {
@@ -23,7 +25,7 @@ var _ = Describe("Cluster level evictionStrategy default value", Label("eviction
 	var (
 		cli client.Client
 
-		initialEvictionStrategy *v1.EvictionStrategy
+		initialEvictionStrategy *kvv1.EvictionStrategy
 		singleWorkerCluster     bool
 	)
 
@@ -36,16 +38,22 @@ var _ = Describe("Cluster level evictionStrategy default value", Label("eviction
 
 		tests.BeforeEach(ctx)
 		hc := tests.GetHCO(ctx, cli)
-		initialEvictionStrategy = hc.Spec.EvictionStrategy
+		initialEvictionStrategy = hc.Spec.Virtualization.EvictionStrategy
 	})
 
 	AfterEach(func(ctx context.Context) {
-		hc := tests.GetHCO(ctx, cli)
-		hc.Spec.EvictionStrategy = initialEvictionStrategy
-		tests.UpdateHCORetry(ctx, cli, hc)
+		patch := rmEvictionStrategyPatch
+		if initialEvictionStrategy != nil {
+			patch = fmt.Appendf(nil, setEvictionStrategyPatch, *initialEvictionStrategy)
+		}
+		Eventually(tests.PatchHCO).
+			WithArguments(ctx, cli, patch).
+			WithPolling(100 * time.Millisecond).
+			WithTimeout(5 * time.Second).
+			Should(Succeed())
 	})
 
-	DescribeTable("test spec.evictionStrategy", func(ctx context.Context, clusterValidationFn func(bool), expectedValue v1.EvictionStrategy) {
+	DescribeTable("test spec.virtualization.evictionStrategy", func(ctx context.Context, clusterValidationFn func(bool), expectedValue kvv1.EvictionStrategy) {
 		clusterValidationFn(singleWorkerCluster)
 
 		Expect(tests.PatchHCO(ctx, cli, rmEvictionStrategyPatch)).To(Succeed())
@@ -53,20 +61,20 @@ var _ = Describe("Cluster level evictionStrategy default value", Label("eviction
 		Eventually(func(g Gomega, ctx context.Context) {
 			hc := tests.GetHCO(ctx, cli)
 			g.Expect(hc).NotTo(BeNil())
-			g.Expect(hc.Spec.EvictionStrategy).To(HaveValue(Equal(expectedValue)))
+			g.Expect(hc.Spec.Virtualization.EvictionStrategy).To(HaveValue(Equal(expectedValue)))
 		}).WithContext(ctx).WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 	},
 		Entry(
-			"Should set spec.evictionStrategy = None by default on single worker clusters",
+			"Should set spec.virtualization.evictionStrategy = None by default on single worker clusters",
 			Label(tests.SingleNodeLabel),
 			tests.FailIfHighAvailableCluster,
-			v1.EvictionStrategyNone,
+			kvv1.EvictionStrategyNone,
 		),
 		Entry(
-			"Should set spec.evictionStrategy = LiveMigrate by default with multiple worker node",
+			"Should set spec.virtualization.evictionStrategy = LiveMigrate by default with multiple worker node",
 			Label(tests.HighlyAvailableClusterLabel),
 			tests.FailIfSingleNodeCluster,
-			v1.EvictionStrategyLiveMigrate,
+			kvv1.EvictionStrategyLiveMigrate,
 		),
 	)
 })

--- a/tests/func-tests/console_plugin_test.go
+++ b/tests/func-tests/console_plugin_test.go
@@ -40,12 +40,12 @@ var _ = Describe("kubevirt console plugin", Label(tests.OpenshiftLabel, "console
 		tests.FailIfNotOpenShift(ctx, cli, "kubevirt console plugin")
 
 		hco := tests.GetHCO(ctx, cli)
-		originalInfra := hco.Spec.Infra
+		originalNodePlacement := hco.Spec.Deployment.NodePlacements.DeepCopy()
 
 		k8sClientSet = tests.GetK8sClientSet()
 
 		DeferCleanup(func(ctx context.Context) {
-			hco.Spec.Infra = originalInfra
+			hco.Spec.Deployment.NodePlacements = originalNodePlacement
 			tests.UpdateHCORetry(ctx, cli, hco)
 		})
 	})
@@ -101,12 +101,11 @@ var _ = Describe("kubevirt console plugin", Label(tests.OpenshiftLabel, "console
 		}
 		expectedNodeSelectorBytes, err := json.Marshal(expectedNodeSelector)
 		Expect(err).ToNot(HaveOccurred())
-		expectedNodeSelectorStr := string(expectedNodeSelectorBytes)
-		addNodeSelectorPatch := []byte(fmt.Sprintf(`[{"op": "add", "path": "/spec/infra", "value": {"nodePlacement": {"nodeSelector": %s}}}]`, expectedNodeSelectorStr))
+
+		addNodeSelectorPatch := fmt.Appendf(nil, `{"spec":{"deployment":{"nodePlacements":{"infra":{"nodeSelector": %s}}}}}`, string(expectedNodeSelectorBytes))
 
 		Eventually(func(ctx context.Context) error {
-			err = tests.PatchHCO(ctx, cli, addNodeSelectorPatch)
-			return err
+			return tests.PatchMergeHCO(ctx, cli, addNodeSelectorPatch)
 		}).WithTimeout(1 * time.Minute).
 			WithPolling(1 * time.Millisecond).
 			WithContext(ctx).
@@ -143,10 +142,9 @@ var _ = Describe("kubevirt console plugin", Label(tests.OpenshiftLabel, "console
 			Should(Succeed())
 
 		// clear node placement from HyperConverged CR and verify the nodeSelector has been cleared as well from the UI Deployments
-		removeNodeSelectorPatch := []byte(`[{"op": "replace", "path": "/spec/infra", "value": {}}]`)
+		removeNodeSelectorPatch := []byte(`[{"op": "remove", "path": "/spec/deployment/nodePlacements/infra"}]`)
 		Eventually(func(ctx context.Context) error {
-			err = tests.PatchHCO(ctx, cli, removeNodeSelectorPatch)
-			return err
+			return tests.PatchHCO(ctx, cli, removeNodeSelectorPatch)
 		}).WithTimeout(1 * time.Minute).
 			WithPolling(1 * time.Millisecond).
 			WithContext(ctx).

--- a/tests/func-tests/console_plugin_test.go
+++ b/tests/func-tests/console_plugin_test.go
@@ -39,7 +39,9 @@ var _ = Describe("kubevirt console plugin", Label(tests.OpenshiftLabel, "console
 
 		tests.FailIfNotOpenShift(ctx, cli, "kubevirt console plugin")
 
-		hco := tests.GetHCO(ctx, cli)
+		hco, err := tests.GetHCO(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+
 		originalNodePlacement := hco.Spec.Deployment.NodePlacements.DeepCopy()
 
 		k8sClientSet = tests.GetK8sClientSet()

--- a/tests/func-tests/conversion_test.go
+++ b/tests/func-tests/conversion_test.go
@@ -41,7 +41,9 @@ var _ = Describe("check v1 <=> v1beta1 API conversion", func() {
 
 		Expect(cli.Get(ctx, hcKey, hcv1beta1)).To(Succeed())
 
-		hcv1 := tests.GetHCO(ctx, cli)
+		hcv1, err := tests.GetHCO(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+
 		converted := &hcov1.HyperConverged{}
 		Expect(hcv1beta1.ConvertTo(converted)).To(Succeed())
 
@@ -137,7 +139,9 @@ func restoreFGsToDefault(ctx context.Context, cl client.Client) {
 	patch := fmt.Appendf(nil, removePathPatchTmplt, "/spec/featureGates")
 
 	Eventually(func(g Gomega, ctx context.Context) {
-		hco := tests.GetHCO(ctx, cl)
+		hco, err := tests.GetHCO(ctx, cl)
+		g.Expect(err).ToNot(HaveOccurred())
+
 		if len(hco.Spec.FeatureGates) == 0 {
 			return
 		}
@@ -149,7 +153,10 @@ func restoreFGsToDefault(ctx context.Context, cl client.Client) {
 		Should(Succeed())
 
 	Eventually(func(g Gomega, ctx context.Context) {
-		hcv1beta1 = tests.GetHCOv1beta1(ctx, cl)
+		var err error
+		hcv1beta1, err = tests.GetHCOv1beta1(ctx, cl)
+		g.Expect(err).NotTo(HaveOccurred())
+
 		v1beta1FGStatus := getCurrentV1Beta1FGStatus(hcv1beta1.Spec.FeatureGates)
 		defaultFGs := featuregates.HyperConvergedFeatureGates{}
 

--- a/tests/func-tests/conversion_test.go
+++ b/tests/func-tests/conversion_test.go
@@ -31,17 +31,17 @@ var _ = Describe("check v1 <=> v1beta1 API conversion", func() {
 		cli = tests.GetControllerRuntimeClient()
 	})
 
-	It("naively read HCO in v1 format", func(ctx context.Context) {
-		hcv1 := &hcov1.HyperConverged{
+	It("naively read HCO in v1beta1 format", func(ctx context.Context) {
+		hcv1beta1 := &hcov1beta1.HyperConverged{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      hcoutil.HyperConvergedName,
 				Namespace: tests.InstallNamespace,
 			},
 		}
 
-		Expect(cli.Get(ctx, hcKey, hcv1)).To(Succeed())
+		Expect(cli.Get(ctx, hcKey, hcv1beta1)).To(Succeed())
 
-		hcv1beta1 := tests.GetHCO(ctx, cli)
+		hcv1 := tests.GetHCO(ctx, cli)
 		converted := &hcov1.HyperConverged{}
 		Expect(hcv1beta1.ConvertTo(converted)).To(Succeed())
 
@@ -62,29 +62,29 @@ var _ = Describe("check v1 <=> v1beta1 API conversion", func() {
 		}
 	})
 
-	It("should allow set fields in HyperConverged v1", func(ctx context.Context) {
+	It("should allow set fields in HyperConverged v1beta1", func(ctx context.Context) {
 		By("Make sure feature gates are with default values")
 		restoreFGsToDefault(ctx, cli)
 
-		By("read HyperConverged in v1 format, then update two FGs")
+		By("read HyperConverged in v1beta1 format, then update two FGs")
 		Eventually(func(g Gomega, ctx context.Context) {
-			hcv1 := &hcov1.HyperConverged{}
-			g.Expect(cli.Get(ctx, hcKey, hcv1)).To(Succeed())
+			hcv1beta1 := &hcov1beta1.HyperConverged{}
+			g.Expect(cli.Get(ctx, hcKey, hcv1beta1)).To(Succeed())
 
-			hcv1.Spec.FeatureGates.Disable("videoConfig")
-			hcv1.Spec.FeatureGates.Enable("downwardMetrics")
+			hcv1beta1.Spec.FeatureGates.VideoConfig = new(false)
+			hcv1beta1.Spec.FeatureGates.DownwardMetrics = new(true)
 
-			g.Expect(cli.Update(ctx, hcv1)).To(Succeed())
+			g.Expect(cli.Update(ctx, hcv1beta1)).To(Succeed())
 		}).WithTimeout(60 * time.Second).
 			WithPolling(time.Second).
 			WithContext(ctx).
 			Should(Succeed())
 
-		By("read HyperConverged in v1beta1 format after the v1 update")
-		hcv1beta1 := &hcov1beta1.HyperConverged{}
-		Expect(cli.Get(ctx, hcKey, hcv1beta1)).To(Succeed())
-		Expect(hcv1beta1.Spec.FeatureGates.DownwardMetrics).To(HaveValue(BeTrueBecause("downwardMetrics was enabled using v1 API. it is expected to be 'true' in v1beta1, but it's not'")))
-		Expect(hcv1beta1.Spec.FeatureGates.VideoConfig).To(HaveValue(BeFalseBecause("videoConfig was disabled using v1 API. it is expected to be 'false' in v1beta1, but it's not'")))
+		By("read HyperConverged in v1 format after the v1beta1 update")
+		hcv1 := &hcov1.HyperConverged{}
+		Expect(cli.Get(ctx, hcKey, hcv1)).To(Succeed())
+		Expect(hcv1.Spec.FeatureGates.IsEnabled("downwardMetrics")).To(BeTrueBecause("downwardMetrics was enabled using v1beta1 API. it is expected to be 'true' in v1, but it's not'"))
+		Expect(hcv1.Spec.FeatureGates.IsEnabled("videoConfig")).To(BeFalseBecause("videoConfig was disabled using v1beta1 API. it is expected to be 'false' in v1, but it's not'"))
 
 		DeferCleanup(func(ctx context.Context) {
 			By("restore the FGs")
@@ -134,9 +134,14 @@ func restoreFGsToDefault(ctx context.Context, cl client.Client) {
 	GinkgoHelper()
 
 	hcv1beta1 := &hcov1beta1.HyperConverged{}
-	patch := []byte(fmt.Sprintf(removePathPatchTmplt, "/spec/featureGates"))
+	patch := fmt.Appendf(nil, removePathPatchTmplt, "/spec/featureGates")
 
 	Eventually(func(g Gomega, ctx context.Context) {
+		hco := tests.GetHCO(ctx, cl)
+		if len(hco.Spec.FeatureGates) == 0 {
+			return
+		}
+
 		g.Expect(tests.PatchHCO(ctx, cl, patch)).To(Succeed())
 	}).WithTimeout(2 * time.Second).
 		WithPolling(500 * time.Millisecond).
@@ -144,7 +149,7 @@ func restoreFGsToDefault(ctx context.Context, cl client.Client) {
 		Should(Succeed())
 
 	Eventually(func(g Gomega, ctx context.Context) {
-		hcv1beta1 = tests.GetHCO(ctx, cl)
+		hcv1beta1 = tests.GetHCOv1beta1(ctx, cl)
 		v1beta1FGStatus := getCurrentV1Beta1FGStatus(hcv1beta1.Spec.FeatureGates)
 		defaultFGs := featuregates.HyperConvergedFeatureGates{}
 

--- a/tests/func-tests/debugFuncs_test.go
+++ b/tests/func-tests/debugFuncs_test.go
@@ -7,21 +7,22 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 )
 
 // printHyperConverged returns a function to print the HyperConverged CR in JSOn format. It is a lazy initialization,
 // so it won't be called unless there is a failure and the output is needed.
-func marshalHyperConverged(hc *v1beta1.HyperConverged) string {
+func marshalHyperConverged(hc *hcov1.HyperConverged) string {
 	ginkgo.GinkgoHelper()
 
 	if hc == nil {
 		return "<nil>"
 	}
 
-	hc.ManagedFields = nil // remove noise
+	hcCopy := hc.DeepCopy()
+	hcCopy.ManagedFields = nil // remove noise
 
-	hcYAML, err := yaml.Marshal(hc)
+	hcYAML, err := yaml.Marshal(hcCopy)
 	Expect(err).NotTo(HaveOccurred())
 
 	return string(hcYAML)
@@ -29,7 +30,7 @@ func marshalHyperConverged(hc *v1beta1.HyperConverged) string {
 
 // PrintHyperConverged returns a function to print the HyperConverged CR in JSOn format. It is a lazy initialization,
 // so it won't be called unless there is a failure and the output is needed.
-func PrintHyperConverged(hc *v1beta1.HyperConverged) func() string {
+func PrintHyperConverged(hc *hcov1.HyperConverged) func() string {
 	return func() string {
 		hcYAML := marshalHyperConverged(hc)
 		return fmt.Sprintf("Current HyperConverged CR:\n%s\n", hcYAML)
@@ -38,7 +39,7 @@ func PrintHyperConverged(hc *v1beta1.HyperConverged) func() string {
 
 // PrintHyperConvergedBecause returns a function to print the HyperConverged CR in JSOn format. It is a lazy initialization,
 // so it won't be called unless there is a failure and the output is needed.
-func PrintHyperConvergedBecause(hc *v1beta1.HyperConverged, format string, args ...any) func() string {
+func PrintHyperConvergedBecause(hc *hcov1.HyperConverged, format string, args ...any) func() string {
 	return func() string {
 		format += "; current HyperConverged CR:\n%s\n"
 		hcYAML := marshalHyperConverged(hc)
@@ -51,26 +52,11 @@ func PrintHyperConvergedBecause(hc *v1beta1.HyperConverged, format string, args 
 // PrintOrigAndCurrentHyperConvergeds returns a function to print two phases of the HyperConverged CR in JSOn
 // format: one before the test. and one as it is now. It is a lazy initialization, so it won't be called unless there is
 // a failure and the output is needed.
-func PrintOrigAndCurrentHyperConvergeds(orig, modified *v1beta1.HyperConverged) func() string {
+func PrintOrigAndCurrentHyperConvergeds(orig, modified *hcov1.HyperConverged) func() string {
 	return func() string {
 		origHCStr := marshalHyperConverged(orig)
 		modifiedHCStr := marshalHyperConverged(modified)
 
 		return fmt.Sprintf("Original HC CR:\n%s\nModified HC CR:\n%s\n", origHCStr, modifiedHCStr)
-	}
-}
-
-// PrintOrigAndCurrentHyperConvergedsBecause returns a function to print two phases of the HyperConverged CR in JSOn
-// format: one before the test. and one as it is now. It is a lazy initialization, so it won't be called unless there is
-// a failure and the output is needed.
-func PrintOrigAndCurrentHyperConvergedsBecause(orig, modified *v1beta1.HyperConverged, format string, args ...any) func() string {
-	return func() string {
-		origHCStr := marshalHyperConverged(orig)
-		modifiedHCStr := marshalHyperConverged(modified)
-
-		format += "; original HC CR:\n%s\nModified HC CR:\n%s\n"
-
-		args = append(args, origHCStr, modifiedHCStr)
-		return fmt.Sprintf(format, args...)
 	}
 }

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -48,7 +48,9 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
+
 				g.Expect(reflect.DeepEqual(hc.Spec.Security.CertConfig, defaultCertConfig)).To(BeTrue(), "certConfig should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
@@ -82,8 +84,10 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 		It("Check that featureGates defaults are behaving as expected", func(ctx context.Context) {
 			patch := fmt.Appendf(nil, removePathPatchTmplt, "/spec/featureGates")
-			Eventually(func(ctx context.Context) error {
-				hc := tests.GetHCO(ctx, cli)
+			Eventually(func(g Gomega, ctx context.Context) error {
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
+
 				if len(hc.Spec.FeatureGates) == 0 {
 					return nil
 				}
@@ -91,7 +95,8 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				for fgName, matcher := range defaultFeatureGates {
 					g.Expect(hc.Spec.FeatureGates.IsEnabled(fgName)).To(matcher)
@@ -117,7 +122,9 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
+
 				g.Expect(reflect.DeepEqual(hc.Spec.Virtualization.LiveMigrationConfig, defaultLiveMigrationConfig)).To(BeTrue(), "liveMigrationConfig should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
@@ -143,7 +150,9 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
+
 				g.Expect(hc.Spec.Virtualization.VmiCPUAllocationRatio).To(HaveValue(Equal(defaultVmiCPUAllocationRatio)), "VmiCPUAllocationRatio should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
@@ -167,7 +176,9 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
+
 				g.Expect(reflect.DeepEqual(hc.Spec.Virtualization.WorkloadUpdateStrategy, defaultWorkloadUpdateStrategy)).To(BeTrue(), "workloadUpdateStrategy should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
@@ -190,7 +201,9 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
+
 				g.Expect(hc.Spec.Deployment.UninstallStrategy).To(Equal(defaultUninstallStrategy), "uninstallStrategy should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
@@ -213,7 +226,9 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
+
 				g.Expect(reflect.DeepEqual(hc.Spec.Virtualization.VirtualMachineOptions, defaultVirtualMachineOptions)).To(BeTrue(), "virtualMachineOptions should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
@@ -237,7 +252,9 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
+
 				g.Expect(reflect.DeepEqual(hc.Spec.Virtualization.HigherWorkloadDensity, defaultHigherWorkloadDensity)).To(BeTrue(), "HigherWorkloadDensity should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -8,12 +8,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
@@ -43,120 +42,113 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 		}
 
 		DescribeTable("Check that certConfig defaults are behaving as expected", func(ctx context.Context, path string) {
-			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
 			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.CertConfig, defaultCertConfig)).To(BeTrue(), "certConfig should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.Security.CertConfig, defaultCertConfig)).To(BeTrue(), "certConfig should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
-			Entry("when removing /spec/certConfig/ca/duration", "/spec/certConfig/ca/duration"),
-			Entry("when removing /spec/certConfig/ca/renewBefore", "/spec/certConfig/ca/renewBefore"),
-			Entry("when removing /spec/certConfig/ca", "/spec/certConfig/ca"),
-			Entry("when removing /spec/certConfig/server/duration", "/spec/certConfig/server/duration"),
-			Entry("when removing /spec/certConfig/server/renewBefore", "/spec/certConfig/server/renewBefore"),
-			Entry("when removing /spec/certConfig/server", "/spec/certConfig/server"),
-			Entry("when removing /spec/certConfig", "/spec/certConfig"),
+			Entry("when removing /spec/security/certConfig/ca/duration", "/spec/security/certConfig/ca/duration"),
+			Entry("when removing /spec/security/certConfig/ca/renewBefore", "/spec/security/certConfig/ca/renewBefore"),
+			Entry("when removing /spec/security/certConfig/ca", "/spec/security/certConfig/ca"),
+			Entry("when removing /spec/security/certConfig/server/duration", "/spec/security/certConfig/server/duration"),
+			Entry("when removing /spec/security/certConfig/server/renewBefore", "/spec/security/certConfig/server/renewBefore"),
+			Entry("when removing /spec/security/certConfig/server", "/spec/security/certConfig/server"),
+			Entry("when removing /spec/security/certConfig", "/spec/security/certConfig"),
+			Entry("when removing /spec/security", "/spec/security"),
 			Entry("when removing /spec", "/spec"),
 		)
 	})
 
 	Context("feature gate defaults", func() {
-		defaultFeatureGates := v1beta1.HyperConvergedFeatureGates{
-			DownwardMetrics:                ptr.To(false),
-			DeployKubeSecondaryDNS:         ptr.To(false),
-			DisableMDevConfiguration:       ptr.To(false),
-			PersistentReservation:          ptr.To(false),
-			AlignCPUs:                      ptr.To(false),
-			EnableMultiArchBootImageImport: ptr.To(false),
-			DecentralizedLiveMigration:     ptr.To(true),
-			DeclarativeHotplugVolumes:      ptr.To(false),
-			VideoConfig:                    ptr.To(true),
-			ObjectGraph:                    ptr.To(false),
-			IncrementalBackup:              ptr.To(false),
-			ContainerPathVolumes:           ptr.To(false),
+		defaultFeatureGates := map[string]gomegatypes.GomegaMatcher{
+			"downwardMetrics":                BeFalseBecause("the downwardMetrics feature gate should be disabled by default"),
+			"deployKubeSecondaryDNS":         BeFalseBecause("the deployKubeSecondaryDNS feature gate should be disabled by default"),
+			"disableMDevConfiguration":       BeFalseBecause("the disableMDevConfiguration feature gate should be disabled by default"),
+			"persistentReservation":          BeFalseBecause("the persistentReservation feature gate should be disabled by default"),
+			"alignCPUs":                      BeFalseBecause("the alignCPUs feature gate should be disabled by default"),
+			"enableMultiArchBootImageImport": BeFalseBecause("the enableMultiArchBootImageImport feature gate should be disabled by default"),
+			"decentralizedLiveMigration":     BeTrueBecause("the decentralizedLiveMigration feature gate should be enabled by default"),
+			"declarativeHotplugVolumes":      BeFalseBecause("the declarativeHotplugVolumes feature gate should be disabled by default"),
+			"videoConfig":                    BeTrueBecause("the videoConfig feature gate should be enabled by default"),
+			"objectGraph":                    BeFalseBecause("the objectGraph feature gate should be disabled by default"),
+			"incrementalBackup":              BeFalseBecause("the incrementalBackup feature gate should be disabled by default"),
+			"containerPathVolumes":           BeFalseBecause("the containerPathVolumes feature gate should be disabled by default"),
 		}
 
-		DescribeTable("Check that featureGates defaults are behaving as expected", func(ctx context.Context, path string) {
-			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+		It("Check that featureGates defaults are behaving as expected", func(ctx context.Context) {
+			patch := fmt.Appendf(nil, removePathPatchTmplt, "/spec/featureGates")
 			Eventually(func(ctx context.Context) error {
+				hc := tests.GetHCO(ctx, cli)
+				if len(hc.Spec.FeatureGates) == 0 {
+					return nil
+				}
 				return tests.PatchHCO(ctx, cli, patch)
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.FeatureGates, defaultFeatureGates)).To(BeTrue(), "featureGates should be equal to default")
+
+				for fgName, matcher := range defaultFeatureGates {
+					g.Expect(hc.Spec.FeatureGates.IsEnabled(fgName)).To(matcher)
+				}
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
-		},
-			Entry("when removing /spec/featureGates/downwardMetrics", "/spec/featureGates/downwardMetrics"),
-			Entry("when removing /spec/featureGates/deployKubeSecondaryDNS", "/spec/featureGates/deployKubeSecondaryDNS"),
-			Entry("when removing /spec/featureGates/persistentReservation", "/spec/featureGates/persistentReservation"),
-			Entry("when removing /spec/featureGates/alignCPUs", "/spec/featureGates/alignCPUs"),
-			Entry("when removing /spec/featureGates/enableMultiArchBootImageImport", "/spec/featureGates/enableMultiArchBootImageImport"),
-			Entry("when removing /spec/featureGates/decentralizedLiveMigration", "/spec/featureGates/decentralizedLiveMigration"),
-			Entry("when removing /spec/featureGates/declarativeHotplugVolumes", "/spec/featureGates/declarativeHotplugVolumes"),
-			Entry("when removing /spec/featureGates/videoConfig", "/spec/featureGates/videoConfig"),
-			Entry("when removing /spec/featureGates/objectGraph", "/spec/featureGates/objectGraph"),
-			Entry("when removing /spec/featureGates/incrementalBackup", "/spec/featureGates/incrementalBackup"),
-			Entry("when removing /spec/featureGates/containerPathVolumes", "/spec/featureGates/containerPathVolumes"),
-			Entry("when removing /spec/featureGates", "/spec/featureGates"),
-			Entry("when removing /spec", "/spec"),
-		)
+		})
 	})
 
 	Context("liveMigrationConfig defaults", func() {
 		defaultLiveMigrationConfig := hcov1.LiveMigrationConfigurations{
-			AllowAutoConverge:                 ptr.To(false),
-			AllowPostCopy:                     ptr.To(false),
-			CompletionTimeoutPerGiB:           ptr.To(int64(150)),
-			ParallelMigrationsPerCluster:      ptr.To(uint32(5)),
-			ParallelOutboundMigrationsPerNode: ptr.To(uint32(2)),
-			ProgressTimeout:                   ptr.To(int64(150)),
+			AllowAutoConverge:                 new(false),
+			AllowPostCopy:                     new(false),
+			CompletionTimeoutPerGiB:           new(int64(150)),
+			ParallelMigrationsPerCluster:      new(uint32(5)),
+			ParallelOutboundMigrationsPerNode: new(uint32(2)),
+			ProgressTimeout:                   new(int64(150)),
 		}
 
 		DescribeTable("Check that liveMigrationConfig defaults are behaving as expected", func(ctx context.Context, path string) {
-			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
 			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.LiveMigrationConfig, defaultLiveMigrationConfig)).To(BeTrue(), "liveMigrationConfig should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.Virtualization.LiveMigrationConfig, defaultLiveMigrationConfig)).To(BeTrue(), "liveMigrationConfig should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
-			Entry("when removing /spec/liveMigrationConfig/allowAutoConverge", "/spec/liveMigrationConfig/allowAutoConverge"),
-			Entry("when removing /spec/liveMigrationConfig/allowPostCopy", "/spec/liveMigrationConfig/allowPostCopy"),
-			Entry("when removing /spec/liveMigrationConfig/completionTimeoutPerGiB", "/spec/liveMigrationConfig/completionTimeoutPerGiB"),
-			Entry("when removing /spec/liveMigrationConfig/parallelMigrationsPerCluster", "/spec/liveMigrationConfig/parallelMigrationsPerCluster"),
-			Entry("when removing /spec/liveMigrationConfig/parallelOutboundMigrationsPerNode", "/spec/liveMigrationConfig/parallelOutboundMigrationsPerNode"),
-			Entry("when removing /spec/liveMigrationConfig/progressTimeout", "/spec/liveMigrationConfig/progressTimeout"),
-			Entry("when removing /spec/liveMigrationConfig", "/spec/liveMigrationConfig"),
+			Entry("when removing /spec/virtualization/liveMigrationConfig/allowAutoConverge", "/spec/virtualization/liveMigrationConfig/allowAutoConverge"),
+			Entry("when removing /spec/virtualization/liveMigrationConfig/allowPostCopy", "/spec/virtualization/liveMigrationConfig/allowPostCopy"),
+			Entry("when removing /spec/virtualization/liveMigrationConfig/completionTimeoutPerGiB", "/spec/virtualization/liveMigrationConfig/completionTimeoutPerGiB"),
+			Entry("when removing /spec/virtualization/liveMigrationConfig/parallelMigrationsPerCluster", "/spec/virtualization/liveMigrationConfig/parallelMigrationsPerCluster"),
+			Entry("when removing /spec/virtualization/liveMigrationConfig/parallelOutboundMigrationsPerNode", "/spec/virtualization/liveMigrationConfig/parallelOutboundMigrationsPerNode"),
+			Entry("when removing /spec/virtualization/liveMigrationConfig/progressTimeout", "/spec/virtualization/liveMigrationConfig/progressTimeout"),
+			Entry("when removing /spec/virtualization/liveMigrationConfig", "/spec/virtualization/liveMigrationConfig"),
+			Entry("when removing /spec/virtualization", "/spec/virtualization"),
 			Entry("when removing /spec", "/spec"),
 		)
 	})
 
-	Context("resourceRequirements defaults", func() {
-		defaultResourceRequirements := v1beta1.OperandResourceRequirements{
-			VmiCPUAllocationRatio: ptr.To(10),
-		}
+	Context("VmiCPUAllocationRatio defaults", func() {
+		const defaultVmiCPUAllocationRatio = 10
 
 		DescribeTable("Check that resourceRequirements defaults are behaving as expected", func(ctx context.Context, path string) {
-			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
 			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
 			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.ResourceRequirements, &defaultResourceRequirements)).To(BeTrue(), "resourceRequirements should be equal to default")
+				g.Expect(hc.Spec.Virtualization.VmiCPUAllocationRatio).To(HaveValue(Equal(defaultVmiCPUAllocationRatio)), "VmiCPUAllocationRatio should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
-			Entry("when removing /spec/resourceRequirements/vmiCPUAllocationRatio", "/spec/resourceRequirements/vmiCPUAllocationRatio"),
-			Entry("when removing /spec/resourceRequirements", "/spec/resourceRequirements"),
+			Entry("when removing /spec/virtualization/vmiCPUAllocationRatio", "/spec/virtualization/vmiCPUAllocationRatio"),
+			Entry("when removing /spec/virtualization", "/spec/virtualization"),
 			Entry("when removing /spec", "/spec"),
 		)
 	})
@@ -164,68 +156,71 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 	Context("workloadUpdateStrategy defaults", func() {
 		defaultWorkloadUpdateStrategy := hcov1.HyperConvergedWorkloadUpdateStrategy{
 			BatchEvictionInterval: &metav1.Duration{Duration: time.Minute},
-			BatchEvictionSize:     ptr.To(10),
+			BatchEvictionSize:     new(10),
 			WorkloadUpdateMethods: []string{"LiveMigrate"},
 		}
 
 		DescribeTable("Check that workloadUpdateStrategy defaults are behaving as expected", func(ctx context.Context, path string) {
-			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
 			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
 			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.WorkloadUpdateStrategy, defaultWorkloadUpdateStrategy)).To(BeTrue(), "workloadUpdateStrategy should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.Virtualization.WorkloadUpdateStrategy, defaultWorkloadUpdateStrategy)).To(BeTrue(), "workloadUpdateStrategy should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
-			Entry("when removing /spec/workloadUpdateStrategy/batchEvictionInterval", "/spec/workloadUpdateStrategy/batchEvictionInterval"),
-			Entry("when removing /spec/workloadUpdateStrategy/batchEvictionSize", "/spec/workloadUpdateStrategy/batchEvictionSize"),
-			Entry("when removing /spec/workloadUpdateStrategy/workloadUpdateMethods", "/spec/workloadUpdateStrategy/workloadUpdateMethods"),
-			Entry("when removing /spec/workloadUpdateStrategy", "/spec/workloadUpdateStrategy"),
+			Entry("when removing /spec/virtualization/workloadUpdateStrategy/batchEvictionInterval", "/spec/virtualization/workloadUpdateStrategy/batchEvictionInterval"),
+			Entry("when removing /spec/virtualization/workloadUpdateStrategy/batchEvictionSize", "/spec/virtualization/workloadUpdateStrategy/batchEvictionSize"),
+			Entry("when removing /spec/virtualization/workloadUpdateStrategy/workloadUpdateMethods", "/spec/virtualization/workloadUpdateStrategy/workloadUpdateMethods"),
+			Entry("when removing /spec/virtualization/workloadUpdateStrategy", "/spec/virtualization/workloadUpdateStrategy"),
+			Entry("when removing /spec/virtualization", "/spec/virtualization"),
 			Entry("when removing /spec", "/spec"),
 		)
 	})
 
 	Context("uninstallStrategy defaults", func() {
-		const defaultUninstallStrategy = `BlockUninstallIfWorkloadsExist`
+		const defaultUninstallStrategy = hcov1.HyperConvergedUninstallStrategyBlockUninstallIfWorkloadsExist
 
 		DescribeTable("Check that uninstallStrategy default is behaving as expected", func(ctx context.Context, path string) {
-			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
 			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(hc.Spec.UninstallStrategy).To(Equal(hcov1.HyperConvergedUninstallStrategy(defaultUninstallStrategy)), "uninstallStrategy should be equal to default")
+				g.Expect(hc.Spec.Deployment.UninstallStrategy).To(Equal(defaultUninstallStrategy), "uninstallStrategy should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
-			Entry("when removing /spec/uninstallStrategy", "/spec/uninstallStrategy"),
+			Entry("when removing /spec/deployment/uninstallStrategy", "/spec/deployment/uninstallStrategy"),
+			Entry("when removing /spec/deployment", "/spec/deployment"),
 			Entry("when removing /spec", "/spec"),
 		)
 	})
 
 	Context("VirtualMachineOptions defaults", func() {
-		defaultVirtualMachineOptions := &v1beta1.VirtualMachineOptions{
-			DisableFreePageReporting: ptr.To(false),
-			DisableSerialConsoleLog:  ptr.To(false),
+		defaultVirtualMachineOptions := &hcov1.VirtualMachineOptions{
+			DisableFreePageReporting: new(false),
+			DisableSerialConsoleLog:  new(false),
 		}
 
 		DescribeTable("Check that featureGates defaults are behaving as expected", func(ctx context.Context, path string) {
-			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
 			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.VirtualMachineOptions, defaultVirtualMachineOptions)).To(BeTrue(), "virtualMachineOptions should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.Virtualization.VirtualMachineOptions, defaultVirtualMachineOptions)).To(BeTrue(), "virtualMachineOptions should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
-			Entry("when removing /spec/virtualMachineOptions/disableFreePageReporting", "/spec/virtualMachineOptions/disableFreePageReporting"),
-			Entry("when removing /spec/virtualMachineOptions/disableSerialConsoleLog", "/spec/virtualMachineOptions/disableSerialConsoleLog"),
-			Entry("when removing /spec/virtualMachineOptions", "/spec/virtualMachineOptions"),
+			Entry("when removing /spec/virtualization/virtualMachineOptions/disableFreePageReporting", "/spec/virtualization/virtualMachineOptions/disableFreePageReporting"),
+			Entry("when removing /spec/virtualization/virtualMachineOptions/disableSerialConsoleLog", "/spec/virtualization/virtualMachineOptions/disableSerialConsoleLog"),
+			Entry("when removing /spec/virtualization/virtualMachineOptions", "/spec/virtualization/virtualMachineOptions"),
+			Entry("when removing /spec/virtualization", "/spec/virtualization"),
 			Entry("when removing /spec", "/spec"),
 		)
 	})
@@ -236,18 +231,19 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 		}
 
 		DescribeTable("Check that HigherWorkloadDensity defaults are behaving as expected", func(ctx context.Context, path string) {
-			patch := []byte(fmt.Sprintf(removePathPatchTmplt, path))
+			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
 			Eventually(func(ctx context.Context) error {
 				return tests.PatchHCO(ctx, cli, patch)
 			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
-				g.Expect(reflect.DeepEqual(hc.Spec.HigherWorkloadDensity, defaultHigherWorkloadDensity)).To(BeTrue(), "HigherWorkloadDensity should be equal to default")
+				g.Expect(reflect.DeepEqual(hc.Spec.Virtualization.HigherWorkloadDensity, defaultHigherWorkloadDensity)).To(BeTrue(), "HigherWorkloadDensity should be equal to default")
 			}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		},
-			Entry("when removing /spec/higherWorkloadDensity/memoryOvercommitPercentage", "/spec/higherWorkloadDensity/memoryOvercommitPercentage"),
-			Entry("when removing /spec/higherWorkloadDensity", "/spec/higherWorkloadDensity"),
+			Entry("when removing /spec/virtualization/higherWorkloadDensity/memoryOvercommitPercentage", "/spec/virtualization/higherWorkloadDensity/memoryOvercommitPercentage"),
+			Entry("when removing /spec/virtualization/higherWorkloadDensity", "/spec/virtualization/higherWorkloadDensity"),
+			Entry("when removing /spec/virtualization", "/spec/virtualization"),
 			Entry("when removing /spec", "/spec"),
 		)
 	})

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -117,7 +117,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 	})
 
 	It("make sure the enabler is set", func(ctx context.Context) {
-		hco := tests.GetHCO(ctx, cli)
+		hco, err := tests.GetHCO(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+
 		Expect(hco.Spec.WorkloadSources.EnableCommonBootImageImport).To(HaveValue(BeTrue()))
 	})
 
@@ -138,7 +140,8 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 		It("should have all the images in the HyperConverged status", func(ctx context.Context) {
 			Eventually(func(g Gomega, ctx context.Context) []string {
-				hco := tests.GetHCO(ctx, cli)
+				hco, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				g.Expect(hco.Status.DataImportCronTemplates).To(HaveLen(len(expectedImages)))
 
@@ -231,8 +234,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		})
 
 		It("should have no images in the HyperConverged status", func(ctx context.Context) {
-			Eventually(func(ctx context.Context) []hcov1.DataImportCronTemplateStatus {
-				hco := tests.GetHCO(ctx, cli)
+			Eventually(func(g Gomega, ctx context.Context) []hcov1.DataImportCronTemplateStatus {
+				hco, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 				return hco.Status.DataImportCronTemplates
 			}).WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(BeEmpty())
 		})
@@ -282,8 +286,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		})
 
 		It("should have all the images in the HyperConverged status", func(ctx context.Context) {
-			Eventually(func(ctx context.Context) []hcov1.DataImportCronTemplateStatus {
-				hco := tests.GetHCO(ctx, cli)
+			Eventually(func(g Gomega, ctx context.Context) []hcov1.DataImportCronTemplateStatus {
+				hco, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
+
 				return hco.Status.DataImportCronTemplates
 			}).WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(HaveLen(len(expectedImages)))
 		})
@@ -302,7 +308,8 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 		AfterEach(func(ctx context.Context) {
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				// make sure there no user-defined DICT
 				if len(hc.Spec.WorkloadSources.DataImportCronTemplates) > 0 {
@@ -318,14 +325,16 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 		It("should add missing annotation in the DICT", func(ctx context.Context) {
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{
 					getDICT(),
 				}
 
 				tests.UpdateHCORetry(ctx, cli, hc)
-				newHC := tests.GetHCO(ctx, cli)
+				newHC, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				g.Expect(newHC.Spec.WorkloadSources.DataImportCronTemplates).To(HaveLen(1))
 				g.Expect(newHC.Spec.WorkloadSources.DataImportCronTemplates[0].Annotations).To(HaveKeyWithValue(cdiImmediateBindAnnotation, "true"), "should add the missing annotation")
@@ -334,7 +343,8 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 		It("should not change existing annotation in the DICT", func(ctx context.Context) {
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{
 					getDICT(),
@@ -345,7 +355,8 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 				}
 
 				tests.UpdateHCORetry(ctx, cli, hc)
-				newHC := tests.GetHCO(ctx, cli)
+				newHC, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				g.Expect(newHC.Spec.WorkloadSources.DataImportCronTemplates).To(HaveLen(1))
 				g.Expect(newHC.Spec.WorkloadSources.DataImportCronTemplates[0].Annotations).To(HaveKeyWithValue(cdiImmediateBindAnnotation, "false"), "should not change existing annotation")
@@ -383,7 +394,8 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			removeCustomDICTFromHC(ctx, cli)
 
 			Eventually(func(g Gomega, ctx context.Context) {
-				origHC = tests.GetHCO(ctx, cli)
+				origHC, err = tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				for _, dictStatus := range origHC.Status.DataImportCronTemplates {
 					g.Expect(dictStatus.Status.OriginalSupportedArchitectures).ToNot(Equal(""), "the originalSupportedArchitectures field is not set in the status of DICT %q", dictStatus.Name)
@@ -394,8 +406,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 				Should(Succeed(), tests.PrintHyperConvergedBecause(origHC, "the dictStatus.Status.OriginalSupportedArchitectures field should not be empty"))
 
 			DeferCleanup(func(ctx context.Context) {
-				Eventually(func(ctx context.Context) error {
-					cleanupHC := tests.GetHCO(ctx, cli)
+				Eventually(func(g Gomega, ctx context.Context) error {
+					cleanupHC, err := tests.GetHCO(ctx, cli)
+					g.Expect(err).NotTo(HaveOccurred())
+
 					var patch []byte
 					idx := slices.IndexFunc(cleanupHC.Spec.FeatureGates, func(fg featuregates.FeatureGate) bool {
 						return fg.Name == goldenimages.EnableMultiArchFeatureGate
@@ -415,7 +429,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		})
 
 		It("should have the architectures in the HCO Status", func(ctx context.Context) {
-			hc := tests.GetHCO(ctx, cli)
+			hc, err := tests.GetHCO(ctx, cli)
+			Expect(err).NotTo(HaveOccurred())
+
 			Expect(hc.Status.NodeInfo.WorkloadsArchitectures).To(Equal(archs))
 		})
 
@@ -425,7 +441,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 				ssp := getSSP(ctx, cli)
 				g.Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(len(expectedImages)))
 
-				hc = tests.GetHCO(ctx, cli)
+				var err error
+				hc, err = tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				for _, dict := range ssp.Spec.CommonTemplates.DataImportCronTemplates {
 					hcoDict, exists := getHCODICT(hc, dict.Name)
@@ -460,7 +478,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 			By("adding a user define DICT to the HyperConverged CR, with some supported and some unsupported architectures")
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc = tests.GetHCO(ctx, cli)
+				var err error
+				hc, err = tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				g.Expect(hc.Status.DataImportCronTemplates).ToNot(BeEmpty())
 				hc.Status.DataImportCronTemplates[0].DataImportCronTemplate.DeepCopyInto(&hcCustomDict)
@@ -477,7 +497,6 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
-				var err error
 				_, err = tests.UpdateHCO(ctx, cli, hc)
 				g.Expect(err).ToNot(HaveOccurred(), "failed to update HCO with custom DICT")
 
@@ -523,7 +542,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 			By("modify a common DICT in the HyperConverged CR, with some supported and some unsupported architectures")
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc = tests.GetHCO(ctx, cli)
+				var err error
+				hc, err = tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				g.Expect(hc.Status.DataImportCronTemplates).ToNot(BeEmpty())
 				hc.Status.DataImportCronTemplates[0].DataImportCronTemplate.DeepCopyInto(&hcCustomDict)
@@ -541,7 +562,6 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
-				var err error
 				_, err = tests.UpdateHCO(ctx, cli, hc)
 				g.Expect(err).ToNot(HaveOccurred(), "failed to update HCO with custom DICT")
 
@@ -575,7 +595,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 			By("Check DICT in HCO status")
 			Eventually(func(g Gomega, ctx context.Context) {
-				hc = tests.GetHCO(ctx, cli)
+				var err error
+				hc, err = tests.GetHCO(ctx, cli)
+				g.Expect(err).NotTo(HaveOccurred())
+
 				idx := slices.IndexFunc(hc.Status.DataImportCronTemplates, func(d hcov1.DataImportCronTemplateStatus) bool {
 					return d.Name == hcCustomDict.Name
 				})
@@ -601,7 +624,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				By("Add a user-defined DICT to the HyperConverged CR, without the multi-arch annotation")
 				Eventually(func(g Gomega, ctx context.Context) {
-					hc = tests.GetHCO(ctx, cli)
+					var err error
+					hc, err = tests.GetHCO(ctx, cli)
+					g.Expect(err).NotTo(HaveOccurred())
 
 					g.Expect(hc.Status.DataImportCronTemplates).ToNot(BeEmpty())
 					hc.Status.DataImportCronTemplates[0].DataImportCronTemplate.DeepCopyInto(&hcCustomDict)
@@ -613,7 +638,6 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 					hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
-					var err error
 					_, err = tests.UpdateHCO(ctx, cli, hc)
 					g.Expect(err).ToNot(HaveOccurred(), "failed to update HCO with custom DICT")
 
@@ -641,7 +665,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 					Should(Succeed())
 
 				Eventually(func(g Gomega, ctx context.Context) {
-					hc = tests.GetHCO(ctx, cli)
+					var err error
+					hc, err = tests.GetHCO(ctx, cli)
+					g.Expect(err).NotTo(HaveOccurred())
+
 					idx := slices.IndexFunc(hc.Status.DataImportCronTemplates, func(d hcov1.DataImportCronTemplateStatus) bool {
 						return d.Name == "custom-dict"
 					})
@@ -668,7 +695,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				By("Add a user-defined DICT to the HyperConverged CR, with no supported architectures")
 				Eventually(func(g Gomega, ctx context.Context) {
-					hc = tests.GetHCO(ctx, cli)
+					var err error
+					hc, err = tests.GetHCO(ctx, cli)
+					g.Expect(err).NotTo(HaveOccurred())
 
 					g.Expect(hc.Status.DataImportCronTemplates).ToNot(BeEmpty())
 					hc.Status.DataImportCronTemplates[0].DataImportCronTemplate.DeepCopyInto(&hcCustomDict)
@@ -684,7 +713,6 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 					hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
-					var err error
 					_, err = tests.UpdateHCO(ctx, cli, hc)
 					g.Expect(err).ToNot(HaveOccurred(), "failed to update HCO with custom DICT")
 
@@ -709,7 +737,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				By("Check the DICT in the HC status")
 				Eventually(func(g Gomega, ctx context.Context) {
-					hc = tests.GetHCO(ctx, cli)
+					var err error
+					hc, err = tests.GetHCO(ctx, cli)
+					g.Expect(err).NotTo(HaveOccurred())
+
 					idx := slices.IndexFunc(hc.Status.DataImportCronTemplates, func(d hcov1.DataImportCronTemplateStatus) bool {
 						return d.Name == "custom-dict"
 					})
@@ -736,7 +767,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				By("modify a common DICT in the HyperConverged CR, to have no supported architectures")
 				Eventually(func(g Gomega, ctx context.Context) {
-					hc = tests.GetHCO(ctx, cli)
+					var err error
+					hc, err = tests.GetHCO(ctx, cli)
+					g.Expect(err).NotTo(HaveOccurred())
 
 					g.Expect(len(hc.Status.DataImportCronTemplates)).To(BeNumerically(">", 1))
 					hc.Status.DataImportCronTemplates[0].DataImportCronTemplate.DeepCopyInto(&hcCustomDict)
@@ -755,7 +788,6 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 					hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
-					var err error
 					_, err = tests.UpdateHCO(ctx, cli, hc)
 					g.Expect(err).ToNot(HaveOccurred(), "failed to update HCO with custom DICT")
 
@@ -781,7 +813,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				By("Check the DICT in the HC status")
 				Eventually(func(g Gomega, ctx context.Context) {
-					hc = tests.GetHCO(ctx, cli)
+					var err error
+					hc, err = tests.GetHCO(ctx, cli)
+					g.Expect(err).NotTo(HaveOccurred())
+
 					idx := slices.IndexFunc(hc.Status.DataImportCronTemplates, func(d hcov1.DataImportCronTemplateStatus) bool {
 						return d.Name == hcCustomDict.Name
 					})
@@ -809,7 +844,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				By("modify a common DICT in the HyperConverged CR, to have no supported architectures")
 				Eventually(func(g Gomega, ctx context.Context) {
-					hc = tests.GetHCO(ctx, cli)
+					var err error
+					hc, err = tests.GetHCO(ctx, cli)
+					g.Expect(err).NotTo(HaveOccurred())
 
 					g.Expect(len(hc.Status.DataImportCronTemplates)).To(BeNumerically(">", 1))
 					hc.Status.DataImportCronTemplates[0].DataImportCronTemplate.DeepCopyInto(&hcCustomDict)
@@ -824,7 +861,6 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 					hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
-					var err error
 					_, err = tests.UpdateHCO(ctx, cli, hc)
 					g.Expect(err).ToNot(HaveOccurred(), "failed to update HCO with custom DICT")
 
@@ -850,7 +886,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				By("Check the DICT in the HC status")
 				Eventually(func(g Gomega, ctx context.Context) {
-					hc := tests.GetHCO(ctx, cli)
+					var err error
+					hc, err = tests.GetHCO(ctx, cli)
+					g.Expect(err).NotTo(HaveOccurred())
+
 					idx := slices.IndexFunc(hc.Status.DataImportCronTemplates, func(d hcov1.DataImportCronTemplateStatus) bool {
 						return d.Name == hcCustomDict.Name
 					})
@@ -883,7 +922,9 @@ func removeCustomDICTFromHC(ctx context.Context, cli client.Client) {
 		Should(Or(Not(HaveOccurred()), MatchError(ContainSubstring("the server rejected our request due to an error in our request"))))
 
 	Eventually(func(g Gomega, ctx context.Context) {
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		g.Expect(err).NotTo(HaveOccurred())
+
 		g.Expect(hc.Spec.WorkloadSources.DataImportCronTemplates).To(BeEmpty(), "should have no DataImportCronTemplates in the HyperConverged CR")
 		g.Expect(hc.Status.DataImportCronTemplates).To(HaveLen(len(expectedImages)))
 

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -18,14 +18,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
 	goldenimages "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/golden-images"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
@@ -33,6 +32,8 @@ import (
 const (
 	defaultImageNamespace      = "kubevirt-os-images"
 	cdiImmediateBindAnnotation = "cdi.kubevirt.io/storage.bind.immediate.requested"
+
+	dictEnablementTemplate = `{"spec":{"workloadSources":{"enableCommonBootImageImport": %t}}}`
 )
 
 var (
@@ -117,7 +118,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 	It("make sure the enabler is set", func(ctx context.Context) {
 		hco := tests.GetHCO(ctx, cli)
-		Expect(hco.Spec.EnableCommonBootImageImport).To(HaveValue(BeTrue()))
+		Expect(hco.Spec.WorkloadSources.EnableCommonBootImageImport).To(HaveValue(BeTrue()))
 	})
 
 	Context("check default golden images", func() {
@@ -196,9 +197,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 	Context("disable the feature", func() {
 		It("Should set the FG to false", func(ctx context.Context) {
-			patch := []byte(`[{ "op": "replace", "path": "/spec/enableCommonBootImageImport", "value": false }]`)
+			patch := fmt.Appendf(nil, dictEnablementTemplate, false)
 			Eventually(func(ctx context.Context) error {
-				return tests.PatchHCO(ctx, cli, patch)
+				return tests.PatchMergeHCO(ctx, cli, patch)
 			}).WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
 		})
 
@@ -247,10 +248,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 	})
 
 	Context("enable the feature again", func() {
-		It("Should set the FG to false", func(ctx context.Context) {
-			patch := []byte(`[{ "op": "replace", "path": "/spec/enableCommonBootImageImport", "value": true }]`)
+		It("Should set the enabler to true", func(ctx context.Context) {
+			patch := fmt.Appendf(nil, dictEnablementTemplate, true)
 			Eventually(func(ctx context.Context) error {
-				return tests.PatchHCO(ctx, cli, patch)
+				return tests.PatchMergeHCO(ctx, cli, patch)
 			}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
 		})
 
@@ -304,10 +305,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 				hc := tests.GetHCO(ctx, cli)
 
 				// make sure there no user-defined DICT
-				if len(hc.Spec.DataImportCronTemplates) > 0 {
-					hc.APIVersion = "hco.kubevirt.io/v1beta1"
+				if len(hc.Spec.WorkloadSources.DataImportCronTemplates) > 0 {
+					hc.APIVersion = hcov1.APIVersion
 					hc.Kind = "HyperConverged"
-					hc.Spec.DataImportCronTemplates = nil
+					hc.Spec.WorkloadSources.DataImportCronTemplates = nil
 
 					tests.UpdateHCORetry(ctx, cli, hc)
 				}
@@ -319,15 +320,15 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
 
-				hc.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{
+				hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{
 					getDICT(),
 				}
 
 				tests.UpdateHCORetry(ctx, cli, hc)
 				newHC := tests.GetHCO(ctx, cli)
 
-				g.Expect(newHC.Spec.DataImportCronTemplates).To(HaveLen(1))
-				g.Expect(newHC.Spec.DataImportCronTemplates[0].Annotations).To(HaveKeyWithValue(cdiImmediateBindAnnotation, "true"), "should add the missing annotation")
+				g.Expect(newHC.Spec.WorkloadSources.DataImportCronTemplates).To(HaveLen(1))
+				g.Expect(newHC.Spec.WorkloadSources.DataImportCronTemplates[0].Annotations).To(HaveKeyWithValue(cdiImmediateBindAnnotation, "true"), "should add the missing annotation")
 			}).WithPolling(time.Second * 3).WithTimeout(time.Second * 60).WithContext(ctx).Should(Succeed())
 		})
 
@@ -335,19 +336,19 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc := tests.GetHCO(ctx, cli)
 
-				hc.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{
+				hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{
 					getDICT(),
 				}
 
-				hc.Spec.DataImportCronTemplates[0].Annotations = map[string]string{
+				hc.Spec.WorkloadSources.DataImportCronTemplates[0].Annotations = map[string]string{
 					cdiImmediateBindAnnotation: "false",
 				}
 
 				tests.UpdateHCORetry(ctx, cli, hc)
 				newHC := tests.GetHCO(ctx, cli)
 
-				g.Expect(newHC.Spec.DataImportCronTemplates).To(HaveLen(1))
-				g.Expect(newHC.Spec.DataImportCronTemplates[0].Annotations).To(HaveKeyWithValue(cdiImmediateBindAnnotation, "false"), "should not change existing annotation")
+				g.Expect(newHC.Spec.WorkloadSources.DataImportCronTemplates).To(HaveLen(1))
+				g.Expect(newHC.Spec.WorkloadSources.DataImportCronTemplates[0].Annotations).To(HaveKeyWithValue(cdiImmediateBindAnnotation, "false"), "should not change existing annotation")
 			}).WithPolling(time.Second * 3).WithTimeout(time.Second * 60).WithContext(ctx).Should(Succeed())
 		})
 	})
@@ -363,7 +364,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 		var (
 			archs  []string
-			origHC *hcov1beta1.HyperConverged
+			origHC *hcov1.HyperConverged
 		)
 
 		BeforeEach(func(ctx context.Context) {
@@ -372,12 +373,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			Expect(err).ToNot(HaveOccurred(), "failed to get worker nodes architectures")
 
 			GinkgoWriter.Printf("Worker nodes architectures: %v\n", archs)
-
-			const patchTmplt = `[{ "op": "replace", "path": "/spec/featureGates/enableMultiArchBootImageImport", "value": %t }]`
-			Eventually(func(ctx context.Context) error {
-				return tests.PatchHCO(ctx, cli, []byte(fmt.Sprintf(patchTmplt, true)))
-			}).WithTimeout(time.Minute).
-				WithPolling(10 * time.Second).
+			Eventually(tests.EnableFG).
+				WithArguments(ctx, cli, goldenimages.EnableMultiArchFeatureGate).
+				WithTimeout(10 * time.Second).
+				WithPolling(1 * time.Second).
 				WithContext(ctx).
 				Should(Succeed())
 
@@ -396,7 +395,16 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 			DeferCleanup(func(ctx context.Context) {
 				Eventually(func(ctx context.Context) error {
-					return tests.PatchHCO(ctx, cli, []byte(fmt.Sprintf(patchTmplt, false)))
+					cleanupHC := tests.GetHCO(ctx, cli)
+					var patch []byte
+					idx := slices.IndexFunc(cleanupHC.Spec.FeatureGates, func(fg featuregates.FeatureGate) bool {
+						return fg.Name == goldenimages.EnableMultiArchFeatureGate
+					})
+					if idx > -1 {
+						patch = fmt.Appendf(nil, `[{ "op": "remove", "path": "/spec/featureGates/%d"}]`, idx)
+						return tests.PatchHCO(ctx, cli, patch)
+					}
+					return nil
 				}).WithTimeout(hcTimeout).
 					WithPolling(hcPolling).
 					WithContext(ctx).
@@ -412,7 +420,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 		})
 
 		It("should have the architectures in the SSP CR", func(ctx context.Context) {
-			var hc *hcov1beta1.HyperConverged
+			var hc *hcov1.HyperConverged
 			Eventually(func(g Gomega, ctx context.Context) {
 				ssp := getSSP(ctx, cli)
 				g.Expect(ssp.Spec.CommonTemplates.DataImportCronTemplates).To(HaveLen(len(expectedImages)))
@@ -446,7 +454,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 		It("should have the architectures in a user-defined DICT the SSP CR", func(ctx context.Context) {
 			var (
-				hc           *hcov1beta1.HyperConverged
+				hc           *hcov1.HyperConverged
 				hcCustomDict hcov1.DataImportCronTemplate
 			)
 
@@ -465,9 +473,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 				customDictArchs := append(archs, "someOtherArch1", "someOtherArch2")
 				hcCustomDict.Annotations[goldenimages.MultiArchDICTAnnotation] = strings.Join(customDictArchs, ",")
-				hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
+				hcCustomDict.Spec.RetentionPolicy = new(cdiv1beta1.DataImportCronRetainNone)
 
-				hc.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
+				hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
 				var err error
 				_, err = tests.UpdateHCO(ctx, cli, hc)
@@ -510,7 +518,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 				hcCustomDict                   hcov1.DataImportCronTemplate
 				originalSupportedArchitectures string
 				expectedArches                 string
-				hc                             *hcov1beta1.HyperConverged
+				hc                             *hcov1.HyperConverged
 			)
 
 			By("modify a common DICT in the HyperConverged CR, with some supported and some unsupported architectures")
@@ -528,10 +536,10 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 				customDictArchs := append(archs, "someOtherArch1", "someOtherArch2")
 				testAnnotation := strings.Join(customDictArchs, ",")
 				hcCustomDict.Annotations[goldenimages.MultiArchDICTAnnotation] = testAnnotation
-				hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
+				hcCustomDict.Spec.RetentionPolicy = new(cdiv1beta1.DataImportCronRetainNone)
 				expectedArches = getExpectedArchs(testAnnotation, archs)
 
-				hc.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
+				hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
 				var err error
 				_, err = tests.UpdateHCO(ctx, cli, hc)
@@ -588,7 +596,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			It("should not implement multi-arch changes for user defined DICT", func(ctx context.Context) {
 				var (
 					hcCustomDict hcov1.DataImportCronTemplate
-					hc           *hcov1beta1.HyperConverged
+					hc           *hcov1.HyperConverged
 				)
 
 				By("Add a user-defined DICT to the HyperConverged CR, without the multi-arch annotation")
@@ -601,9 +609,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 					hcCustomDict.Name = "custom-dict"
 					hcCustomDict.Spec.ManagedDataSource = "custom-source"
 					delete(hcCustomDict.Annotations, goldenimages.MultiArchDICTAnnotation)
-					hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
+					hcCustomDict.Spec.RetentionPolicy = new(cdiv1beta1.DataImportCronRetainNone)
 
-					hc.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
+					hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
 					var err error
 					_, err = tests.UpdateHCO(ctx, cli, hc)
@@ -655,7 +663,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			It("should not add a user-defined DICT to the SSP CR", func(ctx context.Context) {
 				var (
 					hcCustomDict hcov1.DataImportCronTemplate
-					hc           *hcov1beta1.HyperConverged
+					hc           *hcov1.HyperConverged
 				)
 
 				By("Add a user-defined DICT to the HyperConverged CR, with no supported architectures")
@@ -672,9 +680,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 					}
 
 					hcCustomDict.Annotations[goldenimages.MultiArchDICTAnnotation] = "someOtherArch1,someOtherArch2"
-					hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
+					hcCustomDict.Spec.RetentionPolicy = new(cdiv1beta1.DataImportCronRetainNone)
 
-					hc.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
+					hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
 					var err error
 					_, err = tests.UpdateHCO(ctx, cli, hc)
@@ -723,7 +731,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			It("when the image was changed, should not add a customized common DICT to the SSP CR", func(ctx context.Context) {
 				var (
 					hcCustomDict hcov1.DataImportCronTemplate
-					hc           *hcov1beta1.HyperConverged
+					hc           *hcov1.HyperConverged
 				)
 
 				By("modify a common DICT in the HyperConverged CR, to have no supported architectures")
@@ -743,9 +751,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 					hcCustomDict.Spec.Template.Spec.Source.Registry = nextDICT.Spec.Template.Spec.Source.Registry.DeepCopy()
 
 					hcCustomDict.Annotations[goldenimages.MultiArchDICTAnnotation] = "someOtherArch1,someOtherArch2"
-					hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
+					hcCustomDict.Spec.RetentionPolicy = new(cdiv1beta1.DataImportCronRetainNone)
 
-					hc.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
+					hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
 					var err error
 					_, err = tests.UpdateHCO(ctx, cli, hc)
@@ -796,7 +804,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 				var (
 					hcCustomDict                   hcov1.DataImportCronTemplate
 					originalSupportedArchitectures string
-					hc                             *hcov1beta1.HyperConverged
+					hc                             *hcov1.HyperConverged
 				)
 
 				By("modify a common DICT in the HyperConverged CR, to have no supported architectures")
@@ -812,9 +820,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 					originalSupportedArchitectures = hc.Status.DataImportCronTemplates[0].Status.OriginalSupportedArchitectures
 					hcCustomDict.Annotations[goldenimages.MultiArchDICTAnnotation] = "someOtherArch1,someOtherArch2"
-					hcCustomDict.Spec.RetentionPolicy = ptr.To(cdiv1beta1.DataImportCronRetainNone)
+					hcCustomDict.Spec.RetentionPolicy = new(cdiv1beta1.DataImportCronRetainNone)
 
-					hc.Spec.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
+					hc.Spec.WorkloadSources.DataImportCronTemplates = []hcov1.DataImportCronTemplate{hcCustomDict}
 
 					var err error
 					_, err = tests.UpdateHCO(ctx, cli, hc)
@@ -870,13 +878,13 @@ func removeCustomDICTFromHC(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
 	// clear the DICTs if they exist. ignore error of not found, as it may not exist
 	Eventually(func(ctx context.Context) error {
-		return tests.PatchHCO(ctx, cli, []byte(`[{"op": "remove", "path": "/spec/dataImportCronTemplates"}]`))
+		return tests.PatchHCO(ctx, cli, []byte(`[{"op": "remove", "path": "/spec/workloadSources/dataImportCronTemplates"}]`))
 	}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).
 		Should(Or(Not(HaveOccurred()), MatchError(ContainSubstring("the server rejected our request due to an error in our request"))))
 
 	Eventually(func(g Gomega, ctx context.Context) {
 		hc := tests.GetHCO(ctx, cli)
-		g.Expect(hc.Spec.DataImportCronTemplates).To(BeEmpty(), "should have no DataImportCronTemplates in the HyperConverged CR")
+		g.Expect(hc.Spec.WorkloadSources.DataImportCronTemplates).To(BeEmpty(), "should have no DataImportCronTemplates in the HyperConverged CR")
 		g.Expect(hc.Status.DataImportCronTemplates).To(HaveLen(len(expectedImages)))
 
 		for _, dictStatus := range hc.Status.DataImportCronTemplates {
@@ -902,7 +910,7 @@ func getExpectedArchs(originalArchs string, archs []string) string {
 	return strings.Join(expectedArchs, ",")
 }
 
-func getHCODICT(hc *hcov1beta1.HyperConverged, name string) (hcov1.DataImportCronTemplateStatus, bool) {
+func getHCODICT(hc *hcov1.HyperConverged, name string) (hcov1.DataImportCronTemplateStatus, bool) {
 	for _, dict := range hc.Status.DataImportCronTemplates {
 		if dict.Name == name {
 			return dict, true
@@ -938,16 +946,16 @@ func getDICT() hcov1.DataImportCronTemplate {
 			Name: "custom",
 		},
 		Spec: &cdiv1beta1.DataImportCronSpec{
-			RetentionPolicy:   ptr.To(cdiv1beta1.DataImportCronRetainNone),
-			GarbageCollect:    ptr.To(cdiv1beta1.DataImportCronGarbageCollectOutdated),
+			RetentionPolicy:   new(cdiv1beta1.DataImportCronRetainNone),
+			GarbageCollect:    new(cdiv1beta1.DataImportCronGarbageCollectOutdated),
 			ManagedDataSource: "centos10",
 			Schedule:          "18 1/12 * * *",
 			Template: cdiv1beta1.DataVolume{
 				Spec: cdiv1beta1.DataVolumeSpec{
 					Source: &cdiv1beta1.DataVolumeSource{
 						Registry: &cdiv1beta1.DataVolumeSourceRegistry{
-							PullMethod: ptr.To(cdiv1beta1.RegistryPullNode),
-							URL:        ptr.To("docker://quay.io/containerdisks/centos-stream:10"),
+							PullMethod: new(cdiv1beta1.RegistryPullNode),
+							URL:        new("docker://quay.io/containerdisks/centos-stream:10"),
 						},
 					},
 					Storage: &cdiv1beta1.StorageSpec{

--- a/tests/func-tests/hco_prometheus_route.go
+++ b/tests/func-tests/hco_prometheus_route.go
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -182,7 +181,7 @@ func createTempRoute(ctx context.Context, cli client.Client, routeName, serviceN
 			To: openshiftroutev1.RouteTargetReference{
 				Kind:   "Service",
 				Name:   serviceName,
-				Weight: ptr.To[int32](100),
+				Weight: new(int32(100)),
 			},
 			WildcardPolicy: openshiftroutev1.WildcardPolicyNone,
 		},

--- a/tests/func-tests/hyperconverged.go
+++ b/tests/func-tests/hyperconverged.go
@@ -1,0 +1,162 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+// GetHCO reads the HCO CR from the APIServer with a DynamicClient
+func GetHCO(ctx context.Context, cli client.Client) (*hcov1.HyperConverged, error) {
+	hco := HCOWithNameOnly()
+
+	err := cli.Get(ctx, client.ObjectKeyFromObject(hco), hco)
+	if err != nil {
+		return nil, err
+	}
+
+	return hco, nil
+}
+
+// GetHCOv1beta1 reads the HCO CR from the APIServer with a DynamicClient
+func GetHCOv1beta1(ctx context.Context, cli client.Client) (*hcov1beta1.HyperConverged, error) {
+	hco := &hcov1beta1.HyperConverged{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hcoutil.HyperConvergedName,
+			Namespace: InstallNamespace,
+		},
+	}
+
+	err := cli.Get(ctx, client.ObjectKeyFromObject(hco), hco)
+	if err != nil {
+		return nil, err
+	}
+
+	return hco, nil
+}
+
+// UpdateHCORetry updates the HCO CR in a safe way internally calling UpdateHCO_old
+// UpdateHCORetry internally uses an async Eventually block refreshing the in-memory
+// object if needed and setting there Spec, Annotations, Finalizers and Labels from the
+// input object.
+// UpdateHCORetry should be preferred over UpdateHCO_old to reduce test flakiness due to
+// inevitable concurrency conflicts
+func UpdateHCORetry(ctx context.Context, cli client.Client, input *hcov1.HyperConverged) *hcov1.HyperConverged {
+	ginkgo.GinkgoHelper()
+	var output *hcov1.HyperConverged
+
+	Eventually(func(ctx context.Context) error {
+		hco, err := GetHCO(ctx, cli)
+		if err != nil {
+			return err
+		}
+
+		input.Spec.DeepCopyInto(&hco.Spec)
+		hco.Annotations = maps.Clone(input.Annotations)
+		hco.Finalizers = slices.Clone(input.Finalizers)
+		hco.Labels = maps.Clone(input.Labels)
+
+		output, err = UpdateHCO(ctx, cli, hco)
+		return err
+	}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
+
+	return output
+}
+
+// UpdateHCO updates the HCO CR using a DynamicClient, it can return errors on failures
+func UpdateHCO(ctx context.Context, cli client.Client, input *hcov1.HyperConverged) (*hcov1.HyperConverged, error) {
+	hco, err := GetHCO(ctx, cli)
+	if err != nil {
+		return nil, err
+	}
+
+	input.Spec.DeepCopyInto(&hco.Spec)
+	hco.Annotations = input.Annotations
+	hco.Finalizers = input.Finalizers
+	hco.Labels = input.Labels
+	hco.Status = hcov1.HyperConvergedStatus{} // to silence warning about unknown fields.
+
+	err = cli.Update(ctx, hco)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetHCO(ctx, cli)
+}
+
+// PatchHCO updates the HCO CR using a DynamicClient, it can return errors on failures
+func PatchHCO(ctx context.Context, cli client.Client, patchBytes []byte) error {
+	patch := client.RawPatch(types.JSONPatchType, patchBytes)
+	hco := HCOWithNameOnly()
+
+	return cli.Patch(ctx, hco, patch)
+}
+
+// PatchMergeHCO patches the HCO CR using a DynamicClient, it can return errors on failures
+func PatchMergeHCO(ctx context.Context, cli client.Client, patchBytes []byte) error {
+	patch := client.RawPatch(types.MergePatchType, patchBytes)
+	hco := HCOWithNameOnly()
+
+	return cli.Patch(ctx, hco, patch)
+}
+
+func RestoreDefaults(ctx context.Context, cli client.Client) {
+	Eventually(func(ctx context.Context) error {
+		return PatchHCO(ctx, cli, []byte(`[{"op": "replace", "path": "/spec", "value": {}}]`))
+	}).
+		WithOffset(1).
+		WithTimeout(time.Second * 5).
+		WithPolling(time.Millisecond * 100).
+		WithContext(ctx).
+		Should(Succeed())
+}
+
+func EnableFG(ctx context.Context, cli client.Client, fgName string) error {
+	hc, err := GetHCO(ctx, cli)
+	if err != nil {
+		return err
+	}
+
+	if hc.Spec.FeatureGates == nil {
+		patch := fmt.Appendf(nil, `{"spec":{"featureGates":[{"name": %q, "state": "%v"}]}}`, fgName, featuregates.Enabled)
+		return PatchMergeHCO(ctx, cli, patch)
+	}
+
+	if !hc.Spec.FeatureGates.IsEnabled(fgName) {
+		var patch []byte
+		idx := slices.IndexFunc(hc.Spec.FeatureGates, func(fg featuregates.FeatureGate) bool {
+			return fg.Name == fgName
+		})
+		if idx == -1 {
+			patch = fmt.Appendf(nil, `[{"op": "add", "path": "/spec/featureGates/-", "value": {"name": %q}}]`, fgName)
+		} else {
+			patch = fmt.Appendf(nil, `[{"op": "replace", "path": "/spec/featureGates/%d/state", "value": "%v"}]`, idx, featuregates.Enabled)
+		}
+
+		return PatchHCO(ctx, cli, patch)
+	}
+
+	return nil
+}
+
+func HCOWithNameOnly() *hcov1.HyperConverged {
+	return &hcov1.HyperConverged{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hcoutil.HyperConvergedName,
+			Namespace: InstallNamespace,
+		},
+	}
+}

--- a/tests/func-tests/hypervisors_test.go
+++ b/tests/func-tests/hypervisors_test.go
@@ -25,12 +25,16 @@ var _ = Describe("Hypervisors configuration", Label("Hypervisors"), func() {
 		cli = tests.GetControllerRuntimeClient()
 
 		tests.BeforeEach(ctx)
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+
 		initialHypervisors = hc.Spec.Virtualization.Hypervisors
 	})
 
 	AfterEach(func(ctx context.Context) {
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+
 		hc.Spec.Virtualization.Hypervisors = initialHypervisors
 		_ = tests.UpdateHCORetry(ctx, cli, hc)
 	})
@@ -47,7 +51,9 @@ var _ = Describe("Hypervisors configuration", Label("Hypervisors"), func() {
 	}
 
 	It("should propagate hypervisors to KubeVirt CR and add ConfigurableHypervisor feature gate", func(ctx context.Context) {
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+
 		hc.Spec.Virtualization.Hypervisors = []kubevirtcorev1.HypervisorConfiguration{
 			{Name: kubevirtcorev1.KvmHypervisorName},
 		}
@@ -65,7 +71,9 @@ var _ = Describe("Hypervisors configuration", Label("Hypervisors"), func() {
 	})
 
 	It("should remove hypervisors from KubeVirt CR and remove ConfigurableHypervisor FG when cleared from HCO", func(ctx context.Context) {
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+
 		hc.Spec.Virtualization.Hypervisors = []kubevirtcorev1.HypervisorConfiguration{
 			{Name: kubevirtcorev1.KvmHypervisorName},
 		}
@@ -79,7 +87,9 @@ var _ = Describe("Hypervisors configuration", Label("Hypervisors"), func() {
 			WithContext(ctx).
 			Should(Succeed())
 
-		hc = tests.GetHCO(ctx, cli)
+		hc, err = tests.GetHCO(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+
 		hc.Spec.Virtualization.Hypervisors = nil
 		_ = tests.UpdateHCORetry(ctx, cli, hc)
 

--- a/tests/func-tests/hypervisors_test.go
+++ b/tests/func-tests/hypervisors_test.go
@@ -26,12 +26,12 @@ var _ = Describe("Hypervisors configuration", Label("Hypervisors"), func() {
 
 		tests.BeforeEach(ctx)
 		hc := tests.GetHCO(ctx, cli)
-		initialHypervisors = hc.Spec.Hypervisors
+		initialHypervisors = hc.Spec.Virtualization.Hypervisors
 	})
 
 	AfterEach(func(ctx context.Context) {
 		hc := tests.GetHCO(ctx, cli)
-		hc.Spec.Hypervisors = initialHypervisors
+		hc.Spec.Virtualization.Hypervisors = initialHypervisors
 		_ = tests.UpdateHCORetry(ctx, cli, hc)
 	})
 
@@ -48,7 +48,7 @@ var _ = Describe("Hypervisors configuration", Label("Hypervisors"), func() {
 
 	It("should propagate hypervisors to KubeVirt CR and add ConfigurableHypervisor feature gate", func(ctx context.Context) {
 		hc := tests.GetHCO(ctx, cli)
-		hc.Spec.Hypervisors = []kubevirtcorev1.HypervisorConfiguration{
+		hc.Spec.Virtualization.Hypervisors = []kubevirtcorev1.HypervisorConfiguration{
 			{Name: kubevirtcorev1.KvmHypervisorName},
 		}
 		_ = tests.UpdateHCORetry(ctx, cli, hc)
@@ -66,7 +66,7 @@ var _ = Describe("Hypervisors configuration", Label("Hypervisors"), func() {
 
 	It("should remove hypervisors from KubeVirt CR and remove ConfigurableHypervisor FG when cleared from HCO", func(ctx context.Context) {
 		hc := tests.GetHCO(ctx, cli)
-		hc.Spec.Hypervisors = []kubevirtcorev1.HypervisorConfiguration{
+		hc.Spec.Virtualization.Hypervisors = []kubevirtcorev1.HypervisorConfiguration{
 			{Name: kubevirtcorev1.KvmHypervisorName},
 		}
 		_ = tests.UpdateHCORetry(ctx, cli, hc)
@@ -80,7 +80,7 @@ var _ = Describe("Hypervisors configuration", Label("Hypervisors"), func() {
 			Should(Succeed())
 
 		hc = tests.GetHCO(ctx, cli)
-		hc.Spec.Hypervisors = nil
+		hc.Spec.Virtualization.Hypervisors = nil
 		_ = tests.UpdateHCORetry(ctx, cli, hc)
 
 		Eventually(func(g Gomega, ctx context.Context) {

--- a/tests/func-tests/labels_test.go
+++ b/tests/func-tests/labels_test.go
@@ -63,7 +63,9 @@ var _ = Describe("Check that all the sub-resources have the required labels", La
 	It("should have all the required labels in all the controlled resources", func(ctx context.Context) {
 		By("checking all the labels")
 		plural := pluralize.NewClient()
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+
 		for _, resource := range hc.Status.RelatedObjects {
 			By(fmt.Sprintf("checking labels for %s/%s", resource.Kind, resource.Name))
 			parts := strings.Split(resource.APIVersion, "/")

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
@@ -212,7 +211,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 				Namespace: tests.TestNamespace,
 			},
 			Spec: kubevirtcorev1.VirtualMachineSpec{
-				RunStrategy: ptr.To(kubevirtcorev1.RunStrategyAlways),
+				RunStrategy: new(kubevirtcorev1.RunStrategyAlways),
 				Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
 					Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
 						Domain: kubevirtcorev1.DomainSpec{
@@ -464,7 +463,7 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			for gi, group := range pr.Spec.Groups {
 				for ri, rule := range group.Rules {
 					if rule.Alert == alertName && rule.For != nil {
-						pr.Spec.Groups[gi].Rules[ri].For = ptr.To(monitoringv1.Duration("0m"))
+						pr.Spec.Groups[gi].Rules[ri].For = new(monitoringv1.Duration("0m"))
 					}
 				}
 			}

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -168,7 +168,8 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 	It("UnsupportedHCOModification alert should fired when there is a jsonpatch annotation to modify an operand CRs", func(ctx context.Context) {
 		query := fmt.Sprintf(`kubevirt_hco_unsafe_modifications{annotation_name=%q}`, common.JSONPatchKVAnnotationName)
 
-		hco := tests.GetHCO(ctx, cli)
+		hco, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
 
 		hco.Annotations = map[string]string{
 			common.JSONPatchKVAnnotationName: `[{"op": "add", "path": "/spec/configuration/migrations", "value": {"allowPostCopy": true}}]`,
@@ -195,10 +196,17 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 		}).WithTimeout(prometheousTimeout).
 			WithPolling(prometheousPolling).
 			WithContext(ctx).
-			ShouldNot(BeNil(), tests.PrintHyperConvergedBecause(
-				tests.GetHCO(ctx, cli),
-				`can't find the "UnsupportedHCOModification" alert in the list of firing alerts: %s`, getAlertNames(alerts),
-			))
+			ShouldNot(BeNil(), func() func() string {
+				hc, err := tests.GetHCO(ctx, cli)
+				if err != nil {
+					return func() string {
+						return "Error reading HyperConverged CR; " + err.Error()
+					}
+				}
+				return tests.PrintHyperConvergedBecause(hc,
+					`can't find the "UnsupportedHCOModification" alert in the list of firing alerts: %s`, getAlertNames(alerts),
+				)
+			})
 	})
 
 	It("should fire the DeprecatedMachineType alert when a VM is using a deprecated machine type", func(ctx context.Context) {

--- a/tests/func-tests/network_policy_test.go
+++ b/tests/func-tests/network_policy_test.go
@@ -14,10 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
@@ -199,7 +197,7 @@ func createClientPod() *corev1.Pod {
 					Image:   "registry.fedoraproject.org/fedora:43",
 					Name:    clientPodName,
 					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
+						AllowPrivilegeEscalation: new(false),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{"ALL"},
 						},
@@ -211,9 +209,9 @@ func createClientPod() *corev1.Pod {
 			},
 			RestartPolicy: corev1.RestartPolicyAlways,
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsUser:  ptr.To[int64](1000),
-				RunAsGroup: ptr.To[int64](3000),
-				FSGroup:    ptr.To[int64](2000),
+				RunAsUser:  new(int64(1000)),
+				RunAsGroup: new(int64(3000)),
+				FSGroup:    new(int64(2000)),
 			},
 		},
 	}
@@ -247,7 +245,7 @@ nc -l -p %d; done`, testServerPort),
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
+						AllowPrivilegeEscalation: new(false),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{"ALL"},
 						},
@@ -259,9 +257,9 @@ nc -l -p %d; done`, testServerPort),
 			},
 			RestartPolicy: corev1.RestartPolicyAlways,
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsUser:  ptr.To[int64](1000),
-				RunAsGroup: ptr.To[int64](3000),
-				FSGroup:    ptr.To[int64](2000),
+				RunAsUser:  new(int64(1000)),
+				RunAsGroup: new(int64(3000)),
+				FSGroup:    new(int64(2000)),
 			},
 		},
 	}
@@ -327,13 +325,6 @@ func sendReqToTestServer(ctx context.Context, k8sClientSet *kubernetes.Clientset
 }
 
 func createAllowAllIngressNetworkPolicy() *networkingv1.NetworkPolicy {
-	hc := &hcov1beta1.HyperConverged{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      hcov1beta1.HyperConvergedName,
-			Namespace: tests.InstallNamespace,
-		},
-	}
-
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      allowAllNPPluginName,
@@ -344,7 +335,7 @@ func createAllowAllIngressNetworkPolicy() *networkingv1.NetworkPolicy {
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					hcoutil.AppLabel:          hc.Name,
+					hcoutil.AppLabel:          hcoutil.HyperConvergedName,
 					hcoutil.AppLabelComponent: string(hcoutil.AppComponentUIPlugin),
 				},
 			},
@@ -357,13 +348,6 @@ func createAllowAllIngressNetworkPolicy() *networkingv1.NetworkPolicy {
 }
 
 func createAllowAllEgressNetworkPolicy() *networkingv1.NetworkPolicy {
-	hc := &hcov1beta1.HyperConverged{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      hcov1beta1.HyperConvergedName,
-			Namespace: tests.InstallNamespace,
-		},
-	}
-
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      allowAllNPProxyName,
@@ -374,7 +358,7 @@ func createAllowAllEgressNetworkPolicy() *networkingv1.NetworkPolicy {
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					hcoutil.AppLabel:          hc.Name,
+					hcoutil.AppLabel:          hcoutil.HyperConvergedName,
 					hcoutil.AppLabelComponent: string(hcoutil.AppComponentUIProxy),
 				},
 			},

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -61,7 +61,9 @@ var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 		}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
 
 		// modify the HCO CR to use the labels we just applied to the nodes
-		originalHco := tests.GetHCO(ctx, cli)
+		originalHco, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+
 		originalHco.DeepCopyInto(hco)
 		originalNodePlacement = originalHco.Spec.Deployment.NodePlacements.DeepCopy()
 
@@ -90,7 +92,8 @@ var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 
 	AfterAll(func(ctx context.Context) {
 		// undo the modification to HCO CR done in BeforeAll stage
-		modifiedHco := tests.GetHCO(ctx, cli)
+		modifiedHco, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
 
 		modifiedHco.DeepCopyInto(hco)
 		hco.Spec.Deployment.NodePlacements = originalNodePlacement.DeepCopy()

--- a/tests/func-tests/node_placement_test.go
+++ b/tests/func-tests/node_placement_test.go
@@ -17,7 +17,7 @@ import (
 	networkaddonsv1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
@@ -29,14 +29,13 @@ const (
 
 var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:system]Node Placement", Ordered, Serial, Label(tests.HighlyAvailableClusterLabel, "nodePlacement"), func() {
 	tests.FlagParse()
-	hco := &hcov1beta1.HyperConverged{}
+	hco := &hcov1.HyperConverged{}
 	var (
-		workloadsNode        *v1.Node
-		originalInfraSpec    hcov1beta1.HyperConvergedConfig
-		originalWorkloadSpec hcov1beta1.HyperConvergedConfig
-		cli                  client.Client
-		cliSet               *kubernetes.Clientset
-		workerNodes          *v1.NodeList
+		workloadsNode         *v1.Node
+		originalNodePlacement *hcov1.NodePlacements
+		cli                   client.Client
+		cliSet                *kubernetes.Clientset
+		workerNodes           *v1.NodeList
 	)
 
 	BeforeAll(func(ctx context.Context) {
@@ -64,23 +63,17 @@ var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 		// modify the HCO CR to use the labels we just applied to the nodes
 		originalHco := tests.GetHCO(ctx, cli)
 		originalHco.DeepCopyInto(hco)
-		originalInfraSpec = originalHco.Spec.Infra
-		originalWorkloadSpec = originalHco.Spec.Workloads
+		originalNodePlacement = originalHco.Spec.Deployment.NodePlacements.DeepCopy()
 
 		// modify the "infra" and "workloads" keys
-		infraVal := hcov1beta1.HyperConvergedConfig{
-			NodePlacement: &sdkapi.NodePlacement{
+		hco.Spec.Deployment.NodePlacements = &hcov1.NodePlacements{
+			Infra: &sdkapi.NodePlacement{
 				NodeSelector: map[string]string{hcoLabel: infra},
 			},
-		}
-		workloadsVal := hcov1beta1.HyperConvergedConfig{
-			NodePlacement: &sdkapi.NodePlacement{
+			Workload: &sdkapi.NodePlacement{
 				NodeSelector: map[string]string{hcoLabel: workloads},
 			},
 		}
-
-		hco.Spec.Infra = infraVal
-		hco.Spec.Workloads = workloadsVal
 
 		tests.UpdateHCORetry(ctx, cli, hco)
 
@@ -100,8 +93,7 @@ var _ = Describe("[rfe_id:4356][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 		modifiedHco := tests.GetHCO(ctx, cli)
 
 		modifiedHco.DeepCopyInto(hco)
-		hco.Spec.Infra = originalInfraSpec
-		hco.Spec.Workloads = originalWorkloadSpec
+		hco.Spec.Deployment.NodePlacements = originalNodePlacement.DeepCopy()
 
 		tests.UpdateHCORetry(ctx, cli, hco)
 

--- a/tests/func-tests/role_aggregation_strategy_test.go
+++ b/tests/func-tests/role_aggregation_strategy_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
@@ -18,7 +17,8 @@ import (
 var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrategy"), func() {
 	tests.FlagParse()
 	var (
-		cli client.Client
+		cli                client.Client
+		rmRoleAgrStrgPatch = []byte(`[{"op": "remove", "path": "/spec/virtualization/roleAggregationStrategy"}]`)
 	)
 
 	BeforeEach(func(ctx context.Context) {
@@ -27,13 +27,15 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 	})
 
 	AfterEach(func(ctx context.Context) {
-		rmPatch := []byte(`[{"op": "remove", "path": "/spec/roleAggregationStrategy"}]`)
-		_ = tests.PatchHCO(ctx, cli, rmPatch)
+		hco := tests.GetHCO(ctx, cli)
+		if hco.Spec.Virtualization.RoleAggregationStrategy != nil {
+			Expect(tests.PatchHCO(ctx, cli, rmRoleAgrStrgPatch)).To(Succeed())
+		}
 	})
 
 	It("should propagate Manual to KubeVirt CR and add OptOutRoleAggregation feature gate", func(ctx context.Context) {
 		hc := tests.GetHCO(ctx, cli)
-		hc.Spec.RoleAggregationStrategy = ptr.To(kubevirtcorev1.RoleAggregationStrategyManual)
+		hc.Spec.Virtualization.RoleAggregationStrategy = new(kubevirtcorev1.RoleAggregationStrategyManual)
 		tests.UpdateHCORetry(ctx, cli, hc)
 
 		Eventually(func(g Gomega, ctx context.Context) {
@@ -47,7 +49,7 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 	It("should keep OptOutRoleAggregation FG when changing from Manual to AggregateToDefault", func(ctx context.Context) {
 		By("Setting RoleAggregationStrategy to Manual")
 		hc := tests.GetHCO(ctx, cli)
-		hc.Spec.RoleAggregationStrategy = ptr.To(kubevirtcorev1.RoleAggregationStrategyManual)
+		hc.Spec.Virtualization.RoleAggregationStrategy = new(kubevirtcorev1.RoleAggregationStrategyManual)
 		tests.UpdateHCORetry(ctx, cli, hc)
 
 		Eventually(func(g Gomega, ctx context.Context) {
@@ -57,7 +59,7 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 
 		By("Changing RoleAggregationStrategy to AggregateToDefault")
 		hc = tests.GetHCO(ctx, cli)
-		hc.Spec.RoleAggregationStrategy = ptr.To(kubevirtcorev1.RoleAggregationStrategyAggregateToDefault)
+		hc.Spec.Virtualization.RoleAggregationStrategy = new(kubevirtcorev1.RoleAggregationStrategyAggregateToDefault)
 		tests.UpdateHCORetry(ctx, cli, hc)
 
 		Eventually(func(g Gomega, ctx context.Context) {
@@ -71,7 +73,7 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 	It("should clear RoleAggregationStrategy and remove OptOutRoleAggregation FG when removed from HCO", func(ctx context.Context) {
 		By("Setting RoleAggregationStrategy to Manual")
 		hc := tests.GetHCO(ctx, cli)
-		hc.Spec.RoleAggregationStrategy = ptr.To(kubevirtcorev1.RoleAggregationStrategyManual)
+		hc.Spec.Virtualization.RoleAggregationStrategy = new(kubevirtcorev1.RoleAggregationStrategyManual)
 		tests.UpdateHCORetry(ctx, cli, hc)
 
 		Eventually(func(g Gomega, ctx context.Context) {
@@ -80,10 +82,9 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 		}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
 
 		By("Removing RoleAggregationStrategy from HCO")
-		rmPatch := []byte(`[{"op": "remove", "path": "/spec/roleAggregationStrategy"}]`)
 		Eventually(func() error {
-			return tests.PatchHCO(ctx, cli, rmPatch)
-		}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
+			return tests.PatchHCO(ctx, cli, rmRoleAgrStrgPatch)
+		}).WithTimeout(10 * time.Second).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
 
 		Eventually(func(g Gomega, ctx context.Context) {
 			kv := getKubeVirt(ctx, g, cli)

--- a/tests/func-tests/role_aggregation_strategy_test.go
+++ b/tests/func-tests/role_aggregation_strategy_test.go
@@ -27,14 +27,18 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 	})
 
 	AfterEach(func(ctx context.Context) {
-		hco := tests.GetHCO(ctx, cli)
+		hco, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+
 		if hco.Spec.Virtualization.RoleAggregationStrategy != nil {
 			Expect(tests.PatchHCO(ctx, cli, rmRoleAgrStrgPatch)).To(Succeed())
 		}
 	})
 
 	It("should propagate Manual to KubeVirt CR and add OptOutRoleAggregation feature gate", func(ctx context.Context) {
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+
 		hc.Spec.Virtualization.RoleAggregationStrategy = new(kubevirtcorev1.RoleAggregationStrategyManual)
 		tests.UpdateHCORetry(ctx, cli, hc)
 
@@ -48,7 +52,9 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 
 	It("should keep OptOutRoleAggregation FG when changing from Manual to AggregateToDefault", func(ctx context.Context) {
 		By("Setting RoleAggregationStrategy to Manual")
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+
 		hc.Spec.Virtualization.RoleAggregationStrategy = new(kubevirtcorev1.RoleAggregationStrategyManual)
 		tests.UpdateHCORetry(ctx, cli, hc)
 
@@ -58,7 +64,9 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 		}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
 
 		By("Changing RoleAggregationStrategy to AggregateToDefault")
-		hc = tests.GetHCO(ctx, cli)
+		hc, err = tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+
 		hc.Spec.Virtualization.RoleAggregationStrategy = new(kubevirtcorev1.RoleAggregationStrategyAggregateToDefault)
 		tests.UpdateHCORetry(ctx, cli, hc)
 
@@ -72,7 +80,9 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 
 	It("should clear RoleAggregationStrategy and remove OptOutRoleAggregation FG when removed from HCO", func(ctx context.Context) {
 		By("Setting RoleAggregationStrategy to Manual")
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+
 		hc.Spec.Virtualization.RoleAggregationStrategy = new(kubevirtcorev1.RoleAggregationStrategyManual)
 		tests.UpdateHCORetry(ctx, cli, hc)
 

--- a/tests/func-tests/tuningpolicy_test.go
+++ b/tests/func-tests/tuningpolicy_test.go
@@ -27,7 +27,8 @@ var _ = Describe("Check that the TuningPolicy annotation is configuring the KV o
 	})
 
 	AfterEach(func(ctx context.Context) {
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
 
 		delete(hc.Annotations, common.TuningPolicyAnnotationName)
 		hc.Spec.Virtualization.TuningPolicy = ""
@@ -36,7 +37,8 @@ var _ = Describe("Check that the TuningPolicy annotation is configuring the KV o
 	})
 
 	It("should update KV with the tuningPolicy annotation", func(ctx context.Context) {
-		hc := tests.GetHCO(ctx, cli)
+		hc, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
 
 		if hc.Annotations == nil {
 			hc.Annotations = make(map[string]string)

--- a/tests/func-tests/tuningpolicy_test.go
+++ b/tests/func-tests/tuningpolicy_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Check that the TuningPolicy annotation is configuring the KV o
 		hc := tests.GetHCO(ctx, cli)
 
 		delete(hc.Annotations, common.TuningPolicyAnnotationName)
-		hc.Spec.TuningPolicy = ""
+		hc.Spec.Virtualization.TuningPolicy = ""
 
 		tests.UpdateHCORetry(ctx, cli, hc)
 	})
@@ -42,7 +42,7 @@ var _ = Describe("Check that the TuningPolicy annotation is configuring the KV o
 			hc.Annotations = make(map[string]string)
 		}
 		hc.Annotations[common.TuningPolicyAnnotationName] = `{"qps":100,"burst":200}`
-		hc.Spec.TuningPolicy = hcov1.HyperConvergedAnnotationTuningPolicy
+		hc.Spec.Virtualization.TuningPolicy = hcov1.HyperConvergedAnnotationTuningPolicy
 
 		tests.UpdateHCORetry(ctx, cli, hc)
 

--- a/tests/func-tests/utils.go
+++ b/tests/func-tests/utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -132,10 +134,24 @@ func IsOpenShift(ctx context.Context, cli client.Client) (bool, error) {
 }
 
 // GetHCO reads the HCO CR from the APIServer with a DynamicClient
-func GetHCO(ctx context.Context, cli client.Client) *hcov1beta1.HyperConverged {
+func GetHCO(ctx context.Context, cli client.Client) *hcov1.HyperConverged {
 	ginkgo.GinkgoHelper()
 
-	Expect(hcov1beta1.AddToScheme(cli.Scheme())).To(Succeed())
+	hco := &hcov1.HyperConverged{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hcoutil.HyperConvergedName,
+			Namespace: InstallNamespace,
+		},
+	}
+
+	Expect(cli.Get(ctx, client.ObjectKeyFromObject(hco), hco)).To(Succeed())
+
+	return hco
+}
+
+// GetHCOv1beta1 reads the HCO CR from the APIServer with a DynamicClient
+func GetHCOv1beta1(ctx context.Context, cli client.Client) *hcov1beta1.HyperConverged {
+	ginkgo.GinkgoHelper()
 
 	hco := &hcov1beta1.HyperConverged{
 		ObjectMeta: metav1.ObjectMeta{
@@ -155,8 +171,8 @@ func GetHCO(ctx context.Context, cli client.Client) *hcov1beta1.HyperConverged {
 // input object.
 // UpdateHCORetry should be preferred over UpdateHCO_old to reduce test flakiness due to
 // inevitable concurrency conflicts
-func UpdateHCORetry(ctx context.Context, cli client.Client, input *hcov1beta1.HyperConverged) *hcov1beta1.HyperConverged {
-	var output *hcov1beta1.HyperConverged
+func UpdateHCORetry(ctx context.Context, cli client.Client, input *hcov1.HyperConverged) *hcov1.HyperConverged {
+	var output *hcov1.HyperConverged
 	var err error
 
 	Eventually(func(ctx context.Context) error {
@@ -174,8 +190,8 @@ func UpdateHCORetry(ctx context.Context, cli client.Client, input *hcov1beta1.Hy
 }
 
 // UpdateHCO updates the HCO CR using a DynamicClient, it can return errors on failures
-func UpdateHCO(ctx context.Context, cli client.Client, input *hcov1beta1.HyperConverged) (*hcov1beta1.HyperConverged, error) {
-	err := hcov1beta1.AddToScheme(cli.Scheme())
+func UpdateHCO(ctx context.Context, cli client.Client, input *hcov1.HyperConverged) (*hcov1.HyperConverged, error) {
+	err := hcov1.AddToScheme(cli.Scheme())
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +215,7 @@ func UpdateHCO(ctx context.Context, cli client.Client, input *hcov1beta1.HyperCo
 // PatchHCO updates the HCO CR using a DynamicClient, it can return errors on failures
 func PatchHCO(ctx context.Context, cli client.Client, patchBytes []byte) error {
 	patch := client.RawPatch(types.JSONPatchType, patchBytes)
-	hco := &hcov1beta1.HyperConverged{
+	hco := &hcov1.HyperConverged{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      hcoutil.HyperConvergedName,
 			Namespace: InstallNamespace,
@@ -212,7 +228,7 @@ func PatchHCO(ctx context.Context, cli client.Client, patchBytes []byte) error {
 // PatchMergeHCO patches the HCO CR using a DynamicClient, it can return errors on failures
 func PatchMergeHCO(ctx context.Context, cli client.Client, patchBytes []byte) error {
 	patch := client.RawPatch(types.MergePatchType, patchBytes)
-	hco := &hcov1beta1.HyperConverged{
+	hco := &hcov1.HyperConverged{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      hcoutil.HyperConvergedName,
 			Namespace: InstallNamespace,
@@ -316,4 +332,28 @@ func executeCommandOnPod(ctx context.Context, k8scli *kubernetes.Clientset, pod 
 		return "", "", fmt.Errorf("%w Failed executing command %s on %v/%v", err, command, pod.Namespace, pod.Name)
 	}
 	return buf.String(), errBuf.String(), nil
+}
+
+func EnableFG(ctx context.Context, cli client.Client, fgName string) error {
+	hc := GetHCO(ctx, cli)
+	if hc.Spec.FeatureGates == nil {
+		patch := fmt.Appendf(nil, `{"spec":{"featureGates":[{"name": %q, "state": "%v"}]}}`, fgName, featuregates.Enabled)
+		return PatchMergeHCO(ctx, cli, patch)
+	}
+
+	if !hc.Spec.FeatureGates.IsEnabled(fgName) {
+		var patch []byte
+		idx := slices.IndexFunc(hc.Spec.FeatureGates, func(fg featuregates.FeatureGate) bool {
+			return fg.Name == fgName
+		})
+		if idx == -1 {
+			patch = fmt.Appendf(nil, `[{"op": "add", "path": "/spec/featureGates/-", "value": {"name": %q}}]`, fgName)
+		} else {
+			patch = fmt.Appendf(nil, `[{"op": "replace", "path": "/spec/featureGates/%d/state", "value": "%v"}]`, idx, featuregates.Enabled)
+		}
+
+		return PatchHCO(ctx, cli, patch)
+	}
+
+	return nil
 }

--- a/tests/func-tests/utils.go
+++ b/tests/func-tests/utils.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
@@ -17,7 +16,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -25,11 +23,6 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
-	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
-	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 var (
@@ -133,122 +126,6 @@ func IsOpenShift(ctx context.Context, cli client.Client) (bool, error) {
 	return isOpenShiftCache.IsOpenShift(ctx, cli)
 }
 
-// GetHCO reads the HCO CR from the APIServer with a DynamicClient
-func GetHCO(ctx context.Context, cli client.Client) *hcov1.HyperConverged {
-	ginkgo.GinkgoHelper()
-
-	hco := &hcov1.HyperConverged{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      hcoutil.HyperConvergedName,
-			Namespace: InstallNamespace,
-		},
-	}
-
-	Expect(cli.Get(ctx, client.ObjectKeyFromObject(hco), hco)).To(Succeed())
-
-	return hco
-}
-
-// GetHCOv1beta1 reads the HCO CR from the APIServer with a DynamicClient
-func GetHCOv1beta1(ctx context.Context, cli client.Client) *hcov1beta1.HyperConverged {
-	ginkgo.GinkgoHelper()
-
-	hco := &hcov1beta1.HyperConverged{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      hcoutil.HyperConvergedName,
-			Namespace: InstallNamespace,
-		},
-	}
-
-	Expect(cli.Get(ctx, client.ObjectKeyFromObject(hco), hco)).To(Succeed())
-
-	return hco
-}
-
-// UpdateHCORetry updates the HCO CR in a safe way internally calling UpdateHCO_old
-// UpdateHCORetry internally uses an async Eventually block refreshing the in-memory
-// object if needed and setting there Spec, Annotations, Finalizers and Labels from the
-// input object.
-// UpdateHCORetry should be preferred over UpdateHCO_old to reduce test flakiness due to
-// inevitable concurrency conflicts
-func UpdateHCORetry(ctx context.Context, cli client.Client, input *hcov1.HyperConverged) *hcov1.HyperConverged {
-	var output *hcov1.HyperConverged
-	var err error
-
-	Eventually(func(ctx context.Context) error {
-		hco := GetHCO(ctx, cli)
-		input.Spec.DeepCopyInto(&hco.Spec)
-		hco.ObjectMeta.Annotations = input.ObjectMeta.Annotations
-		hco.ObjectMeta.Finalizers = input.ObjectMeta.Finalizers
-		hco.ObjectMeta.Labels = input.ObjectMeta.Labels
-
-		output, err = UpdateHCO(ctx, cli, hco)
-		return err
-	}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
-
-	return output
-}
-
-// UpdateHCO updates the HCO CR using a DynamicClient, it can return errors on failures
-func UpdateHCO(ctx context.Context, cli client.Client, input *hcov1.HyperConverged) (*hcov1.HyperConverged, error) {
-	err := hcov1.AddToScheme(cli.Scheme())
-	if err != nil {
-		return nil, err
-	}
-
-	hco := GetHCO(ctx, cli)
-	input.Spec.DeepCopyInto(&hco.Spec)
-	hco.Annotations = input.Annotations
-	hco.Finalizers = input.Finalizers
-	hco.Labels = input.Labels
-	hco.Status = hcov1.HyperConvergedStatus{} // to silence warning about unknown fields.
-
-	err = cli.Update(ctx, hco)
-	if err != nil {
-		return nil, err
-	}
-
-	hco = GetHCO(ctx, cli)
-	return hco, nil
-}
-
-// PatchHCO updates the HCO CR using a DynamicClient, it can return errors on failures
-func PatchHCO(ctx context.Context, cli client.Client, patchBytes []byte) error {
-	patch := client.RawPatch(types.JSONPatchType, patchBytes)
-	hco := &hcov1.HyperConverged{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      hcoutil.HyperConvergedName,
-			Namespace: InstallNamespace,
-		},
-	}
-
-	return cli.Patch(ctx, hco, patch)
-}
-
-// PatchMergeHCO patches the HCO CR using a DynamicClient, it can return errors on failures
-func PatchMergeHCO(ctx context.Context, cli client.Client, patchBytes []byte) error {
-	patch := client.RawPatch(types.MergePatchType, patchBytes)
-	hco := &hcov1.HyperConverged{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      hcoutil.HyperConvergedName,
-			Namespace: InstallNamespace,
-		},
-	}
-
-	return cli.Patch(ctx, hco, patch)
-}
-
-func RestoreDefaults(ctx context.Context, cli client.Client) {
-	Eventually(func(ctx context.Context) error {
-		return PatchHCO(ctx, cli, []byte(`[{"op": "replace", "path": "/spec", "value": {}}]`))
-	}).
-		WithOffset(1).
-		WithTimeout(time.Second * 5).
-		WithPolling(time.Millisecond * 100).
-		WithContext(ctx).
-		Should(Succeed())
-}
-
 func deleteAllResources(ctx context.Context, restClient rest.Interface, resourceName string) {
 	Eventually(func() bool {
 		err := restClient.Delete().Namespace(TestNamespace).Resource(resourceName).Do(ctx).Error()
@@ -332,28 +209,4 @@ func executeCommandOnPod(ctx context.Context, k8scli *kubernetes.Clientset, pod 
 		return "", "", fmt.Errorf("%w Failed executing command %s on %v/%v", err, command, pod.Namespace, pod.Name)
 	}
 	return buf.String(), errBuf.String(), nil
-}
-
-func EnableFG(ctx context.Context, cli client.Client, fgName string) error {
-	hc := GetHCO(ctx, cli)
-	if hc.Spec.FeatureGates == nil {
-		patch := fmt.Appendf(nil, `{"spec":{"featureGates":[{"name": %q, "state": "%v"}]}}`, fgName, featuregates.Enabled)
-		return PatchMergeHCO(ctx, cli, patch)
-	}
-
-	if !hc.Spec.FeatureGates.IsEnabled(fgName) {
-		var patch []byte
-		idx := slices.IndexFunc(hc.Spec.FeatureGates, func(fg featuregates.FeatureGate) bool {
-			return fg.Name == fgName
-		})
-		if idx == -1 {
-			patch = fmt.Appendf(nil, `[{"op": "add", "path": "/spec/featureGates/-", "value": {"name": %q}}]`, fgName)
-		} else {
-			patch = fmt.Appendf(nil, `[{"op": "replace", "path": "/spec/featureGates/%d/state", "value": "%v"}]`, idx, featuregates.Enabled)
-		}
-
-		return PatchHCO(ctx, cli, patch)
-	}
-
-	return nil
 }

--- a/tests/func-tests/validation_test.go
+++ b/tests/func-tests/validation_test.go
@@ -8,10 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
@@ -29,23 +26,20 @@ var _ = Describe("Check CR validation", Label("validation"), Serial, func() {
 
 	Context("for AutoCPULimitNamespaceLabelSelector", func() {
 		DescribeTable("should", func(ctx context.Context, allocationRatio *int, outcome gomegatypes.GomegaMatcher) {
-			requirements := &v1beta1.OperandResourceRequirements{
-				VmiCPUAllocationRatio: allocationRatio,
-				AutoCPULimitNamespaceLabelSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"someLabel": "true"},
-				},
-			}
 			Eventually(func(ctx context.Context) error {
 				var err error
 				hc := tests.GetHCO(ctx, cli)
-				hc.Spec.ResourceRequirements = requirements
+				hc.Spec.Virtualization.VmiCPUAllocationRatio = allocationRatio
+				hc.Spec.Virtualization.AutoCPULimitNamespaceLabelSelector = &metav1.LabelSelector{MatchLabels: map[string]string{
+					"someLabel": "true",
+				}}
 				_, err = tests.UpdateHCO(ctx, cli, hc)
 				return err
 			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(outcome)
 		},
 			Entry("succeed when VMI CPU allocation is nil", nil, Succeed()),
-			Entry("fail when VMI CPU allocation is 0", ptr.To(0), MatchError(ContainSubstring("vmiCPUAllocationRatio must be greater than 0"))),
-			Entry("succeed when VMI CPU allocation is 2", ptr.To(2), Succeed()),
+			Entry("fail when VMI CPU allocation is 0", new(0), MatchError(ContainSubstring("vmiCPUAllocationRatio must be greater than 0"))),
+			Entry("succeed when VMI CPU allocation is 2", new(2), Succeed()),
 		)
 	})
 })

--- a/tests/func-tests/validation_test.go
+++ b/tests/func-tests/validation_test.go
@@ -26,9 +26,11 @@ var _ = Describe("Check CR validation", Label("validation"), Serial, func() {
 
 	Context("for AutoCPULimitNamespaceLabelSelector", func() {
 		DescribeTable("should", func(ctx context.Context, allocationRatio *int, outcome gomegatypes.GomegaMatcher) {
-			Eventually(func(ctx context.Context) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				var err error
-				hc := tests.GetHCO(ctx, cli)
+				hc, err := tests.GetHCO(ctx, cli)
+				g.Expect(err).ToNot(HaveOccurred())
+
 				hc.Spec.Virtualization.VmiCPUAllocationRatio = allocationRatio
 				hc.Spec.Virtualization.AutoCPULimitNamespaceLabelSelector = &metav1.LabelSelector{MatchLabels: map[string]string{
 					"someLabel": "true",

--- a/tests/func-tests/wasp_agent_test.go
+++ b/tests/func-tests/wasp_agent_test.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wasp_agent "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/wasp-agent"
+	waspagent "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/wasp-agent"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 	"github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/libnode"
 )
@@ -29,7 +29,7 @@ const (
 	sccName                     = "wasp"
 	clusterRoleName             = "wasp-cluster"
 	clusterRoleBindingName      = "wasp-cluster"
-	setMemoryOvercommitTemplate = `[{"op": "replace", "path": "/spec/higherWorkloadDensity/memoryOvercommitPercentage", "value": %d}]`
+	setMemoryOvercommitTemplate = `[{"op": "replace", "path": "/spec/virtualization/higherWorkloadDensity/memoryOvercommitPercentage", "value": %d}]`
 	overcommitPercent           = 150
 
 	workerMachineConfigPoolName = "worker"
@@ -44,8 +44,9 @@ var _ = Describe("Test wasp-agent", Label(tests.OpenshiftLabel, tests.HighlyAvai
 	tests.FlagParse()
 
 	var (
-		cli                       client.Client
-		originalOvercommitPercent int
+		cli                             client.Client
+		originalOvercommitPercent       int
+		originalOvercommitPercentWasSet bool
 	)
 
 	BeforeAll(func(ctx context.Context) {
@@ -59,8 +60,9 @@ var _ = Describe("Test wasp-agent", Label(tests.OpenshiftLabel, tests.HighlyAvai
 		Expect(securityv1.Install(cli.Scheme())).To(Succeed())
 
 		originalHco := tests.GetHCO(ctx, cli)
-		if originalHco.Spec.HigherWorkloadDensity != nil {
-			originalOvercommitPercent = originalHco.Spec.HigherWorkloadDensity.MemoryOvercommitPercentage
+		if originalHco.Spec.Virtualization.HigherWorkloadDensity != nil {
+			originalOvercommitPercent = originalHco.Spec.Virtualization.HigherWorkloadDensity.MemoryOvercommitPercentage
+			originalOvercommitPercentWasSet = true
 		}
 
 		pauseWorkerMachineConfigPool(ctx, cli)
@@ -69,7 +71,7 @@ var _ = Describe("Test wasp-agent", Label(tests.OpenshiftLabel, tests.HighlyAvai
 	AfterAll(func(ctx context.Context) {
 		removeAutopilotSwapAnnotation(ctx, cli)
 
-		if originalOvercommitPercent != 0 {
+		if originalOvercommitPercentWasSet {
 			setMemoryOvercommitPercentage(ctx, cli, originalOvercommitPercent)
 		}
 
@@ -253,7 +255,7 @@ func getWaspSA(ctx context.Context, cli client.Client) error {
 }
 
 func setMemoryOvercommitPercentage(ctx context.Context, cli client.Client, percentage int) {
-	patchBytes := []byte(fmt.Sprintf(setMemoryOvercommitTemplate, percentage))
+	patchBytes := fmt.Appendf(nil, setMemoryOvercommitTemplate, percentage)
 
 	Eventually(tests.PatchHCO).
 		WithArguments(ctx, cli, patchBytes).
@@ -284,7 +286,7 @@ func setAutopilotSwapAnnotation(ctx context.Context, cli client.Client) {
 				%q: %q
 			}
 		}
-	}`, wasp_agent.AutopilotSwapAnnotation, wasp_agent.AutopilotSwapAnnotationValue))
+	}`, waspagent.AutopilotSwapAnnotation, waspagent.AutopilotSwapAnnotationValue))
 
 	Eventually(func(g Gomega, ctx context.Context) {
 		g.Expect(tests.PatchMergeHCO(ctx, cli, patchBytes)).To(Succeed())
@@ -295,7 +297,7 @@ func setAutopilotSwapAnnotation(ctx context.Context, cli client.Client) {
 
 	Eventually(func(g Gomega, ctx context.Context) {
 		hco := tests.GetHCO(ctx, cli)
-		g.Expect(hco.Annotations).To(HaveKeyWithValue(wasp_agent.AutopilotSwapAnnotation, wasp_agent.AutopilotSwapAnnotationValue))
+		g.Expect(hco.Annotations).To(HaveKeyWithValue(waspagent.AutopilotSwapAnnotation, waspagent.AutopilotSwapAnnotationValue))
 	}).WithTimeout(30 * time.Second).
 		WithPolling(time.Second).
 		WithContext(ctx).
@@ -310,7 +312,7 @@ func removeAutopilotSwapAnnotation(ctx context.Context, cli client.Client) {
 				%q: null
 			}
 		}
-	}`, wasp_agent.AutopilotSwapAnnotation))
+	}`, waspagent.AutopilotSwapAnnotation))
 
 	Eventually(func(g Gomega, ctx context.Context) {
 		g.Expect(tests.PatchMergeHCO(ctx, cli, patchBytes)).To(Succeed())
@@ -321,7 +323,7 @@ func removeAutopilotSwapAnnotation(ctx context.Context, cli client.Client) {
 
 	Eventually(func(g Gomega, ctx context.Context) {
 		hco := tests.GetHCO(ctx, cli)
-		g.Expect(hco.Annotations).ToNot(HaveKey(wasp_agent.AutopilotSwapAnnotation))
+		g.Expect(hco.Annotations).ToNot(HaveKey(waspagent.AutopilotSwapAnnotation))
 	}).WithTimeout(30 * time.Second).
 		WithPolling(time.Second).
 		WithContext(ctx).
@@ -342,7 +344,7 @@ func newWorkerMachineConfigPool() *unstructured.Unstructured {
 func patchWorkerMachineConfigPoolPaused(ctx context.Context, cli client.Client, paused bool) {
 	GinkgoHelper()
 	mcp := newWorkerMachineConfigPool()
-	patch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"paused":%t}}`, paused)))
+	patch := client.RawPatch(types.MergePatchType, fmt.Appendf(nil, `{"spec":{"paused":%t}}`, paused))
 
 	Eventually(func(g Gomega, ctx context.Context) {
 		g.Expect(cli.Patch(ctx, mcp, patch)).To(Succeed())

--- a/tests/func-tests/wasp_agent_test.go
+++ b/tests/func-tests/wasp_agent_test.go
@@ -59,7 +59,9 @@ var _ = Describe("Test wasp-agent", Label(tests.OpenshiftLabel, tests.HighlyAvai
 
 		Expect(securityv1.Install(cli.Scheme())).To(Succeed())
 
-		originalHco := tests.GetHCO(ctx, cli)
+		originalHco, err := tests.GetHCO(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+
 		if originalHco.Spec.Virtualization.HigherWorkloadDensity != nil {
 			originalOvercommitPercent = originalHco.Spec.Virtualization.HigherWorkloadDensity.MemoryOvercommitPercentage
 			originalOvercommitPercentWasSet = true
@@ -296,7 +298,9 @@ func setAutopilotSwapAnnotation(ctx context.Context, cli client.Client) {
 		Should(Succeed())
 
 	Eventually(func(g Gomega, ctx context.Context) {
-		hco := tests.GetHCO(ctx, cli)
+		hco, err := tests.GetHCO(ctx, cli)
+		g.Expect(err).NotTo(HaveOccurred())
+
 		g.Expect(hco.Annotations).To(HaveKeyWithValue(waspagent.AutopilotSwapAnnotation, waspagent.AutopilotSwapAnnotationValue))
 	}).WithTimeout(30 * time.Second).
 		WithPolling(time.Second).
@@ -322,7 +326,9 @@ func removeAutopilotSwapAnnotation(ctx context.Context, cli client.Client) {
 		Should(Succeed())
 
 	Eventually(func(g Gomega, ctx context.Context) {
-		hco := tests.GetHCO(ctx, cli)
+		hco, err := tests.GetHCO(ctx, cli)
+		g.Expect(err).NotTo(HaveOccurred())
+
 		g.Expect(hco.Annotations).ToNot(HaveKey(waspagent.AutopilotSwapAnnotation))
 	}).WithTimeout(30 * time.Second).
 		WithPolling(time.Second).


### PR DESCRIPTION
As part of deprecating the v1beta1 API, We already moved the production code to use the v1 API. This PR moves also the functional tests to use v1 API.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
