### PR TITLE
Fix 409 conflict on webhook dry-run validation of operand CRs

### DIFF
--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -544,7 +544,39 @@ func getOperands(ctx context.Context, cli client.Client, isOpenshift bool) ([]cl
 	return resources, nil
 }
 
+const dryRunMaxRetries = 3
+
 func updateOperatorCr(ctx context.Context, cli client.Client, logger logr.Logger, hc *hcov1.HyperConverged, exists client.Object, opts *client.UpdateOptions) error {
+	for attempt := range dryRunMaxRetries {
+		if attempt > 0 {
+			if err := cli.Get(ctx, client.ObjectKeyFromObject(exists), exists); err != nil {
+				logger.Error(err, "failed to re-fetch object for dry-run retry", "kind", exists.GetObjectKind())
+				return err
+			}
+		}
+
+		if err := applyDesiredSpec(hc, exists); err != nil {
+			return err
+		}
+
+		err := cli.Update(ctx, exists, opts)
+		if err == nil {
+			logger.Info("dry-run update the object passed", "kind", exists.GetObjectKind())
+			return nil
+		}
+
+		if !apierrors.IsConflict(err) {
+			logger.Error(err, "failed to dry-run update the object", "kind", exists.GetObjectKind())
+			return err
+		}
+
+		logger.Info("dry-run update conflict, retrying", "kind", exists.GetObjectKind(), "attempt", attempt+1)
+	}
+
+	return fmt.Errorf("failed to dry-run update %v after %d retries due to persistent conflicts", exists.GetObjectKind(), dryRunMaxRetries)
+}
+
+func applyDesiredSpec(hc *hcov1.HyperConverged, exists client.Object) error {
 	switch existing := exists.(type) {
 	case *kubevirtcorev1.KubeVirt:
 		required, err := handlers.NewKubeVirt(hc)
@@ -575,11 +607,5 @@ func updateOperatorCr(ctx context.Context, cli client.Client, logger logr.Logger
 		required.Spec.DeepCopyInto(&existing.Spec)
 	}
 
-	if err := cli.Update(ctx, exists, opts); err != nil {
-		logger.Error(err, "failed to dry-run update the object", "kind", exists.GetObjectKind())
-		return err
-	}
-
-	logger.Info("dry-run update the object passed", "kind", exists.GetObjectKind())
 	return nil
 }

--- a/tests/func-tests/role_aggregation_strategy_test.go
+++ b/tests/func-tests/role_aggregation_strategy_test.go
@@ -81,7 +81,9 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 
 		By("Removing RoleAggregationStrategy from HCO")
 		rmPatch := []byte(`[{"op": "remove", "path": "/spec/roleAggregationStrategy"}]`)
-		Expect(tests.PatchHCO(ctx, cli, rmPatch)).To(Succeed())
+		Eventually(func() error {
+			return tests.PatchHCO(ctx, cli, rmPatch)
+		}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
 
 		Eventually(func(g Gomega, ctx context.Context) {
 			kv := getKubeVirt(ctx, g, cli)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The validating webhook's dry-run update of operand CRs (KubeVirt, CDI, etc.) could fail with a 409 Conflict when the HCO reconciler was concurrently updating the same CR. This race is more likely after an upgrade, where the reconciler performs additional reconciliation rounds.

Add retry-on-conflict logic to the webhook's `updateOperatorCr` so it re-fetches the operand and retries the dry-run update up to 3 times. Also wrap the `PatchHCO` call in the `RoleAggregationStrategy` func-test with `Eventually` to tolerate transient admission errors.


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
