### PR TITLE
netresinjector: Add Certificate handler for non-OpenShift deployments

### DIFF
--- a/controllers/handlers/certmanager_issuer.go
+++ b/controllers/handlers/certmanager_issuer.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	certManagerAPIVersion = "cert-manager.io/v1"
+	issuerName            = "selfsigned"
+	issuerKind            = "Issuer"
+)
+
+func NewCertManagerIssuerHandler(cli client.Client, scheme *runtime.Scheme) operands.Operand {
+	return operands.NewGenericOperand(cli, scheme, issuerKind, &issuerHooks{}, false)
+}
+
+type issuerHooks struct{}
+
+func (h *issuerHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": certManagerAPIVersion,
+			"kind":       issuerKind,
+			"metadata": map[string]any{
+				"name":      issuerName,
+				"namespace": hcoutil.GetOperatorNamespaceFromEnv(),
+			},
+			"spec": map[string]any{
+				"selfSigned": map[string]any{},
+			},
+		},
+	}
+	_ = unstructured.SetNestedStringMap(obj.Object, operands.GetLabels(hcoutil.AppComponentCompute), "metadata", "labels")
+	return obj, nil
+}
+
+func (h *issuerHooks) GetEmptyCr() client.Object {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": certManagerAPIVersion,
+			"kind":       issuerKind,
+		},
+	}
+}
+
+func (h *issuerHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exists, desired runtime.Object) (bool, bool, error) {
+	existingIssuer, ok := exists.(*unstructured.Unstructured)
+	if !ok {
+		return false, false, nil
+	}
+
+	desiredIssuer, ok := desired.(*unstructured.Unstructured)
+	if !ok {
+		return false, false, nil
+	}
+
+	existingLabels, _, _ := unstructured.NestedStringMap(existingIssuer.Object, "metadata", "labels")
+	desiredLabels, _, _ := unstructured.NestedStringMap(desiredIssuer.Object, "metadata", "labels")
+
+	if !reflect.DeepEqual(existingLabels, desiredLabels) {
+		_ = unstructured.SetNestedStringMap(existingIssuer.Object, desiredLabels, "metadata", "labels")
+		if err := Client.Update(req.Ctx, existingIssuer); err != nil {
+			return false, false, err
+		}
+		return true, !req.HCOTriggered, nil
+	}
+
+	return false, false, nil
+}

