### PR TITLE
netresinjector: Temporarily disable by default due to bug

### DIFF
--- a/api/v1/hyperconverged_types.go
+++ b/api/v1/hyperconverged_types.go
@@ -166,7 +166,7 @@ type HyperConvergedSpec struct {
 	Security SecurityConfig `json:"security,omitempty"`
 
 	// Deployment contains all the configurations related to deployment of KubeVirt components
-	// +kubebuilder:default={"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}
+	// +kubebuilder:default={"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}
 	// +optional
 	// +k8s:conversion-gen=false
 	Deployment DeploymentConfig `json:"deployment,omitempty"`
@@ -425,8 +425,6 @@ type DeploymentConfig struct {
 	// When enabled, the network-resources-injector mutating webhook will be deployed to automatically
 	// inject resource requests for custom resources annotated in NetworkAttachmentDefinition.
 	// +optional
-	// +kubebuilder:default=true
-	// +default=true
 	DeployNetworkResourcesInjector *bool `json:"deployNetworkResourcesInjector,omitempty"`
 }
 
@@ -941,7 +939,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}}
+	// +kubebuilder:default={"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/api/v1/zz_generated.defaults.go
+++ b/api/v1/zz_generated.defaults.go
@@ -144,10 +144,6 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.Deployment.DeployVMConsoleProxy = &ptrVar1
 	}
