### PR TITLE
fix CNV-90394: many resources are not deleted when deleting the HCO CR

### DIFF
--- a/controllers/commontestutils/eventEmitterMock.go
+++ b/controllers/commontestutils/eventEmitterMock.go
@@ -3,6 +3,7 @@ package commontestutils
 import (
 	"context"
 	"reflect"
+	"slices"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -83,10 +84,7 @@ func (eem *EventEmitterMock) CheckNoEventEmitted() bool {
 }
 
 func eventInArray(eventList []MockEvent, event MockEvent) bool {
-	for _, expectedEvent := range eventList {
-		if reflect.DeepEqual(event, expectedEvent) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(eventList, func(e MockEvent) bool {
+		return reflect.DeepEqual(event, e)
+	})
 }

--- a/controllers/handlers/cdi.go
+++ b/controllers/handlers/cdi.go
@@ -29,11 +29,19 @@ const (
 	cdiConfigAuthorityAnnotation = "cdi.kubevirt.io/configAuthority"
 )
 
-func NewCdiHandler(Client client.Client, Scheme *runtime.Scheme) *operands.GenericOperand {
+type CDIHandler struct {
+	*operands.GenericOperand
+}
+
+func NewCdiHandler(Client client.Client, Scheme *runtime.Scheme) *CDIHandler {
 	hook := &cdiHooks{Client: Client, Scheme: Scheme}
 
-	return operands.NewGenericOperand(Client, Scheme, "CDI", hook, false)
+	return &CDIHandler{
+		GenericOperand: operands.NewGenericOperand(Client, Scheme, "CDI", hook, false),
+	}
 }
+
+func (CDIHandler) ManualDeletionMark() { /* no implementation */ }
 
 type cdiHooks struct {
 	sync.Mutex

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -192,10 +192,18 @@ var (
 	kvDiskVerificationMemoryLimit = resource.MustParse("2G")
 )
 
-// ************  KubeVirt Handler  **************
-func NewKubevirtHandler(Client client.Client, Scheme *runtime.Scheme) *operands.GenericOperand {
-	return operands.NewGenericOperand(Client, Scheme, "KubeVirt", &kubevirtHooks{}, true)
+type KVHandler struct {
+	*operands.GenericOperand
 }
+
+// ************  KubeVirt Handler  **************
+func NewKubevirtHandler(Client client.Client, Scheme *runtime.Scheme) *KVHandler {
+	return &KVHandler{
+		GenericOperand: operands.NewGenericOperand(Client, Scheme, "KubeVirt", &kubevirtHooks{}, true),
+	}
+}
+
+func (KVHandler) ManualDeletionMark() { /* no implementation */ }
 
 type kubevirtHooks struct {
 	sync.Mutex

--- a/controllers/handlers/ssp.go
+++ b/controllers/handlers/ssp.go
@@ -51,6 +51,11 @@ func (h *sspHandler) Reset() {
 	h.handler.Reset()
 }
 
+// GetFullCr returns the full SSP object. Added in order to satisfy the CRGetter interface
+func (h *sspHandler) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
+	return h.hook.GetFullCr(hc)
+}
+
 func NewSspHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
 	hook := &sspHooks{}
 	handler := operands.NewGenericOperand(Client, Scheme, "SSP", hook, false)

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -16,6 +15,7 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimetav1 "k8s.io/apimachinery/pkg/api/meta"
@@ -800,6 +800,10 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{}))
 
+				depNames, err := getDeploymentNames(context.TODO(), cl)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(depNames).To(ContainElements("kubevirt-apiserver-proxy", "kubevirt-console-plugin"))
+
 				foundResource := &hcov1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
@@ -811,13 +815,16 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.Status.RelatedObjects).To(HaveLen(23))
 				Expect(foundResource.Finalizers).To(Equal([]string{FinalizerName}))
 
-				// Now, delete HCO
-				delTime := time.Now().UTC().Add(-1 * time.Minute)
-				expected.hco.DeletionTimestamp = &metav1.Time{Time: delTime}
-				expected.hco.Finalizers = []string{FinalizerName}
-				cl = expected.initClient()
+				hco := &hcov1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      expected.hco.Name,
+						Namespace: expected.hco.Namespace,
+					},
+				}
 
