### PR TITLE
 netresinjector: Make deployment conditional on spec field

### DIFF
--- a/api/v1/hyperconverged_types.go
+++ b/api/v1/hyperconverged_types.go
@@ -164,7 +164,7 @@ type HyperConvergedSpec struct {
 	Security SecurityConfig `json:"security,omitempty"`
 
 	// Deployment contains all the configurations related to deployment of KubeVirt components
-	// +kubebuilder:default={"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}
+	// +kubebuilder:default={"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}
 	// +optional
 	// +k8s:conversion-gen=false
 	Deployment DeploymentConfig `json:"deployment,omitempty"`
@@ -418,6 +418,14 @@ type DeploymentConfig struct {
 	// +kubebuilder:default=false
 	// +default=false
 	DeployVMConsoleProxy *bool `json:"deployVmConsoleProxy,omitempty"`
+
+	// DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
+	// When enabled, the network-resources-injector mutating webhook will be deployed to automatically
+	// inject resource requests for custom resources annotated in NetworkAttachmentDefinition.
+	// +optional
+	// +kubebuilder:default=true
+	// +default=true
+	DeployNetworkResourcesInjector *bool `json:"deployNetworkResourcesInjector,omitempty"`
 }
 
 // CertRotateConfigCA contains the tunables for TLS certificates.
@@ -925,7 +933,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}}
+	// +kubebuilder:default={"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -204,6 +204,11 @@ func (in *DeploymentConfig) DeepCopyInto(out *DeploymentConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DeployNetworkResourcesInjector != nil {
+		in, out := &in.DeployNetworkResourcesInjector, &out.DeployNetworkResourcesInjector
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1/zz_generated.defaults.go
+++ b/api/v1/zz_generated.defaults.go
@@ -144,6 +144,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.Deployment.DeployVMConsoleProxy = &ptrVar1
 	}
+	if in.Spec.Deployment.DeployNetworkResourcesInjector == nil {
+		var ptrVar1 bool = true
+		in.Spec.Deployment.DeployNetworkResourcesInjector = &ptrVar1
+	}
 }
 
 func SetObjectDefaults_HyperConvergedList(in *HyperConvergedList) {

--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
 	"reflect"
@@ -14,6 +15,11 @@ import (
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 )
+
+const v1OnlyFieldAnnotation = APIVersionGroup + "/v1-only-fields"
+
+type v1OnlyFields struct {
+}
 
 // Implement the conversion.Convertible interface, to be used in the conversion webhook.
 
@@ -44,7 +50,7 @@ func (src *HyperConverged) ConvertTo(dstRaw conversion.Hub) error { //revive:dis
 		return fmt.Errorf("failed to convert HyperConverged's spec.deployment from v1beta1 to v1; %w", err)
 	}
 
-	return nil
+	return restoreV1OnlyFields(src, dst)
 }
 
 func (dst *HyperConverged) ConvertFrom(srcRaw conversion.Hub) error { //revive:disable:receiver-naming
@@ -74,7 +80,7 @@ func (dst *HyperConverged) ConvertFrom(srcRaw conversion.Hub) error { //revive:d
 		return fmt.Errorf("failed to convert HyperConverged's spec.deployment from v1 to v1beta1; %w", err)
 	}
 
-	return nil
+	return storeV1OnlyFields(src, dst)
 }
 
 func convertNodePlacementsV1ToV1beta1(v1Spec hcov1.HyperConvergedSpec, v1beta1Spec *HyperConvergedSpec) {
@@ -496,6 +502,48 @@ func convertAAQConfigV1beta1ToV1(v1beta1Spec HyperConvergedSpec, v1Config *hcov1
 	}
 
 	v1Config.ApplicationAwareConfig.Enable = setPtr(v1beta1Spec.EnableApplicationAwareQuota)
+
+	return nil
+}
+
+func restoreV1OnlyFields(src *HyperConverged, dst *hcov1.HyperConverged) error {
+	v1FieldStr, found := src.Annotations[v1OnlyFieldAnnotation]
+	if !found || v1FieldStr == "" {
+		return nil
+	}
+
+	var v1Fields v1OnlyFields
+	err := json.Unmarshal([]byte(v1FieldStr), &v1Fields)
+	if err != nil {
+		return fmt.Errorf("unable to parse the %s annotation: %w", v1OnlyFieldAnnotation, err)
+	}
+
+	// Field-specific restoration goes here
+
+	delete(dst.Annotations, v1OnlyFieldAnnotation)
+
+	return nil
+}
+
+func storeV1OnlyFields(src *hcov1.HyperConverged, dst *HyperConverged) error {
+	v1Fields := v1OnlyFields{}
+
+	// Field-specific storage goes here
+
+	if v1Fields == (v1OnlyFields{}) {
+		return nil
+	}
+
+	v1FieldAnn, err := json.Marshal(v1Fields)
+	if err != nil {
+		return fmt.Errorf("unable to create the %s annotation: %w", v1OnlyFieldAnnotation, err)
+	}
+
+	if dst.Annotations == nil {
+		dst.Annotations = map[string]string{}
+	}
+
+	dst.Annotations[v1OnlyFieldAnnotation] = string(v1FieldAnn)
 
 	return nil
 }

