### PR TITLE
handlers, netresinjector: Gate ExternalNetResourceInjection FG on NRI deployment readiness status

### DIFF
--- a/api/v1/hyperconverged_types.go
+++ b/api/v1/hyperconverged_types.go
@@ -943,6 +943,10 @@ const (
 	// has been applied to the HyperConverged resource via a specialized annotation.
 	// This condition is exposed only when its value is True, and is otherwise hidden.
 	ConditionTaintedConfiguration = "TaintedConfiguration"
+
+	// ConditionNetworkResourcesInjectorReady indicates whether the network resources injector
+	// deployment is fully ready (all replicas running).
+	ConditionNetworkResourcesInjectorReady = "NetworkResourcesInjectorReady"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/api/v1/hyperconverged_types.go
+++ b/api/v1/hyperconverged_types.go
@@ -166,7 +166,7 @@ type HyperConvergedSpec struct {
 	Security SecurityConfig `json:"security,omitempty"`
 
 	// Deployment contains all the configurations related to deployment of KubeVirt components
-	// +kubebuilder:default={"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}
+	// +kubebuilder:default={"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}
 	// +optional
 	// +k8s:conversion-gen=false
 	Deployment DeploymentConfig `json:"deployment,omitempty"`
@@ -441,6 +441,8 @@ type DeploymentConfig struct {
 	// When enabled, the network-resources-injector mutating webhook will be deployed to automatically
 	// inject resource requests for custom resources annotated in NetworkAttachmentDefinition.
 	// +optional
+	// +kubebuilder:default=true
+	// +default=true
 	DeployNetworkResourcesInjector *bool `json:"deployNetworkResourcesInjector,omitempty"`
 }
 
@@ -955,7 +957,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}}
+	// +kubebuilder:default={"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/api/v1/zz_generated.defaults.go
+++ b/api/v1/zz_generated.defaults.go
@@ -144,6 +144,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.Deployment.DeployVMConsoleProxy = &ptrVar1
 	}
