### PR TITLE
CNV-86236: Move all manifests to v1

### DIFF
--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -1,49 +1,38 @@
 ---
-apiVersion: hco.kubevirt.io/v1beta1
+apiVersion: hco.kubevirt.io/v1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
 spec:
-  certConfig:
-    ca:
-      duration: 48h0m0s
-      renewBefore: 24h0m0s
-    server:
-      duration: 24h0m0s
-      renewBefore: 12h0m0s
-  deployVmConsoleProxy: false
-  enableApplicationAwareQuota: false
-  enableCommonBootImageImport: true
-  featureGates:
-    alignCPUs: false
-    containerPathVolumes: false
-    decentralizedLiveMigration: true
-    declarativeHotplugVolumes: false
-    deployKubeSecondaryDNS: false
-    disableMDevConfiguration: false
-    downwardMetrics: false
-    enableMultiArchBootImageImport: false
-    incrementalBackup: false
-    objectGraph: false
-    persistentReservation: false
-    videoConfig: true
-  higherWorkloadDensity:
-    memoryOvercommitPercentage: 100
-  infra: {}
-  liveMigrationConfig:
-    allowAutoConverge: false
-    allowPostCopy: false
-    completionTimeoutPerGiB: 150
-    parallelMigrationsPerCluster: 5
-    parallelOutboundMigrationsPerNode: 2
-    progressTimeout: 150
-  uninstallStrategy: BlockUninstallIfWorkloadsExist
-  virtualMachineOptions:
-    disableFreePageReporting: false
-    disableSerialConsoleLog: false
-  workloadUpdateStrategy:
-    batchEvictionInterval: 1m0s
-    batchEvictionSize: 10
-    workloadUpdateMethods:
-    - LiveMigrate
-  workloads: {}
+  deployment:
+    deployVmConsoleProxy: false
+    uninstallStrategy: BlockUninstallIfWorkloadsExist
+  security:
+    certConfig:
+      ca:
+        duration: 48h0m0s
+        renewBefore: 24h0m0s
+      server:
+        duration: 24h0m0s
+        renewBefore: 12h0m0s
+  virtualization:
+    higherWorkloadDensity:
+      memoryOvercommitPercentage: 100
+    liveMigrationConfig:
+      allowAutoConverge: false
+      allowPostCopy: false
+      completionTimeoutPerGiB: 150
+      parallelMigrationsPerCluster: 5
+      parallelOutboundMigrationsPerNode: 2
+      progressTimeout: 150
+    virtualMachineOptions:
+      disableFreePageReporting: false
+      disableSerialConsoleLog: false
+    vmiCPUAllocationRatio: 10
+    workloadUpdateStrategy:
+      batchEvictionInterval: 1m0s
+      batchEvictionSize: 10
+      workloadUpdateMethods:
+      - LiveMigrate
+  workloadSources:
+    enableCommonBootImageImport: true

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}},{"apiVersion":"networkaddonsoperator.network.kubevirt.io/v1","kind":"NetworkAddonsConfig","metadata":{"name":"cluster"},"spec":{"imagePullPolicy":"IfNotPresent","kubeMacPool":{"rangeEnd":"FD:FF:FF:FF:FF:FF","rangeStart":"02:00:00:00:00:00"},"linuxBridge":{},"macvtap":{},"multus":{},"ovs":{}}},{"apiVersion":"kubevirt.io/v1","kind":"KubeVirt","metadata":{"name":"kubevirt","namespace":"kubevirt"},"spec":{"imagePullPolicy":"Always"}},{"apiVersion":"ssp.kubevirt.io/v1beta2","kind":"SSP","metadata":{"name":"ssp-sample","namespace":"kubevirt"},"spec":{"commonTemplates":{"namespace":"kubevirt"},"featureGates":{"deployVmConsoleProxy":true},"templateValidator":{"replicas":2}}},{"apiVersion":"ssp.kubevirt.io/v1beta3","kind":"SSP","metadata":{"name":"ssp-sample","namespace":"kubevirt"},"spec":{"commonTemplates":{"namespace":"kubevirt"},"templateValidator":{"replicas":2}}},{"apiVersion":"cdi.kubevirt.io/v1beta1","kind":"CDI","metadata":{"name":"cdi","namespace":"cdi"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"hostpathprovisioner.kubevirt.io/v1beta1","kind":"HostPathProvisioner","metadata":{"name":"hostpath-provisioner"},"spec":{"imagePullPolicy":"IfNotPresent","storagePools":[{"name":"local","path":"/var/hpvolumes","pvcTemplate":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"50Gi"}}}}],"workload":{"nodeSelector":{"kubernetes.io/os":"linux"}}}},{"apiVersion":"aaq.kubevirt.io/v1alpha1","kind":"AAQ","metadata":{"name":"aaq","namespace":"aaq"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"migrations.kubevirt.io/v1alpha1","kind":"MigController","metadata":{"name":"migcontroller"},"spec":{"imagePullPolicy":"IfNotPresent"}}]'
+    alm-examples: '[{"apiVersion":"hco.kubevirt.io/v1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}},{"apiVersion":"networkaddonsoperator.network.kubevirt.io/v1","kind":"NetworkAddonsConfig","metadata":{"name":"cluster"},"spec":{"imagePullPolicy":"IfNotPresent","kubeMacPool":{"rangeEnd":"FD:FF:FF:FF:FF:FF","rangeStart":"02:00:00:00:00:00"},"linuxBridge":{},"macvtap":{},"multus":{},"ovs":{}}},{"apiVersion":"kubevirt.io/v1","kind":"KubeVirt","metadata":{"name":"kubevirt","namespace":"kubevirt"},"spec":{"imagePullPolicy":"Always"}},{"apiVersion":"ssp.kubevirt.io/v1beta2","kind":"SSP","metadata":{"name":"ssp-sample","namespace":"kubevirt"},"spec":{"commonTemplates":{"namespace":"kubevirt"},"featureGates":{"deployVmConsoleProxy":true},"templateValidator":{"replicas":2}}},{"apiVersion":"ssp.kubevirt.io/v1beta3","kind":"SSP","metadata":{"name":"ssp-sample","namespace":"kubevirt"},"spec":{"commonTemplates":{"namespace":"kubevirt"},"templateValidator":{"replicas":2}}},{"apiVersion":"cdi.kubevirt.io/v1beta1","kind":"CDI","metadata":{"name":"cdi","namespace":"cdi"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"hostpathprovisioner.kubevirt.io/v1beta1","kind":"HostPathProvisioner","metadata":{"name":"hostpath-provisioner"},"spec":{"imagePullPolicy":"IfNotPresent","storagePools":[{"name":"local","path":"/var/hpvolumes","pvcTemplate":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"50Gi"}}}}],"workload":{"nodeSelector":{"kubernetes.io/os":"linux"}}}},{"apiVersion":"aaq.kubevirt.io/v1alpha1","kind":"AAQ","metadata":{"name":"aaq","namespace":"aaq"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"migrations.kubevirt.io/v1alpha1","kind":"MigController","metadata":{"name":"migcontroller"},"spec":{"imagePullPolicy":"IfNotPresent"}}]'
     capabilities: Deep Insights
     categories: OpenShift Optional
     certified: "false"