--- a/controllers/handlers/certmanager_issuer_test.go
+++ b/controllers/handlers/certmanager_issuer_test.go
@@ -1,0 +1,225 @@
+package handlers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+type issuerUpdateSpy struct {
+	client.Client
+	updateCalled bool
+}
+
+func (s *issuerUpdateSpy) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	s.updateCalled = true
+	return nil
+}
+
+var _ = Describe("Cert-Manager Issuer Handler", func() {
+	var hooks *issuerHooks
+
+	BeforeEach(func() {
+		hooks = &issuerHooks{}
+	})
+
+	Context("NewCertManagerIssuerHandler", func() {
+		It("should create a handler that returns a valid Issuer via GetFullCr", func() {
+			hco := commontestutils.NewHco()
+			cl := &issuerUpdateSpy{}
+			handler := NewCertManagerIssuerHandler(cl, commontestutils.GetScheme())
+
+			getter, ok := handler.(operands.CRGetter)
+			Expect(ok).To(BeTrue())
+
+			obj, err := getter.GetFullCr(hco)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(obj).ToNot(BeNil())
+
+			issuer, ok := obj.(*unstructured.Unstructured)
+			Expect(ok).To(BeTrue())
+			Expect(issuer.GetAPIVersion()).To(Equal(certManagerAPIVersion))
+			Expect(issuer.GetKind()).To(Equal(issuerKind))
+			Expect(issuer.GetName()).To(Equal(issuerName))
+			Expect(issuer.GetLabels()).ToNot(BeEmpty())
+		})
+	})
+
+	Context("GetFullCr", func() {
+		It("should return a valid Issuer with all required fields", func() {
+			hco := commontestutils.NewHco()
+			obj, err := hooks.GetFullCr(hco)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(obj).ToNot(BeNil())
+
+			issuer, ok := obj.(*unstructured.Unstructured)
+			Expect(ok).To(BeTrue())
+
+			Expect(issuer.GetAPIVersion()).To(Equal(certManagerAPIVersion))
+			Expect(issuer.GetKind()).To(Equal(issuerKind))
+			Expect(issuer.GetName()).To(Equal(issuerName))
+			Expect(issuer.GetNamespace()).To(Equal(hcoutil.GetOperatorNamespaceFromEnv()))
+
+			labels := issuer.GetLabels()
+			expectedLabels := operands.GetLabels(hcoutil.AppComponentCompute)
+			for k, v := range expectedLabels {
+				Expect(labels).To(HaveKeyWithValue(k, v))
+			}
+
+			selfSigned, found, err := unstructured.NestedMap(issuer.Object, "spec", "selfSigned")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(selfSigned).ToNot(BeNil())
+		})
+	})
+
+	Context("GetEmptyCr", func() {
+		It("should return an empty Issuer with apiVersion and kind", func() {
+			obj := hooks.GetEmptyCr()
+			Expect(obj).ToNot(BeNil())
+
+			issuer, ok := obj.(*unstructured.Unstructured)
+			Expect(ok).To(BeTrue())
+
+			Expect(issuer.GetAPIVersion()).To(Equal(certManagerAPIVersion))
+			Expect(issuer.GetKind()).To(Equal(issuerKind))
+			Expect(issuer.GetName()).To(BeEmpty())
+			Expect(issuer.GetNamespace()).To(BeEmpty())
+		})
+	})
+
+	Context("UpdateCR", func() {
+		var (
+			existing *unstructured.Unstructured
+			desired  *unstructured.Unstructured
+			req      *common.HcoRequest
+			cl       *issuerUpdateSpy
+		)
+
+		BeforeEach(func() {
+			hco := commontestutils.NewHco()
+			req = commontestutils.NewReq(hco)
+			cl = &issuerUpdateSpy{}
+
+			existing = &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": certManagerAPIVersion,
+					"kind":       issuerKind,
+					"metadata": map[string]any{
+						"name":      issuerName,
+						"namespace": "test-namespace",
+						"labels": map[string]any{
+							"app": "kubevirt-hyperconverged",
+						},
+					},
+					"spec": map[string]any{
+						"selfSigned": map[string]any{},
+					},
+				},
+			}
+
+			desired = &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": certManagerAPIVersion,
+					"kind":       issuerKind,
+					"metadata": map[string]any{
+						"name":      issuerName,
+						"namespace": "test-namespace",
+						"labels": map[string]any{
+							"app": "kubevirt-hyperconverged",
+						},
+					},
+					"spec": map[string]any{
+						"selfSigned": map[string]any{},
+					},
+				},
+			}
+		})
+
+		It("should return no update needed when labels match", func() {
+			updated, overwritten, err := hooks.UpdateCR(req, cl, existing, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated).To(BeFalse())
+			Expect(overwritten).To(BeFalse())
+			Expect(cl.updateCalled).To(BeFalse())
+		})
+
+		It("should detect and update label changes", func() {
+			_ = unstructured.SetNestedStringMap(desired.Object, map[string]string{
+				"app":                          "kubevirt-hyperconverged",
+				"app.kubernetes.io/component":  "compute",
+				"app.kubernetes.io/managed-by": "hco-operator",
+			}, "metadata", "labels")
+
+			updated, overwritten, err := hooks.UpdateCR(req, cl, existing, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated).To(BeTrue())
+			Expect(overwritten).To(BeFalse())
+			Expect(cl.updateCalled).To(BeTrue())
+
+			updatedLabels, _, _ := unstructured.NestedStringMap(existing.Object, "metadata", "labels")
+			Expect(updatedLabels).To(HaveKeyWithValue("app.kubernetes.io/component", "compute"))
+			Expect(updatedLabels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "hco-operator"))
+		})
+
+		It("should report overwrite when not HCO-triggered", func() {
+			req.HCOTriggered = false
+			_ = unstructured.SetNestedStringMap(desired.Object, map[string]string{
+				"app":     "kubevirt-hyperconverged",
+				"version": "v1",
+			}, "metadata", "labels")
+
+			updated, overwritten, err := hooks.UpdateCR(req, cl, existing, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated).To(BeTrue())
+			Expect(overwritten).To(BeTrue())
+			Expect(cl.updateCalled).To(BeTrue())
+		})
+
+		It("should handle nil existing object gracefully", func() {
+			updated, overwritten, err := hooks.UpdateCR(nil, nil, nil, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated).To(BeFalse())
+			Expect(overwritten).To(BeFalse())
+		})
+
+		It("should handle nil desired object gracefully", func() {
+			updated, overwritten, err := hooks.UpdateCR(nil, nil, existing, nil)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated).To(BeFalse())
+			Expect(overwritten).To(BeFalse())
+		})
+
+		It("should handle wrong type for existing object gracefully", func() {
+			wrongType := &unstructured.UnstructuredList{}
+			updated, overwritten, err := hooks.UpdateCR(nil, nil, wrongType, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated).To(BeFalse())
+			Expect(overwritten).To(BeFalse())
+		})
+
+		It("should handle wrong type for desired object gracefully", func() {
+			wrongType := &unstructured.UnstructuredList{}
+			updated, overwritten, err := hooks.UpdateCR(nil, nil, existing, wrongType)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated).To(BeFalse())
+			Expect(overwritten).To(BeFalse())
+		})
+	})
+})

