### PR TITLE
WIP: annotate HCO CR with platform.kubevirt.io/autopilot=true on deploy

### DIFF
--- a/hack/deploy_only_cr.sh
+++ b/hack/deploy_only_cr.sh
@@ -67,4 +67,7 @@ fi
 
 ${CMD} apply -n kubevirt-hyperconverged -f _out/hco.cr.yaml
 
+# WIP: opt in to virt-platform-autopilot on all CI lanes to measure stability and execution time impact
+${CMD} annotate -n "${HCO_NAMESPACE}" "${HCO_KIND}/${HCO_RESOURCE_NAME}" platform.kubevirt.io/autopilot=true --overwrite
+
 ${CMD} wait -n "${HCO_NAMESPACE}" "${HCO_KIND}" "${HCO_RESOURCE_NAME}" --for condition=Available --timeout="30m"


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a temporary experiment to measure the impact of enabling virt-platform-autopilot across all openshift-ci lanes on test stability and execution time, before deciding how to stably enable it.

PLEASE DON'T MERGE

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
