### PR TITLE
CNV-83939: replace `node-role.kubernetes.io/control-plane` label with `node-role.kubevirt.io/control-plane` for HCP Clusters

### DIFF
--- a/controllers/nodes/nodes_controller.go
+++ b/controllers/nodes/nodes_controller.go
@@ -284,19 +284,41 @@ func HandleHyperShiftNodeLabeling(ctx context.Context, cli client.Client, nodeNa
 	return labelNode(ctx, cli, node, logger)
 }
 
-// labelNode applies the HyperShift label on a single node
+// labelNode applies the HyperShift label on a single node.
+// It adds node-role.kubevirt.io/control-plane and removes the old
+// node-role.kubernetes.io/control-plane label if it was previously set by HCO (upgrade path).
 func labelNode(ctx context.Context, cli client.Client, node *corev1.Node, logger logr.Logger) error {
 	if !isWorkerNode(node) {
 		return nil
 	}
 
-	logger.Info("Adding control-plane label to worker node",
-		"node", node.Name,
-		"labelValue", hypershiftLabelValue,
-	)
-
 	patch := client.MergeFrom(node.DeepCopy())
-	node.Labels[nodeinfo.LabelNodeRoleControlPlane] = hypershiftLabelValue
+	needsPatch := false
+
+	// Add the new kubevirt-specific control-plane label if not already present
+	if node.Labels[nodeinfo.LabelNodeRoleKubevirtControlPlane] != hypershiftLabelValue {
+		logger.Info("Adding kubevirt control-plane label to worker node",
+			"node", node.Name,
+			"label", nodeinfo.LabelNodeRoleKubevirtControlPlane,
+			"labelValue", hypershiftLabelValue,
+		)
+		node.Labels[nodeinfo.LabelNodeRoleKubevirtControlPlane] = hypershiftLabelValue
+		needsPatch = true
+	}
+
+	// Upgrade path: remove the old kubernetes control-plane label if it was set by HCO
+	if node.Labels[nodeinfo.LabelNodeRoleControlPlane] == hypershiftLabelValue {
+		logger.Info("Removing old control-plane label from worker node (upgrade)",
+			"node", node.Name,
+			"label", nodeinfo.LabelNodeRoleControlPlane,
+		)
+		delete(node.Labels, nodeinfo.LabelNodeRoleControlPlane)
+		needsPatch = true
+	}
+
+	if !needsPatch {
+		return nil
+	}
 
 	if err := cli.Patch(ctx, node, patch); err != nil {
 		return fmt.Errorf("failed to patch node %s: %w", node.Name, err)
@@ -306,11 +328,18 @@ func labelNode(ctx context.Context, cli client.Client, node *corev1.Node, logger
 	return nil
 }
 
-// isWorkerNode checks if a node has the worker role label
+// isWorkerNode checks if a node has the worker role label.
+// A node is considered a worker if it has the worker label and does not have
+// the standard Kubernetes control-plane label (ignoring the kubevirt-specific one,
+// which HCO itself sets on HCP clusters).
 func isWorkerNode(node *corev1.Node) bool {
-	// A node is a worker if it has the worker label and doesn't have control-plane label
 	_, hasWorkerLabel := node.Labels[nodeinfo.LabelNodeRoleWorker]
-	_, hasControlPlaneLabel := node.Labels[nodeinfo.LabelNodeRoleControlPlane]
+	cpVal, hasControlPlaneLabel := node.Labels[nodeinfo.LabelNodeRoleControlPlane]
+
+	if hasControlPlaneLabel && cpVal == hypershiftLabelValue {
+		// This is a label HCO set previously; treat the node as a worker for upgrade purposes
+		return hasWorkerLabel
+	}
 
 	return hasWorkerLabel && !hasControlPlaneLabel
 }

--- a/controllers/nodes/nodes_controller_test.go
+++ b/controllers/nodes/nodes_controller_test.go
@@ -138,7 +138,7 @@ var _ = Describe("NodesController", func() {
 		})
 
 		Context("HyperShift Node Labeling", func() {
-			It("Should label worker node when shouldLabelNodes is true", func() {
+			It("Should label worker node with kubevirt control-plane label", func() {
 				workerNode := &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "worker-1",
@@ -162,24 +162,22 @@ var _ = Describe("NodesController", func() {
 					return false, nil
 				}
 
-				// Create a request for the worker node
 				nodeRequest := reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Name: "worker-1",
 					},
 				}
 
-				// Reconcile
 				res, err := r.Reconcile(context.TODO(), nodeRequest)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res.IsZero()).To(BeTrue())
 
-				// Verify the node was labeled
 				updatedNode := &corev1.Node{}
 				err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, updatedNode)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(updatedNode.Labels).To(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
-				Expect(updatedNode.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(hypershiftLabelValue))
+				Expect(updatedNode.Labels).To(HaveKey(nodeinfo.LabelNodeRoleKubevirtControlPlane))
+				Expect(updatedNode.Labels[nodeinfo.LabelNodeRoleKubevirtControlPlane]).To(Equal(hypershiftLabelValue))
+				Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
 			})
 
 			It("Should not label control plane node", func() {
@@ -216,11 +214,11 @@ var _ = Describe("NodesController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res.IsZero()).To(BeTrue())
 
-				// Verify the node label wasn't changed
 				updatedNode := &corev1.Node{}
 				err = cl.Get(context.TODO(), client.ObjectKey{Name: "control-plane-1"}, updatedNode)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedNode.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(""))
+				Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleKubevirtControlPlane))
 			})
 
 			It("Should skip labeling when shouldLabelNodes is false", func() {
@@ -257,10 +255,10 @@ var _ = Describe("NodesController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res.IsZero()).To(BeTrue())
 
-				// Verify the node was not labeled
 				updatedNode := &corev1.Node{}
 				err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, updatedNode)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleKubevirtControlPlane))
 				Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
 			})
 
