### PR TITLE
[release-1.18] Allow downloading of the virtio-win iso image from the artifacts server

### DIFF
--- a/controllers/handlers/virtio_win_ConfigMap.go
+++ b/controllers/handlers/virtio_win_ConfigMap.go
@@ -114,7 +114,7 @@ func NewVirtioWinCmReaderRoleBinding() *rbacv1.RoleBinding {
 }
 
 func getVirtioImageName() (string, error) {
-	virtiowinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
+	virtiowinContainer := os.Getenv(hcoutil.VirtioWinImageEnvV)
 	if virtiowinContainer == "" {
 		return "", errors.New("kv-virtiowin-image-name was not specified")
 	}

--- a/controllers/handlers/virtio_win_ConfigMap.go
+++ b/controllers/handlers/virtio_win_ConfigMap.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"net/url"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -10,7 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
@@ -18,11 +21,12 @@ const virtioWinCmName = "virtio-win"
 
 // NewVirtioWinCmHandler creates the Virtio-Win ConfigMap Handler
 func NewVirtioWinCmHandler(cli client.Client, Scheme *runtime.Scheme) (operands.Operand, error) {
-	virtioWincm, err := NewVirtioWinCm()
+	_, err := getVirtioImageName()
 	if err != nil {
 		return nil, err
 	}
-	return operands.NewCmHandler(cli, Scheme, virtioWincm), nil
+
+	return operands.NewDynamicCmHandler(cli, Scheme, NewVirtioWinCm), nil
 }
 
 // NewVirtioWinCmReaderRoleHandler creates the Virtio-Win ConfigMap Role Handler
@@ -35,10 +39,28 @@ func NewVirtioWinCmReaderRoleBindingHandler(cli client.Client, Scheme *runtime.S
 	return operands.NewRoleBindingHandler(cli, Scheme, NewVirtioWinCmReaderRoleBinding())
 }
 
-func NewVirtioWinCm() (*corev1.ConfigMap, error) {
-	virtiowinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
-	if virtiowinContainer == "" {
-		return nil, errors.New("kv-virtiowin-image-name was not specified")
+const (
+	virtioWinImageKey   = "virtio-win-image"
+	virtioWinImageDLKey = "virtio-win-image-download-url"
+)
+
+func NewVirtioWinCm(_ *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {
+	virtiowinContainer, err := getVirtioImageName()
+	if err != nil {
+		return nil, err
+	}
+
+	data := map[string]string{
+		virtioWinImageKey: virtiowinContainer,
+	}
+
+	if imageDLFilePath, envFound := os.LookupEnv(hcoutil.VirtIOWinDataFileEnvV); envFound && imageDLFilePath != "" {
+		downloadURL := url.URL{
+			Scheme: "https",
+			Host:   string(downloadhost.Get().CurrentHost),
+			Path:   imageDLFilePath,
+		}
+		data[virtioWinImageDLKey] = downloadURL.String()
 	}
 
 	return &corev1.ConfigMap{
@@ -47,9 +69,7 @@ func NewVirtioWinCm() (*corev1.ConfigMap, error) {
 			Labels:    operands.GetLabels(hcoutil.AppComponentDeployment),
 			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
-		Data: map[string]string{
-			"virtio-win-image": virtiowinContainer,
-		},
+		Data: data,
 	}, nil
 }
 
@@ -91,4 +111,13 @@ func NewVirtioWinCmReaderRoleBinding() *rbacv1.RoleBinding {
 			},
 		},
 	}
+}
+
+func getVirtioImageName() (string, error) {
+	virtiowinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
+	if virtiowinContainer == "" {
+		return "", errors.New("kv-virtiowin-image-name was not specified")
+	}
+
+	return virtiowinContainer, nil
 }

--- a/controllers/handlers/virtio_win_ConfigMap_test.go
+++ b/controllers/handlers/virtio_win_ConfigMap_test.go
@@ -17,17 +17,20 @@ import (
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 var _ = Describe("VirtioWin", func() {
+	const virtioImage = "new-virtiowin-container-value"
+
 	Context("Virtio-Win ConfigMap", func() {
 
 		var hco *hcov1beta1.HyperConverged
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", "new-virtiowin-container-value")
+			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})
@@ -43,7 +46,7 @@ var _ = Describe("VirtioWin", func() {
 		})
 
 		It("should create if not present", func() {
-			expectedResource, err := NewVirtioWinCm()
+			expectedResource, err := NewVirtioWinCm(commontestutils.NewHco())
 			Expect(err).ToNot(HaveOccurred())
 			cl := commontestutils.InitClient([]client.Object{})
 			handler, _ := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
@@ -63,7 +66,7 @@ var _ = Describe("VirtioWin", func() {
 		})
 
 		It("should find if present", func() {
-			expectedResource, err := NewVirtioWinCm()
+			expectedResource, err := NewVirtioWinCm(commontestutils.NewHco())
 			Expect(err).ToNot(HaveOccurred())
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
@@ -81,18 +84,17 @@ var _ = Describe("VirtioWin", func() {
 		})
 
 		It("should reconcile according to env values and HCO CR", func() {
-			virtiowink := "virtio-win-image"
-			updatableKeys := [...]string{virtiowink}
-			toBeRemovedKey := "toberemoved"
+			updatableKeys := [...]string{virtioWinImageKey}
+			const toBeRemovedKey = "toberemoved"
 
-			expectedResource, err := NewVirtioWinCm()
+			expectedResource, err := NewVirtioWinCm(commontestutils.NewHco())
 			Expect(err).ToNot(HaveOccurred())
 
-			outdatedResource, err := NewVirtioWinCm()
+			outdatedResource, err := NewVirtioWinCm(commontestutils.NewHco())
 			Expect(err).ToNot(HaveOccurred())
 
 			// values we should update
-			outdatedResource.Data[virtiowink] = "old-virtiowin-container-value-we-have-to-update"
+			outdatedResource.Data[virtioWinImageKey] = "old-virtiowin-container-value-we-have-to-update"
 
 			// add values we should remove
 			outdatedResource.Data[toBeRemovedKey] = "value-we-should-remove"
@@ -112,8 +114,7 @@ var _ = Describe("VirtioWin", func() {
 			).ToNot(HaveOccurred())
 
 			for _, k := range updatableKeys {
-				Expect(foundResource.Data[k]).ToNot(Equal(outdatedResource.Data[k]))
-				Expect(foundResource.Data[k]).To(Equal(expectedResource.Data[k]))
+				Expect(foundResource.Data).To(HaveKeyWithValue(k, expectedResource.Data[k]))
 			}
 
 			Expect(foundResource.Data).ToNot(HaveKey(toBeRemovedKey))
@@ -131,7 +132,7 @@ var _ = Describe("VirtioWin", func() {
 		It("should reconcile managed labels to default without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource, err := NewVirtioWinCm()
+			outdatedResource, err := NewVirtioWinCm(commontestutils.NewHco())
 			Expect(err).ToNot(HaveOccurred())
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			for k, v := range expectedLabels {
@@ -162,7 +163,7 @@ var _ = Describe("VirtioWin", func() {
 		It("should reconcile managed labels to default without touching user added ones", func() {
 			const userLabelKey = "userLabelKey"
 			const userLabelValue = "userLabelValue"
-			outdatedResource, err := NewVirtioWinCm()
+			outdatedResource, err := NewVirtioWinCm(commontestutils.NewHco())
 			Expect(err).ToNot(HaveOccurred())
 			expectedLabels := maps.Clone(outdatedResource.Labels)
 			outdatedResource.Labels[userLabelKey] = userLabelValue
@@ -188,6 +189,98 @@ var _ = Describe("VirtioWin", func() {
 			Expect(foundResource.Labels).To(HaveKeyWithValue(userLabelKey, userLabelValue))
 		})
 
+		It("should not add the download URL if the env var is missing", func() {
+			cl := commontestutils.InitClient([]client.Object{})
+			handler, _ := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+
+			foundResource := &corev1.ConfigMap{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: virtioWinCmName, Namespace: commontestutils.Namespace},
+					foundResource),
+			).To(Succeed())
+
+			Expect(foundResource.Data).To(HaveKeyWithValue(virtioWinImageKey, virtioImage))
+			Expect(foundResource.Data).ToNot(HaveKey(virtioWinImageDLKey))
+		})
+
+		It("should not add the download URL if the env var is empty", func() {
+			Expect(os.Setenv(hcoutil.VirtIOWinDataFileEnvV, "")).To(Succeed())
+			DeferCleanup(func() {
+				Expect(os.Unsetenv(hcoutil.VirtIOWinDataFileEnvV)).To(Succeed())
+			})
+
+			cl := commontestutils.InitClient([]client.Object{})
+			handler, _ := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+
+			foundResource := &corev1.ConfigMap{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: virtioWinCmName, Namespace: commontestutils.Namespace},
+					foundResource),
+			).To(Succeed())
+
+			Expect(foundResource.Data).To(HaveKeyWithValue(virtioWinImageKey, virtioImage))
+			Expect(foundResource.Data).ToNot(HaveKey(virtioWinImageDLKey))
+		})
+
+		It("should add the download URL if the env var is set", func() {
+			origHost := downloadhost.Get()
+			DeferCleanup(func() {
+				downloadhost.Set(origHost)
+			})
+
+			downloadhost.Set(downloadhost.CLIDownloadHost{
+				DefaultHost: "default-host.com",
+				CurrentHost: "default-host.com",
+				Cert:        "crt",
+				Key:         "key",
+			})
+
+			Expect(os.Setenv(hcoutil.VirtIOWinDataFileEnvV, "virtio-win/virtio-win.iso")).To(Succeed())
+			DeferCleanup(func() {
+				Expect(os.Unsetenv(hcoutil.VirtIOWinDataFileEnvV)).To(Succeed())
+			})
+
+			cl := commontestutils.InitClient([]client.Object{})
+			handler, _ := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+
+			foundResource := &corev1.ConfigMap{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: virtioWinCmName, Namespace: commontestutils.Namespace},
+					foundResource),
+			).To(Succeed())
+
+			Expect(foundResource.Data).To(HaveKeyWithValue(virtioWinImageKey, virtioImage))
+			Expect(foundResource.Data).To(HaveKeyWithValue(virtioWinImageDLKey, "https://default-host.com/virtio-win/virtio-win.iso"))
+
+			By("should update the download URL if it was customized")
+			downloadhost.Set(downloadhost.CLIDownloadHost{
+				DefaultHost: "default-host.com",
+				CurrentHost: "cli-dl.example.com",
+				Cert:        "crt",
+				Key:         "key",
+			})
+
+			handler.Reset()
+			res = handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			foundResource = &corev1.ConfigMap{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: virtioWinCmName, Namespace: commontestutils.Namespace},
+					foundResource),
+			).To(Succeed())
+
+			Expect(foundResource.Data).To(HaveKeyWithValue(virtioWinImageDLKey, "https://cli-dl.example.com/virtio-win/virtio-win.iso"))
+		})
 	})
 
 	Context("ConfigMap Reader Role", func() {
@@ -195,7 +288,7 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", "new-virtiowin-container-value")
+			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})
@@ -246,7 +339,7 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", "new-virtiowin-container-value")
+			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})

--- a/controllers/handlers/virtio_win_ConfigMap_test.go
+++ b/controllers/handlers/virtio_win_ConfigMap_test.go
@@ -30,13 +30,13 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
+			Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, virtioImage)).To(Succeed())
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})
 
 		It("should error if VIRTIOWIN_CONTAINER environment var not specified", func() {
-			os.Unsetenv("VIRTIOWIN_CONTAINER")
+			Expect(os.Unsetenv(hcoutil.VirtioWinImageEnvV)).To(Succeed())
 
 			cl := commontestutils.InitClient([]client.Object{})
 			handler, err := NewVirtioWinCmHandler(cl, commontestutils.GetScheme())
@@ -288,7 +288,7 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
+			Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, virtioImage)).To(Succeed())
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})
@@ -339,7 +339,7 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
+			Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, virtioImage)).To(Succeed())
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -57,7 +57,7 @@ var _ = Describe("HyperconvergedController", func() {
 	getClusterInfo := hcoutil.GetClusterInfo
 
 	origOperatorCondVarName := os.Getenv(hcoutil.OperatorConditionNameEnvVar)
-	origVirtIOWinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
+	origVirtIOWinContainer := os.Getenv(hcoutil.VirtioWinImageEnvV)
 	origVersion := os.Getenv(hcoutil.HcoKvIoVersionName)
 
 	BeforeEach(func() {
@@ -67,7 +67,7 @@ var _ = Describe("HyperconvergedController", func() {
 		fakeownresources.OLMV0OwnResourcesMock()
 
 		Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, "OPERATOR_CONDITION")).To(Succeed())
-		Expect(os.Setenv("VIRTIOWIN_CONTAINER", commontestutils.VirtioWinImage)).To(Succeed())
+		Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, commontestutils.VirtioWinImage)).To(Succeed())
 		Expect(os.Setenv(hcoutil.HcoKvIoVersionName, version.Version)).To(Succeed())
 
 		reqresolver.GeneratePlaceHolders()
@@ -77,7 +77,7 @@ var _ = Describe("HyperconvergedController", func() {
 			fakeownresources.ResetOwnResources()
 
 			Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, origOperatorCondVarName)).To(Succeed())
-			Expect(os.Setenv("VIRTIOWIN_CONTAINER", origVirtIOWinContainer)).To(Succeed())
+			Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, origVirtIOWinContainer)).To(Succeed())
 			Expect(os.Setenv(hcoutil.HcoKvIoVersionName, origVersion)).To(Succeed())
 		})
 	})
