### PR TITLE
fix ownresources package

### DIFF
--- a/pkg/internal/ownresources/own_resources.go
+++ b/pkg/internal/ownresources/own_resources.go
@@ -73,8 +73,7 @@ func doInit(ctx context.Context, cl client.Reader, scheme *runtime.Scheme, logge
 
 			thePod = pod
 
-			operatorNs := hcoutil.GetOperatorNamespaceFromEnv()
-			deployment, err := getDeploymentFromPod(ctx, pod, cl, operatorNs, logger)
+			deployment, err := getDeploymentFromPod(ctx, pod, cl, logger)
 			if err != nil {
 				logger.Error(err, "Can't get deployment")
 				return
@@ -139,7 +138,7 @@ func getThePod(ctx context.Context, c client.Reader, logger logr.Logger) (*corev
 	return pod, nil
 }
 
-func getDeploymentFromPod(ctx context.Context, pod *corev1.Pod, c client.Reader, operatorNs string, logger logr.Logger) (*appsv1.Deployment, error) {
+func getDeploymentFromPod(ctx context.Context, pod *corev1.Pod, c client.Reader, logger logr.Logger) (*appsv1.Deployment, error) {
 	if pod == nil {
 		return nil, nil
 	}
@@ -151,7 +150,7 @@ func getDeploymentFromPod(ctx context.Context, pod *corev1.Pod, c client.Reader,
 	}
 	rs := &appsv1.ReplicaSet{}
 	err := c.Get(context.TODO(), client.ObjectKey{
-		Namespace: operatorNs,
+		Namespace: pod.Namespace,
 		Name:      rsReference.Name,
 	}, rs)
 	if err != nil {
@@ -167,7 +166,7 @@ func getDeploymentFromPod(ctx context.Context, pod *corev1.Pod, c client.Reader,
 	}
 	deployment := &appsv1.Deployment{}
 	err = c.Get(ctx, client.ObjectKey{
-		Namespace: operatorNs,
+		Namespace: pod.Namespace,
 		Name:      dReference.Name,
 	}, deployment)
 	if err != nil {

--- a/pkg/internal/ownresources/own_resources_test.go
+++ b/pkg/internal/ownresources/own_resources_test.go
@@ -142,6 +142,55 @@ var _ = Describe("Test OwnResources", func() {
 		Expect(GetDeploymentRef()).To(Equal(*buildOwnerReference(dep)))
 		Expect(GetCSVRef()).To(BeNil())
 	})
+
+	It("should run on a non-standard but allowed namespaces", func(ctx context.Context) {
+		// Note: the allowed namespaces are checked in the cmd/cdmcommon package.
+		// For this function, any namespace will dou.
+		const nonStandardNS = "community-kubevirt-hyperconverged"
+
+		hcoutil.GetClusterInfo = fakeclusterinfo.NewGetClusterInfo(
+			fakeclusterinfo.WithIsOpenshift(true),
+			fakeclusterinfo.WithIsManagedByOLM(true),
+			fakeclusterinfo.WithRunningLocally(false),
+		)
+
+		hcoutil.GetOperatorNamespace = func(_ logr.Logger) (string, error) {
+			return nonStandardNS, nil
+		}
+
+		csv := cretateCSV()
+		csv.Namespace = nonStandardNS
+
+		csvOwnerRef := &metav1.OwnerReference{
+			APIVersion: csvv1alpha1.ClusterServiceVersionAPIVersion,
+			Kind:       csvv1alpha1.ClusterServiceVersionKind,
+			Name:       rsName,
+			Controller: new(true),
+		}
+
+		dep := createDeployment(csvOwnerRef)
+		dep.Namespace = nonStandardNS
+
+		rs := createReplicaSet()
+		rs.Namespace = nonStandardNS
+
+		pod := createPod()
+		pod.Namespace = nonStandardNS
+
+		cl := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(csv, dep, rs, pod).
+			WithStatusSubresource(csv, dep, rs, pod).
+			Build()
+
+		Init(ctx, cl, testScheme, GinkgoLogr)
+		Expect(GetPod()).To(Equal(pod))
+		Expect(GetDeploymentRef()).To(Equal(*buildOwnerReference(dep)))
+		csvObj := GetCSVRef()
+		ref, err := reference.GetReference(testScheme, csvObj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ref).To(HaveValue(Equal(*csvRef)))
+	})
 })
 
 func createPod() *corev1.Pod {


### PR DESCRIPTION
**What this PR does / why we need it**:

The fix in #4354 wan't enough. The release is still failing in the redhat-openshift-ecosystem/community-operators-prod repository.

See here for example, https://gist.githubusercontent.com/rh-operator-bundle-bot/3f68395220eeab46a1386e96eae1c94a/raw/73a319267a7ce42feca8dadfcf8c9297ff43c732/hco-operator-7dbdb66646-s7sxc-hyperconverged-cluster-operator.log

If HCO pod is deployed on a nonstandard (but allowed) namespace, it exit with nil pointer dereference error. 

This PR fixes it by using the actual namespace to get the deployment and the CSV.


**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