+	if in.Spec.Deployment.DeployNetworkResourcesInjector == nil {
+		var ptrVar1 bool = true
+		in.Spec.Deployment.DeployNetworkResourcesInjector = &ptrVar1
+	}
 }
 
 func SetObjectDefaults_HyperConvergedList(in *HyperConvergedList) {

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/controllers/common/consts.go
+++ b/controllers/common/consts.go
@@ -1,6 +1,16 @@
 package common
 
-import "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+import (
+	"k8s.io/utils/ptr"
+
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+)
+
+// ShouldDeployNetworkResourcesInjector checks if network-resources-injector should be deployed
+func ShouldDeployNetworkResourcesInjector(hc *hcov1.HyperConverged) bool {
+	return ptr.Deref(hc.Spec.Deployment.DeployNetworkResourcesInjector, true)
+}
 
 const (
 	ReconcileCompleted        = "ReconcileCompleted"

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -132,18 +133,19 @@ const (
 
 // KubeVirt feature gates that are exposed in HCO API
 const (
-	kvDownwardMetrics            = "DownwardMetrics"
-	kvAlignCPUs                  = "AlignCPUs"
-	kvDecentralizedLiveMigration = "DecentralizedLiveMigration"
-	kvObjectGraph                = "ObjectGraph"
-	kvUtilityVolumes             = "UtilityVolumes"
-	kvIncrementalBackup          = "IncrementalBackup"
-	kvPasstBinding               = "PasstBinding"
-	kvConfigurableHypervisor     = "ConfigurableHypervisor"
-	kvOptOutRoleAggregation      = "OptOutRoleAggregation"
-	kvContainerPathVolumes       = "ContainerPathVolumes"
-	kvPCINUMAAwareTopology       = "PCINUMAAwareTopology"
-	kvTemplateFG                 = "Template"
+	kvDownwardMetrics              = "DownwardMetrics"
+	kvAlignCPUs                    = "AlignCPUs"
+	kvDecentralizedLiveMigration   = "DecentralizedLiveMigration"
+	kvObjectGraph                  = "ObjectGraph"
+	kvUtilityVolumes               = "UtilityVolumes"
+	kvIncrementalBackup            = "IncrementalBackup"
+	kvPasstBinding                 = "PasstBinding"
+	kvConfigurableHypervisor       = "ConfigurableHypervisor"
+	kvOptOutRoleAggregation        = "OptOutRoleAggregation"
+	kvContainerPathVolumes         = "ContainerPathVolumes"
+	kvPCINUMAAwareTopology         = "PCINUMAAwareTopology"
+	kvTemplateFG                   = "Template"
+	kvExternalNetResourceInjection = "ExternalNetResourceInjection"
 )
 
 // CPU Plugin default values
@@ -990,6 +992,11 @@ func getFeatureGateChecks(hc *hcov1.HyperConverged) []string {
 
 	if featureGates.IsEnabled(kvTemplateFG) {
 		fgs = append(fgs, kvTemplateFG)
+	}
+
+	if common.ShouldDeployNetworkResourcesInjector(hc) &&
+		meta.IsStatusConditionTrue(hc.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady) {
+		fgs = append(fgs, kvExternalNetResourceInjection)
 	}
 
 	return fgs

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -2506,6 +2507,42 @@ Version: 1.2.3`)
 					Expect(disabled).To(ContainElement(kvPasstBinding))
 				})
 
+				DescribeTable("should enable ExternalNetResourceInjection FG", func(deploy *bool) {
+					hco.Spec.Deployment.DeployNetworkResourcesInjector = deploy
+					apimeta.SetStatusCondition(&hco.Status.Conditions, metav1.Condition{
+						Type:   hcov1.ConditionNetworkResourcesInjectorReady,
+						Status: metav1.ConditionTrue,
+						Reason: "DeploymentReady",
+					})
+					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
+					fgs := getKvFeatureGateList(hco)
+					disabled := getKvDisabledFeatureGateList(fgs)
+					Expect(disabled).NotTo(ContainElement(kvExternalNetResourceInjection))
+				},
+					Entry("when enabled=true and ready=true", ptr.To(true)),
+					Entry("when enabled=nil (default) and ready=true", (*bool)(nil)),
+				)
+
+				DescribeTable("should disable ExternalNetResourceInjection FG", func(deploy *bool, conditionTrue bool) {
+					hco.Spec.Deployment.DeployNetworkResourcesInjector = deploy
+					if conditionTrue {
+						apimeta.SetStatusCondition(&hco.Status.Conditions, metav1.Condition{
+							Type:   hcov1.ConditionNetworkResourcesInjectorReady,
+							Status: metav1.ConditionTrue,
+							Reason: "DeploymentReady",
+						})
+					}
+					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
+					fgs := getKvFeatureGateList(hco)
+					disabled := getKvDisabledFeatureGateList(fgs)
+					Expect(disabled).To(ContainElement(kvExternalNetResourceInjection))
+				},
+					Entry("when enabled=true and ready=false", ptr.To(true), false),
+					Entry("when enabled=false and ready=true", ptr.To(false), true),
+					Entry("when enabled=false and ready=false", ptr.To(false), false),
+					Entry("when enabled=nil (default) and ready=false", (*bool)(nil), false),
+				)
+
 				It("should include all beta FG if not in the enabled list", func() {
 					mandatoryKvFeatureGates = getMandatoryKvFeatureGates(false)
 					fgs := getKvFeatureGateList(hco)
@@ -3299,6 +3336,28 @@ Version: 1.2.3`)
 				Expect(kv.Spec.Configuration.RoleAggregationStrategy).To(BeNil())
 				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvOptOutRoleAggregation))
 			})
