### PR TITLE
Fix PR creating github actions

### DIFF
--- a/.github/workflows/dashboard-updater.yml
+++ b/.github/workflows/dashboard-updater.yml
@@ -33,7 +33,7 @@ jobs:
           fi
 
       - name: Create a PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         if: ${{ env.UPDATED }}
         with:
           path: hco

--- a/.github/workflows/digester_bot.yml
+++ b/.github/workflows/digester_bot.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ env.CHANGED }}
         run: make build-manifests
 
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v8
         if: ${{ env.CHANGED }}
         with:
           token: ${{ secrets.HCO_BOT_TOKEN }}

--- a/.github/workflows/graphs-updater.yml
+++ b/.github/workflows/graphs-updater.yml
@@ -26,7 +26,7 @@ jobs:
           fi
 
       - name: Create a PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         if: ${{ env.UPDATED }}
         with:
           path: hco

--- a/.github/workflows/perses-dashboard-updater.yml
+++ b/.github/workflows/perses-dashboard-updater.yml
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Create a PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         if: ${{ env.UPDATED }}
         with:
           path: hco

--- a/.github/workflows/publish-community-operators.yaml
+++ b/.github/workflows/publish-community-operators.yaml
@@ -148,7 +148,7 @@ jobs:
           git add ./deploy/
           echo "CHANGED=true" >> $GITHUB_ENV
 
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v8
         if: ${{ env.CHANGED }}
         with:
           token: ${{ secrets.HCO_BOT_TOKEN }}

--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -78,7 +78,7 @@ jobs:
         if: ${{ env.CHANGED }}
         run: rm -f updated_component.txt updated_version.txt
 
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v8
         if: ${{ env.CHANGED }}
         with:
           token: ${{ secrets.HCO_BOT_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
We're using peter-evans/create-pull-request in order to create PRs from github actions. These actions start failing a few days ago.

Try to fix by bumping peter-evans/create-pull-request to v8

**Release note**:
```release-note
None
```