--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -19,6 +19,7 @@ import (
 const v1OnlyFieldAnnotation = APIVersionGroup + "/v1-only-fields"
 
 type v1OnlyFields struct {
+	DeployNetworkResourcesInjector *bool `json:"deployNetworkResourcesInjector,omitempty"`
 }
 
 // Implement the conversion.Convertible interface, to be used in the conversion webhook.
@@ -518,7 +519,9 @@ func restoreV1OnlyFields(src *HyperConverged, dst *hcov1.HyperConverged) error {
 		return fmt.Errorf("unable to parse the %s annotation: %w", v1OnlyFieldAnnotation, err)
 	}
 
-	// Field-specific restoration goes here
+	if v1Fields.DeployNetworkResourcesInjector != nil {
+		dst.Spec.Deployment.DeployNetworkResourcesInjector = new(*v1Fields.DeployNetworkResourcesInjector)
+	}
 
 	delete(dst.Annotations, v1OnlyFieldAnnotation)
 
@@ -526,9 +529,9 @@ func restoreV1OnlyFields(src *HyperConverged, dst *hcov1.HyperConverged) error {
 }
 
 func storeV1OnlyFields(src *hcov1.HyperConverged, dst *HyperConverged) error {
-	v1Fields := v1OnlyFields{}
-
-	// Field-specific storage goes here
+	v1Fields := v1OnlyFields{
+		DeployNetworkResourcesInjector: src.Spec.Deployment.DeployNetworkResourcesInjector,
+	}
 
 	if v1Fields == (v1OnlyFields{}) {
 		return nil

--- a/api/v1beta1/conversion_fuzz_test.go
+++ b/api/v1beta1/conversion_fuzz_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,8 +47,9 @@ func FuzzV1beta1ToV1RoundTrip(f *testing.F) {
 		v1Second := &hcov1.HyperConverged{}
 		g.Expect(roundTripped.ConvertTo(v1Second)).To(Succeed())
 
+		diff := cmp.Diff(v1First.Spec, v1Second.Spec)
 		// the two v1 representations should be equal
-		g.Expect(v1Second.Spec).To(Equal(v1First.Spec))
+		g.Expect(diff).To(BeEmpty(), diff)
 	})
 }
 
@@ -77,7 +79,8 @@ func FuzzV1ToV1beta1RoundTrip(f *testing.F) {
 		g.Expect(v1beta1Second.ConvertFrom(roundTripped)).To(Succeed())
 
 		// the two v1beta1 representations should be equal
-		g.Expect(v1beta1Second.Spec).To(Equal(v1beta1First.Spec))
+		diff := cmp.Diff(v1beta1First.Spec, v1beta1Second.Spec)
+		g.Expect(diff).To(BeEmpty(), diff)
 	})
 }
 

--- a/api/v1beta1/conversion_fuzz_test.go
+++ b/api/v1beta1/conversion_fuzz_test.go
@@ -499,6 +499,10 @@ func randomV1HC(r *rand.Rand) *hcov1.HyperConverged {
 
 	hc.Spec.Deployment.DeployVMConsoleProxy = randPtr(r, r.IntN(2) == 1)
 
+	if r.IntN(2) == 1 {
+		hc.Spec.Deployment.DeployNetworkResourcesInjector = new(r.IntN(2) == 1)
+	}
+
 	return hc
 }
 

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -160,6 +162,13 @@ spec:
                         - GuestEffectiveResources
                         type: string
                     type: object
+                  deployNetworkResourcesInjector:
+                    default: true
+                    description: |-
+                      DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
+                      When enabled, the network-resources-injector mutating webhook will be deployed to automatically
+                      inject resource requests for custom resources annotated in NetworkAttachmentDefinition.
+                    type: boolean
                   deployVmConsoleProxy:
                     default: false
                     description: deploy VM console proxy resources in SSP operator

--- a/controllers/handlers/netresinjector/common.go
+++ b/controllers/handlers/netresinjector/common.go
@@ -1,5 +1,11 @@
 package netresinjector
 
