### PR TITLE
Add OptOutRoleAggregation to the feature-gates.json as beta

### DIFF
--- a/pkg/featuregatedetails/feature-gates.json
+++ b/pkg/featuregatedetails/feature-gates.json
@@ -2,12 +2,17 @@
   {
     "name": "decentralizedLiveMigration",
     "phase": "beta",
-    "description": "DecentralizedLiveMigration enables the decentralized live migration (cross-cluster migration) feature. This feature allows live migration of VirtualMachineInstances between different clusters. This feature is in Developer Preview."
+    "description": "DecentralizedLiveMigration enables the decentralized live migration (cross-cluster migration) feature. This feature allows live migration of VirtualMachineInstances between different clusters. This feature is in Technology Preview."
   },
   {
     "name": "declarativeHotplugVolumes",
     "phase": "beta",
-    "description": "DeclarativeHotplugVolumes enables the use of the declarative volume hotplug feature in KubeVirt. When set to true or nil, the \"DeclarativeHotplugVolumes\" feature gate is enabled and the \"HotplugVolumes\" feature gate is not (default behavior). When set to false, the \"HotplugVolumes\" featuregate is enabled in KubeVirt. This feature is in Technical Preview."
+    "description": "DeclarativeHotplugVolumes enables the use of the declarative volume hotplug feature in KubeVirt. When set to true or nil, the \"DeclarativeHotplugVolumes\" feature gate is enabled and the \"HotplugVolumes\" feature gate is not (default behavior). When set to false, the \"HotplugVolumes\" featuregate is enabled in KubeVirt. This feature is in Technology Preview."
+  },
+  {
+    "name": "OptOutRoleAggregation",
+    "phase": "beta",
+    "description": "OptOutRoleAggregation enables the usage of RoleAggregationStrategy that controls whether RBAC cluster roles should be aggregated to the default Kubernetes roles (admin, edit, view). When set to \"AggregateToDefault\" (default) or not specified, the aggregate-to-* labels are added to the cluster roles. When set to \"Manual\", the labels are not added, and roles will not be aggregated to the default roles. This feature is in Technology Preview."
   },
   {
     "name": "alignCPUs",


### PR DESCRIPTION
the `OptOutRoleAggregation` / `RoleAggregationStrategy` feature has been graduated to Beta in kubevirt v1.9 (https://github.com/kubevirt/kubevirt/pull/18198). 

therefore, we want HCO to recognize this as a Beta feature so it won't remove the feature gate from kubevirt CR.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-92750
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add OptOutRoleAggregation feature gate as beta
```
