### PR TITLE
fix: remove invalid team-reviewers from Perses dashboard workflow

### DIFF
--- a/.github/workflows/perses-dashboard-updater.yml
+++ b/.github/workflows/perses-dashboard-updater.yml
@@ -54,6 +54,5 @@ jobs:
             ```
           assignees: sradco
           reviewers: sradco
-          team-reviewers: owners, maintainers
           branch: update_perses_dashboards
           delete-branch: true


### PR DESCRIPTION
The `team-reviewers: owners, maintainers` parameter in the Perses dashboard
updater workflow references teams that are not collaborators on this repository.
This causes the workflow to fail with:

> Reviews may only be requested from collaborators. One or more of the teams you
> specified is not a collaborator of the kubevirt/hyperconverged-cluster-operator
> repository.

The only collaborating teams are `olm-maintainers` and `openshift-ci`. Since the
PR is already assigned to and reviewed by `sradco`, removing the invalid
`team-reviewers` line is sufficient.

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>

Made with [Cursor](https://cursor.com)