+import (
+	"k8s.io/utils/ptr"
+
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+)
+
 const (
 	clusterRoleName    = "cnv-network-resources-injector"
 	serviceAccountName = "cnv-network-resources-injector-sa"
@@ -10,3 +16,8 @@ const (
 	tlsMountPath       = "/etc/tls"
 	webhookConfigName  = "cnv-network-resources-injector-config"
 )
+
+// shouldDeploy checks if network-resources-injector should be deployed
+func shouldDeploy(hc *hcov1.HyperConverged) bool {
+	return ptr.Deref(hc.Spec.Deployment.DeployNetworkResourcesInjector, true)
+}

--- a/controllers/handlers/netresinjector/conditional_test.go
+++ b/controllers/handlers/netresinjector/conditional_test.go
@@ -1,0 +1,249 @@
+package netresinjector
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+)
+
+var _ = Describe("Network Resources Injector Conditional Handlers", func() {
+	var (
+		hco *hcov1.HyperConverged
+		req *common.HcoRequest
+		cl  client.Client
+	)
+
+	BeforeEach(func() {
+		hco = commontestutils.NewHco()
+		req = commontestutils.NewReq(hco)
+	})
+
+	Context("Conditional ClusterRole Handler", func() {
+		It("should create ClusterRole when deployNetworkResourcesInjector is true", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(true)
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewClusterRoleHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeTrue())
+
+			foundCR := &rbacv1.ClusterRole{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterRoleName}, foundCR)).To(Succeed())
+			Expect(foundCR.Name).To(Equal(clusterRoleName))
+		})
+
+		It("should create ClusterRole when deployNetworkResourcesInjector is not set (default true)", func() {
+			// Don't set deployNetworkResourcesInjector - should default to true
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewClusterRoleHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeTrue())
+
+			foundCR := &rbacv1.ClusterRole{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterRoleName}, foundCR)).To(Succeed())
+		})
+
+		It("should delete ClusterRole when deployNetworkResourcesInjector is false", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(false)
+			cr := newClusterRole()
+			cl = commontestutils.InitClient([]client.Object{hco, cr})
+
+			handler := NewClusterRoleHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Deleted).To(BeTrue())
+
+			foundCR := &rbacv1.ClusterRole{}
+			err := cl.Get(context.Background(), client.ObjectKey{Name: clusterRoleName}, foundCR)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(apierrors.IsNotFound, "not found error"))
+		})
+	})
+
+	Context("Conditional ClusterRoleBinding Handler", func() {
+		It("should create ClusterRoleBinding when enabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(true)
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewClusterRoleBindingHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeTrue())
+		})
+
+		It("should delete ClusterRoleBinding when disabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(false)
+			crb := newClusterRoleBinding()
+			cl = commontestutils.InitClient([]client.Object{hco, crb})
+
+			handler := NewClusterRoleBindingHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Deleted).To(BeTrue())
+		})
+	})
+
+	Context("Conditional ServiceAccount Handler", func() {
+		It("should create ServiceAccount when enabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(true)
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewServiceAccountHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeTrue())
+
+			foundSA := &corev1.ServiceAccount{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: serviceAccountName, Namespace: hco.Namespace}, foundSA)).To(Succeed())
+		})
+
+		It("should delete ServiceAccount when disabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(false)
+			sa := newServiceAccount()
+			sa.Namespace = hco.Namespace
+			cl = commontestutils.InitClient([]client.Object{hco, sa})
+
+			handler := NewServiceAccountHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Deleted).To(BeTrue())
+		})
+	})
+
+	Context("Conditional Service Handler", func() {
+		It("should create Service when enabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(true)
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewServiceHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeTrue())
+
+			foundSvc := &corev1.Service{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: serviceName, Namespace: hco.Namespace}, foundSvc)).To(Succeed())
+		})
+
+		It("should delete Service when disabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(false)
+			svc := newService()
+			svc.Namespace = hco.Namespace
+			cl = commontestutils.InitClient([]client.Object{hco, svc})
+
+			handler := NewServiceHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Deleted).To(BeTrue())
+		})
+	})
+
+	Context("Conditional Deployment Handler", func() {
+		It("should create Deployment when enabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(true)
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeTrue())
+
+			foundDep := &appsv1.Deployment{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: deploymentName, Namespace: hco.Namespace}, foundDep)).To(Succeed())
+		})
+
+		It("should delete Deployment when disabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(false)
+			dep := newDeployment(hco)
+			cl = commontestutils.InitClient([]client.Object{hco, dep})
+
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Deleted).To(BeTrue())
+		})
+	})
+
+	Context("Conditional PodDisruptionBudget Handler", func() {
+		It("should create PDB when enabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(true)
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewPDBHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeTrue())
+
+			foundPDB := &policyv1.PodDisruptionBudget{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: deploymentName + "-pdb", Namespace: hco.Namespace}, foundPDB)).To(Succeed())
+		})
+
+		It("should delete PDB when disabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(false)
+			pdb := newPDB()
+			pdb.Namespace = hco.Namespace
+			cl = commontestutils.InitClient([]client.Object{hco, pdb})
+
+			handler := NewPDBHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Deleted).To(BeTrue())
+		})
+	})
+
+	Context("Conditional MutatingWebhookConfiguration Handler", func() {
+		It("should create MutatingWebhookConfiguration when enabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(true)
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewMutatingWebhookConfigurationHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeTrue())
+
+			foundMWC := &admissionregistrationv1.MutatingWebhookConfiguration{}
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: webhookConfigName}, foundMWC)).To(Succeed())
+		})
+
+		It("should delete MutatingWebhookConfiguration when disabled", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(false)
+			mwc := newMutatingWebhookConfiguration()
+			cl = commontestutils.InitClient([]client.Object{hco, mwc})
+
+			handler := NewMutatingWebhookConfigurationHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Deleted).To(BeTrue())
+		})
+	})
+})