@@ -23,7 +23,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     openshift.io/required-scc: restricted-v2
-    operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
+    operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
     operatorframework.io/suggested-namespace: kubevirt-hyperconverged
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.openshift.io/must-gather-image: quay.io/kubevirt/must-gather
@@ -49,37 +49,37 @@ spec:
       - description: nodeAffinity describes node affinity scheduling rules for the
           infra pods.
         displayName: Infra components node affinity
-        path: infra.nodePlacement.affinity.nodeAffinity
+        path: deployment.nodePlacements.infra.affinity.nodeAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
       - description: podAffinity describes pod affinity scheduling rules for the infra
           pods.
         displayName: Infra components pod affinity
-        path: infra.nodePlacement.affinity.podAffinity
+        path: deployment.nodePlacements.infra.affinity.podAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podAffinity
       - description: podAntiAffinity describes pod anti affinity scheduling rules
           for the infra pods.
         displayName: Infra components pod anti-affinity
-        path: infra.nodePlacement.affinity.podAntiAffinity
+        path: deployment.nodePlacements.infra.affinity.podAntiAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
       - description: nodeAffinity describes node affinity scheduling rules for the
           workloads pods.
         displayName: Workloads components node affinity
-        path: workloads.nodePlacement.affinity.nodeAffinity
+        path: deployment.nodePlacements.workload.affinity.nodeAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
       - description: podAffinity describes pod affinity scheduling rules for the workloads
           pods.
         displayName: Workloads components pod affinity