-				r = initReconciler(cl, nil)
+				// Now, delete HCO
+				Expect(cl.Delete(context.TODO(), hco, &client.DeleteOptions{})).To(Succeed())
+
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
@@ -831,6 +838,18 @@ var _ = Describe("HyperconvergedController", func() {
 					types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
 					foundResource)
 				Expect(err).To(MatchError(apierrors.IsNotFound, "not found error"))
+
+				depNames, err = getDeploymentNames(context.TODO(), cl)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(depNames).To(And(Not(ContainElement("kubevirt-apiserver-proxy")), Not(ContainElement("kubevirt-console-plugin"))))
+
+				kvList := &kubevirtcorev1.KubeVirtList{}
+				Expect(cl.List(context.TODO(), kvList)).To(Succeed())
+				Expect(kvList.Items).To(BeEmpty(), "The KubeVirt object should be deleted")
+
+				cdiList := &cdiv1beta1.CDIList{}
+				Expect(cl.List(context.TODO(), cdiList)).To(Succeed())
+				Expect(cdiList.Items).To(BeEmpty(), "The CDI object should be deleted")
 
 				verifyHyperConvergedCRExistsMetricFalse()
 			})
@@ -2603,4 +2622,19 @@ func openshift2CdiSecProfile(hcProfile *openshiftconfigv1.TLSSecurityProfile) *c
 		Modern:       (*cdiv1beta1.ModernTLSProfile)(hcProfile.Modern),
 		Custom:       custom,
 	}
