### PR TITLE
Expose KubeVirt Template feature gate through HCO API

### DIFF
--- a/api/v1/hyperconverged_types.go
+++ b/api/v1/hyperconverged_types.go
@@ -126,6 +126,11 @@ type HyperConvergedSpec struct {
 	//   gate causes the redeployment of the virt-handler pod.
 	//   Phase: alpha
 	//
+	// * template:
+	//   Enable the deployment of virt-template components by virt-operator. Note:
+	//   this feature is in Developer Preview.
+	//   Phase: alpha
+	//
 	// * disableMDevConfiguration:
 	//   Deprecated: use spec.virtualization.mediatedDevicesConfiguration.enabled
 	//   instead. This feature gate is deprecated and will be removed in a future

--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -512,6 +512,13 @@ type HyperConvergedFeatureGates struct {
 	// +kubebuilder:default=false
 	// +default=false
 	ContainerPathVolumes *bool `json:"containerPathVolumes,omitempty"`
+
+	// Enable the deployment of virt-template components by virt-operator.
+	// Note: this feature is in Developer Preview.
+	// +optional
+	// +kubebuilder:default=false
+	// +default=false
+	Template *bool `json:"template,omitempty"`
 }
 
 // MediatedDevicesConfiguration holds information about MDEV types to be defined, if available

--- a/api/v1beta1/zz_generated.featuregates_conversion.go
+++ b/api/v1beta1/zz_generated.featuregates_conversion.go
@@ -204,6 +204,24 @@ func convert_v1beta1_FeatureGates_To_v1(in *HyperConvergedFeatureGates, out *hco
 		}
 	}
 
+	// converting the Template v1beta1 alpha feature gate to v1
+	v1Idx = out.Index("template")
+	v1Found = v1Idx >= 0
+	if in.Template == nil {
+		if v1Found {
+			*out = slices.Delete(*out, v1Idx, v1Idx+1)
+		}
+	} else {
+		v1Enabled = v1Found && ((*out)[v1Idx].State == nil || *((*out)[v1Idx].State) == "Enabled")
+		if (!v1Found && *in.Template) || (v1Found && v1Enabled != *in.Template) {
+			if *in.Template {
+				out.Enable("template")
+			} else {
+				out.Disable("template")
+			}
+		}
+	}
+
 	// the DisableMDevConfiguration feature gate is deprecated and should have a custom conversion logic in api/v1beta1/conversion.go
 }
 
@@ -237,6 +255,9 @@ func convert_v1_FeatureGates_To_v1beta1(in hcofg.HyperConvergedFeatureGates, out
 
 	// converting the persistentReservation v1 alpha feature gate to v1beta1
 	out.PersistentReservation = new(in.IsEnabled("persistentReservation"))
+
+	// converting the template v1 alpha feature gate to v1beta1
+	out.Template = new(in.IsEnabled("template"))
 
 	// the disableMDevConfiguration feature gate is deprecated and should have a custom conversion logic in api/v1beta1/conversion.go
 }

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -144,6 +144,7 @@ const (
 	kvOptOutRoleAggregation      = "OptOutRoleAggregation"
 	kvContainerPathVolumes       = "ContainerPathVolumes"
 	kvPCINUMAAwareTopology       = "PCINUMAAwareTopology"
+	kvTemplate                   = "Template"
 )
 
 // CPU Plugin default values
@@ -968,6 +969,10 @@ func getFeatureGateChecks(hc *hcov1.HyperConverged) []string {
 
 	if featureGates.IsEnabled("containerPathVolumes") {
 		fgs = append(fgs, kvContainerPathVolumes)
+	}
+
+	if featureGates.IsEnabled("template") {
+		fgs = append(fgs, kvTemplate)
 	}
 
 	return fgs

--- a/pkg/featuregatedetails/feature-gates.json
+++ b/pkg/featuregatedetails/feature-gates.json
@@ -50,6 +50,11 @@
     "description": "Enable persistent reservation of a LUN through the SCSI Persistent Reserve commands on Kubevirt. In order to issue privileged SCSI ioctls, the VM requires activation of the persistent reservation flag. Once this feature gate is enabled, then the additional container with the qemu-pr-helper is deployed inside the virt-handler pod. Enabling (or removing) the feature gate causes the redeployment of the virt-handler pod."
   },
   {
+    "name": "template",
+    "phase": "alpha",
+    "description": "Enable the deployment of virt-template components by virt-operator. Note: this feature is in Developer Preview."
+  },
+  {
     "name": "disableMDevConfiguration",
     "phase": "deprecated",
     "description": "Deprecated: use spec.virtualization.mediatedDevicesConfiguration.enabled instead. This feature gate is deprecated and will be removed in a future release."


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the KubeVirt `Template` feature gate as an alpha-phase HCO feature gate, allowing users to enable the deployment of virt-template components by virt-operator.

When enabled via `spec.featureGates: [{name: "template"}]` (v1) or `spec.featureGates.template: true` (v1beta1), the `Template` KubeVirt feature gate is added to the KubeVirt CR's `featureGates` list instead of being explicitly disabled.

**Reviewer Checklist**

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
```jira-ticket
NONE
```

**Release note**:
```release-note
Expose the KubeVirt Template feature gate as an alpha-phase HCO feature gate, enabling users to opt-in to virt-template component deployment.
```