### PR TITLE
Fix CNV-92870: fix the v1 storage logic

### DIFF
--- a/cmd/hyperconverged-cluster-operator/main.go
+++ b/cmd/hyperconverged-cluster-operator/main.go
@@ -3,13 +3,9 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"os"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -39,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -157,9 +152,6 @@ func main() {
 
 	err = cmdcommon.ClusterInitializations(ctx, apiClient, scheme, logger)
 	cmdHelper.ExitOnError(err, "Cannot detect cluster type")
-
-	err = ensureAPIv1(ctx, apiClient, operatorNamespace, logger)
-	cmdHelper.ExitOnError(err, "Failed to store the HyperConverged CR in v1 format")
 
 	err = cmdcommon.SetHyperConvergedTLSProfile(ctx, operatorNamespace, apiClient)
 	cmdHelper.ExitOnError(err, "Cannot read existing HCO CR")
@@ -343,125 +335,6 @@ func main() {
 		eventEmitter.EmitEvent(nil, corev1.EventTypeWarning, "UnexpectedError", "HyperConverged crashed; "+err.Error())
 		os.Exit(1)
 	}
-}
-
-// ensureAPIv1 makes sure the HyperConverged CR is stored in v1 API version format.
-// This Based on the article in the Kubernetes documentation: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version
-// We are using option 2 from this article: re-write the HyperConverged CR in v1 API version format, then update the
-// HyperConverged CRD status to only have v1 in its storedVersions field.
-func ensureAPIv1(ctx context.Context, cli client.Client, namespace string, logger logr.Logger) error {
-	hcCRD := &apiextensionsv1.CustomResourceDefinition{}
-
-	logger.Info("Reading the HyperConverged CRD")
-	err := cli.Get(ctx, client.ObjectKey{Name: hcoutil.HyperConvergedCRDName}, hcCRD)
-	if err != nil {
-		logger.Error(err, "Failed to read the HyperConverged CRD")
-		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("%s CRD not found", hcoutil.HyperConvergedCRDName)
-		}
-		return err
-	}
-
-	if !slices.Contains(hcCRD.Status.StoredVersions, hcov1.APIVersionV1) {
-		return fmt.Errorf("unexpected stored API versions of %v in the %s CRD; missing %s", hcCRD.Status.StoredVersions, hcoutil.HyperConvergedCRDName, hcov1.APIVersionV1)
-	}
-
-	if len(hcCRD.Status.StoredVersions) == 1 {
-		logger.Info("HyperConverged CRD is already up-to-date")
-		return nil
-	}
-
-	if len(hcCRD.Status.StoredVersions) > 1 {
-		if err = reStoreHCv1(ctx, cli, namespace, logger); err != nil {
-			return err
-		}
-
-		const apiVersionPatch = `{"status":{"storedVersions":["v1"]}}`
-		patchBytes := []byte(apiVersionPatch)
-
-		attempt := 1
-		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			defer func() {
-				attempt++
-			}()
-
-			retryLogger := logger.WithValues("attempt", attempt)
-			retryLogger.Info("Updating HyperConverged CRD to store only the v1 API version")
-			err = cli.Status().Patch(ctx, hcCRD, client.RawPatch(types.StrategicMergePatchType, patchBytes))
-			if err != nil {
-				return fmt.Errorf("failed to patch HyperConverged CRD, to store only the v1 API version; %w", err)
-			}
-
-			retryLogger.Info("Successfully updated the HyperConverged CRD to store only the v1 API version")
-			return nil
-		})
-	}
-
-	return nil
-}
-
-func reStoreHCv1(ctx context.Context, cli client.Client, namespace string, logger logr.Logger) error {
-	attempt := 1
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		defer func() {
-			attempt++
-		}()
-
-		retryLogger := logger.WithValues("attempt", attempt)
-		retryLogger.Info("reading the HyperConverged CR in API v1 format")
-		hc, err := getHyperConvergedV1(ctx, cli, namespace, retryLogger)
-		if err != nil {
-			return err
-		}
-
-		if hc == nil {
-			return nil
-		}
-
-		retryLogger.Info("re-storing the HyperConverged CR in API v1 format")
-		err = cli.Update(ctx, hc)
-		if err != nil {
-			return fmt.Errorf("failed to re-store the HyperConverged CR in API v1 format; %w", err)
-		}
-
-		retryLogger.Info("Successfully re-stored the HyperConverged CR in API v1 format")
-
-		return nil
-	})
-}
-
-func getHyperConvergedV1(ctx context.Context, cli client.Client, namespace string, retryLogger logr.Logger) (*hcov1.HyperConverged, error) {
-	hc := &hcov1.HyperConverged{}
-	hcKey := client.ObjectKey{Name: hcoutil.HyperConvergedName, Namespace: namespace}
-
-	err := cli.Get(ctx, hcKey, hc)
-	if err == nil {
-		return hc, nil
-	}
-
-	if apierrors.IsNotFound(err) {
-		retryLogger.Info("The HyperConverged CR does not exist, yet")
-		return nil, nil
-	}
-
-	suspectedErr := &json.UnmarshalTypeError{}
-	if !errors.Is(err, suspectedErr) && !strings.Contains(err.Error(), "json: cannot unmarshal") {
-		return nil, fmt.Errorf("unknown error while fetching the HyperConverged CR as v1; %w", err)
-	}
-
-	retryLogger.Info("reading the HyperConverged CR in API v1 format failed. Trying v1beta1")
-	hcv1beta1 := &hcov1beta1.HyperConverged{}
-	err = cli.Get(ctx, hcKey, hcv1beta1)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read the HyperConverged CR as v1beta1; %w", err)
-	}
-
-	err = hcv1beta1.ConvertTo(hc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert the HyperConverged CR from v1beta1 to v1; %w", err)
-	}
-
-	return hc, nil
 }
 
 // Restricts the cache's ListWatch to specific fields/labels per GVK at the specified object to control the memory impact