-        path: workloads.nodePlacement.affinity.podAffinity
+        path: deployment.nodePlacements.workload.affinity.podAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podAffinity
       - description: podAntiAffinity describes pod anti affinity scheduling rules
           for the workloads pods.
         displayName: Workloads components pod anti-affinity
-        path: workloads.nodePlacement.affinity.podAntiAffinity
+        path: deployment.nodePlacements.workload.affinity.podAntiAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
       - description: HIDDEN FIELDS - operator version.
@@ -87,7 +87,7 @@ spec:
         path: version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      version: v1beta1
+      version: v1
     - description: Cluster Network Addons
       displayName: Cluster Network Addons
       kind: NetworkAddonsConfig

--- a/deploy/kustomize/base/hco_cr.yaml
+++ b/deploy/kustomize/base/hco_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: hco.kubevirt.io/v1beta1
+apiVersion: hco.kubevirt.io/v1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged

--- a/deploy/kustomize/private_repo/kustomization.yaml
+++ b/deploy/kustomize/private_repo/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
   - ../marketplace
 
-patchesStrategicMerge:
-  - operator_source.patch.yaml
+patches:
+  - path: operator_source.patch.yaml
 

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
@@ -3,13 +3,13 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}},{"apiVersion":"networkaddonsoperator.network.kubevirt.io/v1","kind":"NetworkAddonsConfig","metadata":{"name":"cluster"},"spec":{"imagePullPolicy":"IfNotPresent","kubeMacPool":{"rangeEnd":"FD:FF:FF:FF:FF:FF","rangeStart":"02:00:00:00:00:00"},"linuxBridge":{},"macvtap":{},"multus":{},"ovs":{}}},{"apiVersion":"kubevirt.io/v1","kind":"KubeVirt","metadata":{"name":"kubevirt","namespace":"kubevirt"},"spec":{"imagePullPolicy":"Always"}},{"apiVersion":"ssp.kubevirt.io/v1beta2","kind":"SSP","metadata":{"name":"ssp-sample","namespace":"kubevirt"},"spec":{"commonTemplates":{"namespace":"kubevirt"},"featureGates":{"deployVmConsoleProxy":true},"templateValidator":{"replicas":2}}},{"apiVersion":"ssp.kubevirt.io/v1beta3","kind":"SSP","metadata":{"name":"ssp-sample","namespace":"kubevirt"},"spec":{"commonTemplates":{"namespace":"kubevirt"},"templateValidator":{"replicas":2}}},{"apiVersion":"cdi.kubevirt.io/v1beta1","kind":"CDI","metadata":{"name":"cdi","namespace":"cdi"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"hostpathprovisioner.kubevirt.io/v1beta1","kind":"HostPathProvisioner","metadata":{"name":"hostpath-provisioner"},"spec":{"imagePullPolicy":"IfNotPresent","storagePools":[{"name":"local","path":"/var/hpvolumes","pvcTemplate":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"50Gi"}}}}],"workload":{"nodeSelector":{"kubernetes.io/os":"linux"}}}},{"apiVersion":"aaq.kubevirt.io/v1alpha1","kind":"AAQ","metadata":{"name":"aaq","namespace":"aaq"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"migrations.kubevirt.io/v1alpha1","kind":"MigController","metadata":{"name":"migcontroller"},"spec":{"imagePullPolicy":"IfNotPresent"}}]'
+    alm-examples: '[{"apiVersion":"hco.kubevirt.io/v1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}},{"apiVersion":"networkaddonsoperator.network.kubevirt.io/v1","kind":"NetworkAddonsConfig","metadata":{"name":"cluster"},"spec":{"imagePullPolicy":"IfNotPresent","kubeMacPool":{"rangeEnd":"FD:FF:FF:FF:FF:FF","rangeStart":"02:00:00:00:00:00"},"linuxBridge":{},"macvtap":{},"multus":{},"ovs":{}}},{"apiVersion":"kubevirt.io/v1","kind":"KubeVirt","metadata":{"name":"kubevirt","namespace":"kubevirt"},"spec":{"imagePullPolicy":"Always"}},{"apiVersion":"ssp.kubevirt.io/v1beta2","kind":"SSP","metadata":{"name":"ssp-sample","namespace":"kubevirt"},"spec":{"commonTemplates":{"namespace":"kubevirt"},"featureGates":{"deployVmConsoleProxy":true},"templateValidator":{"replicas":2}}},{"apiVersion":"ssp.kubevirt.io/v1beta3","kind":"SSP","metadata":{"name":"ssp-sample","namespace":"kubevirt"},"spec":{"commonTemplates":{"namespace":"kubevirt"},"templateValidator":{"replicas":2}}},{"apiVersion":"cdi.kubevirt.io/v1beta1","kind":"CDI","metadata":{"name":"cdi","namespace":"cdi"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"hostpathprovisioner.kubevirt.io/v1beta1","kind":"HostPathProvisioner","metadata":{"name":"hostpath-provisioner"},"spec":{"imagePullPolicy":"IfNotPresent","storagePools":[{"name":"local","path":"/var/hpvolumes","pvcTemplate":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"50Gi"}}}}],"workload":{"nodeSelector":{"kubernetes.io/os":"linux"}}}},{"apiVersion":"aaq.kubevirt.io/v1alpha1","kind":"AAQ","metadata":{"name":"aaq","namespace":"aaq"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"migrations.kubevirt.io/v1alpha1","kind":"MigController","metadata":{"name":"migcontroller"},"spec":{"imagePullPolicy":"IfNotPresent"}}]'
     capabilities: Deep Insights
     categories: OpenShift Optional
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.19.0-unstable
-    createdAt: "2026-06-16 10:19:17"
+    createdAt: "2026-06-17 08:28:29"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -23,7 +23,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     openshift.io/required-scc: restricted-v2
-    operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
+    operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
     operatorframework.io/suggested-namespace: kubevirt-hyperconverged
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.openshift.io/must-gather-image: quay.io/kubevirt/must-gather
@@ -49,37 +49,37 @@ spec:
       - description: nodeAffinity describes node affinity scheduling rules for the
           infra pods.
         displayName: Infra components node affinity
