### PR TITLE
Fix issue where HC deletion is stuck

### DIFF
--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -487,6 +487,10 @@ func v1FGsToMap(fgs hcov1fg.HyperConvergedFeatureGates) map[string]bool {
 }
 
 func checkOperands(ctx context.Context, cli client.Client, logger logr.Logger, requested *hcov1.HyperConverged, isOpenshift bool) error {
+	if requested.DeletionTimestamp != nil { // do not check other components when removing HCO
+		return nil
+	}
+
 	resources, err := getOperands(ctx, cli, isOpenshift)
 	if err != nil {
 		return err

--- a/pkg/webhooks/validator/validator_test.go
+++ b/pkg/webhooks/validator/validator_test.go
@@ -770,6 +770,24 @@ var _ = Describe("v1 webhooks validator", func() {
 			)
 		})
 
+		It("should not return error if KV CR is missing, and HC is already deleted", func(ctx context.Context) {
+			kv := handlers.NewKubeVirtWithNameOnly()
+			Expect(cli.Delete(ctx, kv)).To(Succeed())
+
+			tlssecprofile.SetHyperConvergedTLSSecurityProfile(nil)
+
+			newHco := &hcov1.HyperConverged{}
+			cr.DeepCopyInto(newHco)
+			// just do some change to force update
+			newHco.Spec.Deployment.NodePlacements.Infra.NodeSelector["key3"] = "value3"
+
+			// the HC is already deleted
+			newHco.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+			res := wh.validateUpdate(ctx, GinkgoLogr, dryRun, newHco, cr)
+			Expect(res.Allowed).To(BeTrue())
+		})
+
 		It("should return error if dry-run update of KV CR returns error", func(ctx context.Context) {
 			cli.(*commontestutils.HcoTestClient).InitiateUpdateErrors(getUpdateError(kvUpdateFailure))
 
@@ -784,6 +802,22 @@ var _ = Describe("v1 webhooks validator", func() {
 				wh.validateUpdate(ctx, GinkgoLogr, dryRun, newHco, cr),
 				ErrFakeKvError.Error(),
 			)
+		})
+
+		It("should not return error if dry-run update of KV CR returns error and the HC CR was deleted", func(ctx context.Context) {
+			cli.(*commontestutils.HcoTestClient).InitiateUpdateErrors(getUpdateError(kvUpdateFailure))
+
+			tlssecprofile.SetHyperConvergedTLSSecurityProfile(nil)
+
+			newHco := &hcov1.HyperConverged{}
+			cr.DeepCopyInto(newHco)
+			// change something in workloads to trigger dry-run update
+			newHco.Spec.Deployment.NodePlacements.Workload.NodeSelector["a change"] = "Something else"
+
+			newHco.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+			res := wh.validateUpdate(ctx, GinkgoLogr, dryRun, newHco, cr)
+			Expect(res.Allowed).To(BeTrue())
 		})
 
 		It("should return error if CDI CR is missing", func(ctx context.Context) {
@@ -804,6 +838,23 @@ var _ = Describe("v1 webhooks validator", func() {
 			)
 		})
 
+		It("should not return error if CDI CR is missing and HC CR is deleted", func(ctx context.Context) {
+			cdi, err := handlers.NewCDI(cr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cli.Delete(ctx, cdi)).To(Succeed())
+
+			tlssecprofile.SetHyperConvergedTLSSecurityProfile(nil)
+
+			newHco := &hcov1.HyperConverged{}
+			cr.DeepCopyInto(newHco)
+			// just do some change to force update
+			newHco.Spec.Deployment.NodePlacements.Infra.NodeSelector["key3"] = "value3"
+			newHco.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+			res := wh.validateUpdate(ctx, GinkgoLogr, dryRun, newHco, cr)
+			Expect(res.Allowed).To(BeTrue())
+		})
+
 		It("should return error if dry-run update of CDI CR returns error", func(ctx context.Context) {
 			cli.(*commontestutils.HcoTestClient).InitiateUpdateErrors(getUpdateError(cdiUpdateFailure))
 
@@ -816,6 +867,19 @@ var _ = Describe("v1 webhooks validator", func() {
 				wh.validateUpdate(ctx, GinkgoLogr, dryRun, newHco, cr),
 				ErrFakeCdiError.Error(),
 			)
+		})
+
+		It("should not return error if dry-run update of CDI CR returns error and HC CR is deleted", func(ctx context.Context) {
+			cli.(*commontestutils.HcoTestClient).InitiateUpdateErrors(getUpdateError(cdiUpdateFailure))
+
+			newHco := &hcov1.HyperConverged{}
+			cr.DeepCopyInto(newHco)
+			// change something in workloads to trigger dry-run update
+			newHco.Spec.Deployment.NodePlacements.Workload.NodeSelector["a change"] = "Something else"
+			newHco.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+			res := wh.validateUpdate(ctx, GinkgoLogr, dryRun, newHco, cr)
+			Expect(res.Allowed).To(BeTrue())
 		})
 
 		It("should not return error if dry-run update of ALL CR passes", func(ctx context.Context) {


### PR DESCRIPTION
**What this PR does / why we need it**:

After merging PR #4322, sometimes, when deleting the HyperConverged CR, the deletion stuck because HCO fails to update the CR status during the process, if one of the operand (e.g. the CDI CR) is already deleted.

This PR fixes the issue by not performing the dry-run update of the operands, if the HC CR is already marked for deletion.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