--- a/cmd/hyperconverged-cluster-webhook/main.go
+++ b/cmd/hyperconverged-cluster-webhook/main.go
@@ -3,11 +3,15 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
+	"github.com/go-logr/logr"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -15,11 +19,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +44,8 @@ import (
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/api"
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/cmd/cmdcommon"
 	whapiservercontrollers "github.com/kubevirt/hyperconverged-cluster-operator/controllers/webhooks/apiserver-controller"
 	bearertokencontroller "github.com/kubevirt/hyperconverged-cluster-operator/controllers/webhooks/bearer-token-controller"
@@ -139,6 +148,17 @@ func main() {
 	})
 	cmdHelper.ExitOnError(err, "failed to create manager")
 
+	err = mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		err := ensureAPIv1(ctx, apiClient, operatorNamespace, logger)
+		if err != nil {
+			logger.Error(err, "Failed to store the HyperConverged CR in v1 format")
+			return fmt.Errorf("failed to store the HyperConverged CR in v1 format; %w", err)
+		}
+
+		return cmdcommon.SetHyperConvergedTLSProfile(ctx, operatorNamespace, apiClient)
+	}))
+	cmdHelper.ExitOnError(err, "failed to add runnable to manager")
+
 	// register pprof instrumentation if HCO_PPROF_ADDR is set
 	cmdHelper.ExitOnError(cmdHelper.RegisterPPROFServer(mgr), "can't register pprof server")
 