-        path: infra.nodePlacement.affinity.nodeAffinity
+        path: deployment.nodePlacements.infra.affinity.nodeAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
       - description: podAffinity describes pod affinity scheduling rules for the infra
           pods.
         displayName: Infra components pod affinity
-        path: infra.nodePlacement.affinity.podAffinity
+        path: deployment.nodePlacements.infra.affinity.podAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podAffinity
       - description: podAntiAffinity describes pod anti affinity scheduling rules
           for the infra pods.
         displayName: Infra components pod anti-affinity
-        path: infra.nodePlacement.affinity.podAntiAffinity
+        path: deployment.nodePlacements.infra.affinity.podAntiAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
       - description: nodeAffinity describes node affinity scheduling rules for the
           workloads pods.
         displayName: Workloads components node affinity
-        path: workloads.nodePlacement.affinity.nodeAffinity
+        path: deployment.nodePlacements.workload.affinity.nodeAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
       - description: podAffinity describes pod affinity scheduling rules for the workloads
           pods.
         displayName: Workloads components pod affinity
-        path: workloads.nodePlacement.affinity.podAffinity
+        path: deployment.nodePlacements.workload.affinity.podAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podAffinity
       - description: podAntiAffinity describes pod anti affinity scheduling rules
           for the workloads pods.
         displayName: Workloads components pod anti-affinity
-        path: workloads.nodePlacement.affinity.podAntiAffinity
+        path: deployment.nodePlacements.workload.affinity.podAntiAffinity
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
       - description: HIDDEN FIELDS - operator version.
@@ -87,7 +87,7 @@ spec:
         path: version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      version: v1beta1
+      version: v1
     - description: Cluster Network Addons
       displayName: Cluster Network Addons
       kind: NetworkAddonsConfig

--- a/hack/check_tlsprofile.sh
+++ b/hack/check_tlsprofile.sh
@@ -22,7 +22,8 @@ set -ex
 
 KUBECTL_BINARY=oc
 INSTALLED_NAMESPACE=kubevirt-hyperconverged