+}
+
+func getDeploymentNames(ctx context.Context, cl client.Client) ([]string, error) {
+	deps := &appsv1.DeploymentList{}
+	err := cl.List(ctx, deps, &client.ListOptions{Namespace: namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	var depNames []string
+	for _, dep := range deps.Items {
+		depNames = append(depNames, dep.Name)
+	}
+
+	return depNames, nil
 }

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -16,7 +16,7 @@ import (
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers"
-	aie "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/aie"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/aie"
 	waspagent "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/wasp-agent"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/metrics"
@@ -31,7 +31,7 @@ const (
 	uninstallVirtErrorMsg = "The uninstall request failed on virt component: "
 	ErrHCOUninstall       = "ErrHCOUninstall"
 	uninstallHCOErrorMsg  = "The uninstall request failed on dependent components, please check their logs."
-	deleteTimeOut         = 30 * time.Second
+	deleteTimeOut         = time.Minute
 )
 
 var (
@@ -124,7 +124,9 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 // The k8s client is not available when calling to NewOperandHandler.
 // Initial operations that need to read/write from the cluster can only be done when the client is already working.
 func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.ClusterInfo, hc *hcov1.HyperConverged, pwdFS fs.FS) {
-	h.objects = make([]client.Object, 0)
+	for _, operand := range h.operands {
+		h.addOperandObject(operand, hc)
+	}
 
 	if !ci.IsOpenshift() {
 		return
@@ -148,6 +150,10 @@ func (h *OperandHandler) GetImageStreamNames() []string {
 }
 
 func (h *OperandHandler) addOperandObject(handler operands.Operand, hc *hcov1.HyperConverged) {
+	if _, shouldNotBeAdded := handler.(operands.ManualDeletionMarker); shouldNotBeAdded {
+		return
+	}
+
 	var (
 		obj client.Object
 		err error
@@ -156,7 +162,7 @@ func (h *OperandHandler) addOperandObject(handler operands.Operand, hc *hcov1.Hy
 	if gh, ok := handler.(operands.CRGetter); ok {
 		obj, err = gh.GetFullCr(hc)
 	} else {
-		err = fmt.Errorf("unknown handler with type %T", handler)
+		return
 	}
 
 	if err != nil {
@@ -221,26 +227,10 @@ func (h *OperandHandler) handleUpdatedOperand(req *common.HcoRequest, res *opera
 }
 
 func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
-
 	tCtx, cancel := context.WithTimeout(req.Ctx, deleteTimeOut)
 	defer cancel()
 
-	resources := []client.Object{
-		handlers.NewNetworkAddonsWithNameOnly(),
-		handlers.NewSSPWithNameOnly(),
-		handlers.NewConsoleCLIDownload(),
-		handlers.NewAAQWithNameOnly(),
-		handlers.NewMigControllerWithNameOnly(),
-		waspagent.NewWaspAgentSCCWithNameOnly(),
-		aie.NewAIEWebhookClusterRoleWithNameOnly(),
-		aie.NewAIEWebhookClusterRoleBindingWithNameOnly(),
-		aie.NewAIEWebhookMutatingWebhookConfigurationWithNameOnly(),
-		aie.NewIOMMUFDDevicePluginSCCWithNameOnly(),
-	}
-
-	resources = append(resources, h.objects...)
-
-	err := h.deleteMultipleResources(tCtx, req, resources)
+	err := h.deleteMultipleResources(tCtx, req)
 	if err != nil {
 		return err
 	}
@@ -253,23 +243,22 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 	return h.deleteSingleResource(tCtx, req, handlers.NewCDIWithNameOnly(), ErrCDIUninstall, uninstallCDIErrorMsg)
 }
 
-func (h *OperandHandler) deleteMultipleResources(tCtx context.Context, req *common.HcoRequest, resources []client.Object) error {
+func (h *OperandHandler) deleteMultipleResources(tCtx context.Context, req *common.HcoRequest) error {
 	eg, egCtx := errgroup.WithContext(tCtx)
+	eg.SetLimit(10)
 
-	for _, res := range resources {
-		func(o client.Object) {
-			eg.Go(func() error {
-				deleted, err := hcoutil.EnsureDeleted(egCtx, h.client, o, req.Instance.Name, req.Logger, false, true, true)
-				if err != nil {
-					req.Logger.Error(err, "Failed to manually delete objects")
-					h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, ErrHCOUninstall, uninstallHCOErrorMsg)
-					return err
-				} else if deleted {
-					h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed %s %s", o.GetObjectKind().GroupVersionKind().Kind, o.GetName()))
-				}
-				return nil
-			})
-		}(res)
+	for _, o := range h.objects {
+		eg.Go(func() error {
+			deleted, err := hcoutil.EnsureDeleted(egCtx, h.client, o, req.Instance.Name, req.Logger, false, true, true)
+			if err != nil {
+				req.Logger.Error(err, "Failed to manually delete objects")
+				h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, ErrHCOUninstall, uninstallHCOErrorMsg)
+				return err
+			} else if deleted {
+				h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed %s %s", o.GetObjectKind().GroupVersionKind().Kind, o.GetName()))
+			}
+			return nil
+		})
 	}
 
 	return eg.Wait()

--- a/controllers/operands/operand.go
+++ b/controllers/operands/operand.go
@@ -54,6 +54,12 @@ type Reseter interface {
 	Reset()
 }
 
+// ManualDeletionMarker is a marker interface, to exclude specific handlers from batch deletion
+// tracking. these are handled separately.
+type ManualDeletionMarker interface {
+	ManualDeletionMark()
+}
+
 type GetHandler func(log.Logger, client.Client, *runtime.Scheme, *hcov1.HyperConverged) (Operand, error)
 type GetHandlers func(log.Logger, client.Client, *runtime.Scheme, *hcov1.HyperConverged, fs.FS) ([]Operand, error)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

After moving the operands creation to be static in #4164, we introduced a bug where most of the resources created by HCO are not deleted when HCO is removed.

The reason for that is that the old dynamic addition of operand also added the resource to a list in the operandHandler, to be used for the deletion. But when we stopped using the dynamic code, the resources are not listed anymore, and are not deleted.

This commit fixes this issue by re-creating the list.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-90394
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix CNV-90394: many resources are not deleted when deleting
```