@@ -155,9 +175,6 @@ func main() {
 
 	err = mgr.AddReadyzCheck("ready", healthz.Ping)
 	cmdHelper.ExitOnError(err, "unable to add ready check")
-
-	err = cmdcommon.SetHyperConvergedTLSProfile(ctx, operatorNamespace, apiClient)
-	cmdHelper.ExitOnError(err, "Cannot read existing HCO CR")
 
 	logger.Info("Registering the APIServer reconciler")
 	if ci.IsOpenshift() {
@@ -238,4 +255,123 @@ func getCacheOption(operatorNamespace string, ci hcoutil.ClusterInfo) cache.Opti
 	return cache.Options{
 		ByObject: objMap,
 	}
+}
+
+// ensureAPIv1 makes sure the HyperConverged CR is stored in v1 API version format.
+// This Based on the article in the Kubernetes documentation: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version
+// We are using option 2 from this article: re-write the HyperConverged CR in v1 API version format, then update the
+// HyperConverged CRD status to only have v1 in its storedVersions field.
+func ensureAPIv1(ctx context.Context, cli client.Client, namespace string, logger logr.Logger) error {
+	hcCRD := &apiextensionsv1.CustomResourceDefinition{}
+
+	logger.Info("Reading the HyperConverged CRD")
+	err := cli.Get(ctx, client.ObjectKey{Name: hcoutil.HyperConvergedCRDName}, hcCRD)
+	if err != nil {
+		logger.Error(err, "Failed to read the HyperConverged CRD")
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("%s CRD not found", hcoutil.HyperConvergedCRDName)
+		}
+		return err
+	}
+
+	if !slices.Contains(hcCRD.Status.StoredVersions, hcov1.APIVersionV1) {
+		return fmt.Errorf("unexpected stored API versions of %v in the %s CRD; missing %s", hcCRD.Status.StoredVersions, hcoutil.HyperConvergedCRDName, hcov1.APIVersionV1)
+	}
+
+	if len(hcCRD.Status.StoredVersions) == 1 {
+		logger.Info("HyperConverged CRD is already up-to-date")
+		return nil
+	}
+
+	if len(hcCRD.Status.StoredVersions) > 1 {
+		if err = reStoreHCv1(ctx, cli, namespace, logger); err != nil {
+			return err
+		}
+
+		const apiVersionPatch = `{"status":{"storedVersions":["v1"]}}`
+		patchBytes := []byte(apiVersionPatch)
+
+		attempt := 1
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			defer func() {
+				attempt++
+			}()
+
+			retryLogger := logger.WithValues("attempt", attempt)
+			retryLogger.Info("Updating HyperConverged CRD to store only the v1 API version")
+			err = cli.Status().Patch(ctx, hcCRD, client.RawPatch(types.StrategicMergePatchType, patchBytes))
+			if err != nil {
+				return fmt.Errorf("failed to patch HyperConverged CRD, to store only the v1 API version; %w", err)
+			}
+
+			retryLogger.Info("Successfully updated the HyperConverged CRD to store only the v1 API version")
+			return nil
+		})
+	}
+
+	return nil
+}
+
+func reStoreHCv1(ctx context.Context, cli client.Client, namespace string, logger logr.Logger) error {
+	attempt := 1
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		defer func() {
+			attempt++
+		}()
+
+		retryLogger := logger.WithValues("attempt", attempt)
+		retryLogger.Info("reading the HyperConverged CR in API v1 format")
+		hc, err := getHyperConvergedV1(ctx, cli, namespace, retryLogger)
+		if err != nil {
+			return err
+		}
+
+		if hc == nil {
+			return nil
+		}
+
+		retryLogger.Info("re-storing the HyperConverged CR in API v1 format")
+		err = cli.Update(ctx, hc, client.FieldValidation("Ignore"))
+		if err != nil {
+			return fmt.Errorf("failed to re-store the HyperConverged CR in API v1 format; %w", err)
+		}
+
+		retryLogger.Info("Successfully re-stored the HyperConverged CR in API v1 format")
+
+		return nil
+	})
+}
+
+func getHyperConvergedV1(ctx context.Context, cli client.Client, namespace string, retryLogger logr.Logger) (*hcov1.HyperConverged, error) {
+	hc := &hcov1.HyperConverged{}
+	hcKey := client.ObjectKey{Name: hcoutil.HyperConvergedName, Namespace: namespace}
+
+	err := cli.Get(ctx, hcKey, hc)
+	if err == nil {
+		return hc, nil
+	}
+
+	if apierrors.IsNotFound(err) {
+		retryLogger.Info("The HyperConverged CR does not exist, yet")
+		return nil, nil
+	}
+
+	if _, isTypeErr := errors.AsType[*json.UnmarshalTypeError](err); !isTypeErr {
+		return nil, fmt.Errorf("unknown error while fetching the HyperConverged CR as v1; %w", err)
+	}
+
+	retryLogger.Info("reading the HyperConverged CR in API v1 format failed. Trying v1beta1")
+	hcv1beta1 := &hcov1beta1.HyperConverged{}
+	err = cli.Get(ctx, hcKey, hcv1beta1)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the HyperConverged CR as v1beta1; %w", err)
+	}
+
+	hc = &hcov1.HyperConverged{}
+	err = hcv1beta1.ConvertTo(hc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert the HyperConverged CR from v1beta1 to v1; %w", err)
+	}
+
+	return hc, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When upgrading to this version, the CRD storage version is changed from `v1beta1` to `v1`. Then the operator is trying to replace the `HyperConverged` CR object in ETCD, to be in `v1` API format. If the webhook of the previous version is still running, then this will work. 

But if not, the new webhook pod is getting into crash loop, because it's trying to read the `HyperConverged` CR before the webhook server started, and so the conversion webhook is not available, and this read operation fails. At the same time, the operator is failing to read the `HyperConverged` CR, because the conversion webhook is not available. Even reading the `HyperConverged` CR in `v1beta1` format, and manually convert it, fails, because the conversion webhook is needed for the update operation as well.

To fix it, we:
1. moving the v1 storage logic from the operator to the webhook, so the operator does not depend on the webhook anymore.
2. the new code in the logic is moved after the webhook server starts, to make sure the conversion webhook is available for this process.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-92870
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix operator and webhook pods crash loop in update
```