--- a/controllers/handlers/netresinjector/deployment.go
+++ b/controllers/handlers/netresinjector/deployment.go
@@ -51,8 +51,69 @@ func newDeployment(_ *hcov1.HyperConverged) *appsv1.Deployment {
 
 	podLabels := operands.GetLabels(hcoutil.AppComponentNetResInjector)
 
-	infrastructureHighlyAvailable := nodeinfo.IsInfrastructureHighlyAvailable()
-	affinity := operands.GetPodAntiAffinity(podLabels[hcoutil.AppLabelComponent], infrastructureHighlyAvailable)
+	// Configure affinity to prefer control plane nodes
+	// Use PreferredDuringScheduling to support HyperShift (worker-only) and SNO clusters
+	affinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				// Prefer standard Kubernetes control-plane nodes
+				{
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      nodeinfo.LabelNodeRoleControlPlane,
+								Operator: corev1.NodeSelectorOpExists,
+							},
+						},
+					},
+					Weight: 100,
+				},
+				// Prefer KubeVirt control-plane nodes (HyperShift)
+				{
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      nodeinfo.LabelNodeRoleKubevirtControlPlane,
+								Operator: corev1.NodeSelectorOpExists,
+							},
+						},
+					},
+					Weight: 100,
+				},
+				// Avoid worker-only nodes when control plane nodes are available
+				{
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      nodeinfo.LabelNodeRoleWorker,
+								Operator: corev1.NodeSelectorOpDoesNotExist,
+							},
+						},
+					},
+					Weight: 50,
+				},
+			},
+		},
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      hcoutil.AppLabelComponent,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{string(hcoutil.AppComponentNetResInjector)},
+								},
+							},
+						},
+						TopologyKey: corev1.LabelHostname,
+					},
+					Weight: 1,
+				},
+			},
+		},
+	}
 
 	dep := NewDeploymentWithNameOnly()
 	dep.Spec = appsv1.DeploymentSpec{
@@ -71,6 +132,20 @@ func newDeployment(_ *hcov1.HyperConverged) *appsv1.Deployment {
 				ServiceAccountName: serviceAccountName,
 				PriorityClassName:  "system-cluster-critical",
 				Affinity:           affinity,
+				NodeSelector: map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "CriticalAddonsOnly",
+						Operator: corev1.TolerationOpExists,
+					},
+					{
+						Effect:   corev1.TaintEffectNoSchedule,
+						Key:      nodeinfo.LabelNodeRoleControlPlane,
+						Operator: corev1.TolerationOpExists,
+					},
+				},
 				SecurityContext: &corev1.PodSecurityContext{
 					RunAsNonRoot: new(true),
 				},

