### PR TITLE
Fix nil-pointer-dereference

### DIFF
--- a/pkg/internal/ownresources/own_resources.go
+++ b/pkg/internal/ownresources/own_resources.go
@@ -107,13 +107,15 @@ func doInit(ctx context.Context, cl client.Reader, scheme *runtime.Scheme, logge
 
 func getThePod(ctx context.Context, c client.Reader, logger logr.Logger) (*corev1.Pod, error) {
 	ci := hcoutil.GetClusterInfo()
-	operatorNs := hcoutil.GetOperatorNamespaceFromEnv()
-
-	// This is taken from k8sutil.getPod. This method only receives client. But the client is not always ready. We'll
-	// use --- instead
 	if ci.IsRunningLocally() {
 		return nil, nil
 	}
+
+	operatorNs, err := hcoutil.GetOperatorNamespace(logger)
+	if err != nil {
+		return nil, err
+	}
+
 	podName := os.Getenv(hcoutil.PodNameEnvVar)
 	if podName == "" {
 		return nil, fmt.Errorf("required env %q not set, please configure downward API", hcoutil.PodNameEnvVar)
@@ -121,7 +123,7 @@ func getThePod(ctx context.Context, c client.Reader, logger logr.Logger) (*corev
 
 	pod := &corev1.Pod{}
 	key := client.ObjectKey{Namespace: operatorNs, Name: podName}
-	err := c.Get(ctx, key, pod)
+	err = c.Get(ctx, key, pod)
 	if err != nil {
 		logger.Error(err, "Failed to get Pod", "Pod.Namespace", operatorNs, "Pod.Name", podName)
 		return nil, err

--- a/pkg/internal/ownresources/own_resources.go
+++ b/pkg/internal/ownresources/own_resources.go
@@ -68,6 +68,7 @@ func doInit(ctx context.Context, cl client.Reader, scheme *runtime.Scheme, logge
 			pod, err := getThePod(ctx, cl, logger)
 			if err != nil {
 				logger.Error(err, "Can't get self pod")
+				return
 			}
 
 			thePod = pod

--- a/pkg/internal/ownresources/own_resources_test.go
+++ b/pkg/internal/ownresources/own_resources_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -60,6 +61,11 @@ var _ = Describe("Test OwnResources", func() {
 		Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, namespace)).To(Succeed())
 		Expect(os.Setenv(hcoutil.PodNameEnvVar, podName)).To(Succeed())
 
+		origGetOperatorNamespace := hcoutil.GetOperatorNamespace
+		hcoutil.GetOperatorNamespace = func(_ logr.Logger) (string, error) {
+			return namespace, nil
+		}
+
 		testScheme = scheme.Scheme
 		Expect(csvv1alpha1.AddToScheme(testScheme)).To(Succeed())
 
@@ -71,6 +77,7 @@ var _ = Describe("Test OwnResources", func() {
 			Expect(os.Setenv(hcoutil.OperatorNamespaceEnv, origNamespcase)).To(Succeed())
 			Expect(os.Setenv(hcoutil.PodNameEnvVar, origPodName)).To(Succeed())
 			hcoutil.GetClusterInfo = origGetClusterInfo
+			hcoutil.GetOperatorNamespace = origGetOperatorNamespace
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When running the Init function in the `ownresources` package, if the pod is not found, the operator/webhook pods are crash.

Fix by exit the Init function if the pod was not found.

Also, fixed the `ownresources.getThePod` function to use the actual namespace where the pod is running, rather than the `OPERATOR_NAMESPACE` environment variable.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
