### PR TITLE
netresinjector: Rename cnv- prefixed resources to virt-

### DIFF
--- a/controllers/handlers/netresinjector/common.go
+++ b/controllers/handlers/netresinjector/common.go
@@ -7,14 +7,14 @@ import (
 )
 
 const (
-	clusterRoleName    = "cnv-network-resources-injector"
-	serviceAccountName = "cnv-network-resources-injector-sa"
-	serviceName        = "cnv-network-resources-injector-service"
-	deploymentName     = "cnv-network-resources-injector"
-	tlsSecretName      = "cnv-network-resources-injector-secret"
-	tlsCertificateName = "cnv-network-resources-injector-cert"
+	clusterRoleName    = "virt-network-resources-injector"
+	serviceAccountName = "virt-network-resources-injector-sa"
+	serviceName        = "virt-network-resources-injector-service"
+	deploymentName     = "virt-network-resources-injector"
+	tlsSecretName      = "virt-network-resources-injector-secret"
+	tlsCertificateName = "virt-network-resources-injector-cert"
 	tlsMountPath       = "/etc/tls"
-	webhookConfigName  = "cnv-network-resources-injector-config"
+	webhookConfigName  = "virt-network-resources-injector-config"
 )
 
 // shouldDeploy checks if network-resources-injector should be deployed

--- a/controllers/handlers/netresinjector/webhook_config.go
+++ b/controllers/handlers/netresinjector/webhook_config.go
@@ -145,7 +145,7 @@ func newMutatingWebhookConfiguration() *admissionregistrationv1.MutatingWebhookC
 
 	mwc.Webhooks = []admissionregistrationv1.MutatingWebhook{
 		{
-			Name:                    "cnv-network-resources-injector-config.k8s.io",
+			Name:                    "virt-network-resources-injector-config.k8s.io",
 			AdmissionReviewVersions: []string{"v1", "v1beta1"},
 			SideEffects:             new(admissionregistrationv1.SideEffectClassNone),
 			FailurePolicy:           new(admissionregistrationv1.Fail),

--- a/controllers/handlers/netresinjector/webhook_config_test.go
+++ b/controllers/handlers/netresinjector/webhook_config_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Network Resources Injector MutatingWebhookConfiguration", func
 
 			Expect(mwc.Webhooks).To(HaveLen(1))
 			wh := mwc.Webhooks[0]
-			Expect(wh.Name).To(Equal("cnv-network-resources-injector-config.k8s.io"))
+			Expect(wh.Name).To(Equal("virt-network-resources-injector-config.k8s.io"))
 			Expect(wh.AdmissionReviewVersions).To(ConsistOf("v1", "v1beta1"))
 			Expect(wh.FailurePolicy).ToNot(BeNil())
 			Expect(*wh.FailurePolicy).To(Equal(admissionregistrationv1.Fail))

--- a/deploy/webhooks.yaml
+++ b/deploy/webhooks.yaml
@@ -162,13 +162,13 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: cnv-network-resources-injector-cert
+  name: virt-network-resources-injector-cert
   labels:
-    name: cnv-network-resources-injector
+    name: virt-network-resources-injector
 spec:
-  secretName: cnv-network-resources-injector-secret
+  secretName: virt-network-resources-injector-secret
   dnsNames:
-  - cnv-network-resources-injector-service.kubevirt-hyperconverged.svc
+  - virt-network-resources-injector-service.kubevirt-hyperconverged.svc
   issuerRef:
     name: selfsigned
 ---

--- a/docs/component.gv
+++ b/docs/component.gv
@@ -5,9 +5,9 @@ digraph component {
 		fontname="Courier-Bold" fontsize=42 group=autopilot label=autopilot rank=same style=dashed
 		"deployment/virt-platform-autopilot" [label="deployment/virt-platform-autopilot"]
 	}
-	subgraph "cluster_cnv-network-resources-injector" {
-		fontname="Courier-Bold" fontsize=42 group="cnv-network-resources-injector" label="cnv-network-resources-injector" rank=same style=dashed
-		"deployment/cnv-network-resources-injector" [label="deployment/cnv-network-resources-injector"]
+	subgraph "cluster_virt-network-resources-injector" {
+		fontname="Courier-Bold" fontsize=42 group="virt-network-resources-injector" label="virt-network-resources-injector" rank=same style=dashed
+		"deployment/virt-network-resources-injector" [label="deployment/virt-network-resources-injector"]
 	}
 	subgraph cluster_compute {
 		fontname="Courier-Bold" fontsize=42 group=compute label=compute rank=same style=dashed
@@ -80,8 +80,8 @@ digraph component {
 		"HyperConverged/kubevirt-hyperconverged" [label="HyperConverged/kubevirt-hyperconverged"]
 	}
 	edge [style=invis]
-	"deployment/virt-platform-autopilot" -> "deployment/cnv-network-resources-injector"
-	"deployment/cnv-network-resources-injector" -> "KubeVirt/kubevirt-kubevirt-hyperconverged"
+	"deployment/virt-platform-autopilot" -> "deployment/virt-network-resources-injector"
+	"deployment/virt-network-resources-injector" -> "KubeVirt/kubevirt-kubevirt-hyperconverged"
 	"KubeVirt/kubevirt-kubevirt-hyperconverged" -> "deployment/hco-operator"
 	"deployment/hco-operator" -> "deployment/inflightoperations-controller-manager"
 	"deployment/inflightoperations-controller-manager" -> "deployment/kubevirt-apiserver-proxy"

--- a/docs/managed-by.gv
+++ b/docs/managed-by.gv
@@ -36,9 +36,9 @@ digraph "managed-by" {
 	"deployment/cluster-network-addons-operator" [label="deployment/cluster-network-addons-operator"]
 	olm [label=olm]
 	olm -> "deployment/cluster-network-addons-operator"
-	"deployment/cnv-network-resources-injector" [label="deployment/cnv-network-resources-injector"]
+	"deployment/virt-network-resources-injector" [label="deployment/virt-network-resources-injector"]
 	"deployment/hco-operator" [label="deployment/hco-operator"]
-	"deployment/hco-operator" -> "deployment/cnv-network-resources-injector"
+	"deployment/hco-operator" -> "deployment/virt-network-resources-injector"
 	"deployment/hco-operator" [label="deployment/hco-operator"]
 	olm [label=olm]
 	olm -> "deployment/hco-operator"

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -134,5 +134,5 @@ const (
 	AppComponentAIEWebhook          AppComponent = "aie-webhook"
 	AppComponentIOMMUFDDevicePlugin AppComponent = "iommufd-device-plugin"
 	AppComponentInFlightOperations  AppComponent = "inflightoperations"
-	AppComponentNetResInjector      AppComponent = "cnv-network-resources-injector"
+	AppComponentNetResInjector      AppComponent = "virt-network-resources-injector"
 )

--- a/tests/func-tests/netresinjector_test.go
+++ b/tests/func-tests/netresinjector_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	netResInjectorDeploymentName = "cnv-network-resources-injector"
+	netResInjectorDeploymentName = "virt-network-resources-injector"
 )
 
 var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Serial, Ordered, func() {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The cnv- prefix is not viable upstream. Renaming all network-resources-injector resources to use virt- prefix instead.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