--- a/controllers/handlers/netresinjector/deployment.go
+++ b/controllers/handlers/netresinjector/deployment.go
@@ -22,7 +22,13 @@ var (
 )
 
 func NewDeploymentHandler(cli client.Client, scheme *runtime.Scheme) operands.Operand {
-	return operands.NewDeploymentHandler(cli, scheme, newDeployment)
+	return operands.NewConditionalHandler(
+		operands.NewDeploymentHandler(cli, scheme, newDeployment),
+		shouldDeploy,
+		func(hc *hcov1.HyperConverged) client.Object {
+			return NewDeploymentWithNameOnly()
+		},
+	)
 }
 
 func NewDeploymentWithNameOnly() *appsv1.Deployment {

--- a/controllers/handlers/netresinjector/deployment_test.go
+++ b/controllers/handlers/netresinjector/deployment_test.go
@@ -55,6 +55,23 @@ var _ = Describe("Network Resources Injector Deployment", func() {
 			Expect(dep.Spec.Template.Spec.ServiceAccountName).To(Equal(serviceAccountName))
 			Expect(dep.Spec.Template.Spec.PriorityClassName).To(Equal("system-cluster-critical"))
 
+			// Verify control plane scheduling
+			Expect(dep.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("kubernetes.io/os", "linux"))
+			Expect(dep.Spec.Template.Spec.Tolerations).To(HaveLen(2))
+			Expect(dep.Spec.Template.Spec.Tolerations[0].Key).To(Equal("CriticalAddonsOnly"))
+			Expect(dep.Spec.Template.Spec.Tolerations[1].Key).To(Equal("node-role.kubernetes.io/control-plane"))
+
+			Expect(dep.Spec.Template.Spec.Affinity).ToNot(BeNil())
+			Expect(dep.Spec.Template.Spec.Affinity.NodeAffinity).ToNot(BeNil())
+			// Verify preferred scheduling for control plane compatibility (HyperShift, SNO)
+			Expect(dep.Spec.Template.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(3))
+			Expect(dep.Spec.Template.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].Preference.MatchExpressions[0].Key).To(Equal("node-role.kubernetes.io/control-plane"))
+			Expect(dep.Spec.Template.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[1].Preference.MatchExpressions[0].Key).To(Equal("node-role.kubevirt.io/control-plane"))
+			Expect(dep.Spec.Template.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[2].Preference.MatchExpressions[0].Key).To(Equal("node-role.kubernetes.io/worker"))
+
+			Expect(dep.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
+			Expect(dep.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
+
 			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := dep.Spec.Template.Spec.Containers[0]
 			Expect(container.Name).To(Equal("webhook-server"))

--- a/controllers/handlers/netresinjector/pdb.go
+++ b/controllers/handlers/netresinjector/pdb.go
@@ -17,8 +17,13 @@ import (
 )
 
 func NewPDBHandler(cli client.Client, scheme *runtime.Scheme) operands.Operand {
-	return operands.NewGenericOperand(cli, scheme, "PodDisruptionBudget",
-		&pdbHooks{pdb: newPDB()}, true)
+	return operands.NewConditionalHandler(
+		operands.NewGenericOperand(cli, scheme, "PodDisruptionBudget", &pdbHooks{pdb: newPDB()}, true),
+		shouldDeploy,
+		func(hc *hcov1.HyperConverged) client.Object {
+			return NewPDBWithNameOnly()
+		},
+	)
 }
 
 type pdbHooks struct {

--- a/controllers/handlers/netresinjector/rbac.go
+++ b/controllers/handlers/netresinjector/rbac.go
@@ -6,16 +6,29 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func NewClusterRoleHandler(cli client.Client, scheme *runtime.Scheme) operands.Operand {
-	return operands.NewClusterRoleHandler(cli, scheme, newClusterRole())
+	return operands.NewConditionalHandler(
+		operands.NewClusterRoleHandler(cli, scheme, newClusterRole()),
+		shouldDeploy,
+		func(hc *hcov1.HyperConverged) client.Object {
+			return NewClusterRoleWithNameOnly()
+		},
+	)
 }
 
 func NewClusterRoleBindingHandler(cli client.Client, scheme *runtime.Scheme) operands.Operand {
-	return operands.NewClusterRoleBindingHandler(cli, scheme, newClusterRoleBinding())
+	return operands.NewConditionalHandler(
+		operands.NewClusterRoleBindingHandler(cli, scheme, newClusterRoleBinding()),
+		shouldDeploy,
+		func(hc *hcov1.HyperConverged) client.Object {
+			return NewClusterRoleBindingWithNameOnly()
+		},
+	)
 }
 
 func NewClusterRoleWithNameOnly() *rbacv1.ClusterRole {

--- a/controllers/handlers/netresinjector/service.go
+++ b/controllers/handlers/netresinjector/service.go
@@ -7,12 +7,19 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func NewServiceHandler(cli client.Client, scheme *runtime.Scheme) operands.Operand {
-	return operands.NewServiceHandler(cli, scheme, newService())
+	return operands.NewConditionalHandler(
+		operands.NewServiceHandler(cli, scheme, newService()),
+		shouldDeploy,
+		func(hc *hcov1.HyperConverged) client.Object {
+			return newService()
+		},
+	)
 }
 
 func newService() *corev1.Service {

--- a/controllers/handlers/netresinjector/service_account.go
+++ b/controllers/handlers/netresinjector/service_account.go
@@ -6,12 +6,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 func NewServiceAccountHandler(cli client.Client, scheme *runtime.Scheme) operands.Operand {
-	return operands.NewServiceAccountHandler(cli, scheme, newServiceAccount)
+	return operands.NewConditionalHandler(
+		operands.NewServiceAccountHandler(cli, scheme, newServiceAccount),
+		shouldDeploy,
+		func(hc *hcov1.HyperConverged) client.Object {
+			return newServiceAccount()
+		},
+	)
 }
 
 func newServiceAccount() *corev1.ServiceAccount {

--- a/controllers/handlers/netresinjector/webhook_config.go
+++ b/controllers/handlers/netresinjector/webhook_config.go
@@ -19,8 +19,13 @@ import (
 )
 
 func NewMutatingWebhookConfigurationHandler(cli client.Client, scheme *runtime.Scheme) operands.Operand {
-	return operands.NewGenericOperand(cli, scheme, "MutatingWebhookConfiguration",
-		&mwcHooks{required: newMutatingWebhookConfiguration()}, false)
+	return operands.NewConditionalHandler(
+		operands.NewGenericOperand(cli, scheme, "MutatingWebhookConfiguration", &mwcHooks{required: newMutatingWebhookConfiguration()}, false),
+		shouldDeploy,
+		func(hc *hcov1.HyperConverged) client.Object {
+			return NewMutatingWebhookConfigurationWithNameOnly()
+		},
+	)
 }
 
 type mwcHooks struct {

--- a/controllers/handlers/netresinjector/webhook_config.go
+++ b/controllers/handlers/netresinjector/webhook_config.go
@@ -148,7 +148,7 @@ func newMutatingWebhookConfiguration() *admissionregistrationv1.MutatingWebhookC
 			Name:                    "cnv-network-resources-injector-config.k8s.io",
 			AdmissionReviewVersions: []string{"v1", "v1beta1"},
 			SideEffects:             new(admissionregistrationv1.SideEffectClassNone),
-			FailurePolicy:           new(admissionregistrationv1.Ignore),
+			FailurePolicy:           new(admissionregistrationv1.Fail),
 			TimeoutSeconds:          new(int32(10)),
 			MatchPolicy:             new(admissionregistrationv1.Equivalent),
 			ReinvocationPolicy:      new(admissionregistrationv1.NeverReinvocationPolicy),

--- a/controllers/handlers/netresinjector/webhook_config_test.go
+++ b/controllers/handlers/netresinjector/webhook_config_test.go
@@ -40,6 +40,8 @@ var _ = Describe("Network Resources Injector MutatingWebhookConfiguration", func
 			wh := mwc.Webhooks[0]
 			Expect(wh.Name).To(Equal("cnv-network-resources-injector-config.k8s.io"))
 			Expect(wh.AdmissionReviewVersions).To(ConsistOf("v1", "v1beta1"))
+			Expect(wh.FailurePolicy).ToNot(BeNil())
+			Expect(*wh.FailurePolicy).To(Equal(admissionregistrationv1.Fail))
 			Expect(wh.Rules).To(HaveLen(1))
 			Expect(wh.Rules[0].Operations).To(ContainElement(admissionregistrationv1.Create))
 			Expect(wh.Rules[0].Rule.Resources).To(ContainElement("pods"))

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -160,6 +162,13 @@ spec:
                         - GuestEffectiveResources
                         type: string
                     type: object
+                  deployNetworkResourcesInjector:
+                    default: true
+                    description: |-
+                      DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
+                      When enabled, the network-resources-injector mutating webhook will be deployed to automatically
+                      inject resource requests for custom resources annotated in NetworkAttachmentDefinition.
+                    type: boolean
                   deployVmConsoleProxy:
                     default: false
                     description: deploy VM console proxy resources in SSP operator

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kubevirt-hyperconverged
 spec:
   deployment:
+    deployNetworkResourcesInjector: true
     deployVmConsoleProxy: false
     uninstallStrategy: BlockUninstallIfWorkloadsExist
   security:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -160,6 +162,13 @@ spec:
                         - GuestEffectiveResources
                         type: string
                     type: object
+                  deployNetworkResourcesInjector:
+                    default: true
+                    description: |-
+                      DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
+                      When enabled, the network-resources-injector mutating webhook will be deployed to automatically
+                      inject resource requests for custom resources annotated in NetworkAttachmentDefinition.
+                    type: boolean
                   deployVmConsoleProxy:
                     default: false
                     description: deploy VM console proxy resources in SSP operator

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -160,6 +162,13 @@ spec:
                         - GuestEffectiveResources
                         type: string
                     type: object
+                  deployNetworkResourcesInjector:
+                    default: true
+                    description: |-
+                      DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
+                      When enabled, the network-resources-injector mutating webhook will be deployed to automatically
+                      inject resource requests for custom resources annotated in NetworkAttachmentDefinition.
+                    type: boolean
                   deployVmConsoleProxy:
                     default: false
                     description: deploy VM console proxy resources in SSP operator

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -124,6 +124,7 @@ DataImportCronTemplateStatus is a copy of a dataImportCronTemplate as defined in
 | logVerbosityConfig | LogVerbosityConfig configures the verbosity level of Kubevirt's different components. The higher the value - the higher the log verbosity. | *[LogVerbosityConfiguration](#logverbosityconfiguration) |  | false |
 | applicationAwareConfig | ApplicationAwareConfig set the AAQ configurations | *[ApplicationAwareConfigurations](#applicationawareconfigurations) |  | false |
 | deployVmConsoleProxy | deploy VM console proxy resources in SSP operator | *bool | false | false |
+| deployNetworkResourcesInjector | DeployNetworkResourcesInjector enables deployment of the network-resources-injector component. When enabled, the network-resources-injector mutating webhook will be deployed to automatically inject resource requests for custom resources annotated in NetworkAttachmentDefinition. | *bool | true | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -144,7 +145,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | ------- | -------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -183,7 +184,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | networking | Networking contains all the configurations for networking | *[NetworkingConfig](#networkingconfig) |  | false |
 | workloadSources | WorkloadSources contains all the configurations for workload sources | [WorkloadSourcesConfig](#workloadsourcesconfig) |  | false |
 | security | Security contains all the security configurations | [SecurityConfig](#securityconfig) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}} | false |
-| deployment | Deployment contains all the configurations related to deployment of KubeVirt components | [DeploymentConfig](#deploymentconfig) | {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}} | false |
+| deployment | Deployment contains all the configurations related to deployment of KubeVirt components | [DeploymentConfig](#deploymentconfig) | {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}} | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -1814,6 +1814,37 @@ spec:
     deployVmConsoleProxy: true
 ```
 
+### Deploy Network Resources Injector
+The Network Resources Injector is a webhook that injects network-related resource requests into pod specifications based on network annotations. It is critical for proper SR-IOV and other network resource management.
+
+To control the deployment of the Network Resources Injector, set the `spec.deployment.deployNetworkResourcesInjector` field.
+
+**Default**: `true`
+
+**Note**: This component is mandatory for proper network resource management. Set this to `false` only if another instance is running elsewhere (e.g., under SR-IOV operator) to avoid conflicts, or if your system does not make use of multus with custom network resources.
+
+#### Example
+```yaml
+apiVersion: hco.kubevirt.io/v1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  deployment:
+    deployNetworkResourcesInjector: true
+```
+
+To disable the deployment (when running an external instance):
+```yaml
+apiVersion: hco.kubevirt.io/v1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  deployment:
+    deployNetworkResourcesInjector: false
+```
+
 ## Configurations via Annotations
 
 In addition to `featureGates` field in HyperConverged CR's spec, the user can set annotations in the HyperConverged CR

--- a/pkg/upgradepatch/hc.cr.json
+++ b/pkg/upgradepatch/hc.cr.json
@@ -47,7 +47,8 @@
     },
     "deployment": {
       "uninstallStrategy": "BlockUninstallIfWorkloadsExist",
-      "deployVmConsoleProxy": false
+      "deployVmConsoleProxy": false,
+      "deployNetworkResourcesInjector": true
     }
   },
   "status": {

--- a/tests/func-tests/netresinjector_test.go
+++ b/tests/func-tests/netresinjector_test.go
@@ -1,0 +1,154 @@
+package tests_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
+)
+
+const (
+	netResInjectorDeploymentName = "cnv-network-resources-injector"
+)
+
+var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Serial, Ordered, func() {
+	tests.FlagParse()
+
+	var cli client.Client
+
+	BeforeAll(func(ctx context.Context) {
+		cli = tests.GetControllerRuntimeClient()
+	})
+
+	AfterAll(func(ctx context.Context) {
+		restoreNetResInjectorToDefault(ctx, cli)
+	})
+
+	Context("when deployNetworkResourcesInjector is true (default)", func() {
+		It("should deploy the network resources injector", func(ctx context.Context) {
+			By("verifying the deployment exists and is ready")
+			Eventually(func(g Gomega, ctx context.Context) {
+				dep := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      netResInjectorDeploymentName,
+						Namespace: tests.InstallNamespace,
+					},
+				}
+				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
+				g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
+			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+
+			By("verifying the deployment has control plane node affinity")
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      netResInjectorDeploymentName,
+					Namespace: tests.InstallNamespace,
+				},
+			}
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
+
+			affinity := dep.Spec.Template.Spec.Affinity
+			Expect(affinity).NotTo(BeNil(), "deployment should have affinity set")
+			Expect(affinity.NodeAffinity).NotTo(BeNil(), "deployment should have node affinity")
+			Expect(affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).NotTo(BeEmpty())
+
+			// Verify it prefers control plane nodes
+			foundControlPlaneSelector := false
+			for _, preferred := range affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+				for _, expr := range preferred.Preference.MatchExpressions {
+					if expr.Key == "node-role.kubernetes.io/control-plane" {
+						foundControlPlaneSelector = true
+						break
+					}
+				}
+			}
+			Expect(foundControlPlaneSelector).To(BeTrue(), "should prefer control plane nodes")
+		})
+	})
+
+	Context("when deployNetworkResourcesInjector is false", func() {
+		BeforeAll(func(ctx context.Context) {
+			disableNetResInjector(ctx, cli)
+		})
+
+		It("should not deploy the network resources injector", func(ctx context.Context) {
+			validateNetResInjectorDeleted(ctx, cli)
+		})
+
+		It("should recreate the deployment when set back to true", func(ctx context.Context) {
+			enableNetResInjector(ctx, cli)
+
+			By("verifying the deployment is recreated and ready")
+			Eventually(func(g Gomega, ctx context.Context) {
+				dep := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      netResInjectorDeploymentName,
+						Namespace: tests.InstallNamespace,
+					},
+				}
+				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
+				g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
+			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+		})
+	})
+})
+
+func getNetResInjectorDeploymentErr(ctx context.Context, cli client.Client) error {
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      netResInjectorDeploymentName,
+			Namespace: tests.InstallNamespace,
+		},
+	}
+	return cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)
+}
+
+func validateNetResInjectorDeleted(ctx context.Context, cli client.Client) {
+	GinkgoHelper()
+	Eventually(func(ctx context.Context) error {
+		return getNetResInjectorDeploymentErr(ctx, cli)
+	}).WithTimeout(2 * time.Minute).
+		WithPolling(time.Second).
+		WithContext(ctx).
+		Should(MatchError(k8serrors.IsNotFound, "should be not-found error"))
+}
+
+func enableNetResInjector(ctx context.Context, cli client.Client) {
+	GinkgoHelper()
+	By("setting deployNetworkResourcesInjector to true")
+	patch := []byte(`[{"op": "replace", "path": "/spec/deployment/deployNetworkResourcesInjector", "value": true}]`)
+	tests.PatchHCO(ctx, cli, patch)
+}
+
+func disableNetResInjector(ctx context.Context, cli client.Client) {
+	GinkgoHelper()
+	By("setting deployNetworkResourcesInjector to false")
+	patch := []byte(`[{"op": "add", "path": "/spec/deployment/deployNetworkResourcesInjector", "value": false}]`)
+	tests.PatchHCO(ctx, cli, patch)
+}
+
+func restoreNetResInjectorToDefault(ctx context.Context, cli client.Client) {
+	GinkgoHelper()
+	By("restoring deployNetworkResourcesInjector to default")
+	patch := []byte(`[{"op": "remove", "path": "/spec/deployment/deployNetworkResourcesInjector"}]`)
+	tests.PatchHCO(ctx, cli, patch)
+
+	// Wait for deployment to be recreated
+	Eventually(func(g Gomega, ctx context.Context) {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      netResInjectorDeploymentName,
+				Namespace: tests.InstallNamespace,
+			},
+		}
+		g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
+		g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
+	}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+}

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -160,6 +162,13 @@ spec:
                         - GuestEffectiveResources
                         type: string
                     type: object
+                  deployNetworkResourcesInjector:
+                    default: true
+                    description: |-
+                      DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
+                      When enabled, the network-resources-injector mutating webhook will be deployed to automatically
+                      inject resource requests for custom resources annotated in NetworkAttachmentDefinition.
+                    type: boolean
                   deployVmConsoleProxy:
                     default: false
                     description: deploy VM console proxy resources in SSP operator

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -160,6 +162,13 @@ spec:
                         - GuestEffectiveResources
                         type: string
                     type: object
+                  deployNetworkResourcesInjector:
+                    default: true
+                    description: |-
+                      DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
+                      When enabled, the network-resources-injector mutating webhook will be deployed to automatically
+                      inject resource requests for custom resources annotated in NetworkAttachmentDefinition.
+                    type: boolean
                   deployVmConsoleProxy:
                     default: false
                     description: deploy VM console proxy resources in SSP operator


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently there are 2 operators in the OLM catalog that deploy the `netwrok-resources-injector` webhook: `HCO` and `SR-IOV Network Operator`. While they are safe to use 
concurrently, users can benefit from disabling one instance.
In such cases the instance that should be disabled is the HCO one, because its scope is specific to CNV, while the other one has a more general scope. 

Adds spec.deployment.deployNetworkResourcesInjector boolean field to
control deployment of the network-resources-injector component.

When enabled (default: true), the network-resources-injector mutating
webhook is deployed to automatically inject resource requests for
custom resources annotated in NetworkAttachmentDefinition.

This is a deployment configuration field (not a feature gate),
allowing users to opt-out of the network-resources-injector if needed.


In addition
- Modify affinity to run injectors in control plain
- Change webhook failure policy to `Fail`


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-89798
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
DeploymentConfig in in HCO API now includes the deployNetworkResourcesInjector switch to support opting out of network-resources-injector deployment.
```
