### PR TITLE
Set the default architecture in the KubeVirt CR

### DIFF
--- a/controllers/commontestutils/nodeinfomocks.go
+++ b/controllers/commontestutils/nodeinfomocks.go
@@ -8,6 +8,7 @@ var (
 	origIsInfraHighlyAvailable        = nodeinfo.IsInfrastructureHighlyAvailable
 	origGetControlPlaneArchitectures  = nodeinfo.GetControlPlaneArchitectures
 	origGetWorkloadsArchitectures     = nodeinfo.GetWorkloadsArchitectures
+	origGetDefaultArchitecture        = nodeinfo.GetDefaultArchitecture
 )
 
 func ResetNodeInfoMocks() {
@@ -16,6 +17,7 @@ func ResetNodeInfoMocks() {
 	nodeinfo.IsInfrastructureHighlyAvailable = origIsInfraHighlyAvailable
 	nodeinfo.GetControlPlaneArchitectures = origGetControlPlaneArchitectures
 	nodeinfo.GetWorkloadsArchitectures = origGetWorkloadsArchitectures
+	nodeinfo.GetDefaultArchitecture = origGetDefaultArchitecture
 }
 
 // HighlyAvailableNodeInfoMocks mocks highly available cluster
@@ -70,9 +72,16 @@ func ControlPlaneArchitecturesMock(arch ...string) {
 	}
 }
 
-// WorkloadseArchitecturesMock mocks the architecures for compute nodes
+// WorkloadsArchitecturesMock mocks the architecures for compute nodes
 func WorkloadsArchitecturesMock(arch ...string) {
 	nodeinfo.GetWorkloadsArchitectures = func() []string {
+		return arch
+	}
+}
+
+// DefaultArchitectureMock mocks the default architecture
+func DefaultArchitectureMock(arch string) {
+	nodeinfo.GetDefaultArchitecture = func() string {
 		return arch
 	}
 }

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -508,27 +508,39 @@ func hcoVmOptionsToKV(vmOpts *hcov1.VirtualMachineOptions, config *kubevirtcorev
 }
 
 var (
-	archConfigOnce            = &sync.Once{}
-	architectureConfiguration *kubevirtcorev1.ArchConfiguration
+	staticArchCfg = generateStaticArchConfig()
 )
 
+func generateStaticArchConfig() *kubevirtcorev1.ArchConfiguration {
+	amd64Config := getAMD64ArchConfig()
+	arm64Config := getARM64ArchConfig()
+	s390xConfig := getS390xArchConfig()
+
+	if amd64Config == nil && arm64Config == nil && s390xConfig == nil {
+		return nil
+	}
+
+	return &kubevirtcorev1.ArchConfiguration{
+		Amd64: amd64Config,
+		Arm64: arm64Config,
+		S390x: s390xConfig,
+	}
+}
+
 func getArchConfiguration() *kubevirtcorev1.ArchConfiguration {
-	archConfigOnce.Do(func() {
-		amd64Comfig := getAMD64ArchConfig()
-		arm64Config := getARM64ArchConfig()
-		s390xConfig := getS390xArchConfig()
-		if amd64Comfig == nil && arm64Config == nil && s390xConfig == nil {
-			return
-		}
+	defaultArch := nodeinfo.GetDefaultArchitecture()
+	var archCfg *kubevirtcorev1.ArchConfiguration
 
-		architectureConfiguration = &kubevirtcorev1.ArchConfiguration{
-			Amd64: amd64Comfig,
-			Arm64: arm64Config,
-			S390x: s390xConfig,
+	if staticArchCfg != nil {
+		archCfg = staticArchCfg.DeepCopy()
+		archCfg.DefaultArchitecture = defaultArch
+	} else if defaultArch != "" {
+		archCfg = &kubevirtcorev1.ArchConfiguration{
+			DefaultArchitecture: defaultArch,
 		}
-	})
+	}
 
-	return architectureConfiguration.DeepCopy()
+	return archCfg
 }
 
 func getAMD64ArchConfig() *kubevirtcorev1.ArchSpecificConfiguration {

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -290,7 +290,7 @@ Version: 1.2.3`)).To(Succeed())
 			Expect(os.Setenv(s390xMachineTypeEnvName, "s390-ccw-virtio")).To(Succeed())
 			Expect(os.Setenv(kvmEmulationEnvName, "false")).To(Succeed())
 
-			restArchConfig()
+			resetArchConfig()
 
 			DeferCleanup(func() {
 				mandatoryKvFeatureGates = slices.Clone(origMandatoryKvFeatureGates)
@@ -304,7 +304,7 @@ Version: 1.2.3`)).To(Succeed())
 				Expect(os.Unsetenv(s390xMachineTypeEnvName)).To(Succeed())
 				Expect(os.Unsetenv(kvmEmulationEnvName)).To(Succeed())
 