@@ -1805,7 +1805,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 		Context("Update Conflict Error", func() {
 			BeforeEach(func() {
-				Expect(os.Setenv("VIRTIOWIN_CONTAINER", commontestutils.VirtioWinImage)).To(Succeed())
+				Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, commontestutils.VirtioWinImage)).To(Succeed())
 			})
 
 			It("Should requeue in case of update conflict", func() {

--- a/controllers/hyperconverged/testUtils_test.go
+++ b/controllers/hyperconverged/testUtils_test.go
@@ -278,7 +278,7 @@ func getBasicDeployment() *BasicExpected {
 	expectedCliDownloadsService := handlers.NewCliDownloadsService()
 	res.cliDownloadsService = expectedCliDownloadsService
 
-	expectedVirtioWinConfig, err := handlers.NewVirtioWinCm()
+	expectedVirtioWinConfig, err := handlers.NewVirtioWinCm(hco)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	res.virtioWinConfig = expectedVirtioWinConfig
 

--- a/controllers/hyperconverged/upgrade_test.go
+++ b/controllers/hyperconverged/upgrade_test.go
@@ -51,14 +51,14 @@ var _ = Describe("Upgrade Mode", func() {
 		fakeownresources.OLMV0OwnResourcesMock()
 
 		origOperatorCondVarName := os.Getenv(hcoutil.OperatorConditionNameEnvVar)
-		origVirtIOWinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
+		origVirtIOWinContainer := os.Getenv(hcoutil.VirtioWinImageEnvV)
 		origVersion := os.Getenv(hcoutil.HcoKvIoVersionName)
 
 		hcoutil.GetClusterInfo = func() hcoutil.ClusterInfo {
 			return commontestutils.ClusterInfoMock{}
 		}
 		Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, "OPERATOR_CONDITION")).To(Succeed())
-		Expect(os.Setenv("VIRTIOWIN_CONTAINER", commontestutils.VirtioWinImage)).To(Succeed())
+		Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, commontestutils.VirtioWinImage)).To(Succeed())
 		Expect(os.Setenv(hcoutil.HcoKvIoVersionName, version.Version)).To(Succeed())
 
 		reqresolver.GeneratePlaceHolders()
@@ -108,7 +108,7 @@ var _ = Describe("Upgrade Mode", func() {
 			fakeownresources.ResetOwnResources()
 
 			Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, origOperatorCondVarName)).To(Succeed())
-			Expect(os.Setenv("VIRTIOWIN_CONTAINER", origVirtIOWinContainer)).To(Succeed())
+			Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, origVirtIOWinContainer)).To(Succeed())
 			Expect(os.Setenv(hcoutil.HcoKvIoVersionName, origVersion)).To(Succeed())
 		})
 	})

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -1,6 +1,8 @@
 package components
 
 import (
+	"path"
+
 	persesv1alpha1 "github.com/rhobs/perses-operator/api/v1alpha1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -28,6 +30,8 @@ const DisableOperandDeletionAnnotation = "console.openshift.io/disable-operand-d
 
 const (
 	crName = util.HyperConvergedName
+
+	artifactServerMountName = "virtiowin-data"
 )
 
 type DeploymentOperatorParams struct {
@@ -46,6 +50,8 @@ type DeploymentOperatorParams struct {
 	ConversionContainer       string
 	VmwareContainer           string
 	VirtIOWinContainer        string
+	VirtIOWinDataFile         string
+	VirtIOWinMountPath        string
 	Smbios                    string
 	Machinetype               string
 	Amd64MachineType          string
@@ -68,8 +74,6 @@ type DeploymentOperatorParams struct {
 }
 
 func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.DeploymentSpec {
-	envs := buildEnvVars(params)
-
 	return appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
 		Selector: &metav1.LabelSelector{
@@ -95,7 +99,7 @@ func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.Deployme
 						Command:         stringListToSlice(util.HCOOperatorName),
 						ReadinessProbe:  getReadinessProbe(util.ReadinessEndpointName, util.HealthProbePort),
 						LivenessProbe:   getLivenessProbe(util.LivenessEndpointName, util.HealthProbePort),
-						Env:             envs,
+						Env:             buildOperatorEnvVars(params),
 						Resources: corev1.ResourceRequirements{
 							Requests: map[corev1.ResourceName]resource.Quantity{
 								corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -115,7 +119,7 @@ func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.Deployme
 	}
 }
 
-func buildEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
+func buildOperatorEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
 	envs := append([]corev1.EnvVar{
 		{
 			// deprecated: left here for CI test.
@@ -258,11 +262,19 @@ func buildEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
 		})
 	}
 
+	if params.VirtIOWinDataFile != "" && params.VirtIOWinMountPath != "" {
+		value := path.Join(util.VirtIODownloadDir, path.Base(params.VirtIOWinDataFile))
+		envs = append(envs, corev1.EnvVar{
+			Name:  util.VirtIOWinDataFileEnvV,
+			Value: value,
+		})
+	}
+
 	return envs
 }
 
 func GetDeploymentSpecCliDownloads(params *DeploymentOperatorParams) appsv1.DeploymentSpec {
-	return appsv1.DeploymentSpec{
+	spec := appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -307,6 +319,49 @@ func GetDeploymentSpecCliDownloads(params *DeploymentOperatorParams) appsv1.Depl
 			},
 		},
 	}
+
+	addVirtIOVolume(&spec, params)
+
+	return spec
+}
+
+func addVirtIOVolume(spec *appsv1.DeploymentSpec, params *DeploymentOperatorParams) {
+	const initContainerMount = "/mnt/" + artifactServerMountName
+	if params.VirtIOWinDataFile == "" || params.VirtIOWinMountPath == "" {
+		return
+	}
+
+	spec.Template.Spec.Volumes = append(spec.Template.Spec.Volumes, corev1.Volume{
+		Name:         artifactServerMountName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	})
+	spec.Template.Spec.InitContainers = append(spec.Template.Spec.InitContainers, corev1.Container{
+		Name:            "virtiowin-data-loader",
+		Image:           params.VirtIOWinContainer,
+		ImagePullPolicy: corev1.PullPolicy(params.ImagePullPolicy),
+		Command:         []string{"cp", params.VirtIOWinDataFile, initContainerMount},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: artifactServerMountName, MountPath: initContainerMount},
+		},
+		SecurityContext:          getVirtIOWinInitContainerSecurityContext(),
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+		},
+	})
+
+	mountPath := path.Join(params.VirtIOWinMountPath, util.VirtIODownloadDir)
+	spec.Template.Spec.Containers[0].VolumeMounts = append(
+		spec.Template.Spec.Containers[0].VolumeMounts,
+		corev1.VolumeMount{Name: artifactServerMountName, MountPath: mountPath, ReadOnly: true},
+	)
 }
 
 func GetLabels(name, hcoKvIoVersion string) map[string]string {
@@ -344,6 +399,15 @@ func GetStdContainerSecurityContext() *corev1.SecurityContext {
 			Drop: []corev1.Capability{"ALL"},
 		},
 	}