-HCO_TYPE="hyperconvergeds.v1beta1.hco.kubevirt.io"
+HCO_TYPE="hyperconvergeds"
+TLS_PATH="/spec/security/tlsSecurityProfile"
 
 clean_nmap_output () {
   sed -i '/^$/d' "$1"
@@ -81,44 +82,44 @@ else
   sleep 5
 fi
 
-./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {old: {}, type: \"Old\"} }]'"
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": \"${TLS_PATH}\", \"value\": {old: {}, type: \"Old\"} }]'"
 sleep 2
 run_nmap old.txt
 clean_nmap_output old.txt
 diff -w old.txt "hack/tlsprofiles/old.expected${FIPS}"
 
 # nothing should happen in dry-run mode
-./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} --dry-run=client -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {modern: {}, type: \"Modern\"} }]'"
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} --dry-run=client -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": \"${TLS_PATH}\", \"value\": {modern: {}, type: \"Modern\"} }]'"
 sleep 2
 run_nmap old.txt
 clean_nmap_output old.txt
 diff -w old.txt "hack/tlsprofiles/old.expected${FIPS}"
 check_ssp_up
 
-./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {intermediate: {}, type: \"Intermediate\"} }]'"
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": \"${TLS_PATH}\", \"value\": {intermediate: {}, type: \"Intermediate\"} }]'"
 sleep 2
 run_nmap intermediate.txt
 clean_nmap_output intermediate.txt
 diff -w intermediate.txt "hack/tlsprofiles/intermediate.expected${FIPS}"
 check_ssp_up
 
-./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {modern: {}, type: \"Modern\"} }]'"
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": \"${TLS_PATH}\", \"value\": {modern: {}, type: \"Modern\"} }]'"
 sleep 2
 run_nmap modern.txt
 clean_nmap_output modern.txt
 diff -w modern.txt "hack/tlsprofiles/modern.expected${FIPS}"
 check_ssp_up
 
-./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {custom: {minTLSVersion: \"VersionTLS12\", ciphers: [\"ECDHE-ECDSA-CHACHA20-POLY1305\", \"ECDHE-ECDSA-AES256-GCM-SHA384\", \"AES256-GCM-SHA384\", \"AES128-SHA256\"]}, type: \"Custom\"} }]'  2>&1 | grep 'missing an HTTP/2-required'"
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": \"${TLS_PATH}\", \"value\": {custom: {minTLSVersion: \"VersionTLS12\", ciphers: [\"ECDHE-ECDSA-CHACHA20-POLY1305\", \"ECDHE-ECDSA-AES256-GCM-SHA384\", \"AES256-GCM-SHA384\", \"AES128-SHA256\"]}, type: \"Custom\"} }]'  2>&1 | grep 'missing an HTTP/2-required'"
 check_ssp_up
 
-./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": /spec/tlsSecurityProfile, \"value\": {custom: {minTLSVersion: \"VersionTLS12\", ciphers: [\"ECDHE-RSA-AES128-GCM-SHA256\", \"ECDHE-ECDSA-CHACHA20-POLY1305\", \"ECDHE-ECDSA-AES256-GCM-SHA384\", \"AES256-GCM-SHA384\", \"AES128-SHA256\"]}, type: \"Custom\"} }]'"
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"replace\", \"path\": \"${TLS_PATH}\", \"value\": {custom: {minTLSVersion: \"VersionTLS12\", ciphers: [\"ECDHE-RSA-AES128-GCM-SHA256\", \"ECDHE-ECDSA-CHACHA20-POLY1305\", \"ECDHE-ECDSA-AES256-GCM-SHA384\", \"AES256-GCM-SHA384\", \"AES128-SHA256\"]}, type: \"Custom\"} }]'"
 run_nmap custom.txt
 clean_nmap_output custom.txt
 diff -w custom.txt "hack/tlsprofiles/custom.expected${FIPS}"
 check_ssp_up
 
-./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"remove\", \"path\": /spec/tlsSecurityProfile }]'"
+./hack/retry.sh 10 3 "${KUBECTL_BINARY} patch ${HCO_TYPE} -n ${INSTALLED_NAMESPACE} --type=json kubevirt-hyperconverged -p '[{\"op\": \"remove\", \"path\": \"${TLS_PATH}\" }]'"
 sleep 2
 run_nmap default.txt
 clean_nmap_output default.txt

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -201,9 +201,6 @@ for op in "${OPERATORS[@]}"; do
     "${CMD}" wait deployment/"${op}" --for=condition=Available --timeout="540s" || CONTAINER_ERRORED+="${op} "
 done
 
-# TODO: remove this after re-generating the manifests in v1:
-go run ./tools/crwriter --api-version="v1" --format=yaml | tee _out/hco.cr.yaml
-
 "${CMD}" apply -f _out/hco.cr.yaml
 
 sleep 10

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -621,13 +621,15 @@ func roleWithAllPermissions(apiGroup string, resources []string) rbacv1.PolicyRu
 	}
 }
 
-func GetOperatorCR() *hcov1beta1.HyperConverged {
+var GetOperatorCR = GetOperatorV1CR
+
+func GetOperatorV1beta1CR() *hcov1beta1.HyperConverged {
 	defaultScheme := runtime.NewScheme()
 	_ = hcov1beta1.AddToScheme(defaultScheme)
 	_ = hcov1beta1.RegisterDefaults(defaultScheme)
 	defaultHco := &hcov1beta1.HyperConverged{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: util.APIVersion,
+			APIVersion: hcov1beta1.APIVersion,
 			Kind:       util.HyperConvergedKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -1,6 +1,8 @@
 package util
 
-import "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+import (
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+)
 
 // pod names
 const (
@@ -48,9 +50,8 @@ const (
 	AppLabel                                = "app"
 	UndefinedNamespace                      = ""
 	OpenshiftNamespace                      = "openshift"
-	APIVersionBeta                          = v1beta1.APIVersionBeta
-	CurrentAPIVersion                       = v1beta1.APIVersionBeta
-	APIVersionGroup                         = v1beta1.APIVersionGroup
+	CurrentAPIVersion                       = hcov1.APIVersionV1
+	APIVersionGroup                         = hcov1.APIVersionGroup
 	HyperConvergedKind                      = "HyperConverged"
 
 	// Recommended labels by Kubernetes. See
@@ -112,7 +113,7 @@ const (
 )
 
 var (
-	APIVersion = v1beta1.APIVersion
+	APIVersion = hcov1.APIVersion
 )
 
 type AppComponent string

--- a/tools/crwriter/crwriter.go
+++ b/tools/crwriter/crwriter.go
@@ -46,8 +46,8 @@ func init() {
 func main() {
 	var cr any
 	switch apiVersion {
-	case "v1":
-		cr = components.GetOperatorV1CR()
+	case "v1beta1":
+		cr = components.GetOperatorV1beta1CR()
 	default:
 		cr = components.GetOperatorCR()
 	}

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -312,17 +312,17 @@ type csvBaseParams struct {
 // getCSVBase returns a base HCO CSV without an InstallStrategy
 func getCSVBase(params *csvBaseParams) *csvv1alpha1.ClusterServiceVersion {
 	almExamples, _ := json.Marshal(
-		map[string]interface{}{
-			"apiVersion": hcoutil.APIVersion,
+		map[string]any{
+			"apiVersion": hcov1.APIVersion,
 			"kind":       hcoutil.HyperConvergedKind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      packageName,
 				"namespace": params.Namespace,
 				"annotations": map[string]string{
 					"deployOVS": "false",
 				},
 			},
-			"spec": map[string]interface{}{},
+			"spec": map[string]any{},
 		})
 
 	// Explicitly fail on unvalidated (for any reason) requests:
@@ -496,13 +496,11 @@ func getCSVBase(params *csvBaseParams) *csvv1alpha1.ClusterServiceVersion {
 						Kind:        hcoutil.HyperConvergedKind,
 						DisplayName: params.CrdDisplay + " Deployment",
 						Description: "Represents the deployment of " + params.CrdDisplay,
-						// TODO: move this to annotations on hyperconverged_types.go once kubebuilder
-						// properly supports SpecDescriptors as the operator-sdk already does
 						SpecDescriptors: []csvv1alpha1.SpecDescriptor{
 							{
 								DisplayName: "Infra components node affinity",
 								Description: "nodeAffinity describes node affinity scheduling rules for the infra pods.",
-								Path:        "infra.nodePlacement.affinity.nodeAffinity",
+								Path:        "deployment.nodePlacements.infra.affinity.nodeAffinity",
 								XDescriptors: []string{
 									"urn:alm:descriptor:com.tectonic.ui:nodeAffinity",
 								},
@@ -510,7 +508,7 @@ func getCSVBase(params *csvBaseParams) *csvv1alpha1.ClusterServiceVersion {
 							{
 								DisplayName: "Infra components pod affinity",
 								Description: "podAffinity describes pod affinity scheduling rules for the infra pods.",
-								Path:        "infra.nodePlacement.affinity.podAffinity",
+								Path:        "deployment.nodePlacements.infra.affinity.podAffinity",
 								XDescriptors: []string{
 									"urn:alm:descriptor:com.tectonic.ui:podAffinity",
 								},
@@ -518,7 +516,7 @@ func getCSVBase(params *csvBaseParams) *csvv1alpha1.ClusterServiceVersion {
 							{
 								DisplayName: "Infra components pod anti-affinity",
 								Description: "podAntiAffinity describes pod anti affinity scheduling rules for the infra pods.",
-								Path:        "infra.nodePlacement.affinity.podAntiAffinity",
+								Path:        "deployment.nodePlacements.infra.affinity.podAntiAffinity",
 								XDescriptors: []string{
 									"urn:alm:descriptor:com.tectonic.ui:podAntiAffinity",
 								},
@@ -526,7 +524,7 @@ func getCSVBase(params *csvBaseParams) *csvv1alpha1.ClusterServiceVersion {
 							{
 								DisplayName: "Workloads components node affinity",
 								Description: "nodeAffinity describes node affinity scheduling rules for the workloads pods.",
-								Path:        "workloads.nodePlacement.affinity.nodeAffinity",
+								Path:        "deployment.nodePlacements.workload.affinity.nodeAffinity",
 								XDescriptors: []string{
 									"urn:alm:descriptor:com.tectonic.ui:nodeAffinity",
 								},
@@ -534,7 +532,7 @@ func getCSVBase(params *csvBaseParams) *csvv1alpha1.ClusterServiceVersion {
 							{
 								DisplayName: "Workloads components pod affinity",
 								Description: "podAffinity describes pod affinity scheduling rules for the workloads pods.",
-								Path:        "workloads.nodePlacement.affinity.podAffinity",
+								Path:        "deployment.nodePlacements.workload.affinity.podAffinity",
 								XDescriptors: []string{
 									"urn:alm:descriptor:com.tectonic.ui:podAffinity",
 								},
@@ -542,7 +540,7 @@ func getCSVBase(params *csvBaseParams) *csvv1alpha1.ClusterServiceVersion {
 							{
 								DisplayName: "Workloads components pod anti-affinity",
 								Description: "podAntiAffinity describes pod anti affinity scheduling rules for the workloads pods.",
-								Path:        "workloads.nodePlacement.affinity.podAntiAffinity",
+								Path:        "deployment.nodePlacements.workload.affinity.podAntiAffinity",
 								XDescriptors: []string{
 									"urn:alm:descriptor:com.tectonic.ui:podAntiAffinity",
 								},
@@ -678,8 +676,8 @@ func processOneCsv(c util.CsvWithComponent, installStrategyBase *csvv1alpha1.Str
 	}
 	csvBaseAlmString := csvBase.Annotations[almExamplesAnnotation]
 	csvStructAlmString := csvStruct.Annotations[almExamplesAnnotation]
-	var baseAlmcrs []interface{}
-	var structAlmcrs []interface{}
+	var baseAlmcrs []any
+	var structAlmcrs []any
 
 	if !strings.HasPrefix(csvBaseAlmString, "[") {
 		csvBaseAlmString = "[" + csvBaseAlmString + "]"


### PR DESCRIPTION
**What this PR does / why we need it**:

Any HyperConverged manifest should be now in v1 API. For example, the hc.cr.yaml file, or the example field in the CSV file.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-86236
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Move all manifests to v1
```
