### PR TITLE
[release-1.18] fix sanity

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -5,11 +5,11 @@ name: Sanity Checks
 # Controls when the action will run.
 on:
   push:
-    branches: [main]
+    branches: [release-1.18]
     paths-ignore:
       - "renovate.json"
   pull_request:
-    branches: [main]
+    branches: [release-1.18]
     paths-ignore:
       - "renovate.json"
 

--- a/pkg/webhooks/validator/v1beta1_validator.go
+++ b/pkg/webhooks/validator/v1beta1_validator.go
@@ -169,7 +169,7 @@ func (wh *WebhookV1Beta1Handler) ValidateCreate(ctx context.Context, logger logr
 	return nil
 }
 
-func (wh *WebhookV1Beta1Handler) getOperands(ctx context.Context, requested *v1beta1.HyperConverged) (*kubevirtcorev1.KubeVirt, *cdiv1beta1.CDI, *networkaddonsv1.NetworkAddonsConfig, error) {
+func (wh *WebhookV1Beta1Handler) getOperands(ctx context.Context) (*kubevirtcorev1.KubeVirt, *cdiv1beta1.CDI, *networkaddonsv1.NetworkAddonsConfig, error) {
 	kv := handlers.NewKubeVirtWithNameOnly()
 	err := wh.cli.Get(ctx, client.ObjectKeyFromObject(kv), kv)
 	if err != nil {
@@ -246,7 +246,7 @@ func (wh *WebhookV1Beta1Handler) dryRunUpdateComponents(ctx context.Context, req
 		return nil
 	}
 
-	kv, cdi, cna, err := wh.getOperands(ctx, requested)
+	kv, cdi, cna, err := wh.getOperands(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhooks/validator/validator.go
+++ b/pkg/webhooks/validator/validator.go
@@ -297,7 +297,7 @@ func (wh *WebhookHandler) dryRunUpdateComponents(ctx context.Context, logger log
 		return nil
 	}
 
-	kv, cdi, cna, err := wh.v1beta1Handler.getOperands(ctx, v1beta1Req)
+	kv, cdi, cna, err := wh.v1beta1Handler.getOperands(ctx)
 	if err != nil {
 		return err
 	}

--- a/tests/func-tests/conversion_test.go
+++ b/tests/func-tests/conversion_test.go
@@ -99,7 +99,7 @@ func getCurrentV1Beta1FGStatus(fgs hcov1beta1.HyperConvergedFeatureGates) map[st
 	fgVal := reflect.ValueOf(fgs)
 	fgType := reflect.TypeOf(fgs)
 
-	if fgVal.Kind() == reflect.Ptr {
+	if fgVal.Kind() == reflect.Pointer {
 		fgVal = fgVal.Elem()
 		fgType = fgType.Elem()
 	}
@@ -114,7 +114,7 @@ func getCurrentV1Beta1FGStatus(fgs hcov1beta1.HyperConvergedFeatureGates) map[st
 		}
 
 		var fgValue bool
-		if value.Kind() == reflect.Ptr {
+		if value.Kind() == reflect.Pointer {
 			if value.IsNil() {
 				continue
 			}


### PR DESCRIPTION
Sanity didn't run for the release-1.18 branch. The PR fixes it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