@@ -285,7 +283,6 @@ var _ = Describe("NodesController", func() {
 					},
 				}
 
-				// Should not return error for missing node
 				res, err := r.Reconcile(context.TODO(), nodeRequest)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res.IsZero()).To(BeTrue())
@@ -314,19 +311,18 @@ var _ = Describe("NodesController", func() {
 					return false, nil
 				}
 
-				// Use hcoReq instead of node request
 				res, err := r.Reconcile(context.TODO(), hcoReq)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res.IsZero()).To(BeTrue())
 
-				// Verify the node was not labeled (HCO event should skip node labeling)
 				updatedNode := &corev1.Node{}
 				err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, updatedNode)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleKubevirtControlPlane))
 				Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
 			})
 
-			It("Should label all nodes at startup", func() {
+			It("Should label all nodes at startup with kubevirt control-plane label", func() {
 				worker1 := &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "worker-1",
@@ -363,22 +359,198 @@ var _ = Describe("NodesController", func() {
 				err := r.labelAllNodesAtStartup(context.TODO())
 				Expect(err).ToNot(HaveOccurred())
 
-				// Verify worker nodes were labeled
 				updatedWorker1 := &corev1.Node{}
 				err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, updatedWorker1)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(updatedWorker1.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(hypershiftLabelValue))
+				Expect(updatedWorker1.Labels[nodeinfo.LabelNodeRoleKubevirtControlPlane]).To(Equal(hypershiftLabelValue))
+				Expect(updatedWorker1.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
 
 				updatedWorker2 := &corev1.Node{}
 				err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-2"}, updatedWorker2)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(updatedWorker2.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(hypershiftLabelValue))
+				Expect(updatedWorker2.Labels[nodeinfo.LabelNodeRoleKubevirtControlPlane]).To(Equal(hypershiftLabelValue))
+				Expect(updatedWorker2.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
 
 				// Verify control plane node was not changed
 				updatedCP := &corev1.Node{}
 				err = cl.Get(context.TODO(), client.ObjectKey{Name: "control-plane-1"}, updatedCP)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedCP.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(""))
+				Expect(updatedCP.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleKubevirtControlPlane))
+			})
+
+			Context("Upgrade scenarios", func() {
+				It("Should replace old kubernetes control-plane label with kubevirt label on upgrade", func() {
+					workerNode := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "worker-1",
+							Labels: map[string]string{
+								nodeinfo.LabelNodeRoleWorker:       "",
+								nodeinfo.LabelNodeRoleControlPlane: hypershiftLabelValue,
+							},
+						},
+					}
+
+					hco := commontestutils.NewHco()
+					resources := []client.Object{hco, workerNode}
+					cl := commontestutils.InitClient(resources)
+
+					r := &ReconcileNodeCounter{
+						Client:                       cl,
+						nodeEvents:                   nodeEvents,
+						HandleHyperShiftNodeLabeling: HandleHyperShiftNodeLabeling,
+					}
+
+					nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
+						return false, nil
+					}
+
+					nodeRequest := reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Name: "worker-1",
+						},
+					}
+
+					res, err := r.Reconcile(context.TODO(), nodeRequest)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(res.IsZero()).To(BeTrue())
+
+					updatedNode := &corev1.Node{}
+					err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, updatedNode)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(updatedNode.Labels).To(HaveKey(nodeinfo.LabelNodeRoleKubevirtControlPlane))
+					Expect(updatedNode.Labels[nodeinfo.LabelNodeRoleKubevirtControlPlane]).To(Equal(hypershiftLabelValue))
+					Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
+				})
+
+				It("Should replace old label on all nodes at startup (upgrade)", func() {
+					worker1 := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "worker-1",
+							Labels: map[string]string{
+								nodeinfo.LabelNodeRoleWorker:       "",
+								nodeinfo.LabelNodeRoleControlPlane: hypershiftLabelValue,
+							},
+						},
+					}
+					worker2 := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "worker-2",
+							Labels: map[string]string{
+								nodeinfo.LabelNodeRoleWorker:       "",
+								nodeinfo.LabelNodeRoleControlPlane: hypershiftLabelValue,
+							},
+						},
+					}
+
+					resources := []client.Object{worker1, worker2}
+					cl := commontestutils.InitClient(resources)
+
+					r := &ReconcileNodeCounter{
+						Client:     cl,
+						nodeEvents: nodeEvents,
+					}
+
+					err := r.labelAllNodesAtStartup(context.TODO())
+					Expect(err).ToNot(HaveOccurred())
+
+					for _, name := range []string{"worker-1", "worker-2"} {
+						updatedNode := &corev1.Node{}
+						err = cl.Get(context.TODO(), client.ObjectKey{Name: name}, updatedNode)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(updatedNode.Labels[nodeinfo.LabelNodeRoleKubevirtControlPlane]).To(Equal(hypershiftLabelValue))
+						Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
+					}
+				})
+
+				It("Should not remove kubernetes control-plane label if not set by HCO", func() {
+					cpNode := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "control-plane-1",
+							Labels: map[string]string{
+								nodeinfo.LabelNodeRoleControlPlane: "",
+							},
+						},
+					}
+
+					hco := commontestutils.NewHco()
+					resources := []client.Object{hco, cpNode}
+					cl := commontestutils.InitClient(resources)
+
+					r := &ReconcileNodeCounter{
+						Client:                       cl,
+						nodeEvents:                   nodeEvents,
+						HandleHyperShiftNodeLabeling: HandleHyperShiftNodeLabeling,
+					}
+
+					nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
+						return false, nil
+					}
+
+					nodeRequest := reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Name: "control-plane-1",
+						},
+					}
+
+					res, err := r.Reconcile(context.TODO(), nodeRequest)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(res.IsZero()).To(BeTrue())
+
+					updatedNode := &corev1.Node{}
+					err = cl.Get(context.TODO(), client.ObjectKey{Name: "control-plane-1"}, updatedNode)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(updatedNode.Labels[nodeinfo.LabelNodeRoleControlPlane]).To(Equal(""))
+					Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleKubevirtControlPlane))
+				})
+
+				It("Should not patch node already having the new label and no old label", func() {
+					workerNode := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "worker-1",
+							Labels: map[string]string{
+								nodeinfo.LabelNodeRoleWorker:               "",
+								nodeinfo.LabelNodeRoleKubevirtControlPlane: hypershiftLabelValue,
+							},
+						},
+					}
+
+					hco := commontestutils.NewHco()
+					resources := []client.Object{hco, workerNode}
+					cl := commontestutils.InitClient(resources)
+
+					r := &ReconcileNodeCounter{
+						Client:                       cl,
+						nodeEvents:                   nodeEvents,
+						HandleHyperShiftNodeLabeling: HandleHyperShiftNodeLabeling,
+					}
+
+					nodeinfo.HandleNodeChanges = func(_ context.Context, _ client.Client, _ *hcov1.HyperConverged, _ logr.Logger) (bool, error) {
+						return false, nil
+					}
+
+					nodeRequest := reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Name: "worker-1",
+						},
+					}
+
+					origNode := &corev1.Node{}
+					err := cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, origNode)
+					Expect(err).ToNot(HaveOccurred())
+					originalRV := origNode.ResourceVersion
+
+					res, err := r.Reconcile(context.TODO(), nodeRequest)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(res.IsZero()).To(BeTrue())
+
+					updatedNode := &corev1.Node{}
+					err = cl.Get(context.TODO(), client.ObjectKey{Name: "worker-1"}, updatedNode)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(updatedNode.ResourceVersion).To(Equal(originalRV), "node should not have been patched")
+					Expect(updatedNode.Labels[nodeinfo.LabelNodeRoleKubevirtControlPlane]).To(Equal(hypershiftLabelValue))
+					Expect(updatedNode.Labels).NotTo(HaveKey(nodeinfo.LabelNodeRoleControlPlane))
+				})
 			})
 		})
 
