### PR TITLE
components: Rm orphaned network-attachment-definitions RBAC

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1316,17 +1316,6 @@ rules:
   - update
   - delete
 - apiGroups:
-  - k8s.cni.cncf.io
-  resources:
-  - network-attachment-definitions
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
-- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.16.0/manifests/kubevirt-hyperconverged-operator.v1.16.0.clusterserviceversion.yaml
@@ -597,17 +597,6 @@ spec:
           - update
           - delete
         - apiGroups:
-          - k8s.cni.cncf.io
-          resources:
-          - network-attachment-definitions
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - delete
-        - apiGroups:
           - security.openshift.io
           resources:
           - securitycontextconstraints

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.17.0/manifests/kubevirt-hyperconverged-operator.v1.17.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.17.0/manifests/kubevirt-hyperconverged-operator.v1.17.0.clusterserviceversion.yaml
@@ -616,17 +616,6 @@ spec:
           - update
           - delete
         - apiGroups:
-          - k8s.cni.cncf.io
-          resources:
-          - network-attachment-definitions
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - delete
-        - apiGroups:
           - security.openshift.io
           resources:
           - securitycontextconstraints

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.18.0/manifests/kubevirt-hyperconverged-operator.v1.18.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.18.0/manifests/kubevirt-hyperconverged-operator.v1.18.0.clusterserviceversion.yaml
@@ -645,17 +645,6 @@ spec:
           - update
           - delete
         - apiGroups:
-          - k8s.cni.cncf.io
-          resources:
-          - network-attachment-definitions
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - delete
-        - apiGroups:
           - security.openshift.io
           resources:
           - securitycontextconstraints

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
@@ -645,17 +645,6 @@ spec:
           - update
           - delete
         - apiGroups:
-          - k8s.cni.cncf.io
-          resources:
-          - network-attachment-definitions
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - delete
-        - apiGroups:
           - security.openshift.io
           resources:
           - securitycontextconstraints

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -586,11 +586,6 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 			Verbs:     stringListToSlice("get", "list", "watch", "create", "update", "delete"),
 		},
 		{
-			APIGroups: stringListToSlice("k8s.cni.cncf.io"),
-			Resources: stringListToSlice("network-attachment-definitions"),
-			Verbs:     stringListToSlice("get", "list", "watch", "create", "update", "delete"),
-		},
-		{
 			APIGroups: stringListToSlice("security.openshift.io"),
 			Resources: stringListToSlice("securitycontextconstraints"),
 			Verbs:     stringListToSlice("get", "list", "watch", "create", "update", "delete"),


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The CRUD permissions on k8s.cni.cncf.io/network-attachment-definitions were added in 6ad122f76 for the passt binding plugin, which was removed in #4229 (743bc3157). The RBAC entry was left behind. No remaining code manages NetworkAttachmentDefinitions, so this permission is unused.


Assisted by: Claude Sonnet 4.5 <noreply@anthropic.com>

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
