### PR TITLE
[release 1.18] many resources are not deleted when deleting the HCO CR

### DIFF
--- a/controllers/commontestutils/eventEmitterMock.go
+++ b/controllers/commontestutils/eventEmitterMock.go
@@ -3,6 +3,7 @@ package commontestutils
 import (
 	"context"
 	"reflect"
+	"slices"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -83,10 +84,7 @@ func (eem *EventEmitterMock) CheckNoEventEmitted() bool {
 }
 
 func eventInArray(eventList []MockEvent, event MockEvent) bool {
-	for _, expectedEvent := range eventList {
-		if reflect.DeepEqual(event, expectedEvent) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(eventList, func(e MockEvent) bool {
+		return reflect.DeepEqual(event, e)
+	})
 }

--- a/controllers/handlers/cdi.go
+++ b/controllers/handlers/cdi.go
@@ -29,11 +29,19 @@ const (
 	cdiConfigAuthorityAnnotation = "cdi.kubevirt.io/configAuthority"
 )
 
-func NewCdiHandler(Client client.Client, Scheme *runtime.Scheme) *operands.GenericOperand {
+type CDIHandler struct {
+	*operands.GenericOperand
+}
+
+func NewCdiHandler(Client client.Client, Scheme *runtime.Scheme) *CDIHandler {
 	hook := &cdiHooks{Client: Client, Scheme: Scheme}
 
-	return operands.NewGenericOperand(Client, Scheme, "CDI", hook, false)
+	return &CDIHandler{
+		GenericOperand: operands.NewGenericOperand(Client, Scheme, "CDI", hook, false),
+	}
 }
+
+func (CDIHandler) ManualDeletionMark() { /* no implementation */ }
 
 type cdiHooks struct {
 	sync.Mutex

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -218,10 +218,18 @@ var (
 	kvDiskVerificationMemoryLimit = resource.MustParse("2G")
 )
 
-// ************  KubeVirt Handler  **************
-func NewKubevirtHandler(Client client.Client, Scheme *runtime.Scheme) *operands.GenericOperand {
-	return operands.NewGenericOperand(Client, Scheme, "KubeVirt", &kubevirtHooks{}, true)
+type KVHandler struct {
+	*operands.GenericOperand
 }
+
+// ************  KubeVirt Handler  **************
+func NewKubevirtHandler(Client client.Client, Scheme *runtime.Scheme) *KVHandler {
+	return &KVHandler{
+		GenericOperand: operands.NewGenericOperand(Client, Scheme, "KubeVirt", &kubevirtHooks{}, true),
+	}
+}
+
+func (KVHandler) ManualDeletionMark() { /* no implementation */ }
 
 type kubevirtHooks struct {
 	sync.Mutex

--- a/controllers/handlers/ssp.go
+++ b/controllers/handlers/ssp.go
@@ -51,6 +51,11 @@ func (h *sspHandler) Reset() {
 	h.handler.Reset()
 }
 
+// GetFullCr returns the full SSP object. Added in order to satisfy the CRGetter interface
+func (h *sspHandler) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+	return h.hook.GetFullCr(hc)
+}
+
 func NewSspHandler(Client client.Client, Scheme *runtime.Scheme) operands.Operand {
 	hook := &sspHooks{}
 	handler := operands.NewGenericOperand(Client, Scheme, "SSP", hook, false)

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -16,6 +15,7 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimetav1 "k8s.io/apimachinery/pkg/api/meta"
@@ -805,6 +805,10 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{}))
 
+				depNames, err := getDeploymentNames(context.TODO(), cl)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(depNames).To(ContainElements("kubevirt-apiserver-proxy", "kubevirt-console-plugin"))
+
 				foundResource := &hcov1beta1.HyperConverged{}
 				Expect(
 					cl.Get(context.TODO(),
@@ -816,13 +820,16 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(foundResource.Status.RelatedObjects).To(HaveLen(23))
 				Expect(foundResource.Finalizers).To(Equal([]string{FinalizerName}))
 
-				// Now, delete HCO
-				delTime := time.Now().UTC().Add(-1 * time.Minute)
-				expected.hco.DeletionTimestamp = &metav1.Time{Time: delTime}
-				expected.hco.Finalizers = []string{FinalizerName}
-				cl = expected.initClient()
+				hco := &hcov1beta1.HyperConverged{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      expected.hco.Name,
+						Namespace: expected.hco.Namespace,
+					},
+				}
 
-				r = initReconciler(cl, nil)
+				// Now, delete HCO
+				Expect(cl.Delete(context.TODO(), hco, &client.DeleteOptions{})).To(Succeed())
+
 				res, err = r.Reconcile(context.TODO(), request)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
@@ -836,6 +843,18 @@ var _ = Describe("HyperconvergedController", func() {
 					types.NamespacedName{Name: expected.hco.Name, Namespace: expected.hco.Namespace},
 					foundResource)
 				Expect(err).To(MatchError(apierrors.IsNotFound, "not found error"))
+
+				depNames, err = getDeploymentNames(context.TODO(), cl)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(depNames).To(And(Not(ContainElement("kubevirt-apiserver-proxy")), Not(ContainElement("kubevirt-console-plugin"))))
+
+				kvList := &kubevirtcorev1.KubeVirtList{}
+				Expect(cl.List(context.TODO(), kvList)).To(Succeed())
+				Expect(kvList.Items).To(BeEmpty(), "The KubeVirt object should be deleted")
+
+				cdiList := &cdiv1beta1.CDIList{}
+				Expect(cl.List(context.TODO(), cdiList)).To(Succeed())
+				Expect(cdiList.Items).To(BeEmpty(), "The CDI object should be deleted")
 
 				verifyHyperConvergedCRExistsMetricFalse()
 			})
@@ -2608,4 +2627,19 @@ func openshift2CdiSecProfile(hcProfile *openshiftconfigv1.TLSSecurityProfile) *c
 		Modern:       (*cdiv1beta1.ModernTLSProfile)(hcProfile.Modern),
 		Custom:       custom,
 	}
+}
+
+func getDeploymentNames(ctx context.Context, cl client.Client) ([]string, error) {
+	deps := &appsv1.DeploymentList{}
+	err := cl.List(ctx, deps, &client.ListOptions{Namespace: namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	var depNames []string
+	for _, dep := range deps.Items {
+		depNames = append(depNames, dep.Name)
+	}
+
+	return depNames, nil
 }

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -33,7 +33,7 @@ const (
 	uninstallVirtErrorMsg = "The uninstall request failed on virt component: "
 	ErrHCOUninstall       = "ErrHCOUninstall"
 	uninstallHCOErrorMsg  = "The uninstall request failed on dependent components, please check their logs."
-	deleteTimeOut         = 30 * time.Second
+	deleteTimeOut         = time.Minute
 )
 
 var (
@@ -130,7 +130,9 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 // The k8s client is not available when calling to NewOperandHandler.
 // Initial operations that need to read/write from the cluster can only be done when the client is already working.
 func (h *OperandHandler) FirstUseInitiation(scheme *runtime.Scheme, ci hcoutil.ClusterInfo, hc *hcov1beta1.HyperConverged, pwdFS fs.FS) {
-	h.objects = make([]client.Object, 0)
+	for _, operand := range h.operands {
+		h.addOperandObject(operand, hc)
+	}
 
 	if !ci.IsOpenshift() {
 		return
@@ -154,6 +156,10 @@ func (h *OperandHandler) GetImageStreamNames() []string {
 }
 
 func (h *OperandHandler) addOperandObject(handler operands.Operand, hc *hcov1beta1.HyperConverged) {
+	if _, shouldNotBeAdded := handler.(operands.ManualDeletionMarker); shouldNotBeAdded {
+		return
+	}
+
 	var (
 		obj client.Object
 		err error
@@ -162,7 +168,7 @@ func (h *OperandHandler) addOperandObject(handler operands.Operand, hc *hcov1bet
 	if gh, ok := handler.(operands.CRGetter); ok {
 		obj, err = gh.GetFullCr(hc)
 	} else {
-		err = fmt.Errorf("unknown handler with type %T", handler)
+		return
 	}
 
 	if err != nil {
@@ -227,28 +233,10 @@ func (h *OperandHandler) handleUpdatedOperand(req *common.HcoRequest, res *opera
 }
 
 func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
-
 	tCtx, cancel := context.WithTimeout(req.Ctx, deleteTimeOut)
 	defer cancel()
 
-	resources := []client.Object{
-		handlers.NewNetworkAddonsWithNameOnly(),
-		handlers.NewSSPWithNameOnly(),
-		handlers.NewConsoleCLIDownload(),
-		handlers.NewAAQWithNameOnly(),
-		handlers.NewMigControllerWithNameOnly(),
-		passt.NewPasstBindingCNINetworkAttachmentDefinition(),
-		passt.NewPasstBindingCNISecurityContextConstraints(),
-		waspagent.NewWaspAgentSCCWithNameOnly(),
-		aie.NewAIEWebhookClusterRoleWithNameOnly(),
-		aie.NewAIEWebhookClusterRoleBindingWithNameOnly(),
-		aie.NewAIEWebhookMutatingWebhookConfigurationWithNameOnly(),
-		aie.NewIOMMUFDDevicePluginSCCWithNameOnly(),
-	}
-
-	resources = append(resources, h.objects...)
-
-	err := h.deleteMultipleResources(tCtx, req, resources)
+	err := h.deleteMultipleResources(tCtx, req)
 	if err != nil {
 		return err
 	}
@@ -261,23 +249,22 @@ func (h *OperandHandler) EnsureDeleted(req *common.HcoRequest) error {
 	return h.deleteSingleResource(tCtx, req, handlers.NewCDIWithNameOnly(), ErrCDIUninstall, uninstallCDIErrorMsg)
 }
 
-func (h *OperandHandler) deleteMultipleResources(tCtx context.Context, req *common.HcoRequest, resources []client.Object) error {
+func (h *OperandHandler) deleteMultipleResources(tCtx context.Context, req *common.HcoRequest) error {
 	eg, egCtx := errgroup.WithContext(tCtx)
+	eg.SetLimit(10)
 
-	for _, res := range resources {
-		func(o client.Object) {
-			eg.Go(func() error {
-				deleted, err := hcoutil.EnsureDeleted(egCtx, h.client, o, req.Instance.Name, req.Logger, false, true, true)
-				if err != nil {
-					req.Logger.Error(err, "Failed to manually delete objects")
-					h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, ErrHCOUninstall, uninstallHCOErrorMsg)
-					return err
-				} else if deleted {
-					h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed %s %s", o.GetObjectKind().GroupVersionKind().Kind, o.GetName()))
-				}
-				return nil
-			})
-		}(res)
+	for _, o := range h.objects {
+		eg.Go(func() error {
+			deleted, err := hcoutil.EnsureDeleted(egCtx, h.client, o, req.Instance.Name, req.Logger, false, true, true)
+			if err != nil {
+				req.Logger.Error(err, "Failed to manually delete objects")
+				h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeWarning, ErrHCOUninstall, uninstallHCOErrorMsg)
+				return err
+			} else if deleted {
+				h.eventEmitter.EmitEvent(req.Instance, corev1.EventTypeNormal, "Killing", fmt.Sprintf("Removed %s %s", o.GetObjectKind().GroupVersionKind().Kind, o.GetName()))
+			}
+			return nil
+		})
 	}
 
 	return eg.Wait()

--- a/controllers/operands/operand.go
+++ b/controllers/operands/operand.go
@@ -55,6 +55,12 @@ type Reseter interface {
 	Reset()
 }
 
+// ManualDeletionMarker is a marker interface, to exclude specific handlers from batch deletion
+// tracking. these are handled separately.
+type ManualDeletionMarker interface {
+	ManualDeletionMark()
+}
+
 type GetHandler func(log.Logger, client.Client, *runtime.Scheme, *hcov1beta1.HyperConverged) (Operand, error)
 type GetHandlers func(log.Logger, client.Client, *runtime.Scheme, *hcov1beta1.HyperConverged, fs.FS) ([]Operand, error)
 

--- a/pkg/webhooks/validator/v1beta1_validator.go
+++ b/pkg/webhooks/validator/v1beta1_validator.go
@@ -170,10 +170,6 @@ func (wh *WebhookV1Beta1Handler) ValidateCreate(ctx context.Context, logger logr
 }
 
 func (wh *WebhookV1Beta1Handler) getOperands(ctx context.Context, requested *v1beta1.HyperConverged) (*kubevirtcorev1.KubeVirt, *cdiv1beta1.CDI, *networkaddonsv1.NetworkAddonsConfig, error) {
-	if err := wh.validateCertConfig(requested); err != nil {
-		return nil, nil, nil, err
-	}
-
 	kv := handlers.NewKubeVirtWithNameOnly()
 	err := wh.cli.Get(ctx, client.ObjectKeyFromObject(kv), kv)
 	if err != nil {
@@ -230,6 +226,26 @@ func (wh *WebhookV1Beta1Handler) ValidateUpdate(ctx context.Context, logger logr
 		return nil
 	}
 
+	if err := wh.validateCertConfig(requested); err != nil {
+		return err
+	}
+
+	if err := wh.dryRunUpdateComponents(ctx, requested, logger); err != nil {
+		return err
+	}
+
+	if !dryrun {
+		tlssecprofile.SetHyperConvergedTLSSecurityProfile(requested.Spec.TLSSecurityProfile)
+	}
+
+	return nil
+}
+
+func (wh *WebhookV1Beta1Handler) dryRunUpdateComponents(ctx context.Context, requested *v1beta1.HyperConverged, logger logr.Logger) error {
+	if requested.DeletionTimestamp != nil {
+		return nil
+	}
+
 	kv, cdi, cna, err := wh.getOperands(ctx, requested)
 	if err != nil {
 		return err
@@ -277,16 +293,7 @@ func (wh *WebhookV1Beta1Handler) ValidateUpdate(ctx context.Context, logger logr
 		}(obj)
 	}
 
-	err = eg.Wait()
-	if err != nil {
-		return err
-	}
-
-	if !dryrun {
-		tlssecprofile.SetHyperConvergedTLSSecurityProfile(requested.Spec.TLSSecurityProfile)
-	}
-
-	return nil
+	return eg.Wait()
 }
 
 func (wh *WebhookV1Beta1Handler) updateOperatorCr(ctx context.Context, logger logr.Logger, hc *v1beta1.HyperConverged, exists client.Object, opts *client.UpdateOptions) error {

--- a/pkg/webhooks/validator/v1beta1_validator_test.go
+++ b/pkg/webhooks/validator/v1beta1_validator_test.go
@@ -900,6 +900,24 @@ var _ = Describe("v1beta1 webhooks validator", func() {
 			Expect(err).To(MatchError(ContainSubstring("cdis.cdi.kubevirt.io")))
 		})
 
+		It("should not return error if CDI CR is missing and the HC CR is deleted", func(ctx context.Context) {
+			cli := getFakeClient(hco)
+			cdi, err := handlers.NewCDI(hco)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cli.Delete(ctx, cdi)).To(Succeed())
+
+			wh := NewWebhookV1Beta1Handler(GinkgoLogr, cli, decoder, HcoValidNamespace, true)
+			tlssecprofile.SetHyperConvergedTLSSecurityProfile(nil)
+
+			newHco := &v1beta1.HyperConverged{}
+			hco.DeepCopyInto(newHco)
+			// just do some change to force update
+			newHco.Spec.Infra.NodePlacement.NodeSelector["key3"] = "value3"
+			newHco.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+			Expect(wh.ValidateUpdate(ctx, GinkgoLogr, dryRun, newHco, hco)).To(Succeed())
+		})
+
 		It("should return error if dry-run update of CDI CR returns error", func(ctx context.Context) {
 			cli := getFakeClient(hco)
 			cli.InitiateUpdateErrors(getUpdateError(cdiUpdateFailure))

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -208,6 +208,10 @@ func (wh *WebhookHandler) validateUpdate(ctx context.Context, logger logr.Logger
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
+	if err = wh.v1beta1Handler.validateCertConfig(v1beta1Req); err != nil {
+		return errToResponse(err)
+	}
+
 	err = wh.dryRunUpdateComponents(ctx, logger, v1beta1Req, requested)
 	if err != nil {
 		return errToResponse(err)
@@ -289,6 +293,10 @@ func (wh *WebhookHandler) validateCreateComponents(v1beta1HC *hcov1beta1.HyperCo
 }
 
 func (wh *WebhookHandler) dryRunUpdateComponents(ctx context.Context, logger logr.Logger, v1beta1Req *hcov1beta1.HyperConverged, requested *hcov1.HyperConverged) error {
+	if requested.DeletionTimestamp != nil {
+		return nil
+	}
+
 	kv, cdi, cna, err := wh.v1beta1Handler.getOperands(ctx, v1beta1Req)
 	if err != nil {
 		return err
@@ -343,10 +351,10 @@ func (wh *WebhookHandler) validateCertConfig(hc *hcov1.HyperConverged) error {
 	minimalDuration := metav1.Duration{Duration: 10 * time.Minute}
 
 	ccValues := make(map[string]time.Duration)
-	ccValues["spec.certConfig.ca.duration"] = hc.Spec.Security.CertConfig.CA.Duration.Duration
-	ccValues["spec.certConfig.ca.renewBefore"] = hc.Spec.Security.CertConfig.CA.RenewBefore.Duration
-	ccValues["spec.certConfig.server.duration"] = hc.Spec.Security.CertConfig.Server.Duration.Duration
-	ccValues["spec.certConfig.server.renewBefore"] = hc.Spec.Security.CertConfig.Server.RenewBefore.Duration
+	ccValues["spec.security.certConfig.ca.duration"] = hc.Spec.Security.CertConfig.CA.Duration.Duration
+	ccValues["spec.security.certConfig.ca.renewBefore"] = hc.Spec.Security.CertConfig.CA.RenewBefore.Duration
+	ccValues["spec.security.certConfig.server.duration"] = hc.Spec.Security.CertConfig.Server.Duration.Duration
+	ccValues["spec.security.certConfig.server.renewBefore"] = hc.Spec.Security.CertConfig.Server.RenewBefore.Duration
 
 	for key, value := range ccValues {
 		if value < minimalDuration.Duration {
@@ -355,15 +363,15 @@ func (wh *WebhookHandler) validateCertConfig(hc *hcov1.HyperConverged) error {
 	}
 
 	if hc.Spec.Security.CertConfig.CA.Duration.Duration < hc.Spec.Security.CertConfig.CA.RenewBefore.Duration {
-		return errors.New("spec.certConfig.ca: duration is smaller than renewBefore")
+		return errors.New("spec.security.certConfig.ca: duration is smaller than renewBefore")
 	}
 
 	if hc.Spec.Security.CertConfig.Server.Duration.Duration < hc.Spec.Security.CertConfig.Server.RenewBefore.Duration {
-		return errors.New("spec.certConfig.server: duration is smaller than renewBefore")
+		return errors.New("spec.security.certConfig.server: duration is smaller than renewBefore")
 	}
 
 	if hc.Spec.Security.CertConfig.CA.Duration.Duration < hc.Spec.Security.CertConfig.Server.Duration.Duration {
-		return errors.New("spec.certConfig: ca.duration is smaller than server.duration")
+		return errors.New("spec.security.certConfig: ca.duration is smaller than server.duration")
 	}
 
 	return nil

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"context"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -810,6 +811,22 @@ var _ = Describe("v1 webhooks validator", func() {
 				wh.validateUpdate(ctx, GinkgoLogr, dryRun, newHco, cr),
 				"kubevirts.kubevirt.io",
 			)
+		})
+
+		It("should not return error if KV CR is missing and the HC CR is deleted", func(ctx context.Context) {
+			kv := handlers.NewKubeVirtWithNameOnly()
+			Expect(cli.Delete(ctx, kv)).To(Succeed())
+
+			tlssecprofile.SetHyperConvergedTLSSecurityProfile(nil)
+
+			newHco := &hcov1.HyperConverged{}
+			cr.DeepCopyInto(newHco)
+			// just do some change to force update
+			newHco.Spec.Deployment.NodePlacements.Infra.NodeSelector["key3"] = "value3"
+			newHco.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+			res := wh.validateUpdate(ctx, GinkgoLogr, dryRun, newHco, cr)
+			Expect(res.Allowed).To(BeTrue())
 		})
 
 		It("should return error if dry-run update of KV CR returns error", func(ctx context.Context) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual cherry pick of #4322.

After moving the operands creation to be static in #4164, we introduced a bug where most of the resources created by HCO are not deleted when HCO is removed.

The reason for that is that the old dynamic addition of operand also added the resource to a list in the operandHandler, to be used for the deletion. But when we stopped using the dynamic code, the resources are not listed anymore, and are not deleted.

This commit fixes this issue by re-creating the list.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-90394
```

**Release note**:
```release-note
fix CNV-90394: many resources are not deleted when deleting
```