@@ -419,7 +591,7 @@ var _ = Describe("NodesController", func() {
 				Expect(isWorkerNode(masterNode)).To(BeFalse())
 			})
 
-			It("Should not identify node with both worker and control-plane labels as worker", func() {
+			It("Should not identify node with both worker and non-HCO control-plane labels as worker", func() {
 				mixedNode := &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mixed-1",
@@ -430,6 +602,19 @@ var _ = Describe("NodesController", func() {
 					},
 				}
 				Expect(isWorkerNode(mixedNode)).To(BeFalse())
+			})
+
+			It("Should identify worker node with HCO-set control-plane label as worker (upgrade path)", func() {
+				upgradedNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-hco-labeled",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleWorker:       "",
+							nodeinfo.LabelNodeRoleControlPlane: hypershiftLabelValue,
+						},
+					},
+				}
+				Expect(isWorkerNode(upgradedNode)).To(BeTrue())
 			})
 
 			It("Should not identify node without labels as worker", func() {

--- a/pkg/internal/nodeinfo/high_availability.go
+++ b/pkg/internal/nodeinfo/high_availability.go
@@ -7,6 +7,9 @@ import (
 const (
 	// LabelNodeRoleControlPlane is the label used to identify control plane nodes
 	LabelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
+	// LabelNodeRoleKubevirtControlPlane is the label used by HCO on HCP clusters to allow
+	// virt-operator scheduling without mislabeling worker nodes as Kubernetes control plane nodes
+	LabelNodeRoleKubevirtControlPlane = "node-role.kubevirt.io/control-plane"
 	// LabelNodeRoleMaster is the old label used to identify control plane nodes
 	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
 	// LabelNodeRoleWorker is the label used to identify worker nodes

--- a/pkg/nodeinfo/nodeinfo.go
+++ b/pkg/nodeinfo/nodeinfo.go
@@ -7,6 +7,8 @@ const (
 
 	// LabelNodeRoleControlPlane is the label used to identify control plane nodes
 	LabelNodeRoleControlPlane = internal.LabelNodeRoleControlPlane
+	// LabelNodeRoleKubevirtControlPlane is the label used by HCO on HCP clusters
+	LabelNodeRoleKubevirtControlPlane = internal.LabelNodeRoleKubevirtControlPlane
 	// LabelNodeRoleMaster is the old label used to identify control plane nodes
 	LabelNodeRoleMaster = internal.LabelNodeRoleMaster
 	// LabelNodeRoleWorker is the label used to identify worker nodes


### PR DESCRIPTION
Use a kubevirt-specific label for HCP worker nodes instead of the standard Kubernetes control-plane label, in order to prevent misidentification of workers as control-plane nodes. Handle upgrade by removing the old HCO-set label when the new one is applied.
the new label of `node-role.kubevirt.io/control-plane` for `virt-operator` placement has been introduced at https://github.com/kubevirt/kubevirt/pull/17763


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-83939
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Label HCP worker nodes with node-role.kubevirt.io/control-plane rather than node-role.kubernetes.io/control-plane
```