+		})
+
+		Context("DeployNetworkResourcesInjector", func() {
+			It("should add ExternalNetResourceInjection FG when NetResInj is ready", func() {
+				apimeta.SetStatusCondition(&hco.Status.Conditions, metav1.Condition{
+					Type:   hcov1.ConditionNetworkResourcesInjectorReady,
+					Status: metav1.ConditionTrue,
+					Reason: "DeploymentReady",
+				})
+				kv, err := NewKubeVirt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement(kvExternalNetResourceInjection))
+			})
+
+			It("should not add ExternalNetResourceInjection FG when NetResInj not ready", func() {
+				kv, err := NewKubeVirt(hco)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement(kvExternalNetResourceInjection))
+			})
+
 		})
 
 		Context("VM state storage class", func() {

--- a/controllers/handlers/netresinjector/common.go
+++ b/controllers/handlers/netresinjector/common.go
@@ -1,9 +1,8 @@
 package netresinjector
 
 import (
-	"k8s.io/utils/ptr"
-
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 )
 
 const (
@@ -17,7 +16,6 @@ const (
 	webhookConfigName  = "virt-network-resources-injector-config"
 )
 
-// shouldDeploy checks if network-resources-injector should be deployed
 func shouldDeploy(hc *hcov1.HyperConverged) bool {
-	return ptr.Deref(hc.Spec.Deployment.DeployNetworkResourcesInjector, true)
+	return common.ShouldDeployNetworkResourcesInjector(hc)
 }

--- a/controllers/handlers/netresinjector/common.go
+++ b/controllers/handlers/netresinjector/common.go
@@ -19,5 +19,5 @@ const (
 
 // shouldDeploy checks if network-resources-injector should be deployed
 func shouldDeploy(hc *hcov1.HyperConverged) bool {
-	return ptr.Deref(hc.Spec.Deployment.DeployNetworkResourcesInjector, false)
+	return ptr.Deref(hc.Spec.Deployment.DeployNetworkResourcesInjector, true)
 }

--- a/controllers/handlers/netresinjector/conditional_test.go
+++ b/controllers/handlers/netresinjector/conditional_test.go
@@ -47,21 +47,18 @@ var _ = Describe("Network Resources Injector Conditional Handlers", func() {
 			Expect(foundCR.Name).To(Equal(clusterRoleName))
 		})
 
-		It("should not create ClusterRole when deployNetworkResourcesInjector is not set (default false)", func() {
-			// Don't set deployNetworkResourcesInjector - should default to false
+		It("should create ClusterRole when deployNetworkResourcesInjector is not set (default true)", func() {
+			// Don't set deployNetworkResourcesInjector - should default to true
 			cl = commontestutils.InitClient([]client.Object{hco})
 
 			handler := NewClusterRoleHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 
 			Expect(res.Err).ToNot(HaveOccurred())
-			Expect(res.Created).To(BeFalse())
-			Expect(res.Updated).To(BeFalse())
+			Expect(res.Created).To(BeTrue())
 
 			foundCR := &rbacv1.ClusterRole{}
-			err := cl.Get(context.Background(), client.ObjectKey{Name: clusterRoleName}, foundCR)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(apierrors.IsNotFound, "not found error"))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterRoleName}, foundCR)).To(Succeed())
 		})
 
 		It("should delete ClusterRole when deployNetworkResourcesInjector is false", func() {

--- a/controllers/handlers/netresinjector/deployment.go
+++ b/controllers/handlers/netresinjector/deployment.go
@@ -1,6 +1,7 @@
 package netresinjector
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -8,12 +9,15 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
+	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
@@ -26,13 +30,84 @@ var (
 )
 
 func NewDeploymentHandler(cli client.Client, scheme *runtime.Scheme) operands.Operand {
-	return operands.NewConditionalHandler(
-		operands.NewDeploymentHandler(cli, scheme, newDeployment),
-		shouldDeploy,
-		func(hc *hcov1.HyperConverged) client.Object {
-			return NewDeploymentWithNameOnly()
-		},
-	)
+	return &netResInjDeploymentHandler{
+		inner: operands.NewConditionalHandler(
+			operands.NewDeploymentHandler(cli, scheme, newDeployment),
+			shouldDeploy,
+			func(hc *hcov1.HyperConverged) client.Object {
+				return NewDeploymentWithNameOnly()
+			},
+		),
+		client: cli,
+	}
+}
+
+type netResInjDeploymentHandler struct {
+	inner  operands.Operand
+	client client.Client
+}
+
+func (h *netResInjDeploymentHandler) Ensure(req *common.HcoRequest) *operands.EnsureResult {
+	result := h.inner.Ensure(req)
+	if result.Err != nil {
+		return result
+	}
+
+	if !shouldDeploy(req.Instance) {
+		removeNetResInjCondition(req)
+		return result
+	}
+
+	dep := &appsv1.Deployment{}
+	key := client.ObjectKeyFromObject(NewDeploymentWithNameOnly())
+	if err := h.client.Get(req.Ctx, key, dep); err != nil {
+		if !apierrors.IsNotFound(err) {
+			result.Err = err
+			return result
+		}
+		setNetResInjCondition(req, metav1.ConditionFalse, "DeploymentNotFound", "Network resources injector deployment not found")
+		return result
+	}
+
+	if dep.Spec.Replicas != nil && *dep.Spec.Replicas > 0 && dep.Status.ReadyReplicas == *dep.Spec.Replicas {
+		setNetResInjCondition(req, metav1.ConditionTrue, "DeploymentReady", "All replicas are ready")
+	} else {
+		setNetResInjCondition(req, metav1.ConditionFalse, "DeploymentNotReady",
+			fmt.Sprintf("%d/%d replicas ready", dep.Status.ReadyReplicas, *dep.Spec.Replicas))
+	}
+
+	return result
+}
+
+func (h *netResInjDeploymentHandler) Reset() {
+	h.inner.Reset()
+}
+
+func (h *netResInjDeploymentHandler) GetFullCr(hc *hcov1.HyperConverged) (client.Object, error) {
+	if getter, ok := h.inner.(operands.CRGetter); ok {
+		return getter.GetFullCr(hc)
+	}
+	return nil, nil
+}
+
+func setNetResInjCondition(req *common.HcoRequest, status metav1.ConditionStatus, reason, message string) {
+	cond := metav1.Condition{
+		Type:    hcov1.ConditionNetworkResourcesInjectorReady,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}
+	changed := meta.SetStatusCondition(&req.Instance.Status.Conditions, cond)
+	if changed {
+		req.StatusDirty = true
+	}
+}
+
+func removeNetResInjCondition(req *common.HcoRequest) {
+	changed := meta.RemoveStatusCondition(&req.Instance.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+	if changed {
+		req.StatusDirty = true
+	}
 }
 
 func NewDeploymentWithNameOnly() *appsv1.Deployment {

--- a/controllers/handlers/netresinjector/deployment_test.go
+++ b/controllers/handlers/netresinjector/deployment_test.go
@@ -41,7 +41,6 @@ var _ = Describe("Network Resources Injector Deployment", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 		Expect(os.Setenv(hcoutil.NetworkResourcesInjectorImageEnvV, testImage)).To(Succeed())
 

--- a/controllers/handlers/netresinjector/deployment_test.go
+++ b/controllers/handlers/netresinjector/deployment_test.go
@@ -10,6 +10,8 @@ import (
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
@@ -187,6 +189,98 @@ var _ = Describe("Network Resources Injector Deployment", func() {
 			Expect(cl.List(context.Background(), foundDeps)).To(Succeed())
 			Expect(foundDeps.Items).To(HaveLen(1))
 			Expect(foundDeps.Items[0].Name).To(Equal(deploymentName))
+		})
+	})
+
+	Context("NetResInj readiness condition", func() {
+		It("should set condition to True when deployment is ready", func() {
+			dep := newDeployment(hco)
+			replicas := *dep.Spec.Replicas
+			dep.Status.ReadyReplicas = replicas
+			dep.Status.Replicas = replicas
+			cl = commontestutils.InitClient([]client.Object{hco, dep})
+
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(meta.IsStatusConditionTrue(req.Instance.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)).To(BeTrue())
+			cond := meta.FindStatusCondition(req.Instance.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+			Expect(cond.Reason).To(Equal("DeploymentReady"))
+			Expect(req.StatusDirty).To(BeTrue())
+		})
+
+		It("should set condition to False when deployment is just created", func() {
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			Expect(res.Created).To(BeTrue())
+			cond := meta.FindStatusCondition(req.Instance.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("DeploymentNotReady"))
+		})
+
+		It("should set condition to False when deployment is not ready", func() {
+			dep := newDeployment(hco)
+			dep.Status.ReadyReplicas = 0
+			dep.Status.Replicas = *dep.Spec.Replicas
+			cl = commontestutils.InitClient([]client.Object{hco, dep})
+
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			cond := meta.FindStatusCondition(req.Instance.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("DeploymentNotReady"))
+		})
+
+		It("should flip condition to False when deployment becomes unready", func() {
+			meta.SetStatusCondition(&hco.Status.Conditions, metav1.Condition{
+				Type:   hcov1.ConditionNetworkResourcesInjectorReady,
+				Status: metav1.ConditionTrue,
+				Reason: "DeploymentReady",
+			})
+			req = commontestutils.NewReq(hco)
+
+			dep := newDeployment(hco)
+			dep.Status.ReadyReplicas = 0
+			dep.Status.Replicas = *dep.Spec.Replicas
+			cl = commontestutils.InitClient([]client.Object{hco, dep})
+
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			cond := meta.FindStatusCondition(req.Instance.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("DeploymentNotReady"))
+			Expect(req.StatusDirty).To(BeTrue())
+		})
+
+		It("should remove condition when shouldDeploy is false", func() {
+			hco.Spec.Deployment.DeployNetworkResourcesInjector = new(bool)
+			meta.SetStatusCondition(&hco.Status.Conditions, metav1.Condition{
+				Type:   hcov1.ConditionNetworkResourcesInjectorReady,
+				Status: metav1.ConditionTrue,
+				Reason: "DeploymentReady",
+			})
+			req = commontestutils.NewReq(hco)
+			cl = commontestutils.InitClient([]client.Object{hco})
+
+			handler := NewDeploymentHandler(cl, commontestutils.GetScheme())
+			res := handler.Ensure(req)
+
+			Expect(res.Err).ToNot(HaveOccurred())
+			cond := meta.FindStatusCondition(req.Instance.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+			Expect(cond).To(BeNil())
+			Expect(req.StatusDirty).To(BeTrue())
 		})
 	})
 

--- a/controllers/handlers/netresinjector/pdb_test.go
+++ b/controllers/handlers/netresinjector/pdb_test.go
@@ -25,7 +25,6 @@ var _ = Describe("Network Resources Injector PodDisruptionBudget", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/rbac_test.go
+++ b/controllers/handlers/netresinjector/rbac_test.go
@@ -24,7 +24,6 @@ var _ = Describe("Network Resources Injector ClusterRole", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 
@@ -95,7 +94,6 @@ var _ = Describe("Network Resources Injector ClusterRoleBinding", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/service_account_test.go
+++ b/controllers/handlers/netresinjector/service_account_test.go
@@ -24,7 +24,6 @@ var _ = Describe("Network Resources Injector ServiceAccount", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/service_test.go
+++ b/controllers/handlers/netresinjector/service_test.go
@@ -25,7 +25,6 @@ var _ = Describe("Network Resources Injector Service", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/webhook_config_test.go
+++ b/controllers/handlers/netresinjector/webhook_config_test.go
@@ -24,7 +24,6 @@ var _ = Describe("Network Resources Injector MutatingWebhookConfiguration", func
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -244,7 +244,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 				// Check conditions
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(32))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(39))
 				expectedRef := corev1.ObjectReference{
 					Kind:            "PrometheusRule",
 					Namespace:       namespace,

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -979,6 +979,67 @@ var _ = Describe("HyperconvergedController", func() {
 				Expect(int(value)).To(BeEquivalentTo(42))
 
 			})
+
+			It("should set NetworkResourcesInjectorReady condition to False after initial reconcile", func() {
+				expected := getBasicDeployment()
+				cl := expected.initClient()
+
+				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+
+				cond := apimetav1.FindStatusCondition(foundResource.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+				Expect(cond).ToNot(BeNil())
+				Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(cond.Reason).To(Equal("DeploymentNotReady"))
+			})
+
+			It("should set NetworkResourcesInjectorReady condition to True and enable ExternalNetResourceInjection FG when deployment is ready", func() {
+				expected := getBasicDeployment()
+				cl := expected.initClient()
+
+				_, r, _ := doReconcile(cl, expected.hco, nil)
+
+				dep := &appsv1.Deployment{}
+				Expect(cl.Get(context.TODO(), types.NamespacedName{
+					Name:      "virt-network-resources-injector",
+					Namespace: namespace,
+				}, dep)).To(Succeed())
+				dep.Status.ReadyReplicas = *dep.Spec.Replicas
+				dep.Status.Replicas = *dep.Spec.Replicas
+				Expect(cl.Status().Update(context.TODO(), dep)).To(Succeed())
+
+				// KV is reconciled before NRI, so the first reconcile updates the
+				// condition to True but KV still sees the old value.
+				foundResource, r, _ := doReconcile(cl, expected.hco, r)
+
+				cond := apimetav1.FindStatusCondition(foundResource.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+				Expect(cond).ToNot(BeNil())
+				Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				Expect(cond.Reason).To(Equal("DeploymentReady"))
+
+				// Second reconcile: KV now sees condition=True and enables the FG.
+				_, _, _ = doReconcile(cl, expected.hco, r)
+
+				kvList := &kubevirtcorev1.KubeVirtList{}
+				Expect(cl.List(context.TODO(), kvList)).To(Succeed())
+				Expect(kvList.Items).To(HaveLen(1))
+				Expect(kvList.Items[0].Spec.Configuration.DeveloperConfiguration.FeatureGates).To(ContainElement("ExternalNetResourceInjection"))
+			})
+
+			It("should remove NetworkResourcesInjectorReady condition and not enable ExternalNetResourceInjection FG when deployment is disabled", func() {
+				expected := getBasicDeployment()
+				expected.hco.Spec.Deployment.DeployNetworkResourcesInjector = ptr.To(false)
+				cl := expected.initClient()
+
+				foundResource, _, _ := doReconcile(cl, expected.hco, nil)
+
+				cond := apimetav1.FindStatusCondition(foundResource.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+				Expect(cond).To(BeNil())
+
+				kvList := &kubevirtcorev1.KubeVirtList{}
+				Expect(cl.List(context.TODO(), kvList)).To(Succeed())
+				Expect(kvList.Items).To(HaveLen(1))
+				Expect(kvList.Items[0].Spec.Configuration.DeveloperConfiguration.FeatureGates).ToNot(ContainElement("ExternalNetResourceInjection"))
+			})
 		})
 
 		Context("TLS Security Profile", func() {

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kubevirt-hyperconverged
 spec:
   deployment:
+    deployNetworkResourcesInjector: true
     deployVmConsoleProxy: false
     uninstallStrategy: BlockUninstallIfWorkloadsExist
   security:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/docs/api.md
+++ b/docs/api.md
@@ -125,7 +125,7 @@ DataImportCronTemplateStatus is a copy of a dataImportCronTemplate as defined in
 | logVerbosityConfig | LogVerbosityConfig configures the verbosity level of Kubevirt's different components. The higher the value - the higher the log verbosity. | *[LogVerbosityConfiguration](#logverbosityconfiguration) |  | false |
 | applicationAwareConfig | ApplicationAwareConfig set the AAQ configurations | *[ApplicationAwareConfigurations](#applicationawareconfigurations) |  | false |
 | deployVmConsoleProxy | deploy VM console proxy resources in SSP operator | *bool | false | false |
-| deployNetworkResourcesInjector | DeployNetworkResourcesInjector enables deployment of the network-resources-injector component. When enabled, the network-resources-injector mutating webhook will be deployed to automatically inject resource requests for custom resources annotated in NetworkAttachmentDefinition. | *bool |  | false |
+| deployNetworkResourcesInjector | DeployNetworkResourcesInjector enables deployment of the network-resources-injector component. When enabled, the network-resources-injector mutating webhook will be deployed to automatically inject resource requests for custom resources annotated in NetworkAttachmentDefinition. | *bool | true | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -146,7 +146,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | ------- | -------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -185,7 +185,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | networking | Networking contains all the configurations for networking | *[NetworkingConfig](#networkingconfig) |  | false |
 | workloadSources | WorkloadSources contains all the configurations for workload sources | [WorkloadSourcesConfig](#workloadsourcesconfig) |  | false |
 | security | Security contains all the security configurations | [SecurityConfig](#securityconfig) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}} | false |
-| deployment | Deployment contains all the configurations related to deployment of KubeVirt components | [DeploymentConfig](#deploymentconfig) | {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}} | false |
+| deployment | Deployment contains all the configurations related to deployment of KubeVirt components | [DeploymentConfig](#deploymentconfig) | {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}} | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/upgradepatch/hc.cr.json
+++ b/pkg/upgradepatch/hc.cr.json
@@ -47,7 +47,8 @@
     },
     "deployment": {
       "uninstallStrategy": "BlockUninstallIfWorkloadsExist",
-      "deployVmConsoleProxy": false
+      "deployVmConsoleProxy": false,
+      "deployNetworkResourcesInjector": true
     }
   },
   "status": {

--- a/tests/func-tests/netresinjector_test.go
+++ b/tests/func-tests/netresinjector_test.go
@@ -33,21 +33,7 @@ var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Ser
 		restoreNetResInjectorToDefault(ctx, cli)
 	})
 
-	Context("when deployNetworkResourcesInjector is not set (default false)", func() {
-		BeforeAll(func(ctx context.Context) {
-			restoreNetResInjectorToDefault(ctx, cli)
-		})
-
-		It("should not deploy the network resources injector", func(ctx context.Context) {
-			validateNetResInjectorDeleted(ctx, cli)
-		})
-	})
-
-	Context("when deployNetworkResourcesInjector is true", func() {
-		BeforeAll(func(ctx context.Context) {
-			enableNetResInjector(ctx, cli)
-		})
-
+	Context("when deployNetworkResourcesInjector is true (default)", func() {
 		It("should deploy the network resources injector", func(ctx context.Context) {
 			By("verifying the deployment exists and is ready")
 			Eventually(func(g Gomega, ctx context.Context) {
@@ -113,9 +99,20 @@ var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Ser
 			validateNetResInjectorDeleted(ctx, cli)
 		})
 
-		It("should delete the deployment when set back to default (false)", func(ctx context.Context) {
-			restoreNetResInjectorToDefault(ctx, cli)
-			validateNetResInjectorDeleted(ctx, cli)
+		It("should recreate the deployment when set back to true", func(ctx context.Context) {
+			enableNetResInjector(ctx, cli)
+
+			By("verifying the deployment is recreated and ready")
+			Eventually(func(g Gomega, ctx context.Context) {
+				dep := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      netResInjectorDeploymentName,
+						Namespace: tests.InstallNamespace,
+					},
+				}
+				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
+				g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
+			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
 		})
 	})
 })
@@ -158,12 +155,21 @@ func restoreNetResInjectorToDefault(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
 	By("restoring deployNetworkResourcesInjector to default")
 
-	// Read the HyperConverged CR first to check if the field exists
 	hc, err := tests.GetHCO(ctx, cli)
 	Expect(err).ToNot(HaveOccurred())
 	if hc.Spec.Deployment.DeployNetworkResourcesInjector != nil {
-		// Field exists, remove it by setting to null in merge patch
 		patch := []byte(`{"spec":{"deployment":{"deployNetworkResourcesInjector": null}}}`)
 		tests.PatchMergeHCO(ctx, cli, patch)
 	}
+
+	Eventually(func(g Gomega, ctx context.Context) {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      netResInjectorDeploymentName,
+				Namespace: tests.InstallNamespace,
+			},
+		}
+		g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
+		g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
+	}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
 }

--- a/tests/func-tests/netresinjector_test.go
+++ b/tests/func-tests/netresinjector_test.go
@@ -9,9 +9,11 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
@@ -46,6 +48,9 @@ var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Ser
 				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
 				g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
 			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+
+			By("verifying the NetworkResourcesInjectorReady condition is True")
+			validateNetResInjCondition(ctx, cli, metav1.ConditionTrue, "DeploymentReady")
 
 			By("verifying the deployment has control plane node affinity")
 			dep := &appsv1.Deployment{
@@ -97,6 +102,9 @@ var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Ser
 
 		It("should not deploy the network resources injector", func(ctx context.Context) {
 			validateNetResInjectorDeleted(ctx, cli)
+
+			By("verifying the NetworkResourcesInjectorReady condition is removed")
+			validateNetResInjConditionAbsent(ctx, cli)
 		})
 
 		It("should recreate the deployment when set back to true", func(ctx context.Context) {
@@ -113,9 +121,34 @@ var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Ser
 				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
 				g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
 			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+
+			By("verifying the NetworkResourcesInjectorReady condition flips back to True")
+			validateNetResInjCondition(ctx, cli, metav1.ConditionTrue, "DeploymentReady")
 		})
 	})
 })
+
+func validateNetResInjConditionAbsent(ctx context.Context, cli client.Client) {
+	GinkgoHelper()
+	Eventually(func(g Gomega, ctx context.Context) {
+		hc, err := tests.GetHCO(ctx, cli)
+		g.Expect(err).ToNot(HaveOccurred())
+		cond := meta.FindStatusCondition(hc.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+		g.Expect(cond).To(BeNil(), "condition %s should not exist when disabled", hcov1.ConditionNetworkResourcesInjectorReady)
+	}).WithTimeout(2 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+}
+
+func validateNetResInjCondition(ctx context.Context, cli client.Client, expectedStatus metav1.ConditionStatus, expectedReason string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega, ctx context.Context) {
+		hc, err := tests.GetHCO(ctx, cli)
+		g.Expect(err).ToNot(HaveOccurred())
+		cond := meta.FindStatusCondition(hc.Status.Conditions, hcov1.ConditionNetworkResourcesInjectorReady)
+		g.Expect(cond).ToNot(BeNil(), "condition %s should exist", hcov1.ConditionNetworkResourcesInjectorReady)
+		g.Expect(cond.Status).To(Equal(expectedStatus))
+		g.Expect(cond.Reason).To(Equal(expectedReason))
+	}).WithTimeout(2 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+}
 
 func getNetResInjectorDeploymentErr(ctx context.Context, cli client.Client) error {
 	dep := &appsv1.Deployment{

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Enable the ExternalNetResourceInjection KubeVirt feature gate when
deployNetworkResourcesInjector is set to true in the HCO CR, so the
injector deployment and its corresponding FG are controlled by the
same knob.

Use a NetworkResourcesInjectorReady status condition on the HCO CR
to signal readiness, with reasons DeploymentReady, DeploymentNotReady,
DeploymentNotFound, and DeploymentDisabled.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-93112
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New CR condition indicating network-resources-injector deployment status
```