+}
+
+// getVirtIOWinInitContainerSecurityContext returns a security context for the virtiowin init
+// container. It sets runAsUser explicitly so that the pod-level runAsNonRoot constraint is met
+// even when the data-only image has no USER directive and would otherwise run as root.
+func getVirtIOWinInitContainerSecurityContext() *corev1.SecurityContext {
+	sc := GetStdContainerSecurityContext()
+	sc.RunAsUser = ptr.To[int64](1001)
+	return sc
 }
 
 // Currently we are abusing the pod readiness to signal to OLM that HCO is not ready
@@ -384,41 +448,7 @@ func GetDeploymentSpecWebhook(params *DeploymentOperatorParams) appsv1.Deploymen
 						Command:         stringListToSlice(util.HCOWebhookName),
 						ReadinessProbe:  getReadinessProbe(util.ReadinessEndpointName, util.HealthProbePort),
 						LivenessProbe:   getLivenessProbe(util.LivenessEndpointName, util.HealthProbePort),
-						Env: append([]corev1.EnvVar{
-							{
-								// deprecated: left here for CI test.
-								Name:  util.OperatorWebhookModeEnv,
-								Value: "true",
-							},
-							{
-								Name:  util.ContainerAppName,
-								Value: util.ContainerWebhookApp,
-							},
-							{
-								Name:  "OPERATOR_IMAGE",
-								Value: params.WebhookImage,
-							},
-							{
-								Name:  "OPERATOR_NAME",
-								Value: util.HCOWebhookName,
-							},
-							{
-								Name:  "OPERATOR_NAMESPACE",
-								Value: params.Namespace,
-							},
-							{
-								Name: "POD_NAME",
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "metadata.name",
-									},
-								},
-							},
-							{
-								Name:  util.HcoKvIoVersionName,
-								Value: params.HcoKvIoVersion,
-							},
-						}, params.Env...),
+						Env:             buildWebhookEnvVars(params),
 						Resources: corev1.ResourceRequirements{
 							Requests: map[corev1.ResourceName]resource.Quantity{
 								corev1.ResourceCPU:    resource.MustParse("5m"),
@@ -437,6 +467,44 @@ func GetDeploymentSpecWebhook(params *DeploymentOperatorParams) appsv1.Deploymen
 			},
 		},
 	}
