### PR TITLE
Fix flaky functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ lint-metrics:
 
 lint-monitoring:
 	go install github.com/kubevirt/monitoring/monitoringlinter/cmd/monitoringlinter@a697c0c
-	monitoringlinter ./...
+	monitoringlinter ./api/... ./pkg/... ./controllers/...
 
 bump-hco:
 	./hack/bump-hco.sh ${HCO_BUMP_LEVEL}

--- a/tests/func-tests/aaq_test.go
+++ b/tests/func-tests/aaq_test.go
@@ -116,11 +116,5 @@ func disableAAQ(ctx context.Context, cli client.Client) {
 func setAAQEnablement(ctx context.Context, cli client.Client, shouldEnable bool) {
 	patchBytes := fmt.Appendf(nil, setAAQFGPatchTemplate, shouldEnable)
 
-	Eventually(tests.PatchMergeHCO).
-		WithArguments(ctx, cli, patchBytes).
-		WithTimeout(10 * time.Second).
-		WithPolling(100 * time.Millisecond).
-		WithContext(ctx).
-		WithOffset(2).
-		Should(Succeed())
+	tests.PatchMergeHCO(ctx, cli, patchBytes)
 }

--- a/tests/func-tests/aie_test.go
+++ b/tests/func-tests/aie_test.go
@@ -174,12 +174,7 @@ var _ = Describe("Test AIE", Label("AIE"), Serial, Ordered, func() {
 
 			By("triggering a reconcile by touching the HCO CR")
 			patchBytes := fmt.Appendf(nil, `{"metadata":{"annotations":{"%s":"true"}}}`, deployAIEAnnotationKey)
-			Eventually(tests.PatchMergeHCO).
-				WithArguments(ctx, cli, patchBytes).
-				WithTimeout(10 * time.Second).
-				WithPolling(100 * time.Millisecond).
-				WithContext(ctx).
-				Should(Succeed())
+			tests.PatchMergeHCO(ctx, cli, patchBytes)
 
 			By("verifying user edits persist after reconciliation")
 			Consistently(func(g Gomega, ctx context.Context) {
@@ -250,26 +245,14 @@ func enableAIEAnnotation(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
 	patchBytes := fmt.Appendf(nil, `{"metadata":{"annotations":{"%s":"true"}}}`, deployAIEAnnotationKey)
 
-	Eventually(tests.PatchMergeHCO).
-		WithArguments(ctx, cli, patchBytes).
-		WithTimeout(10 * time.Second).
-		WithPolling(100 * time.Millisecond).
-		WithContext(ctx).
-		WithOffset(1).
-		Should(Succeed())
+	tests.PatchMergeHCO(ctx, cli, patchBytes)
 }
 
 func disableAIEAnnotation(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
 	patchBytes := fmt.Appendf(nil, `{"metadata":{"annotations":{"%s":null}}}`, deployAIEAnnotationKey)
 
-	Eventually(tests.PatchMergeHCO).
-		WithArguments(ctx, cli, patchBytes).
-		WithTimeout(10 * time.Second).
-		WithPolling(100 * time.Millisecond).
-		WithContext(ctx).
-		WithOffset(1).
-		Should(Succeed())
+	tests.PatchMergeHCO(ctx, cli, patchBytes)
 }
 
 func getAIEWebhookDeploymentErr(ctx context.Context, cli client.Client) error {

--- a/tests/func-tests/cluster_eviction_strategy_test.go
+++ b/tests/func-tests/cluster_eviction_strategy_test.go
@@ -48,17 +48,13 @@ var _ = Describe("Cluster level evictionStrategy default value", Label("eviction
 		if initialEvictionStrategy != nil {
 			patch = fmt.Appendf(nil, setEvictionStrategyPatch, *initialEvictionStrategy)
 		}
-		Eventually(tests.PatchHCO).
-			WithArguments(ctx, cli, patch).
-			WithPolling(100 * time.Millisecond).
-			WithTimeout(5 * time.Second).
-			Should(Succeed())
+		tests.PatchHCO(ctx, cli, patch)
 	})
 
 	DescribeTable("test spec.virtualization.evictionStrategy", func(ctx context.Context, clusterValidationFn func(bool), expectedValue kvv1.EvictionStrategy) {
 		clusterValidationFn(singleWorkerCluster)
 
-		Expect(tests.PatchHCO(ctx, cli, rmEvictionStrategyPatch)).To(Succeed())
+		tests.PatchHCO(ctx, cli, rmEvictionStrategyPatch)
 
 		Eventually(func(g Gomega, ctx context.Context) {
 			hc, err := tests.GetHCO(ctx, cli)

--- a/tests/func-tests/console_plugin_test.go
+++ b/tests/func-tests/console_plugin_test.go
@@ -106,12 +106,7 @@ var _ = Describe("kubevirt console plugin", Label(tests.OpenshiftLabel, "console
 
 		addNodeSelectorPatch := fmt.Appendf(nil, `{"spec":{"deployment":{"nodePlacements":{"infra":{"nodeSelector": %s}}}}}`, string(expectedNodeSelectorBytes))
 
-		Eventually(func(ctx context.Context) error {
-			return tests.PatchMergeHCO(ctx, cli, addNodeSelectorPatch)
-		}).WithTimeout(1 * time.Minute).
-			WithPolling(1 * time.Millisecond).
-			WithContext(ctx).
-			Should(Succeed())
+		tests.PatchMergeHCO(ctx, cli, addNodeSelectorPatch)
 
 		Eventually(func(g Gomega, ctx context.Context) {
 			consoleUIDeployment := &appsv1.Deployment{
@@ -145,12 +140,7 @@ var _ = Describe("kubevirt console plugin", Label(tests.OpenshiftLabel, "console
 
 		// clear node placement from HyperConverged CR and verify the nodeSelector has been cleared as well from the UI Deployments
 		removeNodeSelectorPatch := []byte(`[{"op": "remove", "path": "/spec/deployment/nodePlacements/infra"}]`)
-		Eventually(func(ctx context.Context) error {
-			return tests.PatchHCO(ctx, cli, removeNodeSelectorPatch)
-		}).WithTimeout(1 * time.Minute).
-			WithPolling(1 * time.Millisecond).
-			WithContext(ctx).
-			Should(Succeed())
+		tests.PatchHCO(ctx, cli, removeNodeSelectorPatch)
 
 		Eventually(func(g Gomega, ctx context.Context) {
 			consoleUIDeployment := &appsv1.Deployment{

--- a/tests/func-tests/conversion_test.go
+++ b/tests/func-tests/conversion_test.go
@@ -187,25 +187,16 @@ func getCurrentV1Beta1FGStatus(fgs hcov1beta1.HyperConvergedFeatureGates) map[st
 func restoreFGsToDefault(ctx context.Context, cl client.Client) {
 	GinkgoHelper()
 
+	hco, err := tests.GetHCO(ctx, cl)
+	Expect(err).ToNot(HaveOccurred())
+
+	if hco.Spec.FeatureGates != nil {
+		patch := fmt.Appendf(nil, removePathPatchTmplt, "/spec/featureGates")
+		tests.PatchHCO(ctx, cl, patch)
+	}
+
 	hcv1beta1 := &hcov1beta1.HyperConverged{}
-	patch := fmt.Appendf(nil, removePathPatchTmplt, "/spec/featureGates")
-
 	Eventually(func(g Gomega, ctx context.Context) {
-		hco, err := tests.GetHCO(ctx, cl)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		if hco.Spec.FeatureGates == nil {
-			return
-		}
-
-		g.Expect(tests.PatchHCO(ctx, cl, patch)).To(Succeed())
-	}).WithTimeout(2 * time.Second).
-		WithPolling(500 * time.Millisecond).
-		WithContext(ctx).
-		Should(Succeed())
-
-	Eventually(func(g Gomega, ctx context.Context) {
-		var err error
 		hcv1beta1, err = tests.GetHCOv1beta1(ctx, cl)
 		g.Expect(err).NotTo(HaveOccurred())
 

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -43,9 +43,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 		DescribeTable("Check that certConfig defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
-			Eventually(func(ctx context.Context) error {
-				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
+			tests.PatchHCO(ctx, cli, patch)
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc, err := tests.GetHCO(ctx, cli)
@@ -84,15 +82,12 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 		It("Check that featureGates defaults are behaving as expected", func(ctx context.Context) {
 			patch := fmt.Appendf(nil, removePathPatchTmplt, "/spec/featureGates")
-			Eventually(func(g Gomega, ctx context.Context) error {
-				hc, err := tests.GetHCO(ctx, cli)
-				g.Expect(err).NotTo(HaveOccurred())
+			hc, err := tests.GetHCO(ctx, cli)
+			Expect(err).NotTo(HaveOccurred())
 
-				if len(hc.Spec.FeatureGates) == 0 {
-					return nil
-				}
-				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
+			if len(hc.Spec.FeatureGates) > 0 {
+				tests.PatchHCO(ctx, cli, patch)
+			}
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc, err := tests.GetHCO(ctx, cli)
@@ -117,9 +112,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 		DescribeTable("Check that liveMigrationConfig defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
-			Eventually(func(ctx context.Context) error {
-				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
+			tests.PatchHCO(ctx, cli, patch)
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc, err := tests.GetHCO(ctx, cli)
@@ -145,9 +138,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 		DescribeTable("Check that resourceRequirements defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
-			Eventually(func(ctx context.Context) error {
-				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
+			tests.PatchHCO(ctx, cli, patch)
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc, err := tests.GetHCO(ctx, cli)
@@ -171,9 +162,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 		DescribeTable("Check that workloadUpdateStrategy defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
-			Eventually(func(ctx context.Context) error {
-				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
+			tests.PatchHCO(ctx, cli, patch)
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc, err := tests.GetHCO(ctx, cli)
@@ -196,9 +185,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 		DescribeTable("Check that uninstallStrategy default is behaving as expected", func(ctx context.Context, path string) {
 			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
-			Eventually(func(ctx context.Context) error {
-				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
+			tests.PatchHCO(ctx, cli, patch)
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc, err := tests.GetHCO(ctx, cli)
@@ -221,9 +208,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 		DescribeTable("Check that featureGates defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
-			Eventually(func(ctx context.Context) error {
-				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
+			tests.PatchHCO(ctx, cli, patch)
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc, err := tests.GetHCO(ctx, cli)
@@ -247,9 +232,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 
 		DescribeTable("Check that HigherWorkloadDensity defaults are behaving as expected", func(ctx context.Context, path string) {
 			patch := fmt.Appendf(nil, removePathPatchTmplt, path)
-			Eventually(func(ctx context.Context) error {
-				return tests.PatchHCO(ctx, cli, patch)
-			}).WithTimeout(2 * time.Second).WithPolling(500 * time.Millisecond).WithContext(ctx).Should(Succeed())
+			tests.PatchHCO(ctx, cli, patch)
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				hc, err := tests.GetHCO(ctx, cli)

--- a/tests/func-tests/golden_image_test.go
+++ b/tests/func-tests/golden_image_test.go
@@ -24,7 +24,6 @@ import (
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
-	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
 	goldenimages "github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers/golden-images"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
@@ -110,7 +109,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			Eventually(func(g Gomega, ctx context.Context) string {
 				is = getImageStream(ctx, cli, expectedIS.Name, imageNamespace)
 				return is.GetLabels()["app.kubernetes.io/part-of"]
-			}).WithTimeout(time.Second * 15).WithPolling(time.Millisecond * 100).WithContext(ctx).Should(Equal(expectedValue))
+			}).WithTimeout(time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Equal(expectedValue))
 		},
 			isEntries,
 		)
@@ -199,11 +198,9 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 	})
 
 	Context("disable the feature", func() {
-		It("Should set the FG to false", func(ctx context.Context) {
+		It("Should set the enabler to false", func(ctx context.Context) {
 			patch := fmt.Appendf(nil, dictEnablementTemplate, false)
-			Eventually(func(ctx context.Context) error {
-				return tests.PatchMergeHCO(ctx, cli, patch)
-			}).WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
+			tests.PatchMergeHCO(ctx, cli, patch)
 		})
 
 		var isEntries []TableEntry
@@ -254,9 +251,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 	Context("enable the feature again", func() {
 		It("Should set the enabler to true", func(ctx context.Context) {
 			patch := fmt.Appendf(nil, dictEnablementTemplate, true)
-			Eventually(func(ctx context.Context) error {
-				return tests.PatchMergeHCO(ctx, cli, patch)
-			}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
+			tests.PatchMergeHCO(ctx, cli, patch)
 		})
 
 		var isEntries []TableEntry
@@ -384,12 +379,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 			Expect(err).ToNot(HaveOccurred(), "failed to get worker nodes architectures")
 
 			GinkgoWriter.Printf("Worker nodes architectures: %v\n", archs)
-			Eventually(tests.EnableFG).
-				WithArguments(ctx, cli, goldenimages.EnableMultiArchFeatureGate).
-				WithTimeout(10 * time.Second).
-				WithPolling(1 * time.Second).
-				WithContext(ctx).
-				Should(Succeed())
+			Expect(tests.EnableFG(ctx, cli, goldenimages.EnableMultiArchFeatureGate)).To(Succeed())
 
 			removeCustomDICTFromHC(ctx, cli)
 
@@ -406,23 +396,7 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 				Should(Succeed(), tests.PrintHyperConvergedBecause(origHC, "the dictStatus.Status.OriginalSupportedArchitectures field should not be empty"))
 
 			DeferCleanup(func(ctx context.Context) {
-				Eventually(func(g Gomega, ctx context.Context) error {
-					cleanupHC, err := tests.GetHCO(ctx, cli)
-					g.Expect(err).NotTo(HaveOccurred())
-
-					var patch []byte
-					idx := slices.IndexFunc(cleanupHC.Spec.FeatureGates, func(fg featuregates.FeatureGate) bool {
-						return fg.Name == goldenimages.EnableMultiArchFeatureGate
-					})
-					if idx > -1 {
-						patch = fmt.Appendf(nil, `[{ "op": "remove", "path": "/spec/featureGates/%d"}]`, idx)
-						return tests.PatchHCO(ctx, cli, patch)
-					}
-					return nil
-				}).WithTimeout(hcTimeout).
-					WithPolling(hcPolling).
-					WithContext(ctx).
-					Should(Succeed())
+				Expect(tests.DisableFG(ctx, cli, goldenimages.EnableMultiArchFeatureGate)).To(Succeed())
 
 				removeCustomDICTFromHC(ctx, cli)
 			})
@@ -915,14 +889,17 @@ var _ = Describe("golden image test", Label("data-import-cron"), Serial, Ordered
 
 func removeCustomDICTFromHC(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
+	hc, err := tests.GetHCO(ctx, cli)
+	Expect(err).NotTo(HaveOccurred())
+	if hc.Spec.WorkloadSources.DataImportCronTemplates == nil {
+		return
+	}
+
 	// clear the DICTs if they exist. ignore error of not found, as it may not exist
-	Eventually(func(ctx context.Context) error {
-		return tests.PatchHCO(ctx, cli, []byte(`[{"op": "remove", "path": "/spec/workloadSources/dataImportCronTemplates"}]`))
-	}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).
-		Should(Or(Not(HaveOccurred()), MatchError(ContainSubstring("the server rejected our request due to an error in our request"))))
+	tests.PatchHCO(ctx, cli, []byte(`[{"op": "remove", "path": "/spec/workloadSources/dataImportCronTemplates"}]`))
 
 	Eventually(func(g Gomega, ctx context.Context) {
-		hc, err := tests.GetHCO(ctx, cli)
+		hc, err = tests.GetHCO(ctx, cli)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		g.Expect(hc.Spec.WorkloadSources.DataImportCronTemplates).To(BeEmpty(), "should have no DataImportCronTemplates in the HyperConverged CR")

--- a/tests/func-tests/hyperconverged.go
+++ b/tests/func-tests/hyperconverged.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -16,7 +17,14 @@ import (
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/api/v1/featuregates"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/featuregatedetails"
+	fgs "github.com/kubevirt/hyperconverged-cluster-operator/pkg/featuregates"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	HCPatchTimeout = 2 * time.Minute
+	HCPatchPolling = 5 * time.Second
 )
 
 // GetHCO reads the HCO CR from the APIServer with a DynamicClient
@@ -97,31 +105,62 @@ func UpdateHCO(ctx context.Context, cli client.Client, input *hcov1.HyperConverg
 	return GetHCO(ctx, cli)
 }
 
-// PatchHCO updates the HCO CR using a DynamicClient, it can return errors on failures
-func PatchHCO(ctx context.Context, cli client.Client, patchBytes []byte) error {
-	patch := client.RawPatch(types.JSONPatchType, patchBytes)
+func doPatch(ctx context.Context, cli client.Client, patch client.Patch) {
+	ginkgo.GinkgoHelper()
+
 	hco := HCOWithNameOnly()
 
-	return cli.Patch(ctx, hco, patch)
+	Eventually(cli.Patch).
+		WithContext(ctx).
+		WithArguments(hco, patch).
+		WithTimeout(HCPatchTimeout).
+		WithPolling(HCPatchPolling).
+		Should(Succeed(), func() string {
+			b := strings.Builder{}
+			// looking at the patch implementation, it never returns error and never uses the object argument
+			data, _ := patch.Data(nil)
+			b.WriteString("patch: ")
+			b.Write(data)
+			b.WriteByte('\n')
+
+			hc, err := GetHCO(ctx, cli)
+			if err != nil {
+				b.WriteString("Can't get the HyperConverged CR; ")
+				b.WriteString(err.Error())
+			} else {
+				b.WriteString("Current HyperConverged CR:\n")
+				b.WriteString(marshalHyperConverged(hc))
+			}
+
+			b.WriteByte('\n')
+
+			return b.String()
+		})
+
 }
 
-// PatchMergeHCO patches the HCO CR using a DynamicClient, it can return errors on failures
-func PatchMergeHCO(ctx context.Context, cli client.Client, patchBytes []byte) error {
-	patch := client.RawPatch(types.MergePatchType, patchBytes)
-	hco := HCOWithNameOnly()
+// PatchHCO updates the HCO CR using jsonpatch
+func PatchHCO(ctx context.Context, cli client.Client, patchBytes []byte) {
+	ginkgo.GinkgoHelper()
 
-	return cli.Patch(ctx, hco, patch)
+	patch := client.RawPatch(types.JSONPatchType, patchBytes)
+
+	doPatch(ctx, cli, patch)
+}
+
+// PatchMergeHCO patches the HCO CR using merge strategy
+func PatchMergeHCO(ctx context.Context, cli client.Client, patchBytes []byte) {
+	ginkgo.GinkgoHelper()
+
+	patch := client.RawPatch(types.MergePatchType, patchBytes)
+
+	doPatch(ctx, cli, patch)
 }
 
 func RestoreDefaults(ctx context.Context, cli client.Client) {
-	Eventually(func(ctx context.Context) error {
-		return PatchHCO(ctx, cli, []byte(`[{"op": "replace", "path": "/spec", "value": {}}]`))
-	}).
-		WithOffset(1).
-		WithTimeout(time.Second * 5).
-		WithPolling(time.Millisecond * 100).
-		WithContext(ctx).
-		Should(Succeed())
+	ginkgo.GinkgoHelper()
+
+	PatchHCO(ctx, cli, []byte(`[{"op": "replace", "path": "/spec", "value": {}}]`))
 }
 
 func EnableFG(ctx context.Context, cli client.Client, fgName string) error {
@@ -130,25 +169,90 @@ func EnableFG(ctx context.Context, cli client.Client, fgName string) error {
 		return err
 	}
 
-	if hc.Spec.FeatureGates == nil {
-		patch := fmt.Appendf(nil, `{"spec":{"featureGates":[{"name": %q, "state": "%v"}]}}`, fgName, featuregates.Enabled)
-		return PatchMergeHCO(ctx, cli, patch)
+	if hc.Spec.FeatureGates.IsEnabled(fgName) {
+		// already enabled
+		return nil
+	}
+
+	idx := slices.IndexFunc(hc.Spec.FeatureGates, func(fg featuregates.FeatureGate) bool {
+		return fg.Name == fgName
+	})
+
+	var patch []byte
+	switch phase, _ := featuregatedetails.GetFeatureGatePhase(fgName); phase {
+	case fgs.PhaseUnknown:
+		return fmt.Errorf("unknown feature gate %q", fgName)
+
+	case fgs.PhaseBeta:
+		// beta FG are enabled by default. We just need to drop them in order to enable them.
+		if idx == -1 {
+			// Should never happen
+			return fmt.Errorf("unknown issue. the beta feature gate %q is disabled, but is not in spec.featureGates", fgName)
+		}
+
+		patch = fmt.Appendf(nil, `[{ "op": "remove", "path": "/spec/featureGates/%d"}]`, idx)
+
+	default:
+		// alpha/deprecated FG are false by default. We need to explicitly enable them.
+		if idx == -1 {
+			if hc.Spec.FeatureGates == nil {
+				patch = fmt.Appendf(nil, `[{"op": "add", "path": "/spec/featureGates", "value": [{"name": %q}]}]`, fgName)
+			} else {
+				patch = fmt.Appendf(nil, `[{"op": "add", "path": "/spec/featureGates/-", "value": {"name": %q}}]`, fgName)
+			}
+		} else {
+			patch = fmt.Appendf(nil, `[{"op": "add", "path": "/spec/featureGates/%d", "value": {"name": %q, "state": "%s"}}]`, idx, fgName, featuregates.Enabled)
+		}
+	}
+
+	PatchHCO(ctx, cli, patch)
+	return nil
+}
+
+func DisableFG(ctx context.Context, cli client.Client, fgName string) error {
+	hc, err := GetHCO(ctx, cli)
+	if err != nil {
+		return err
 	}
 
 	if !hc.Spec.FeatureGates.IsEnabled(fgName) {
-		var patch []byte
-		idx := slices.IndexFunc(hc.Spec.FeatureGates, func(fg featuregates.FeatureGate) bool {
-			return fg.Name == fgName
-		})
-		if idx == -1 {
-			patch = fmt.Appendf(nil, `[{"op": "add", "path": "/spec/featureGates/-", "value": {"name": %q}}]`, fgName)
-		} else {
-			patch = fmt.Appendf(nil, `[{"op": "replace", "path": "/spec/featureGates/%d/state", "value": "%v"}]`, idx, featuregates.Enabled)
-		}
-
-		return PatchHCO(ctx, cli, patch)
+		// already disabled
+		return nil
 	}
 
+	idx := slices.IndexFunc(hc.Spec.FeatureGates, func(fg featuregates.FeatureGate) bool {
+		return fg.Name == fgName
+	})
+
+	var patch []byte
+	switch phase, _ := featuregatedetails.GetFeatureGatePhase(fgName); phase {
+	case fgs.PhaseUnknown:
+		return fmt.Errorf("unknown feature gate %q", fgName)
+
+	case fgs.PhaseBeta:
+		// beta FG are enabled by default. We need to explicitly disable them.
+		if idx == -1 {
+			if hc.Spec.FeatureGates == nil {
+				patch = fmt.Appendf(nil, `[{"op": "add", "path": "/spec/featureGates", "value": [{"name": %q, "state": "%s"}]}]`, fgName, featuregates.Disabled)
+			} else {
+				patch = fmt.Appendf(nil, `[{"op": "add", "path": "/spec/featureGates/-", "value": {"name": %q, "state": "%s"}}]`, fgName, featuregates.Disabled)
+			}
+
+		} else {
+			patch = fmt.Appendf(nil, `[{"op": "add", "path": "/spec/featureGates/%d", "value": {"name": %q, "state": "%s"}}]`, idx, fgName, featuregates.Disabled)
+		}
+
+	default:
+		// alpha/deprecated FG are false by default. We just need to drop them in order to disable them
+		if idx == -1 {
+			// Should never happen
+			return fmt.Errorf("unknown issue. the alpha feature gate %q is enabled, but is not in spec.featureGates", fgName)
+		}
+
+		patch = fmt.Appendf(nil, `[{ "op": "remove", "path": "/spec/featureGates/%d"}]`, idx)
+	}
+
+	PatchHCO(ctx, cli, patch)
 	return nil
 }
 

--- a/tests/func-tests/labels_test.go
+++ b/tests/func-tests/labels_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Check that all the sub-resources have the required labels", La
 		Eventually(func(g Gomega, ctx context.Context) {
 			g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(cdi), cdi)).To(Succeed())
 			g.Expect(cdi.Labels).To(HaveKeyWithValue(hcoutil.AppLabelVersion, expectedVersion))
-		}).WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(Succeed())
+		}).WithTimeout(time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
 	})
 
 	It("should have all the required labels in all the controlled resources", func(ctx context.Context) {
@@ -108,9 +108,10 @@ var _ = Describe("Check that all the sub-resources have the required labels", La
 })
 
 func checkLabels(labels map[string]string) {
-	ExpectWithOffset(1, labels).To(HaveKey("app.kubernetes.io/component"))
-	ExpectWithOffset(1, labels).To(HaveKey("app.kubernetes.io/version"))
-	ExpectWithOffset(1, labels).To(HaveKeyWithValue("app", "kubevirt-hyperconverged"))
-	ExpectWithOffset(1, labels).To(HaveKeyWithValue("app.kubernetes.io/part-of", "hyperconverged-cluster"))
-	ExpectWithOffset(1, labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "hco-operator"))
+	GinkgoHelper()
+	Expect(labels).To(HaveKey(hcoutil.AppLabelComponent))
+	Expect(labels).To(HaveKey(hcoutil.AppLabelVersion))
+	Expect(labels).To(HaveKeyWithValue(hcoutil.AppLabel, "kubevirt-hyperconverged"))
+	Expect(labels).To(HaveKeyWithValue(hcoutil.AppLabelPartOf, "hyperconverged-cluster"))
+	Expect(labels).To(HaveKeyWithValue(hcoutil.AppLabelManagedBy, "hco-operator"))
 }

--- a/tests/func-tests/monitoring_test.go
+++ b/tests/func-tests/monitoring_test.go
@@ -137,7 +137,8 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 		}
 
 		Eventually(cli.Patch).
-			WithArguments(ctx, kv, patch).
+			WithContext(ctx).
+			WithArguments(kv, patch).
 			WithTimeout(time.Minute).
 			WithPolling(time.Second).
 			To(Succeed())
@@ -247,14 +248,16 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 		}
 
 		Eventually(cli.Create).
-			WithArguments(ctx, vm).
+			WithContext(ctx).
+			WithArguments(vm).
 			WithTimeout(time.Minute).
 			WithPolling(time.Second * 10).
 			Should(Succeed())
 
 		DeferCleanup(func(ctx context.Context) {
 			Eventually(cli.Delete).
-				WithArguments(ctx, vm).
+				WithContext(ctx).
+				WithArguments(vm).
 				WithTimeout(time.Minute * 5).
 				WithPolling(time.Second * 10).
 				Should(Succeed())
@@ -334,7 +337,9 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			}
 
 			By("Misconfiguring the descheduler")
-			Eventually(cli.Patch).WithArguments(ctx, descheduler, patchMisconfigure).
+			Eventually(cli.Patch).
+				WithContext(ctx).
+				WithArguments(descheduler, patchMisconfigure).
 				WithTimeout(10 * time.Second).
 				WithPolling(500 * time.Millisecond).
 				Should(Succeed())
@@ -374,7 +379,9 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			}).WithTimeout(prometheousTimeout).WithPolling(prometheousPolling).WithContext(ctx).ShouldNot(BeNil())
 
 			By("Correctly configuring the descheduler for KubeVirt")
-			Eventually(cli.Patch).WithArguments(ctx, descheduler, patchConfigure).
+			Eventually(cli.Patch).
+				WithContext(ctx).
+				WithArguments(descheduler, patchConfigure).
 				WithTimeout(10 * time.Second).
 				WithPolling(500 * time.Millisecond).
 				Should(Succeed())
@@ -414,7 +421,9 @@ var _ = Describe("[crit:high][vendor:cnv-qe@redhat.com][level:system]Monitoring"
 			}).WithTimeout(prometheousTimeout).WithPolling(prometheousPolling).WithContext(ctx).Should(BeNil())
 
 			By("Misconfiguring a second time the descheduler")
-			Eventually(cli.Patch).WithArguments(ctx, descheduler, patchMisconfigure).
+			Eventually(cli.Patch).
+				WithContext(ctx).
+				WithArguments(descheduler, patchMisconfigure).
 				WithTimeout(10 * time.Second).
 				WithPolling(500 * time.Millisecond).
 				Should(Succeed())

--- a/tests/func-tests/role_aggregation_strategy_test.go
+++ b/tests/func-tests/role_aggregation_strategy_test.go
@@ -31,7 +31,7 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 		Expect(err).ToNot(HaveOccurred())
 
 		if hco.Spec.Virtualization.RoleAggregationStrategy != nil {
-			Expect(tests.PatchHCO(ctx, cli, rmRoleAgrStrgPatch)).To(Succeed())
+			tests.PatchHCO(ctx, cli, rmRoleAgrStrgPatch)
 		}
 	})
 
@@ -92,9 +92,7 @@ var _ = Describe("RoleAggregationStrategy", Serial, Label("RoleAggregationStrate
 		}).WithTimeout(time.Minute).WithPolling(10 * time.Second).WithContext(ctx).Should(Succeed())
 
 		By("Removing RoleAggregationStrategy from HCO")
-		Eventually(func() error {
-			return tests.PatchHCO(ctx, cli, rmRoleAgrStrgPatch)
-		}).WithTimeout(10 * time.Second).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+		tests.PatchHCO(ctx, cli, rmRoleAgrStrgPatch)
 
 		Eventually(func(g Gomega, ctx context.Context) {
 			kv := getKubeVirt(ctx, g, cli)

--- a/tests/func-tests/wasp_agent_test.go
+++ b/tests/func-tests/wasp_agent_test.go
@@ -257,15 +257,10 @@ func getWaspSA(ctx context.Context, cli client.Client) error {
 }
 
 func setMemoryOvercommitPercentage(ctx context.Context, cli client.Client, percentage int) {
+	GinkgoHelper()
 	patchBytes := fmt.Appendf(nil, setMemoryOvercommitTemplate, percentage)
 
-	Eventually(tests.PatchHCO).
-		WithArguments(ctx, cli, patchBytes).
-		WithTimeout(10 * time.Second).
-		WithPolling(100 * time.Millisecond).
-		WithContext(ctx).
-		WithOffset(2).
-		Should(Succeed())
+	tests.PatchHCO(ctx, cli, patchBytes)
 }
 
 func getWaspDS(ctx context.Context, cli client.Client) (*appsv1.DaemonSet, error) {
@@ -290,12 +285,7 @@ func setAutopilotSwapAnnotation(ctx context.Context, cli client.Client) {
 		}
 	}`, waspagent.AutopilotSwapAnnotation, waspagent.AutopilotSwapAnnotationValue))
 
-	Eventually(func(g Gomega, ctx context.Context) {
-		g.Expect(tests.PatchMergeHCO(ctx, cli, patchBytes)).To(Succeed())
-	}).WithTimeout(30 * time.Second).
-		WithPolling(time.Second).
-		WithContext(ctx).
-		Should(Succeed())
+	tests.PatchMergeHCO(ctx, cli, patchBytes)
 
 	Eventually(func(g Gomega, ctx context.Context) {
 		hco, err := tests.GetHCO(ctx, cli)
@@ -318,12 +308,7 @@ func removeAutopilotSwapAnnotation(ctx context.Context, cli client.Client) {
 		}
 	}`, waspagent.AutopilotSwapAnnotation))
 
-	Eventually(func(g Gomega, ctx context.Context) {
-		g.Expect(tests.PatchMergeHCO(ctx, cli, patchBytes)).To(Succeed())
-	}).WithTimeout(30 * time.Second).
-		WithPolling(time.Second).
-		WithContext(ctx).
-		Should(Succeed())
+	tests.PatchMergeHCO(ctx, cli, patchBytes)
 
 	Eventually(func(g Gomega, ctx context.Context) {
 		hco, err := tests.GetHCO(ctx, cli)


### PR DESCRIPTION
**What this PR does / why we need it**:

Several functional tests are randomly failing when trying to patch HCO. This is usually happening when the webhook is down, usually when the the leader election is lost.

This PR wraps the HCO Patch helper functions with Eventually of two minutes. This should be enough time for the webhook pod to be back online.

In addition, this PR introduces better versions of the enable/disable feature gate helpers, to handle all cases.

**Release note**:
```release-note
None
```