--- a/controllers/handlers/netresinjector/certificate.go
+++ b/controllers/handlers/netresinjector/certificate.go
@@ -1,0 +1,115 @@
+package netresinjector
+
+import (
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+const (
+	certManagerAPIVersion = "cert-manager.io/v1"
+	certificateKind       = "Certificate"
+)
+
+func NewCertManagerCertHandler(cli client.Client, scheme *runtime.Scheme) operands.Operand {
+	return operands.NewGenericOperand(cli, scheme, certificateKind, &certHooks{}, false)
+}
+
+type certHooks struct{}
+
+func (h *certHooks) GetFullCr(_ *hcov1.HyperConverged) (client.Object, error) {
+	ns := hcoutil.GetOperatorNamespaceFromEnv()
+	dnsName := serviceName + "." + ns + ".svc"
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": certManagerAPIVersion,
+			"kind":       certificateKind,
+			"metadata": map[string]any{
+				"name":      tlsCertificateName,
+				"namespace": ns,
+			},
+			"spec": map[string]any{
+				"secretName": tlsSecretName,
+				"dnsNames": []any{
+					dnsName,
+				},
+				"issuerRef": map[string]any{
+					"name": "selfsigned",
+				},
+			},
+		},
+	}
+	_ = unstructured.SetNestedStringMap(obj.Object, operands.GetLabels(hcoutil.AppComponentNetResInjector), "metadata", "labels")
+	return obj, nil
+}
+
+func (h *certHooks) GetEmptyCr() client.Object {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": certManagerAPIVersion,
+			"kind":       certificateKind,
+		},
+	}
+}
+
+func (h *certHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exists, desired runtime.Object) (bool, bool, error) {
+	existingCert, ok := exists.(*unstructured.Unstructured)
+	if !ok {
+		return false, false, nil
+	}
+	desiredCert, ok := desired.(*unstructured.Unstructured)
+	if !ok {
+		return false, false, nil
+	}
+
+	needsUpdate := false
+
+	existingLabels, _, _ := unstructured.NestedStringMap(existingCert.Object, "metadata", "labels")
+	desiredLabels, _, _ := unstructured.NestedStringMap(desiredCert.Object, "metadata", "labels")
+
+	if !reflect.DeepEqual(existingLabels, desiredLabels) {
+		needsUpdate = true
+		_ = unstructured.SetNestedStringMap(existingCert.Object, desiredLabels, "metadata", "labels")
+	}
+
+	existingDNS, _, _ := unstructured.NestedStringSlice(existingCert.Object, "spec", "dnsNames")
+	desiredDNS, _, _ := unstructured.NestedStringSlice(desiredCert.Object, "spec", "dnsNames")
+
+	if !reflect.DeepEqual(existingDNS, desiredDNS) {
+		needsUpdate = true
+		_ = unstructured.SetNestedStringSlice(existingCert.Object, desiredDNS, "spec", "dnsNames")
+	}
+
+	existingIssuerRef, _, _ := unstructured.NestedMap(existingCert.Object, "spec", "issuerRef")
+	desiredIssuerRef, _, _ := unstructured.NestedMap(desiredCert.Object, "spec", "issuerRef")
+
+	if !reflect.DeepEqual(existingIssuerRef, desiredIssuerRef) {
+		needsUpdate = true
+		_ = unstructured.SetNestedMap(existingCert.Object, desiredIssuerRef, "spec", "issuerRef")
+	}
+
+	existingSecretName, _, _ := unstructured.NestedString(existingCert.Object, "spec", "secretName")
+	desiredSecretName, _, _ := unstructured.NestedString(desiredCert.Object, "spec", "secretName")
+
+	if existingSecretName != desiredSecretName {
+		needsUpdate = true
+		_ = unstructured.SetNestedField(existingCert.Object, desiredSecretName, "spec", "secretName")
+	}
+
+	if needsUpdate {
+		if err := Client.Update(req.Ctx, existingCert); err != nil {
+			return false, false, err
+		}
+		return true, !req.HCOTriggered, nil
+	}
+
+	return false, false, nil
+}