+}
+
+func buildWebhookEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
+	return append([]corev1.EnvVar{
+		{
+			// deprecated: left here for CI test.
+			Name:  util.OperatorWebhookModeEnv,
+			Value: "true",
+		},
+		{
+			Name:  util.ContainerAppName,
+			Value: util.ContainerWebhookApp,
+		},
+		{
+			Name:  "OPERATOR_IMAGE",
+			Value: params.WebhookImage,
+		},
+		{
+			Name:  "OPERATOR_NAME",
+			Value: util.HCOWebhookName,
+		},
+		{
+			Name:  "OPERATOR_NAMESPACE",
+			Value: params.Namespace,
+		},
+		{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name:  util.HcoKvIoVersionName,
+			Value: params.HcoKvIoVersion,
+		},
+	}, params.Env...)
 }
 
 var (

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -155,7 +155,7 @@ func buildOperatorEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
 			},
 		},
 		{
-			Name:  "VIRTIOWIN_CONTAINER",
+			Name:  util.VirtioWinImageEnvV,
 			Value: params.VirtIOWinContainer,
 		},
 		{

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -35,6 +35,8 @@ const (
 	AIEWebhookImageEnvV                     = "AIE_WEBHOOK_IMAGE"
 	IOMMUFDDevicePluginImageEnvV            = "IOMMUFD_DEVICE_PLUGIN_IMAGE"
 	DeployNetworkPoliciesEnvV               = "DEPLOY_NETWORK_POLICIES"
+	VirtIOWinDataFileEnvV                   = "DEPLOY_VIRT_IO_WIN_DATA_FILE"
+	VirtIODownloadDir                       = "virtio-win"
 	HcoValidatingWebhook                    = "validate-hco.kubevirt.io"
 	HcoV1Beta1ValidatingWebhook             = "validate-hco-v1beta1.kubevirt.io"
 	HcoMutatingWebhookNS                    = "mutate-ns-hco.kubevirt.io"

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -31,6 +31,7 @@ const (
 	KVUIProxyImageEnvV                      = "KV_CONSOLE_PROXY_IMAGE"
 	PasstImageEnvV                          = "PASST_SIDECAR_IMAGE"
 	PasstCNIImageEnvV                       = "PASST_CNI_IMAGE"
+	VirtioWinImageEnvV                      = "VIRTIOWIN_CONTAINER"
 	WaspAgentImageEnvV                      = "WASP_AGENT_IMAGE"
 	AIEWebhookImageEnvV                     = "AIE_WEBHOOK_IMAGE"
 	IOMMUFDDevicePluginImageEnvV            = "IOMMUFD_DEVICE_PLUGIN_IMAGE"

--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	v1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -23,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
@@ -59,6 +62,8 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 
 		Expect(ccd.Spec.Links).To(HaveLen(7))
 
+		httpClient := getHTTPClient()
+
 		for _, link := range ccd.Spec.Links {
 			// virtctl for Windows for ARM 64 is still not shipped, avoid checking it
 			// TODO: remove this once ready
@@ -66,16 +71,19 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 				continue
 			}
 			By("Checking links. Link:" + link.Href)
-			client := &http.Client{Transport: &http.Transport{
-				// ssl of the route is irrelevant
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}}
-			resp, err := client.Get(link.Href)
-			_ = resp.Body.Close()
+			resp, err := httpClient.Head(link.Href)
+
+			Expect(err).NotTo(HaveOccurred(), "HEAD failed for %s", link.Href)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "non OK response for %s", link.Href)
 
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			ExpectWithOffset(1, resp).To(HaveHTTPStatus(http.StatusOK))
 		}
+
+		link, err := url.Parse(ccd.Spec.Links[0].Href)
+		Expect(err).ToNot(HaveOccurred())
+
+		checkVirtioWinDownload(ctx, cli, httpClient, link.Host)
 	})
 
 	Context("URL Download customization", func() {
@@ -122,9 +130,7 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 			patch := []byte(fmt.Sprintf(`[{"op": "add", "path": "/spec/componentRoutes", "value": [{"name": "virt-downloads", "hostname": %q, "namespace": %q}]}]`, newCLIDLHost, tests.InstallNamespace))
 			Expect(cli.Patch(ctx, ingress, client.RawPatch(types.JSONPatchType, patch))).To(Succeed())
 
-			customTransport := http.DefaultTransport.(*http.Transport).Clone()
-			customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-			httpClient := &http.Client{Transport: customTransport, Timeout: time.Second * 1}
+			httpClient := getHTTPClient()
 
 			ccdKey := client.ObjectKey{Name: "virtctl-clidownloads-kubevirt-hyperconverged"}
 
@@ -144,13 +150,17 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 					g.Expect(link.Href).To(ContainSubstring(newCLIDLHost))
 					res, err := httpClient.Head(link.Href)
 					g.Expect(err).NotTo(HaveOccurred(), "HEAD failed for %s", link.Href)
+					if res.Body != nil {
+						g.Expect(res.Body.Close()).To(Succeed())
+					}
 					g.Expect(res.StatusCode).To(Equal(http.StatusOK), "non OK response for %s", link.Href)
 				}
 			}).WithContext(ctx).
 				WithTimeout(60 * time.Second).
