### PR TITLE
Fix a bug in NetResInjector: deployment's replicas

### DIFF
--- a/controllers/handlers/netresinjector/deployment.go
+++ b/controllers/handlers/netresinjector/deployment.go
@@ -44,6 +44,13 @@ func NewDeploymentWithNameOnly() *appsv1.Deployment {
 func newDeployment(_ *hcov1.HyperConverged) *appsv1.Deployment {
 	image := os.Getenv(hcoutil.NetworkResourcesInjectorImageEnvV)
 
+	var replicas int32
+	if nodeinfo.IsInfrastructureHighlyAvailable() {
+		replicas = int32(2)
+	} else {
+		replicas = int32(1)
+	}
+
 	selectorLabels := map[string]string{
 		hcoutil.AppLabel:          hcoutil.HyperConvergedName,
 		hcoutil.AppLabelComponent: string(hcoutil.AppComponentNetResInjector),
@@ -117,7 +124,7 @@ func newDeployment(_ *hcov1.HyperConverged) *appsv1.Deployment {
 
 	dep := NewDeploymentWithNameOnly()
 	dep.Spec = appsv1.DeploymentSpec{
-		Replicas: new(int32(2)),
+		Replicas: &replicas,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: selectorLabels,
 		},

--- a/controllers/handlers/netresinjector/deployment_test.go
+++ b/controllers/handlers/netresinjector/deployment_test.go
@@ -14,6 +14,7 @@ import (
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
@@ -39,6 +40,15 @@ var _ = Describe("Network Resources Injector Deployment", func() {
 
 	Context("newDeployment", func() {
 		It("should have all default values", func() {
+			origFunc := nodeinfo.IsInfrastructureHighlyAvailable
+			DeferCleanup(func() {
+				nodeinfo.IsInfrastructureHighlyAvailable = origFunc
+			})
+
+			nodeinfo.IsInfrastructureHighlyAvailable = func() bool {
+				return true
+			}
+
 			dep := newDeployment(hco)
 
 			Expect(dep.Name).To(Equal(deploymentName))
@@ -95,6 +105,20 @@ var _ = Describe("Network Resources Injector Deployment", func() {
 			Expect(dep.Spec.Template.Spec.Volumes).To(HaveLen(1))
 			Expect(dep.Spec.Template.Spec.Volumes[0].Name).To(Equal("tls"))
 			Expect(dep.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(tlsSecretName))
+		})
+
+		It("should set only one replica in an SNO cluster", func() {
+			origFunc := nodeinfo.IsInfrastructureHighlyAvailable
+			DeferCleanup(func() {
+				nodeinfo.IsInfrastructureHighlyAvailable = origFunc
+			})
+
+			nodeinfo.IsInfrastructureHighlyAvailable = func() bool {
+				return false
+			}
+
+			dep := newDeployment(hco)
+			Expect(dep.Spec.Replicas).To(HaveValue(Equal(int32(1))))
 		})
 	})
 

--- a/tests/func-tests/netresinjector_test.go
+++ b/tests/func-tests/netresinjector_test.go
@@ -87,6 +87,21 @@ var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Ser
 			}
 			Expect(foundControlPlaneSelector).To(BeTrue(), "should prefer control plane nodes")
 		})
+
+		DescribeTable("check replicas by cluster type", func(ctx context.Context, expectedReplicas int32) {
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      netResInjectorDeploymentName,
+					Namespace: tests.InstallNamespace,
+				},
+			}
+
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
+			Expect(dep.Spec.Replicas).To(HaveValue(Equal(expectedReplicas)))
+		},
+			Entry("should have 2 replicas in highly available cluster", Label(tests.HighlyAvailableClusterLabel), int32(2)),
+			Entry("should have 1 replica in non-highly available cluster", Label(tests.SingleNodeLabel), int32(1)),
+		)
 	})
 
 	Context("when deployNetworkResourcesInjector is false", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

The number of the virt-network-resources-injector deployment is constantly 2. This is a problem in a non-highly available or single-node clusters.

This PR set the replica to 1 on a non-highly available clusters.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