-				restArchConfig()
+				resetArchConfig()
 			})
 		})
 
@@ -493,7 +493,7 @@ Version: 1.2.3`)
 			Expect(os.Setenv(arm64MachineTypeEnvName, "virt")).To(Succeed())
 			Expect(os.Setenv(s390xMachineTypeEnvName, "s390-ccw-virtio")).To(Succeed())
 
-			restArchConfig()
+			resetArchConfig()
 
 			existKv, err := NewKubeVirt(hco, commontestutils.Namespace)
 			Expect(err).ToNot(HaveOccurred())
@@ -596,7 +596,7 @@ Version: 1.2.3`)
 			Expect(os.Setenv(amd64MachineTypeEnvName, "q35")).To(Succeed())
 			Expect(os.Unsetenv(arm64MachineTypeEnvName)).To(Succeed())
 			Expect(os.Unsetenv(s390xMachineTypeEnvName)).To(Succeed())
-			restArchConfig()
+			resetArchConfig()
 
 			kv, err := NewKubeVirt(hco, commontestutils.Namespace)
 			Expect(err).ToNot(HaveOccurred())
@@ -613,7 +613,7 @@ Version: 1.2.3`)
 			Expect(os.Setenv(amd64MachineTypeEnvName, "q35")).To(Succeed())
 			Expect(os.Unsetenv(arm64MachineTypeEnvName)).To(Succeed())
 			Expect(os.Unsetenv(s390xMachineTypeEnvName)).To(Succeed())
-			restArchConfig()
+			resetArchConfig()
 
 			kv, err := NewKubeVirt(hco, commontestutils.Namespace)
 			Expect(err).ToNot(HaveOccurred())
@@ -623,6 +623,56 @@ Version: 1.2.3`)
 			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Amd64.OVMFPath).To(Equal(DefaultAMD64OVMFPath))
 			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Arm64).To(BeNil())
 			Expect(kv.Spec.Configuration.ArchitectureConfiguration.S390x).To(BeNil())
+		})
+
+		It("should set DefaultArchitecture when default arch is available", func() {
+			Expect(os.Setenv(amd64MachineTypeEnvName, "q35")).To(Succeed())
+			Expect(os.Unsetenv(arm64MachineTypeEnvName)).To(Succeed())
+			Expect(os.Unsetenv(s390xMachineTypeEnvName)).To(Succeed())
+			commontestutils.DefaultArchitectureMock("amd64")
+			DeferCleanup(commontestutils.ResetNodeInfoMocks)
+			resetArchConfig()
+
+			kv, err := NewKubeVirt(hco, commontestutils.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration).ToNot(BeNil())
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).To(Equal("q35"))
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.DefaultArchitecture).To(Equal("amd64"))
+		})
+
+		It("should set DefaultArchitecture even when no machine type envs are set", func() {
+			Expect(os.Unsetenv(machineTypeEnvName)).To(Succeed())
+			Expect(os.Unsetenv(amd64MachineTypeEnvName)).To(Succeed())
+			Expect(os.Unsetenv(arm64MachineTypeEnvName)).To(Succeed())
+			Expect(os.Unsetenv(s390xMachineTypeEnvName)).To(Succeed())
+			commontestutils.DefaultArchitectureMock("arm64")
+			DeferCleanup(commontestutils.ResetNodeInfoMocks)
+			resetArchConfig()
+
+			kv, err := NewKubeVirt(hco, commontestutils.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration).ToNot(BeNil())
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Amd64).To(BeNil())
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.Arm64).To(BeNil())
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.S390x).To(BeNil())
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration.DefaultArchitecture).To(Equal("arm64"))
+		})
+
+		It("should return nil ArchitectureConfiguration when no machine types and no default arch", func() {
+			Expect(os.Unsetenv(machineTypeEnvName)).To(Succeed())
+			Expect(os.Unsetenv(amd64MachineTypeEnvName)).To(Succeed())
+			Expect(os.Unsetenv(arm64MachineTypeEnvName)).To(Succeed())
+			Expect(os.Unsetenv(s390xMachineTypeEnvName)).To(Succeed())
+			commontestutils.DefaultArchitectureMock("")
+			DeferCleanup(commontestutils.ResetNodeInfoMocks)
+			resetArchConfig()
+
+			kv, err := NewKubeVirt(hco, commontestutils.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(kv.Spec.Configuration.ArchitectureConfiguration).To(BeNil())
 		})
 
 		It("should fail if the SMBIOS is wrongly formatted mandatory configurations", func() {
@@ -4212,8 +4262,8 @@ Version: 1.2.3`)
 
 		Context("validate bug fixes", func() {
 
-			It("Removing HCO machine type annotation does not restore default in KubeVirt ", func() {
-				restArchConfig()
+			It("Removing HCO machine type annotation does not restore default in KubeVirt", func() {
+				resetArchConfig()
 
 				By("validate the default machine type")
 				kv, err := NewKubeVirt(hco)
@@ -4237,7 +4287,7 @@ Version: 1.2.3`)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(kv.Spec.Configuration.ArchitectureConfiguration.Amd64.MachineType).To(Equal("q35"))
 
-				restArchConfig()
+				resetArchConfig()
 			})
 		})
 	})
