### PR TITLE
handlers, kubevirt: Conditionally enable ExternalNetResourceInjection FG

### DIFF
--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -132,19 +132,20 @@ const (
 
 // KubeVirt feature gates that are exposed in HCO API
 const (
-	kvDownwardMetrics            = "DownwardMetrics"
-	kvPersistentReservation      = "PersistentReservation"
-	kvAlignCPUs                  = "AlignCPUs"
-	kvDecentralizedLiveMigration = "DecentralizedLiveMigration"
-	kvObjectGraph                = "ObjectGraph"
-	kvUtilityVolumes             = "UtilityVolumes"
-	kvIncrementalBackup          = "IncrementalBackup"
-	kvPasstBinding               = "PasstBinding"
-	kvConfigurableHypervisor     = "ConfigurableHypervisor"
-	kvOptOutRoleAggregation      = "OptOutRoleAggregation"
-	kvContainerPathVolumes       = "ContainerPathVolumes"
-	kvPCINUMAAwareTopology       = "PCINUMAAwareTopology"
-	kvTemplateFG                 = "Template"
+	kvDownwardMetrics              = "DownwardMetrics"
+	kvPersistentReservation        = "PersistentReservation"
+	kvAlignCPUs                    = "AlignCPUs"
+	kvDecentralizedLiveMigration   = "DecentralizedLiveMigration"
+	kvObjectGraph                  = "ObjectGraph"
+	kvUtilityVolumes               = "UtilityVolumes"
+	kvIncrementalBackup            = "IncrementalBackup"
+	kvPasstBinding                 = "PasstBinding"
+	kvConfigurableHypervisor       = "ConfigurableHypervisor"
+	kvOptOutRoleAggregation        = "OptOutRoleAggregation"
+	kvContainerPathVolumes         = "ContainerPathVolumes"
+	kvPCINUMAAwareTopology         = "PCINUMAAwareTopology"
+	kvTemplateFG                   = "Template"
+	kvExternalNetResourceInjection = "ExternalNetResourceInjection"
 )
 
 // CPU Plugin default values
@@ -973,6 +974,10 @@ func getFeatureGateChecks(hc *hcov1.HyperConverged) []string {
 
 	if featureGates.IsEnabled(kvTemplateFG) {
 		fgs = append(fgs, kvTemplateFG)
+	}
+
+	if ptr.Deref(hc.Spec.Deployment.DeployNetworkResourcesInjector, false) {
+		fgs = append(fgs, kvExternalNetResourceInjection)
 	}
 
 	return fgs

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -2544,6 +2544,29 @@ Version: 1.2.3`)
 					Expect(disabled).To(ContainElement(kvPasstBinding))
 				})
 
+				It("should enable ExternalNetResourceInjection FG when deployNetworkResourcesInjector is true", func() {
+					hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(true)
+					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
+					fgs := getKvFeatureGateList(hco)
+					disabled := getKvDisabledFeatureGateList(fgs)
+					Expect(disabled).NotTo(ContainElement(kvExternalNetResourceInjection))
+				})
+
+				It("should disable ExternalNetResourceInjection FG when deployNetworkResourcesInjector is not set", func() {
+					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
+					fgs := getKvFeatureGateList(hco)
+					disabled := getKvDisabledFeatureGateList(fgs)
+					Expect(disabled).To(ContainElement(kvExternalNetResourceInjection))
+				})
+
+				It("should disable ExternalNetResourceInjection FG when deployNetworkResourcesInjector is false", func() {
+					hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(false)
+					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
+					fgs := getKvFeatureGateList(hco)
+					disabled := getKvDisabledFeatureGateList(fgs)
+					Expect(disabled).To(ContainElement(kvExternalNetResourceInjection))
+				})
+
 				It("should include all beta FG if not in the enabled list", func() {
 					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
 					fgs := getKvFeatureGateList(hco)
@@ -3336,6 +3359,31 @@ Version: 1.2.3`)
 
 				Expect(kv.Spec.Configuration.RoleAggregationStrategy).To(BeNil())
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvOptOutRoleAggregation))
+			})
+		})
+
+		Context("DeployNetworkResourcesInjector", func() {
+			It("should add ExternalNetResourceInjection FG when deployNetworkResourcesInjector is true", func() {
+				hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(true)
+				kv, err := NewKubeVirt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvExternalNetResourceInjection))
+			})
+
+			It("should not add ExternalNetResourceInjection FG when deployNetworkResourcesInjector is false", func() {
+				hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(false)
+				kv, err := NewKubeVirt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvExternalNetResourceInjection))
+			})
+
+			It("should not add ExternalNetResourceInjection FG when deployNetworkResourcesInjector is not set", func() {
+				kv, err := NewKubeVirt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvExternalNetResourceInjection))
 			})
 		})
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Enable the ExternalNetResourceInjection KubeVirt feature gate when deployNetworkResourcesInjector is set to true in the HCO CR, so the injector deployment and its corresponding FG are controlled by the same knob.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-93112
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enabled ExternalNetResourceInjection Feature Gate
```