-	if in.Spec.Deployment.DeployNetworkResourcesInjector == nil {
-		var ptrVar1 bool = true
-		in.Spec.Deployment.DeployNetworkResourcesInjector = &ptrVar1
-	}
 }
 
 func SetObjectDefaults_HyperConvergedList(in *HyperConvergedList) {

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -52,7 +52,6 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
-                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -83,7 +82,6 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
-                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -163,7 +161,6 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
-                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/controllers/handlers/netresinjector/common.go
+++ b/controllers/handlers/netresinjector/common.go
@@ -19,5 +19,5 @@ const (
 
 // shouldDeploy checks if network-resources-injector should be deployed
 func shouldDeploy(hc *hcov1.HyperConverged) bool {
-	return ptr.Deref(hc.Spec.Deployment.DeployNetworkResourcesInjector, true)
+	return ptr.Deref(hc.Spec.Deployment.DeployNetworkResourcesInjector, false)
 }

--- a/controllers/handlers/netresinjector/conditional_test.go
+++ b/controllers/handlers/netresinjector/conditional_test.go
@@ -47,18 +47,21 @@ var _ = Describe("Network Resources Injector Conditional Handlers", func() {
 			Expect(foundCR.Name).To(Equal(clusterRoleName))
 		})
 
-		It("should create ClusterRole when deployNetworkResourcesInjector is not set (default true)", func() {
-			// Don't set deployNetworkResourcesInjector - should default to true
+		It("should not create ClusterRole when deployNetworkResourcesInjector is not set (default false)", func() {
+			// Don't set deployNetworkResourcesInjector - should default to false
 			cl = commontestutils.InitClient([]client.Object{hco})
 
 			handler := NewClusterRoleHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 
 			Expect(res.Err).ToNot(HaveOccurred())
-			Expect(res.Created).To(BeTrue())
+			Expect(res.Created).To(BeFalse())
+			Expect(res.Updated).To(BeFalse())
 
 			foundCR := &rbacv1.ClusterRole{}
-			Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterRoleName}, foundCR)).To(Succeed())
+			err := cl.Get(context.Background(), client.ObjectKey{Name: clusterRoleName}, foundCR)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(apierrors.IsNotFound, "not found error"))
 		})
 
 		It("should delete ClusterRole when deployNetworkResourcesInjector is false", func() {

--- a/controllers/handlers/netresinjector/deployment_test.go
+++ b/controllers/handlers/netresinjector/deployment_test.go
@@ -28,6 +28,7 @@ var _ = Describe("Network Resources Injector Deployment", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
+		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 		Expect(os.Setenv(hcoutil.NetworkResourcesInjectorImageEnvV, testImage)).To(Succeed())
 

--- a/controllers/handlers/netresinjector/pdb_test.go
+++ b/controllers/handlers/netresinjector/pdb_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Network Resources Injector PodDisruptionBudget", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
+		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/rbac_test.go
+++ b/controllers/handlers/netresinjector/rbac_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Network Resources Injector ClusterRole", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
+		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 
@@ -94,6 +95,7 @@ var _ = Describe("Network Resources Injector ClusterRoleBinding", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
+		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/service_account_test.go
+++ b/controllers/handlers/netresinjector/service_account_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Network Resources Injector ServiceAccount", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
+		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/service_test.go
+++ b/controllers/handlers/netresinjector/service_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Network Resources Injector Service", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
+		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/webhook_config_test.go
+++ b/controllers/handlers/netresinjector/webhook_config_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Network Resources Injector MutatingWebhookConfiguration", func
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
+		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -245,7 +245,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 				// Check conditions
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(39))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(32))
 				expectedRef := corev1.ObjectReference{
 					Kind:            "PrometheusRule",
 					Namespace:       namespace,

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -52,7 +52,6 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
-                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -83,7 +82,6 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
-                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -163,7 +161,6 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
-                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -5,7 +5,6 @@ metadata:
   name: kubevirt-hyperconverged
 spec:
   deployment:
-    deployNetworkResourcesInjector: true
     deployVmConsoleProxy: false
     uninstallStrategy: BlockUninstallIfWorkloadsExist
   security:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -52,7 +52,6 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
-                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -83,7 +82,6 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
-                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -163,7 +161,6 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
-                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -52,7 +52,6 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
-                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -83,7 +82,6 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
-                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -163,7 +161,6 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
-                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -124,7 +124,7 @@ DataImportCronTemplateStatus is a copy of a dataImportCronTemplate as defined in
 | logVerbosityConfig | LogVerbosityConfig configures the verbosity level of Kubevirt's different components. The higher the value - the higher the log verbosity. | *[LogVerbosityConfiguration](#logverbosityconfiguration) |  | false |
 | applicationAwareConfig | ApplicationAwareConfig set the AAQ configurations | *[ApplicationAwareConfigurations](#applicationawareconfigurations) |  | false |
 | deployVmConsoleProxy | deploy VM console proxy resources in SSP operator | *bool | false | false |
-| deployNetworkResourcesInjector | DeployNetworkResourcesInjector enables deployment of the network-resources-injector component. When enabled, the network-resources-injector mutating webhook will be deployed to automatically inject resource requests for custom resources annotated in NetworkAttachmentDefinition. | *bool | true | false |
+| deployNetworkResourcesInjector | DeployNetworkResourcesInjector enables deployment of the network-resources-injector component. When enabled, the network-resources-injector mutating webhook will be deployed to automatically inject resource requests for custom resources annotated in NetworkAttachmentDefinition. | *bool |  | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -145,7 +145,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | ------- | -------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -184,7 +184,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | networking | Networking contains all the configurations for networking | *[NetworkingConfig](#networkingconfig) |  | false |
 | workloadSources | WorkloadSources contains all the configurations for workload sources | [WorkloadSourcesConfig](#workloadsourcesconfig) |  | false |
 | security | Security contains all the security configurations | [SecurityConfig](#securityconfig) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}} | false |
-| deployment | Deployment contains all the configurations related to deployment of KubeVirt components | [DeploymentConfig](#deploymentconfig) | {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}} | false |
+| deployment | Deployment contains all the configurations related to deployment of KubeVirt components | [DeploymentConfig](#deploymentconfig) | {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}} | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/upgradepatch/hc.cr.json
+++ b/pkg/upgradepatch/hc.cr.json
@@ -47,8 +47,7 @@
     },
     "deployment": {
       "uninstallStrategy": "BlockUninstallIfWorkloadsExist",
-      "deployVmConsoleProxy": false,
-      "deployNetworkResourcesInjector": true
+      "deployVmConsoleProxy": false
     }
   },
   "status": {

--- a/tests/func-tests/netresinjector_test.go
+++ b/tests/func-tests/netresinjector_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,7 +16,8 @@ import (
 )
 
 const (
-	netResInjectorDeploymentName = "virt-network-resources-injector"
+	netResInjectorDeploymentName          = "virt-network-resources-injector"
+	netResInjectorDeploymentPatchTemplate = `{"spec":{"deployment":{"deployNetworkResourcesInjector": %t}}}`
 )
 
 var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Serial, Ordered, func() {
@@ -31,7 +33,21 @@ var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Ser
 		restoreNetResInjectorToDefault(ctx, cli)
 	})
 
-	Context("when deployNetworkResourcesInjector is true (default)", func() {
+	Context("when deployNetworkResourcesInjector is not set (default false)", func() {
+		BeforeAll(func(ctx context.Context) {
+			restoreNetResInjectorToDefault(ctx, cli)
+		})
+
+		It("should not deploy the network resources injector", func(ctx context.Context) {
+			validateNetResInjectorDeleted(ctx, cli)
+		})
+	})
+
+	Context("when deployNetworkResourcesInjector is true", func() {
+		BeforeAll(func(ctx context.Context) {
+			enableNetResInjector(ctx, cli)
+		})
+
 		It("should deploy the network resources injector", func(ctx context.Context) {
 			By("verifying the deployment exists and is ready")
 			Eventually(func(g Gomega, ctx context.Context) {
@@ -82,20 +98,9 @@ var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Ser
 			validateNetResInjectorDeleted(ctx, cli)
 		})
 
-		It("should recreate the deployment when set back to true", func(ctx context.Context) {
-			enableNetResInjector(ctx, cli)
-
-			By("verifying the deployment is recreated and ready")
-			Eventually(func(g Gomega, ctx context.Context) {
-				dep := &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      netResInjectorDeploymentName,
-						Namespace: tests.InstallNamespace,
-					},
-				}
-				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
-				g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
-			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+		It("should delete the deployment when set back to default (false)", func(ctx context.Context) {
+			restoreNetResInjectorToDefault(ctx, cli)
+			validateNetResInjectorDeleted(ctx, cli)
 		})
 	})
 })
@@ -123,32 +128,27 @@ func validateNetResInjectorDeleted(ctx context.Context, cli client.Client) {
 func enableNetResInjector(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
 	By("setting deployNetworkResourcesInjector to true")
-	patch := []byte(`[{"op": "replace", "path": "/spec/deployment/deployNetworkResourcesInjector", "value": true}]`)
-	tests.PatchHCO(ctx, cli, patch)
+	patch := []byte(fmt.Sprintf(netResInjectorDeploymentPatchTemplate, true))
+	tests.PatchMergeHCO(ctx, cli, patch)
 }
 
 func disableNetResInjector(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
 	By("setting deployNetworkResourcesInjector to false")
-	patch := []byte(`[{"op": "add", "path": "/spec/deployment/deployNetworkResourcesInjector", "value": false}]`)
-	tests.PatchHCO(ctx, cli, patch)
+	patch := []byte(fmt.Sprintf(netResInjectorDeploymentPatchTemplate, false))
+	tests.PatchMergeHCO(ctx, cli, patch)
 }
 
 func restoreNetResInjectorToDefault(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
 	By("restoring deployNetworkResourcesInjector to default")
-	patch := []byte(`[{"op": "remove", "path": "/spec/deployment/deployNetworkResourcesInjector"}]`)
-	tests.PatchHCO(ctx, cli, patch)
 
-	// Wait for deployment to be recreated
-	Eventually(func(g Gomega, ctx context.Context) {
-		dep := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      netResInjectorDeploymentName,
-				Namespace: tests.InstallNamespace,
-			},
-		}
-		g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
-		g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
-	}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+	// Read the HyperConverged CR first to check if the field exists
+	hc, err := tests.GetHCO(ctx, cli)
+	Expect(err).ToNot(HaveOccurred())
+	if hc.Spec.Deployment.DeployNetworkResourcesInjector != nil {
+		// Field exists, remove it by setting to null in merge patch
+		patch := []byte(`{"spec":{"deployment":{"deployNetworkResourcesInjector": null}}}`)
+		tests.PatchMergeHCO(ctx, cli, patch)
+	}
 }

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -52,7 +52,6 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
-                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -83,7 +82,6 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
-                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -163,7 +161,6 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
-                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -52,7 +52,6 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
-                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -83,7 +82,6 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
-                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -163,7 +161,6 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
-                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Changes the network-resources-injector deployment default from enabled to disabled to work around [1].

This is a temporary measure to prevent breaking environments until the underlying bug is fixed. Users can still explicitly enable the feature by setting spec.deployment.deployNetworkResourcesInjector to true.

[1] https://redhat.atlassian.net/browse/OCPBUGS-96963


Assisted by: Claude Sonnet 4.5 <noreply@anthropic.com>
**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