-				WithPolling(time.Second).
+				WithPolling(5 * time.Second).
 				Should(Succeed())
 
+			By("check route")
 			routeKey := client.ObjectKey{Name: downloadhost.CLIDownloadsServiceName, Namespace: tests.InstallNamespace}
 			Eventually(func(g Gomega, ctx context.Context) {
 				route := &v1.Route{}
@@ -160,6 +170,51 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 				WithTimeout(60 * time.Second).
 				WithPolling(time.Second).
 				Should(Succeed())
+
+			checkVirtioWinDownload(ctx, cli, httpClient, newCLIDLHost)
 		})
 	})
 })
+
+func getHTTPClient() *http.Client {
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	return &http.Client{Transport: customTransport, Timeout: time.Second * 3}
+}
+
+func checkVirtioWinDownload(ctx context.Context, cli client.Client, httpClient *http.Client, cliDLHost string) {
+	GinkgoHelper()
+
+	By("check the virtio-win iso download")
+	var hcoPods corev1.PodList
+	Expect(cli.List(ctx, &hcoPods, &client.MatchingLabels{
+		"name": "hyperconverged-cluster-operator",
+	})).To(Succeed())
+	Expect(hcoPods.Items).ToNot(BeEmpty())
+
+	pod := hcoPods.Items[0]
+	idx := slices.IndexFunc(pod.Spec.Containers[0].Env, func(env corev1.EnvVar) bool {
+		return env.Name == hcoutil.VirtIOWinDataFileEnvV
+	})
+
+	if idx < 0 {
+		GinkgoLogr.Info(fmt.Sprintf("The HCO pod does not have the %s env var; virtio-win image download is not implemented", hcoutil.VirtIOWinDataFileEnvV))
+		return
+	}
+
+	virtioWinDLPath := pod.Spec.Containers[0].Env[idx].Value
+
+	virtioWinCM := &corev1.ConfigMap{}
+	Expect(cli.Get(ctx, client.ObjectKey{Namespace: tests.InstallNamespace, Name: "virtio-win"}, virtioWinCM)).To(Succeed())
+
+	virtioWinDLPathURL, urlExists := virtioWinCM.Data["virtio-win-image-download-url"]
+	Expect(urlExists).To(BeTrue())
+	Expect(virtioWinDLPathURL).To(ContainSubstring(cliDLHost))
+	Expect(virtioWinDLPathURL).To(HaveSuffix(virtioWinDLPath))
+	res, err := httpClient.Head(virtioWinDLPathURL)
+	Expect(err).NotTo(HaveOccurred(), "HEAD failed for %s", virtioWinDLPathURL)
+	if res.Body != nil {
+		Expect(res.Body.Close()).To(Succeed())
+	}
+	Expect(res.StatusCode).To(Equal(http.StatusOK), "non OK response for %s", virtioWinDLPathURL)
+}

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -102,6 +102,8 @@ var (
 	kvUIPluginImage          = flag.String("kubevirt-consoleplugin-image-name", "", "KubeVirt Console Plugin image")
 	kvUIProxyImage           = flag.String("kubevirt-consoleproxy-image-name", "", "KubeVirt Console Proxy image")
 	kvVirtIOWinImage         = flag.String("kv-virtiowin-image-name", "", "KubeVirt VirtIO Win image")
+	kvVirtIOWinDataFile      = flag.String("kv-virtiowin-data-file", "", "Path to the data file inside the VirtIO Win image")
+	kvVirtIOWinMountPath     = flag.String("kv-virtiowin-data-mount-path", "", "Absolute mount path for the VirtIO Win data file in the server container")
 	passtImage               = flag.String("network-passt-binding-image-name", "", "Passt binding image")
 	passtCNIImage            = flag.String("network-passt-binding-cni-image-name", "", "Passt binding cni image")
 	waspAgentImage           = flag.String("wasp-agent-image-name", "", "Wasp Agent image")
@@ -311,17 +313,17 @@ type csvBaseParams struct {
 // getCSVBase returns a base HCO CSV without an InstallStrategy
 func getCSVBase(params *csvBaseParams) *csvv1alpha1.ClusterServiceVersion {
 	almExamples, _ := json.Marshal(
-		map[string]interface{}{
+		map[string]any{
 			"apiVersion": hcoutil.APIVersion,
 			"kind":       hcoutil.HyperConvergedKind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      packageName,
 				"namespace": params.Namespace,
 				"annotations": map[string]string{
 					"deployOVS": "false",
 				},
 			},
-			"spec": map[string]interface{}{},
+			"spec": map[string]any{},
 		})
 
 	// Explicitly fail on unvalidated (for any reason) requests:
@@ -495,8 +497,6 @@ func getCSVBase(params *csvBaseParams) *csvv1alpha1.ClusterServiceVersion {
 						Kind:        hcoutil.HyperConvergedKind,
 						DisplayName: params.CrdDisplay + " Deployment",
 						Description: "Represents the deployment of " + params.CrdDisplay,
-						// TODO: move this to annotations on hyperconverged_types.go once kubebuilder
-						// properly supports SpecDescriptors as the operator-sdk already does
 						SpecDescriptors: []csvv1alpha1.SpecDescriptor{
 							{
 								DisplayName: "Infra components node affinity",
@@ -677,8 +677,8 @@ func processOneCsv(c util.CsvWithComponent, installStrategyBase *csvv1alpha1.Str
 	}
 	csvBaseAlmString := csvBase.Annotations[almExamplesAnnotation]
 	csvStructAlmString := csvStruct.Annotations[almExamplesAnnotation]
-	var baseAlmcrs []interface{}
-	var structAlmcrs []interface{}
+	var baseAlmcrs []any
+	var structAlmcrs []any
 
 	if !strings.HasPrefix(csvBaseAlmString, "[") {
 		csvBaseAlmString = "[" + csvBaseAlmString + "]"
@@ -775,6 +775,8 @@ func getDeploymentParams() *components.DeploymentOperatorParams {
 		KVUIProxyImage:            *kvUIProxyImage,
 		ImagePullPolicy:           "IfNotPresent",
 		VirtIOWinContainer:        *kvVirtIOWinImage,
+		VirtIOWinDataFile:         *kvVirtIOWinDataFile,
+		VirtIOWinMountPath:        *kvVirtIOWinMountPath,
 		Smbios:                    *smbios,
 		Machinetype:               *machinetype,
 		Amd64MachineType:          *amd64MachineType,

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -56,6 +56,8 @@ var (
 	webhookImage              = flag.String("webhook-image", "", "HyperConverged Cluster Webhook image")
 	cliDownloadsImage         = flag.String("cli-downloads-image", "", "Downloads Server image")
 	kvVirtIOWinImage          = flag.String("kv-virtiowin-image-name", "", "KubeVirt VirtIO Win image")
+	kvVirtIOWinDataFile       = flag.String("kv-virtiowin-data-file", "", "Path to the data file inside the VirtIO Win image")
+	kvVirtIOWinMountPath      = flag.String("kv-virtiowin-data-mount-path", "", "Absolute mount path for the VirtIO Win data file in the server container")
 	waspAgentImage            = flag.String("wasp-agent-image-name", "", "wasp-agent image")
 	aieWebhookImage           = flag.String("aie-webhook-image-name", "", "AIE webhook image")
 	iommufdDevicePluginImage  = flag.String("iommufd-device-plugin-image-name", "", "IOMMUFD device plugin image")
@@ -440,6 +442,8 @@ func getOperatorParameters() *components.DeploymentOperatorParams {
 		CliDownloadsImage:         *cliDownloadsImage,
 		ImagePullPolicy:           "IfNotPresent",
 		VirtIOWinContainer:        *kvVirtIOWinImage,
+		VirtIOWinDataFile:         *kvVirtIOWinDataFile,
+		VirtIOWinMountPath:        *kvVirtIOWinMountPath,
 		WaspAgentImage:            *waspAgentImage,
 		AIEWebhookImage:           *aieWebhookImage,
 		IOMMUFDDevicePluginImage:  *iommufdDevicePluginImage,


### PR DESCRIPTION
**What this PR does / why we need it**:

*This is a manual cherry pick of #4413*

Windows virtual machine users need the virtio-win iso file for debugging of their VMs. The purpose of this PR is to make this image available for download using the existing artifact download server.

The csv-merger and the manifest-templator tools were modified to accept new optional parameters:
* `kv-virtiowin-data-mount-path` - The mount point of the image.
* `kv-virtiowin-data-file`- The location of the iso file within the image.

If these new parameter are sent, the artifacts download server deployment manifest will mount run the virtio-win image, as an init container, to copy the file to new mounted volume. The server will allow downloading the iso file from `${kv-virtiowin-data-mount-path}/virtio-win` path.

If the new `DEPLOY_VIRT_IO_WIN_DATA_FILE` environment variable is set, HCO will add the download URL of the virtio-win iso file, to the existing `virtio-win` ConfigMap, under the new optional `"virtio-win-image-download-url"` key.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-47050
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow downloading of the virtio-win iso image from the artifacts server
```
