### PR TITLE
fix: make functest build and TLS check multi-arch aware

### DIFF
--- a/build/Dockerfile.functest
+++ b/build/Dockerfile.functest
@@ -9,6 +9,7 @@ RUN ARCH=${TARGETARCH} make build-functest
 
 FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/ubi-minimal
 ARG TARGETPLATFORM
+ARG TARGETARCH
 
 ENV USER_UID=1001 \
     TEST_OUT_PATH=/test
@@ -16,12 +17,11 @@ ENV USER_UID=1001 \
 WORKDIR ${TEST_OUT_PATH}
 ENTRYPOINT ["./hack/run-tests.sh"]
 
-RUN microdnf install -y tar gzip which openssl diffutils && \
-    curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+RUN microdnf install -y tar gzip which openssl diffutils jq && \
+    microdnf clean all && \
+    curl -fLo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -fs https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" && \
     chmod a+x /usr/local/bin/kubectl && \
-    curl -Lsv --fail https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar xvzf - -C /usr/local/bin/ oc && \
-    curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    chmod a+x /usr/local/bin/jq
+    curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/${TARGETARCH}/clients/ocp/stable/openshift-client-linux.tar.gz" | tar xzf - -C /usr/local/bin/ oc
 
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/_out/func-tests.test  ${TEST_OUT_PATH}/
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/hack  ${TEST_OUT_PATH}/hack

--- a/build/Dockerfile.functest.ci
+++ b/build/Dockerfile.functest.ci
@@ -1,11 +1,14 @@
 # registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
+FROM --platform=${BUILDPLATFORM} registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
+
+ARG TARGETARCH
 
 WORKDIR /go/src/github.com/kubevirt/hyperconverged-cluster-operator/
 COPY . .
-RUN make build-functest
+RUN ARCH=${TARGETARCH} make build-functest
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
+ARG TARGETARCH
 
 ENV USER_UID=1001 \
     TEST_OUT_PATH=/test
@@ -13,12 +16,11 @@ ENV USER_UID=1001 \
 WORKDIR ${TEST_OUT_PATH}
 ENTRYPOINT ["./hack/run-tests.sh"]
 
-RUN microdnf install -y tar gzip which openssl diffutils && \
-    curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+RUN microdnf install -y tar gzip which openssl diffutils jq && \
+    microdnf clean all && \
+    curl -fLo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -fs https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" && \
     chmod a+x /usr/local/bin/kubectl && \
-    curl -Lsv --fail https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar xvzf - -C /usr/local/bin/ oc && \
-    curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    chmod a+x /usr/local/bin/jq
+    curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/${TARGETARCH}/clients/ocp/stable/openshift-client-linux.tar.gz" | tar xzf - -C /usr/local/bin/ oc
 
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/_out/func-tests.test  ${TEST_OUT_PATH}/
 COPY --from=builder --chown=${USER_UID}:0 /go/src/github.com/kubevirt/hyperconverged-cluster-operator/hack  ${TEST_OUT_PATH}/hack

--- a/hack/check_tlsprofile.sh
+++ b/hack/check_tlsprofile.sh
@@ -20,7 +20,7 @@
 
 set -ex
 
-KUBECTL_BINARY=oc
+KUBECTL_BINARY=${KUBECTL_BINARY:-oc}
 INSTALLED_NAMESPACE=kubevirt-hyperconverged
 HCO_TYPE="hyperconvergeds"
 TLS_PATH="/spec/security/tlsSecurityProfile"
@@ -62,9 +62,17 @@ fi
 
 if ! which nmap ; then
     echo "Try to install nmap"
-    rpm -vhU --nodeps https://nmap.org/dist/nmap-7.94-1.x86_64.rpm
-    rpm -vhU https://nmap.org/dist/ncat-7.94-1.x86_64.rpm
-    rpm -vhU https://nmap.org/dist/nping-0.7.94-1.x86_64.rpm
+    if command -v microdnf &>/dev/null; then
+        microdnf install -y nmap
+    elif command -v dnf &>/dev/null; then
+        dnf install -y nmap
+    elif command -v yum &>/dev/null; then
+        yum install -y nmap
+    else
+        rpm -vhU --nodeps https://nmap.org/dist/nmap-7.94-1.x86_64.rpm
+        rpm -vhU https://nmap.org/dist/ncat-7.94-1.x86_64.rpm
+        rpm -vhU https://nmap.org/dist/nping-0.7.94-1.x86_64.rpm
+    fi
 fi
 
 if [ -n "${OPENSHIFT_BUILD_NAMESPACE:-}" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Prep work for adding an s390x e2e test lane. The functest Dockerfiles and TLS check script had hardcoded x86 binary URLs that prevent building/running on other architectures. This makes them architecture-aware using Docker's built-in TARGETARCH and distro packages instead of x86-only downloads.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
NONE
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
