### PR TITLE
ci: fix perses dashboard updater workflow

### DIFF
--- a/.github/workflows/perses-dashboard-updater.yml
+++ b/.github/workflows/perses-dashboard-updater.yml
@@ -20,6 +20,7 @@ jobs:
           repository: kubevirt/monitoring
           ref: main
           path: monitoring
+          persist-credentials: false
 
       - name: Sync dashboards (full replace handles additions and removals)
         run: |
@@ -35,7 +36,7 @@ jobs:
           fi
 
       - name: Create a PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         if: ${{ env.UPDATED }}
         with:
           path: hco


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to the monitoring repo checkout to prevent a duplicate `Authorization` header that causes git push to fail with HTTP 400.
- Bump `peter-evans/create-pull-request` from v6 to v7 ahead of the Node.js 20 deprecation on June 2, 2026.

## Root cause
The workflow checks out two repositories (HCO and monitoring) with `actions/checkout@v6`. Both checkouts persist credentials by default, injecting `includeIf.gitdir` entries into the git global config. When `create-pull-request` pushes to the HCO repo, it picks up both credential helpers, producing a duplicate `Authorization` header that GitHub rejects:

```
remote: Duplicate header: "Authorization"
fatal: unable to access '...': The requested URL returned error: 400
```

Failing run: https://github.com/kubevirt/hyperconverged-cluster-operator/actions/runs/26563555973/job/78252326983

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and verify the "Create a PR" step succeeds.

```release-note
NONE
```

Made with [Cursor](https://cursor.com)