@@ -4626,7 +4676,6 @@ Version: 1.2.3`)
 	})
 })
 
-func restArchConfig() {
-	archConfigOnce = &sync.Once{}
-	getArchConfiguration()
+func resetArchConfig() {
+	staticArchCfg = generateStaticArchConfig()
 }

--- a/pkg/internal/nodeinfo/architectures.go
+++ b/pkg/internal/nodeinfo/architectures.go
@@ -1,6 +1,7 @@
 package nodeinfo
 
 import (
+	"maps"
 	"slices"
 	"sync"
 
@@ -14,21 +15,34 @@ import (
 const S390X = "s390x"
 
 var (
-	controlPlaneArchitectures = newArchitectures()
-	workloadArchitectures     = newArchitectures()
+	architectures = newArchitectures()
 )
 
 func GetControlPlaneArchitectures() []string {
-	return controlPlaneArchitectures.get()
+	return architectures.getCPArches()
 }
 
 func GetWorkloadsArchitectures() []string {
-	return workloadArchitectures.get()
+	return architectures.getWorkloadArches()
+}
+
+// GetDefaultArchitecture returns the default architecture for virtual machines
+// Assuming a single control plane architecture, HCO will choose this architecture as default, if the workload
+// architecture contains it. If not, HCO will choose the architecture used by most of the workload nodes.
+func GetDefaultArchitecture() string {
+	architectures.lock.RLock()
+	defer architectures.lock.RUnlock()
+
+	return architectures.defaultArch
 }
 
 type Architectures struct {
-	architectures []string
-	lock          *sync.RWMutex
+	workloadArches []string
+	cpArches       []string
+	workloadCount  map[string]int
+	defaultArch    string
+
+	lock *sync.RWMutex
 }
 
 func newArchitectures() *Architectures {
@@ -37,25 +51,61 @@ func newArchitectures() *Architectures {
 	}
 }
 
-func (a *Architectures) get() []string {
+func (a *Architectures) getWorkloadArches() []string {
 	a.lock.RLock()
 	defer a.lock.RUnlock()
 
-	return slices.Clone(a.architectures)
+	return slices.Clone(a.workloadArches)
 }
 
-func (a *Architectures) set(archs sets.Set[string]) bool {
+func (a *Architectures) getCPArches() []string {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+
+	return slices.Clone(a.cpArches)
+}
+
+func (a *Architectures) set(wlArches map[string]int, cpArches sets.Set[string]) bool {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
-	archList := archs.UnsortedList()
-	slices.Sort(archList)
-	if slices.Compare(a.architectures, archList) != 0 {
-		a.architectures = archList
-		return true
+	modified := false
+	if !maps.Equal(a.workloadCount, wlArches) {
+		a.workloadArches = getSortedMapKeys(wlArches)
+		a.workloadCount = maps.Clone(wlArches)
+		modified = true
 	}
 
-	return false
+	cpArchesList := cpArches.UnsortedList()
+	slices.Sort(cpArchesList)
+
+	if !slices.Equal(a.cpArches, cpArchesList) {
+		a.cpArches = cpArchesList
+		modified = true
+	}
+
+	if modified {
+		if len(cpArchesList) > 0 {
+			if cpArch := cpArchesList[0]; slices.Contains(a.workloadArches, cpArch) {
+				a.defaultArch = cpArch
+				return true
+			}
+		}
+
+		maxCount := 0
+		maxArch := ""
+		for _, wrkArch := range a.workloadArches {
+			count := a.workloadCount[wrkArch]
+			if maxCount < count {
+				maxCount = count
+				maxArch = wrkArch
+			}
+		}
+
+		a.defaultArch = maxArch
+	}
+
+	return modified
 }
 
 func hasWorkloadRequirements(hc *hcov1.HyperConverged) bool {
@@ -78,4 +128,8 @@ func getWorkloadMatcher(hc *hcov1.HyperConverged) nodeaffinity.RequiredNodeAffin
 	}
 
 	return nodeaffinity.GetRequiredNodeAffinity(pod)
+}
+
+func getSortedMapKeys(m map[string]int) []string {
+	return slices.Sorted(maps.Keys(m))
 }

--- a/pkg/internal/nodeinfo/architectures_test.go
+++ b/pkg/internal/nodeinfo/architectures_test.go
@@ -698,6 +698,23 @@ var _ = Describe("test node architectures", func() {
 		})
 
 		It("should not changed if control plane architectures were not changed, even with different node list", func() {
+			nodes := genNodeList(3, 0, 3)
+			nodes[0].(*corev1.Node).Status.NodeInfo.Architecture = cpArch
+			nodes[1].(*corev1.Node).Status.NodeInfo.Architecture = cpArch
+			nodes[2].(*corev1.Node).Status.NodeInfo.Architecture = cpArch
+			nodes[3].(*corev1.Node).Status.NodeInfo.Architecture = wlArch1
+			nodes[4].(*corev1.Node).Status.NodeInfo.Architecture = wlArch2
+			nodes[5].(*corev1.Node).Status.NodeInfo.Architecture = wlArch3
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nodes...).Build()
+
+			changed, err := nodeinfo.HandleNodeChanges(context.TODO(), cli, nil, GinkgoLogr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(changed).To(BeFalse())
+			Expect(nodeinfo.GetControlPlaneArchitectures()).To(Equal([]string{"cp-arch"}))
+			Expect(nodeinfo.GetWorkloadsArchitectures()).To(Equal([]string{wlArch1, wlArch2, wlArch3}))
+		})
+
+		It("should changed if control plane architectures were not changed, but number of nodes per arch was changed", func() {
 			nodes := genNodeList(6, 0, 9)
 			nodes[0].(*corev1.Node).Status.NodeInfo.Architecture = cpArch
 			nodes[1].(*corev1.Node).Status.NodeInfo.Architecture = cpArch
@@ -719,7 +736,7 @@ var _ = Describe("test node architectures", func() {
 
 			changed, err := nodeinfo.HandleNodeChanges(context.TODO(), cli, nil, GinkgoLogr)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(changed).To(BeFalse())
+			Expect(changed).To(BeTrue())
 			Expect(nodeinfo.GetControlPlaneArchitectures()).To(Equal([]string{"cp-arch"}))
 			Expect(nodeinfo.GetWorkloadsArchitectures()).To(Equal([]string{wlArch1, wlArch2, wlArch3}))
 		})
@@ -895,5 +912,303 @@ var _ = Describe("test node architectures", func() {
 			Expect(nodeinfo.GetControlPlaneArchitectures()).To(Equal([]string{"cp-arch"}))
 			Expect(nodeinfo.GetWorkloadsArchitectures()).To(Equal([]string{wlArch1, wlArch2, wlArch3, wlArch5}))
 		})
+	})
+
+	Context("GetDefaultArchitecture", func() {
+		DescribeTable("should return the correct default architecture",
+			func(ctx context.Context, nodes []client.Object, expectedDefault string) {
+				cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nodes...).Build()
+				_, err := nodeinfo.HandleNodeChanges(ctx, cl, nil, GinkgoLogr)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nodeinfo.GetDefaultArchitecture()).To(Equal(expectedDefault))
+			},
+			Entry("no nodes - empty string", nil, ""),
+			Entry("only control plane nodes - empty string", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "cp1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleControlPlane: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+			}, ""),
+			Entry("only worker nodes - returns first workload arch", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+			}, "arm64"),
+			Entry("CP arch matches workload arch - returns CP arch", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "cp1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleControlPlane: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker2",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+			}, "amd64"),
+			Entry("CP arch does not match any workload arch - returns first workload arch", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "cp1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleControlPlane: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker2",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "s390x"},
+					},
+				},
+			}, "arm64"),
+			Entry("single node cluster - returns the shared arch", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "single",
+						Labels: map[string]string{
+							nodeinfo.LabelNodeRoleControlPlane: "",
+							nodeinfo.LabelNodeRoleWorker:       "",
+						},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+			}, "amd64"),
+			Entry("multiple workload archs, no CP - returns first sorted", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "s390x"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker2",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker3",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+			}, "amd64"),
+			Entry("CP arch is not first sorted but matches workload - returns CP arch", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "cp1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleControlPlane: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "s390x"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker2",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "s390x"},
+					},
+				},
+			}, "s390x"),
+			Entry("if no CP arch, use the architecture with most nodes", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker2",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker3",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+			}, "amd64"),
+			Entry("if no CP arch, use the architecture with most nodes, even if it's not the first arch", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker2",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker3",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+			}, "arm64"),
+			Entry("choose the CP arch, even if not equal to the arch with most workers", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "cp",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleControlPlane: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker2",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker3",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+			}, "amd64"),
+			Entry("choose the max arch, if CP node does not shar arch with the workers", []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "cp",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleControlPlane: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "s390x"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker1",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker2",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker3",
+						Labels: map[string]string{nodeinfo.LabelNodeRoleWorker: ""},
+					},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"},
+					},
+				},
+			}, "arm64"),
+		)
 	})
 })

--- a/pkg/internal/nodeinfo/nodeinfo.go
+++ b/pkg/internal/nodeinfo/nodeinfo.go
@@ -37,8 +37,8 @@ func processNodeInfo(nodes []corev1.Node, hc *hcov1.HyperConverged) bool {
 	cpNodeCount := 0
 	arbiterNodeCount := 0
 
-	workloadArchs := sets.New[string]()
-	cpArchs := sets.New[string]()
+	workloadArchMap := map[string]int{}
+	cpArches := sets.New[string]()
 
 	isWorkloadNode := isWorkloadNodeFunc(hc)
 
@@ -49,14 +49,14 @@ func processNodeInfo(nodes []corev1.Node, hc *hcov1.HyperConverged) bool {
 		}
 
 		if isWorkloadNode(node) {
-			workloadArchs.Insert(arch)
+			workloadArchMap[arch]++
 		}
 
 		_, masterLabelExists := node.Labels[LabelNodeRoleMaster]
 		_, cpLabelExists := node.Labels[LabelNodeRoleControlPlane]
 		if masterLabelExists || cpLabelExists {
 			cpNodeCount++
-			cpArchs.Insert(arch)
+			cpArches.Insert(arch)
 		}
 
 		if _, arbiterLabelExists := node.Labels[LabelNodeRoleArbiter]; arbiterLabelExists {
@@ -65,8 +65,8 @@ func processNodeInfo(nodes []corev1.Node, hc *hcov1.HyperConverged) bool {
 	}
 
 	// remove empty architectures
-	workloadArchs.Delete("")
-	cpArchs.Delete("")
+	delete(workloadArchMap, "")
+	cpArches.Delete("")
 
 	newValue := cpNodeCount >= 3 || (cpNodeCount >= 2 && arbiterNodeCount >= 1)
 	changed := controlPlaneHighlyAvailable.Swap(newValue) != newValue
@@ -77,8 +77,7 @@ func processNodeInfo(nodes []corev1.Node, hc *hcov1.HyperConverged) bool {
 	newValue = workerNodeCount >= 2
 	changed = infrastructureHighlyAvailable.Swap(newValue) != newValue || changed
 
-	changed = workloadArchitectures.set(workloadArchs) || changed
-	changed = controlPlaneArchitectures.set(cpArchs) || changed
+	changed = architectures.set(workloadArchMap, cpArches) || changed
 
 	return changed
 }

--- a/pkg/nodeinfo/nodeinfo.go
+++ b/pkg/nodeinfo/nodeinfo.go
@@ -26,4 +26,5 @@ var (
 
 	GetControlPlaneArchitectures = internal.GetControlPlaneArchitectures
 	GetWorkloadsArchitectures    = internal.GetWorkloadsArchitectures
+	GetDefaultArchitecture       = internal.GetDefaultArchitecture
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets the KubeVirt's `spec.configuration.architectureConfiguration.defaultArchitecture` field.
 
Assuming a single control plan architecture, HCO will choose this architecture as default, if the workload architecture contains it. If not, HCO will choose the architecture used by most of the workload nodes.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-90106
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set the default architecture in the KubeVirt CR
```
