### PR TITLE
fix: make DeprecatedMachineType alert test multi-arch aware

### DIFF
--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -209,8 +209,19 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			})
 	})
 
-	It("should fire the DeprecatedMachineType alert when a VM is using a deprecated machine type", func(ctx context.Context) {
-		const deprecatedMachineType = "pc-q35-rhel7.6.0"
+	It("should fire the DeprecatedMachineType alert when a VM is using a deprecated machine type", Label(tests.DeprecatedArchLabel), func(ctx context.Context) {
+		archs, err := getArchs(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		var deprecatedMachineType string
+		switch {
+		case slices.Contains(archs, "amd64"):
+			deprecatedMachineType = "pc-q35-rhel7.6.0"
+		case slices.Contains(archs, "s390x"):
+			deprecatedMachineType = "s390-ccw-virtio-rhel7.6.0"
+		default:
+			Fail(fmt.Sprintf("no known deprecated machine type for architectures %v; Use the \"!%s\" label filter in order to skip this test", archs, tests.DeprecatedArchLabel))
+		}
 
 		By("Creating a VM with a deprecated machine type")
 		vm := &kubevirtcorev1.VirtualMachine{

--- a/tests/func-tests/utils.go
+++ b/tests/func-tests/utils.go
@@ -37,6 +37,7 @@ const (
 	HighlyAvailableClusterLabel = "HIGHLY_AVAILABLE_CLUSTER"
 	DestructiveLabel            = "DESTRUCTIVE"
 	OpenshiftLabel              = "OpenShift"
+	DeprecatedArchLabel         = "DEPRECATED_ARCH"
 
 	TestNamespace = "hco-test-default"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The DeprecatedMachineType alert functional test hardcodes pc-q35-rhel7.6.0 as the deprecated machine type to test with. This is an x86-only machine type and fails on s390x clusters with:
```
spec.template.spec.domain.machine.type is not supported: pc-q35-rhel7.6.0
```
This PR makes the test multi-arch aware by using the existing getArchs() helper to detect the cluster architecture and select the appropriate deprecated machine type:
1. amd64: pc-q35-rhel7.6.0 (existing behavior, no change)
2. s390x: s390-ccw-virtio-rhel7.6.0
3. Other: gracefully skips the test

Both machine types are the oldest RHEL-versioned types for their respective architecture, guaranteed to be marked Deprecated: "yes" by QEMU/libvirt on any modern (RHEL 9-based) CNV cluster.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