--- a/controllers/handlers/netresinjector/certificate_test.go
+++ b/controllers/handlers/netresinjector/certificate_test.go
@@ -1,0 +1,288 @@
+package netresinjector
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+type updateSpy struct {
+	client.Client
+}
+
+func (s *updateSpy) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return nil
+}
+
+var _ = Describe("Certificate Handler", func() {
+	var hooks *certHooks
+
+	BeforeEach(func() {
+		hooks = &certHooks{}
+	})
+
+	Context("GetFullCr", func() {
+		It("should return a valid Certificate with all required fields", func() {
+			hco := commontestutils.NewHco()
+			obj, err := hooks.GetFullCr(hco)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(obj).ToNot(BeNil())
+
+			cert, ok := obj.(*unstructured.Unstructured)
+			Expect(ok).To(BeTrue())
+
+			Expect(cert.GetAPIVersion()).To(Equal(certManagerAPIVersion))
+			Expect(cert.GetKind()).To(Equal(certificateKind))
+
+			Expect(cert.GetName()).To(Equal(tlsCertificateName))
+			Expect(cert.GetNamespace()).To(Equal(hcoutil.GetOperatorNamespaceFromEnv()))
+
+			secretName, found, err := unstructured.NestedString(cert.Object, "spec", "secretName")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(secretName).To(Equal(tlsSecretName))
+
+			dnsNames, found, err := unstructured.NestedStringSlice(cert.Object, "spec", "dnsNames")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(dnsNames).To(HaveLen(1))
+			expectedDNS := serviceName + "." + hcoutil.GetOperatorNamespaceFromEnv() + ".svc"
+			Expect(dnsNames[0]).To(Equal(expectedDNS))
+
+			issuerRef, found, err := unstructured.NestedMap(cert.Object, "spec", "issuerRef")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(issuerRef["name"]).To(Equal("selfsigned"))
+		})
+	})
+
+	Context("GetEmptyCr", func() {
+		It("should return an empty Certificate with apiVersion and kind", func() {
+			obj := hooks.GetEmptyCr()
+			Expect(obj).ToNot(BeNil())
+
+			cert, ok := obj.(*unstructured.Unstructured)
+			Expect(ok).To(BeTrue())
+
+			Expect(cert.GetAPIVersion()).To(Equal(certManagerAPIVersion))
+			Expect(cert.GetKind()).To(Equal(certificateKind))
+			Expect(cert.GetName()).To(BeEmpty())
+			Expect(cert.GetNamespace()).To(BeEmpty())
+		})
+	})
+
+	Context("NewCertManagerCertHandler", func() {
+		It("should create a handler that returns a valid Certificate via GetFullCr", func() {
+			hco := commontestutils.NewHco()
+			cl := &updateSpy{}
+			handler := NewCertManagerCertHandler(cl, commontestutils.GetScheme())
+
+			getter, ok := handler.(operands.CRGetter)
+			Expect(ok).To(BeTrue())
+
+			obj, err := getter.GetFullCr(hco)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(obj).ToNot(BeNil())
+
+			cert, ok := obj.(*unstructured.Unstructured)
+			Expect(ok).To(BeTrue())
+			Expect(cert.GetAPIVersion()).To(Equal(certManagerAPIVersion))
+			Expect(cert.GetKind()).To(Equal(certificateKind))
+			Expect(cert.GetName()).To(Equal(tlsCertificateName))
+			Expect(cert.GetLabels()).ToNot(BeEmpty())
+		})
+	})
+
+	Context("UpdateCR", func() {
+		var (
+			existing *unstructured.Unstructured
+			desired  *unstructured.Unstructured
+			req      *common.HcoRequest
+			cl       client.Client
+		)
+
+		BeforeEach(func() {
+			ns := "test-namespace"
+			hco := commontestutils.NewHco()
+			req = commontestutils.NewReq(hco)
+			cl = &updateSpy{}
+
+			existing = &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": certManagerAPIVersion,
+					"kind":       certificateKind,
+					"metadata": map[string]any{
+						"name":      tlsCertificateName,
+						"namespace": ns,
+						"labels": map[string]any{
+							"app": "test",
+						},
+					},
+					"spec": map[string]any{
+						"secretName": tlsSecretName,
+						"dnsNames":   []any{serviceName + "." + ns + ".svc"},
+						"issuerRef":  map[string]any{"name": "selfsigned"},
+					},
+				},
+			}
+
+			desired = &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": certManagerAPIVersion,
+					"kind":       certificateKind,
+					"metadata": map[string]any{
+						"name":      tlsCertificateName,
+						"namespace": ns,
+						"labels": map[string]any{
+							"app": "test",
+						},
+					},
+					"spec": map[string]any{
+						"secretName": tlsSecretName,
+						"dnsNames":   []any{serviceName + "." + ns + ".svc"},
+						"issuerRef":  map[string]any{"name": "selfsigned"},
+					},
+				},
+			}
+		})
+
+		It("should return no update needed when everything matches", func() {
+			needsUpdate, overwritten, err := hooks.UpdateCR(req, cl, existing, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeFalse())
+			Expect(overwritten).To(BeFalse())
+		})
+
+		It("should detect and update label changes", func() {
+			_ = unstructured.SetNestedStringMap(desired.Object, map[string]string{
+				"app":     "test",
+				"version": "v1",
+			}, "metadata", "labels")
+
+			needsUpdate, overwritten, err := hooks.UpdateCR(req, cl, existing, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeTrue())
+			Expect(overwritten).To(BeFalse())
+
+			updatedLabels, _, _ := unstructured.NestedStringMap(existing.Object, "metadata", "labels")
+			Expect(updatedLabels).To(HaveKeyWithValue("version", "v1"))
+		})
+
+		It("should detect and update dnsNames changes", func() {
+			_ = unstructured.SetNestedStringSlice(desired.Object, []string{
+				"new-service.test-namespace.svc",
+				"another-service.test-namespace.svc",
+			}, "spec", "dnsNames")
+
+			needsUpdate, overwritten, err := hooks.UpdateCR(req, cl, existing, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeTrue())
+			Expect(overwritten).To(BeFalse())
+
+			updatedDNS, _, _ := unstructured.NestedStringSlice(existing.Object, "spec", "dnsNames")
+			Expect(updatedDNS).To(HaveLen(2))
+			Expect(updatedDNS).To(ContainElement("new-service.test-namespace.svc"))
+		})
+
+		It("should detect and update issuerRef changes", func() {
+			_ = unstructured.SetNestedMap(desired.Object, map[string]any{
+				"name": "ca-issuer",
+				"kind": "ClusterIssuer",
+			}, "spec", "issuerRef")
+
+			needsUpdate, overwritten, err := hooks.UpdateCR(req, cl, existing, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeTrue())
+			Expect(overwritten).To(BeFalse())
+
+			updatedIssuerRef, _, _ := unstructured.NestedMap(existing.Object, "spec", "issuerRef")
+			Expect(updatedIssuerRef["name"]).To(Equal("ca-issuer"))
+			Expect(updatedIssuerRef["kind"]).To(Equal("ClusterIssuer"))
+		})
+
+		It("should detect and update secretName changes", func() {
+			_ = unstructured.SetNestedField(desired.Object, "new-secret-name", "spec", "secretName")
+
+			needsUpdate, overwritten, err := hooks.UpdateCR(req, cl, existing, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeTrue())
+			Expect(overwritten).To(BeFalse())
+
+			updatedSecretName, _, _ := unstructured.NestedString(existing.Object, "spec", "secretName")
+			Expect(updatedSecretName).To(Equal("new-secret-name"))
+		})
+
+		It("should detect multiple changes at once", func() {
+			_ = unstructured.SetNestedStringMap(desired.Object, map[string]string{
+				"new-label": "value",
+			}, "metadata", "labels")
+			_ = unstructured.SetNestedField(desired.Object, "updated-secret", "spec", "secretName")
+			_ = unstructured.SetNestedMap(desired.Object, map[string]any{
+				"name": "new-issuer",
+			}, "spec", "issuerRef")
+
+			needsUpdate, overwritten, err := hooks.UpdateCR(req, cl, existing, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeTrue())
+			Expect(overwritten).To(BeFalse())
+
+			updatedLabels, _, _ := unstructured.NestedStringMap(existing.Object, "metadata", "labels")
+			Expect(updatedLabels).To(HaveKeyWithValue("new-label", "value"))
+
+			updatedSecretName, _, _ := unstructured.NestedString(existing.Object, "spec", "secretName")
+			Expect(updatedSecretName).To(Equal("updated-secret"))
+
+			updatedIssuerRef, _, _ := unstructured.NestedMap(existing.Object, "spec", "issuerRef")
+			Expect(updatedIssuerRef["name"]).To(Equal("new-issuer"))
+		})
+
+		It("should handle nil existing object gracefully", func() {
+			needsUpdate, overwritten, err := hooks.UpdateCR(nil, nil, nil, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeFalse())
+			Expect(overwritten).To(BeFalse())
+		})
+
+		It("should handle nil desired object gracefully", func() {
+			needsUpdate, overwritten, err := hooks.UpdateCR(nil, nil, existing, nil)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeFalse())
+			Expect(overwritten).To(BeFalse())
+		})
+
+		It("should handle wrong type for existing object gracefully", func() {
+			wrongType := &unstructured.UnstructuredList{}
+			needsUpdate, overwritten, err := hooks.UpdateCR(nil, nil, wrongType, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeFalse())
+			Expect(overwritten).To(BeFalse())
+		})
+
+		It("should handle wrong type for desired object gracefully", func() {
+			wrongType := &unstructured.UnstructuredList{}
+			needsUpdate, overwritten, err := hooks.UpdateCR(nil, nil, existing, wrongType)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeFalse())
+			Expect(overwritten).To(BeFalse())
+		})
+	})
+})

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -119,6 +119,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 	} else {
 		operandList = append(operandList,
 			handlers.NewCertManagerIssuerHandler(client, scheme),
+			netresinjector.NewCertManagerCertHandler(client, scheme),
 		)
 	}
 

