### PR TITLE
monitoring: add vm typed resource label to VM/VMI-scoped alerts

### DIFF
--- a/hack/prom-rule-ci/hyperconverged-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/hyperconverged-prom-rules-tests.yaml
@@ -1170,6 +1170,7 @@ tests:
             operator_health_impact: "none"
             namespace: "default"
             name: "deprecated-vm"
+            vm: "deprecated-vm"
             machine_type: "pc-q35-rhel7.6.0"
             kubernetes_operator_part_of: "kubevirt"
             kubernetes_operator_component: "hyperconverged-cluster-operator"

--- a/hack/prom-rule-ci/observability-prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/observability-prom-rules-tests.yaml
@@ -472,6 +472,7 @@ tests:
               kubernetes_operator_component: "kubevirt"
               namespace: "test"
               name: "vm-01"
+              vm: "vm-01"
 
   # VMNonRecoverableOSPanic - Case 2: Multiple panics (should show integer value, no fractions)
   - interval: 1m
@@ -494,6 +495,7 @@ tests:
               kubernetes_operator_component: "kubevirt"
               namespace: "test"
               name: "vm-03"
+              vm: "vm-03"
 
   # VMNonRecoverableOSPanic - Case 3: Should NOT fire above 5 panics
   - interval: 1m
@@ -542,6 +544,7 @@ tests:
               kubernetes_operator_component: "kubevirt"
               namespace: "test"
               name: "vm-05"
+              vm: "vm-05"
 
   # VMNonRecoverableOSPanic - Case 6: Auto-resolves after 24h with no new panics
   - interval: 1m
@@ -565,6 +568,7 @@ tests:
               kubernetes_operator_component: "kubevirt"
               namespace: "test"
               name: "vm-06"
+              vm: "vm-06"
       # Auto-resolves after 24h — offset finds the metric, unless removes it, increase()=0
       - eval_time: 1450m
         alertname: VMNonRecoverableOSPanic

--- a/pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go
+++ b/pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go
@@ -1,10 +1,19 @@
 package alerts
 
 import (
+	"fmt"
+
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
+
+// withVMLabel wraps a PromQL expression with label_replace to add a "vm"
+// typed resource label derived from the "name" label. This enables the
+// monitoring-plugin to navigate from alerts to the VM resource page.
+func withVMLabel(expr string) string {
+	return fmt.Sprintf(`label_replace(%s, "vm", "$1", "name", "(.+)")`, expr)
+}
 
 const (
 	outOfBandUpdateAlert             = "KubeVirtCRModified"
@@ -108,11 +117,11 @@ func operatorAlerts() []promv1.Rule {
 		},
 		{
 			Alert: "DeprecatedMachineType",
-			Expr: intstr.FromString(`
+			Expr: intstr.FromString(withVMLabel(`
 			  kubevirt_vm_info
 			  * on(machine_type) group_left()
 				max(kubevirt_node_deprecated_machine_types) by (machine_type)
-			`),
+			`)),
 			For: ptr.To(promv1.Duration("5m")),
 			Annotations: map[string]string{
 				"summary":     "Virtual Machine '{{ $labels.name }}' in namespace '{{ $labels.namespace }}' is using a deprecated machine type.",

--- a/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
+++ b/pkg/monitoring/observability/rules/alerts/cluster_alerts.go
@@ -28,6 +28,13 @@ var ignoredInterfacesForNetworkDown = []string{
 	"br-int",      // OVN integration bridge
 }
 
+// withVMLabel wraps a PromQL expression with label_replace to add a "vm"
+// typed resource label derived from the "name" label. This enables the
+// monitoring-plugin to navigate from alerts to the VM resource page.
+func withVMLabel(expr string) string {
+	return fmt.Sprintf(`label_replace(%s, "vm", "$1", "name", "(.+)")`, expr)
+}
+
 func clusterAlerts() []promv1.Rule {
 	return []promv1.Rule{
 		{
@@ -122,7 +129,7 @@ func clusterAlerts() []promv1.Rule {
 		},
 		{
 			Alert: "VMNonRecoverableOSPanic",
-			Expr: intstr.FromString(`
+			Expr: intstr.FromString(withVMLabel(`
 				floor(
 					(
 						sum by (namespace, name) (kubevirt_vmi_guest_os_panic_total)
@@ -142,7 +149,7 @@ func clusterAlerts() []promv1.Rule {
 					or
 					sum by (namespace, name) (increase(kubevirt_vmi_guest_os_panic_total[24h]))
 				) <= 5
-			`),
+			`)),
 			For: ptr.To[promv1.Duration]("1m"),
 			Annotations: map[string]string{
 				"summary":     "VM {{ $labels.name }} in namespace {{ $labels.namespace }} experienced a non-recoverable guest OS panic",


### PR DESCRIPTION
## Summary

Add a `vm` typed resource label to 2 VM and VMI-scoped alerts defined in the kubevirt/hyperconverged-cluster-operator repository. This enables the monitoring-plugin to detect which VirtualMachine resource an alert is about and provide clickable navigation from alerts to the VM resource page.

Jira-url: CNV-92991

## Why `vm` only (not `vmi`)

VM and VMI always share the same name in KubeVirt. Users navigate to the VM page (not VMI). A single `vm` label simplifies correlation, dashboard queries, and console integration.

## Changes

### Alerts modified (2)

Each alert expression is wrapped with `label_replace(<expr>, "vm", "$1", "name", "(.+)")` to copy the existing `name` label into a new `vm` label:

| Alert | File | Severity |
| --- | --- | --- |
| DeprecatedMachineType | pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go | warning |
| VMNonRecoverableOSPanic | pkg/monitoring/observability/rules/alerts/cluster_alerts.go | warning |

### Implementation

A `withVMLabel(expr string) string` helper is added to each package to wrap expressions with `label_replace(..., "vm", "$1", "name", "(.+)")`, keeping the pattern DRY.

### Files changed

* `pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go` — Added `withVMLabel` helper + wrapped DeprecatedMachineType expression
* `pkg/monitoring/observability/rules/alerts/cluster_alerts.go` — Added `withVMLabel` helper + wrapped VMNonRecoverableOSPanic expression
* `hack/prom-rule-ci/hyperconverged-prom-rules-tests.yaml` — Added `vm:` to expected labels for DeprecatedMachineType
* `hack/prom-rule-ci/observability-prom-rules-tests.yaml` — Added `vm:` to expected labels for VMNonRecoverableOSPanic (4 test cases)

## Test plan

* `promtool check rules` passes (no lint errors)
* `promtool test rules` passes (all existing + updated test cases)
* Existing `name` label preserved in all alerts (backward compatible)
* Monitoring-plugin can navigate from alert to VM resource page using `vm` label
* No breaking changes to dashboards or korrel8r correlation rules

### Release note
```release-note
NONE
```
Made with [Cursor](https://cursor.com)