### PR TITLE
netresinjector: Use objectSelector for virt-launcher filtering

### DIFF
--- a/controllers/handlers/netresinjector/webhook_config.go
+++ b/controllers/handlers/netresinjector/webhook_config.go
@@ -152,7 +152,11 @@ func newMutatingWebhookConfiguration() *admissionregistrationv1.MutatingWebhookC
 			TimeoutSeconds:          new(int32(10)),
 			MatchPolicy:             new(admissionregistrationv1.Equivalent),
 			ReinvocationPolicy:      new(admissionregistrationv1.NeverReinvocationPolicy),
-			ObjectSelector:          &metav1.LabelSelector{},
+			ObjectSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					kubevirtcorev1.AppLabel: "virt-launcher",
+				},
+			},
 			ClientConfig: admissionregistrationv1.WebhookClientConfig{
 				Service: &admissionregistrationv1.ServiceReference{
 					Name:      serviceName,
@@ -171,10 +175,6 @@ func newMutatingWebhookConfiguration() *admissionregistrationv1.MutatingWebhookC
 				},
 			},
 			MatchConditions: []admissionregistrationv1.MatchCondition{
-				{
-					Name:       "isVirtLauncherPod",
-					Expression: `has(object.metadata.labels) && object.metadata.labels["` + kubevirtcorev1.AppLabel + `"] == "virt-launcher"`,
-				},
 				{
 					Name:       "hasMultusAnnotation",
 					Expression: `has(object.metadata.annotations) && "k8s.v1.cni.cncf.io/networks" in object.metadata.annotations`,

--- a/controllers/handlers/netresinjector/webhook_config_test.go
+++ b/controllers/handlers/netresinjector/webhook_config_test.go
@@ -46,7 +46,12 @@ var _ = Describe("Network Resources Injector MutatingWebhookConfiguration", func
 			Expect(wh.Rules).To(HaveLen(1))
 			Expect(wh.Rules[0].Operations).To(ContainElement(admissionregistrationv1.Create))
 			Expect(wh.Rules[0].Rule.Resources).To(ContainElement("pods"))
-			Expect(wh.MatchConditions).To(HaveLen(2))
+			Expect(wh.MatchConditions).ToNot(ContainElement(
+				WithTransform(func(mc admissionregistrationv1.MatchCondition) string { return mc.Expression },
+					ContainSubstring("labels")),
+			), "label filtering should use objectSelector, not matchConditions")
+			Expect(wh.ObjectSelector).ToNot(BeNil())
+			Expect(wh.ObjectSelector.MatchLabels).To(HaveKeyWithValue("kubevirt.io", "virt-launcher"))
 			Expect(wh.ClientConfig.Service).ToNot(BeNil())
 			Expect(wh.ClientConfig.Service.Name).To(Equal(serviceName))
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The CEL matchCondition accessed object.metadata.labels["kubevirt.io"]
without checking if the key exists, causing a runtime error on pods
that lack the label. Replace with an objectSelector using matchLabels
to filter for virt-launcher pods at the API server's request-matching
stage instead (also more efficient since the API server skips the
webhook call entirely rather than invoking it and evaluating CEL).

Reproducer - any pod with the networks annotation:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: reproducer
  annotations:
    k8s.v1.cni.cncf.io/networks: net1
  labels:
    foo: bar
spec:
  containers:
    - name: test
      image: busybox
```

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-92373
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Importer pod rejected by ValidatingAdmissionPolicy 'kubevirt-plugin-sidecar-subpath-policy'
```
