### PR TITLE
Add VMNonRecoverableOSPanic and ClusterVMPanicDetected alerts

### DIFF
--- a/hack/prom-rule-ci/observability-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/observability-prom-rules-tests.yaml
@@ -446,6 +446,69 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cnv-observability"
 
+  # VM non-recoverable OS panic
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_guest_os_panic_total{namespace="test", name="vm-01", type="pvpanic", bugcheck_code="unknown"}'
+        values: '0 0 1 1 1 1 1'
+
+    alert_rule_test:
+      # No alert at 1m (no panics yet)
+      - eval_time: 1m
+        alertname: VMNonRecoverableOSPanic
+        exp_alerts: []
+      # Alert fires at 4m (1 panic detected, within 1-5 range)
+      - eval_time: 4m
+        alertname: VMNonRecoverableOSPanic
+        exp_alerts:
+          - exp_annotations:
+              summary: "VM vm-01 in namespace test experienced a non-recoverable guest OS panic"
+              description: "The VM has experienced 1 non-recoverable guest OS panic(s) in the last 24 hours."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VMNonRecoverableOSPanic"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "test"
+              name: "vm-01"
+
+  # VM non-recoverable OS panic - should NOT fire above 5
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_guest_os_panic_total{namespace="test", name="vm-02", type="pvpanic", bugcheck_code="unknown"}'
+        values: '0 0 6 6 6 6 6'
+
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: VMNonRecoverableOSPanic
+        exp_alerts: []
+
+  # ClusterVMPanicDetected - should fire when any VM has panics (> 0)
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_guest_os_panic_total{namespace="ns1", name="vm-01", type="pvpanic", bugcheck_code="unknown"}'
+        values: '0 0 1 1 1 1 1 1 1 1'
+
+    alert_rule_test:
+      # At 4m, not enough time for For: 5m
+      - eval_time: 4m
+        alertname: ClusterVMPanicDetected
+        exp_alerts: []
+      # At 9m, 1 VM has panicked - alert should fire
+      - eval_time: 9m
+        alertname: ClusterVMPanicDetected
+        exp_alerts:
+          - exp_annotations:
+              summary: "VMs experienced non-recoverable guest OS panics in the last 24 hours"
+              description: "1 VM(s) across the cluster have experienced non-recoverable guest OS panics in the last 24 hours. This may indicate a cluster-wide infrastructure issue."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/ClusterVMPanicDetected"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
   - interval: 1m
     input_series:
       - series: 'kubevirt_hco_memory_overcommit_percentage'

--- a/pkg/monitoring/observability/rules/alerts/alerts.go
+++ b/pkg/monitoring/observability/rules/alerts/alerts.go
@@ -28,7 +28,9 @@ func Register(operatorRegistry *operatorrules.Registry) error {
 	for _, alertGroup := range alerts {
 		for _, alert := range alertGroup {
 			alert.Labels["kubernetes_operator_part_of"] = "kubevirt"
-			alert.Labels["kubernetes_operator_component"] = "cnv-observability"
+			if _, ok := alert.Labels["kubernetes_operator_component"]; !ok {
+				alert.Labels["kubernetes_operator_component"] = "cnv-observability"
+			}
 			if _, ok := alert.Annotations["runbook_url"]; !ok {
 				alert.Annotations["runbook_url"] = fmt.Sprintf(runbookURLTemplate, alert.Alert)
 			}

--- a/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
+++ b/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
@@ -15,6 +15,8 @@ const (
 	IFF_UP       = 1
 	IFF_RUNNING  = 64
 	IFF_LOWER_UP = 65536
+
+	kubevirtComponentLabelValue = "kubevirt"
 )
 
 var ignoredInterfacesForNetworkDown = []string{
@@ -116,6 +118,34 @@ func clusterAlerts() []promv1.Rule {
 			Labels: map[string]string{
 				"severity":               "warning",
 				"operator_health_impact": "none",
+			},
+		},
+		{
+			Alert: "VMNonRecoverableOSPanic",
+			Expr:  intstr.FromString(`sum by (namespace, name) (increase(kubevirt_vmi_guest_os_panic_total[24h])) > 0 and sum by (namespace, name) (increase(kubevirt_vmi_guest_os_panic_total[24h])) <= 5`),
+			For:   ptr.To[promv1.Duration]("1m"),
+			Annotations: map[string]string{
+				"summary":     "VM {{ $labels.name }} in namespace {{ $labels.namespace }} experienced a non-recoverable guest OS panic",
+				"description": "The VM has experienced {{ $value }} non-recoverable guest OS panic(s) in the last 24 hours.",
+			},
+			Labels: map[string]string{
+				"severity":                      "warning",
+				"operator_health_impact":        "none",
+				"kubernetes_operator_component": kubevirtComponentLabelValue,
+			},
+		},
+		{
+			Alert: "ClusterVMPanicDetected",
+			Expr:  intstr.FromString(`count(sum by (namespace, name) (increase(kubevirt_vmi_guest_os_panic_total[24h])) > 0) > 0`),
+			For:   ptr.To[promv1.Duration]("5m"),
+			Annotations: map[string]string{
+				"summary":     "VMs experienced non-recoverable guest OS panics in the last 24 hours",
+				"description": "{{ $value }} VM(s) across the cluster have experienced non-recoverable guest OS panics in the last 24 hours. This may indicate a cluster-wide infrastructure issue.",
+			},
+			Labels: map[string]string{
+				"severity":                      "warning",
+				"operator_health_impact":        "none",
+				"kubernetes_operator_component": kubevirtComponentLabelValue,
 			},
 		},
 		{


### PR DESCRIPTION
Add a VMNonRecoverableOSPanic warning alert that fires when any non-recoverable guest OS panic is detected (> 0 and <= 5), based on the existing kubevirt_vmi_guest_os_panic_total metric. Also add a ClusterVMPanicDetected
warning alert for admins that fires when any VM(s) across the cluster have experienced panics.

This complements the KubeVirt-side VMNonRecoverableOSPanic alert ([kubevirt#18004](https://github.com/kubevirt/kubevirt/pull/18004)) which fires at critical severity when a VM exceeds 5 panics (crash-looping). Both fire independently from separate PrometheusRule CRs and are visible as distinct alerts in Alertmanager (differentiated by `severity` and `kubernetes_operator_component` labels).

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```
jira-ticket: https://redhat.atlassian.net/browse/VIRTCE-162

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added VMNonRecoverableOSPanic and ClusterVMPanicDetected alerts
```