--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -116,6 +116,10 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 				handlers.NewKVAPIServerProxyNetworkPolicyHandler(client, scheme),
 			}...)
 		}
+	} else {
+		operandList = append(operandList,
+			handlers.NewCertManagerIssuerHandler(client, scheme),
+		)
 	}
 
 	if ci.IsManagedByOLM() {

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1384,6 +1384,19 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
@@ -712,6 +712,19 @@ spec:
           - create
           - update
           - delete
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          - issuers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
         serviceAccountName: hyperconverged-cluster-operator
       - rules: []
         serviceAccountName: hyperconverged-cluster-cli-download

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.19.0-unstable
-    createdAt: "2026-07-06 15:48:55"
+    createdAt: "2026-07-12 13:33:50"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -712,6 +712,19 @@ spec:
           - create
           - update
           - delete
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          - issuers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
         serviceAccountName: hyperconverged-cluster-operator
       - rules: []
         serviceAccountName: hyperconverged-cluster-cli-download

--- a/deploy/webhooks.yaml
+++ b/deploy/webhooks.yaml
@@ -159,19 +159,6 @@ spec:
   issuerRef:
     name: selfsigned
 ---
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: virt-network-resources-injector-cert
-  labels:
-    name: virt-network-resources-injector
-spec:
-  secretName: virt-network-resources-injector-secret
-  dnsNames:
-  - virt-network-resources-injector-service.kubevirt-hyperconverged.svc
-  issuerRef:
-    name: selfsigned
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -615,6 +615,7 @@ func GetClusterPermissions() []rbacv1.PolicyRule {
 			Resources: stringListToSlice("poddisruptionbudgets"),
 			Verbs:     stringListToSlice("get", "list", "watch", "create", "update", "delete"),
 		},
+		roleWithAllPermissions("cert-manager.io", stringListToSlice("certificates", "issuers")),
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:


In non-OpenShift environments, the TLS secret for network-resources-injector needs to be created by cert-manager. Previously, this relied on a static Certificate resource in deploy/webhooks.yaml, which is not applied in OLM deployments (like nightly-bundle).

Add a minimal Certificate handler that:
- Only deploys when network-resources-injector is enabled
- Only in non-OpenShift clusters (OpenShift uses service-ca)
- Creates a cert-manager Certificate resource dynamically
- Tells cert-manager to generate virt-network-resources-injector-secret

This fixes the "secret not found" error in non-OpenShift OLM deployments.


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
