### PR TITLE
Expose AllowWorkloadDisruption in LiveMigrationConfig

### DIFF
--- a/api/v1/hyperconverged_types.go
+++ b/api/v1/hyperconverged_types.go
@@ -145,7 +145,7 @@ type HyperConvergedSpec struct {
 	FeatureGates featuregates.HyperConvergedFeatureGates `json:"featureGates,omitempty"`
 
 	// Virtualization contains all the configurations for virtualization
-	// +kubebuilder:default={"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10}
+	// +kubebuilder:default={"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false, "allowWorkloadDisruption": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10}
 	// +kubebuilder:validation:XValidation:rule="!has(self.vmiCPUAllocationRatio) || self.vmiCPUAllocationRatio > 0",message="vmiCPUAllocationRatio must be greater than 0"
 	// +k8s:conversion-gen=false
 	Virtualization VirtualizationConfig `json:"virtualization,omitempty"`
@@ -187,7 +187,7 @@ type VirtualizationConfig struct {
 
 	// Live migration limits and timeouts are applied so that migration processes do not
 	// overwhelm the cluster.
-	// +kubebuilder:default={"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}
+	// +kubebuilder:default={"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false, "allowWorkloadDisruption": false}
 	// +optional
 	LiveMigrationConfig LiveMigrationConfigurations `json:"liveMigrationConfig,omitempty"`
 
@@ -561,6 +561,16 @@ type LiveMigrationConfigurations struct {
 	// +kubebuilder:default=false
 	// +default=false
 	AllowPostCopy *bool `json:"allowPostCopy,omitempty"`
+
+	// AllowWorkloadDisruption indicates that the migration shouldn't be
+	// canceled after the acceptable completion time is exceeded. Instead, if
+	// permitted, migration will be switched to post-copy or the VMI will be
+	// paused to allow the migration to complete.
+	// Defaults to false.
+	// +optional
+	// +kubebuilder:default=false
+	// +default=false
+	AllowWorkloadDisruption *bool `json:"allowWorkloadDisruption,omitempty"`
 }
 
 // VirtualMachineOptions holds the cluster level information regarding the virtual machine.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -500,6 +500,11 @@ func (in *LiveMigrationConfigurations) DeepCopyInto(out *LiveMigrationConfigurat
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AllowWorkloadDisruption != nil {
+		in, out := &in.AllowWorkloadDisruption, &out.AllowWorkloadDisruption
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1/zz_generated.defaults.go
+++ b/api/v1/zz_generated.defaults.go
@@ -64,6 +64,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.Virtualization.LiveMigrationConfig.AllowPostCopy = &ptrVar1
 	}
+	if in.Spec.Virtualization.LiveMigrationConfig.AllowWorkloadDisruption == nil {
+		var ptrVar1 bool = false
+		in.Spec.Virtualization.LiveMigrationConfig.AllowWorkloadDisruption = &ptrVar1
+	}
 	if in.Spec.Virtualization.WorkloadUpdateStrategy.WorkloadUpdateMethods == nil {
 		if err := json.Unmarshal([]byte(`["LiveMigrate"]`), &in.Spec.Virtualization.WorkloadUpdateStrategy.WorkloadUpdateMethods); err != nil {
 			panic(err)

--- a/api/v1/zz_generated.openapi.go
+++ b/api/v1/zz_generated.openapi.go
@@ -564,6 +564,14 @@ func schema_kubevirt_hyperconverged_cluster_operator_api_v1_LiveMigrationConfigu
 							Format:      "",
 						},
 					},
+					"allowWorkloadDisruption": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AllowWorkloadDisruption indicates that the migration shouldn't be canceled after the acceptable completion time is exceeded. Instead, if permitted, migration will be switched to post-copy or the VMI will be paused to allow the migration to complete. Defaults to false.",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/api/v1beta1/conversion_fuzz_test.go
+++ b/api/v1beta1/conversion_fuzz_test.go
@@ -101,6 +101,7 @@ func randomV1beta1HC(r *rand.Rand) *HyperConverged {
 				ProgressTimeout:                   randPtr(r, r.Int64()),
 				AllowAutoConverge:                 randPtr(r, r.IntN(2) == 1),
 				AllowPostCopy:                     randPtr(r, r.IntN(2) == 1),
+				AllowWorkloadDisruption:           randPtr(r, r.IntN(2) == 1),
 			},
 			WorkloadUpdateStrategy: hcov1.HyperConvergedWorkloadUpdateStrategy{
 				WorkloadUpdateMethods: randStringSlice(r),
@@ -315,6 +316,7 @@ func randomV1HC(r *rand.Rand) *hcov1.HyperConverged {
 					ProgressTimeout:                   randPtr(r, r.Int64()),
 					AllowAutoConverge:                 randPtr(r, r.IntN(2) == 1),
 					AllowPostCopy:                     randPtr(r, r.IntN(2) == 1),
+					AllowWorkloadDisruption:           randPtr(r, r.IntN(2) == 1),
 				},
 				WorkloadUpdateStrategy: hcov1.HyperConvergedWorkloadUpdateStrategy{
 					WorkloadUpdateMethods: randStringSlice(r),

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -1520,6 +1520,7 @@ var _ = Describe("api/v1beta1", func() {
 						ProgressTimeout:                   new(int64(200)),
 						AllowAutoConverge:                 new(true),
 						AllowPostCopy:                     new(false),
+						AllowWorkloadDisruption:           new(true),
 					},
 				}
 
@@ -1533,6 +1534,7 @@ var _ = Describe("api/v1beta1", func() {
 				Expect(v1beta1Spec.LiveMigrationConfig.ProgressTimeout).To(HaveValue(Equal(int64(200))))
 				Expect(v1beta1Spec.LiveMigrationConfig.AllowAutoConverge).To(HaveValue(BeTrue()))
 				Expect(v1beta1Spec.LiveMigrationConfig.AllowPostCopy).To(HaveValue(BeFalse()))
+				Expect(v1beta1Spec.LiveMigrationConfig.AllowWorkloadDisruption).To(HaveValue(BeTrue()))
 			})
 
 			It("should convert PermittedHostDevices", func() {
@@ -1920,6 +1922,7 @@ var _ = Describe("api/v1beta1", func() {
 						ProgressTimeout:                   new(int64(200)),
 						AllowAutoConverge:                 new(true),
 						AllowPostCopy:                     new(false),
+						AllowWorkloadDisruption:           new(true),
 					},
 				}
 
@@ -1933,6 +1936,7 @@ var _ = Describe("api/v1beta1", func() {
 				Expect(v1VirtConfig.LiveMigrationConfig.ProgressTimeout).To(HaveValue(Equal(int64(200))))
 				Expect(v1VirtConfig.LiveMigrationConfig.AllowAutoConverge).To(HaveValue(BeTrue()))
 				Expect(v1VirtConfig.LiveMigrationConfig.AllowPostCopy).To(HaveValue(BeFalse()))
+				Expect(v1VirtConfig.LiveMigrationConfig.AllowWorkloadDisruption).To(HaveValue(BeTrue()))
 			})
 
 			It("should convert PermittedHostDevices", func() {

--- a/api/v1beta1/zz_generated.defaults.go
+++ b/api/v1beta1/zz_generated.defaults.go
@@ -104,6 +104,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.LiveMigrationConfig.AllowPostCopy = &ptrVar1
 	}
+	if in.Spec.LiveMigrationConfig.AllowWorkloadDisruption == nil {
+		var ptrVar1 bool = false
+		in.Spec.LiveMigrationConfig.AllowWorkloadDisruption = &ptrVar1
+	}
 	if in.Spec.CertConfig.CA.Duration == nil {
 		if err := json.Unmarshal([]byte(`"48h0m0s"`), &in.Spec.CertConfig.CA.Duration); err != nil {
 			panic(err)

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -2750,6 +2750,7 @@ spec:
                   liveMigrationConfig:
                     allowAutoConverge: false
                     allowPostCopy: false
+                    allowWorkloadDisruption: false
                     completionTimeoutPerGiB: 150
                     parallelMigrationsPerCluster: 5
                     parallelOutboundMigrationsPerNode: 2
@@ -3023,6 +3024,7 @@ spec:
                     default:
                       allowAutoConverge: false
                       allowPostCopy: false
+                      allowWorkloadDisruption: false
                       completionTimeoutPerGiB: 150
                       parallelMigrationsPerCluster: 5
                       parallelOutboundMigrationsPerNode: 2
@@ -3047,6 +3049,15 @@ spec:
                           destination nodes can cause the migrated VM to crash or reach inconsistency.
                           Enable this option when evicting nodes is more important than keeping VMs
                           alive.
+                          Defaults to false.
+                        type: boolean
+                      allowWorkloadDisruption:
+                        default: false
+                        description: |-
+                          AllowWorkloadDisruption indicates that the migration shouldn't be
+                          canceled after the acceptable completion time is exceeded. Instead, if
+                          permitted, migration will be switched to post-copy or the VMI will be
+                          paused to allow the migration to complete.
                           Defaults to false.
                         type: boolean
                       bandwidthPerMigration:
@@ -7834,6 +7845,15 @@ spec:
                       destination nodes can cause the migrated VM to crash or reach inconsistency.
                       Enable this option when evicting nodes is more important than keeping VMs
                       alive.
+                      Defaults to false.
+                    type: boolean
+                  allowWorkloadDisruption:
+                    default: false
+                    description: |-
+                      AllowWorkloadDisruption indicates that the migration shouldn't be
+                      canceled after the acceptable completion time is exceeded. Instead, if
+                      permitted, migration will be switched to post-copy or the VMI will be
+                      paused to allow the migration to complete.
                       Defaults to false.
                     type: boolean
                   bandwidthPerMigration:

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -759,6 +759,7 @@ func hcLiveMigrationToKv(lm hcov1.LiveMigrationConfigurations) (*kubevirtcorev1.
 		Network:                           lm.Network,
 		AllowAutoConverge:                 lm.AllowAutoConverge,
 		AllowPostCopy:                     lm.AllowPostCopy,
+		AllowWorkloadDisruption:           lm.AllowWorkloadDisruption,
 	}, nil
 }
 

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -378,6 +378,7 @@ Version: 1.2.3`)).To(Succeed())
 			Expect(mc.Network).To(BeNil())
 			Expect(*mc.AllowAutoConverge).To(BeFalse())
 			Expect(*mc.AllowPostCopy).To(BeFalse())
+			Expect(mc.AllowWorkloadDisruption).To(HaveValue(BeFalse()))
 		})
 
 		It("should find if present", func() {
@@ -534,6 +535,7 @@ Version: 1.2.3`)
 				Network:                           ptr.To("testNetwork"),
 				AllowAutoConverge:                 ptr.To(false),
 				AllowPostCopy:                     ptr.To(false),
+				AllowWorkloadDisruption:           new(false),
 			}
 
 			cl := commontestutils.InitClient([]client.Object{hco, existKv})
@@ -589,6 +591,7 @@ Version: 1.2.3`)
 			Expect(mc.Network).To(BeNil())
 			Expect(*mc.AllowAutoConverge).To(BeFalse())
 			Expect(*mc.AllowPostCopy).To(BeFalse())
+			Expect(mc.AllowWorkloadDisruption).To(HaveValue(BeFalse()))
 		})
 
 		It("should use legacy MACHINETYPE env if provided", func() {
@@ -805,6 +808,7 @@ Version: 1.2.3`)
 			hco.Spec.Virtualization.LiveMigrationConfig.Network = ptr.To(network)
 			hco.Spec.Virtualization.LiveMigrationConfig.AllowAutoConverge = ptr.To(true)
 			hco.Spec.Virtualization.LiveMigrationConfig.AllowPostCopy = ptr.To(true)
+			hco.Spec.Virtualization.LiveMigrationConfig.AllowWorkloadDisruption = new(true)
 
 			cl := commontestutils.InitClient([]client.Object{hco, existKv})
 			handler := NewKubevirtHandler(cl, commontestutils.GetScheme())
@@ -831,6 +835,7 @@ Version: 1.2.3`)
 			Expect(mc.Network).To(HaveValue(Equal(network)))
 			Expect(mc.AllowAutoConverge).To(HaveValue(BeTrue()))
 			Expect(mc.AllowPostCopy).To(HaveValue(BeTrue()))
+			Expect(mc.AllowWorkloadDisruption).To(HaveValue(BeTrue()))
 
 			// ObjectReference should have been updated
 			Expect(hco.Status.RelatedObjects).ToNot(BeNil())
@@ -4363,6 +4368,7 @@ Version: 1.2.3`)
 				Network:                           ptr.To(network),
 				AllowAutoConverge:                 ptr.To(true),
 				AllowPostCopy:                     ptr.To(true),
+				AllowWorkloadDisruption:           new(true),
 			}
 			mc, err := hcLiveMigrationToKv(lmc)
 			Expect(err).ToNot(HaveOccurred())
@@ -4375,6 +4381,7 @@ Version: 1.2.3`)
 			Expect(mc.Network).To(HaveValue(Equal(network)))
 			Expect(mc.AllowAutoConverge).To(HaveValue(BeTrue()))
 			Expect(mc.AllowPostCopy).To(HaveValue(BeTrue()))
+			Expect(mc.AllowWorkloadDisruption).To(HaveValue(BeTrue()))
 		})
 
 		It("should create valid empty KV LM config from a valid empty HC LM config", func() {
@@ -4390,6 +4397,7 @@ Version: 1.2.3`)
 			Expect(mc.Network).To(BeNil())
 			Expect(mc.AllowAutoConverge).To(BeNil())
 			Expect(mc.AllowPostCopy).To(BeNil())
+			Expect(mc.AllowWorkloadDisruption).To(BeNil())
 		})
 
 		It("should return error if the value of the BandwidthPerMigration field is not valid", func() {
@@ -4402,6 +4410,7 @@ Version: 1.2.3`)
 				Network:                           ptr.To(network),
 				AllowAutoConverge:                 ptr.To(true),
 				AllowPostCopy:                     ptr.To(true),
+				AllowWorkloadDisruption:           new(true),
 			}
 			mc, err := hcLiveMigrationToKv(lmc)
 			Expect(err).To(HaveOccurred())

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -2750,6 +2750,7 @@ spec:
                   liveMigrationConfig:
                     allowAutoConverge: false
                     allowPostCopy: false
+                    allowWorkloadDisruption: false
                     completionTimeoutPerGiB: 150
                     parallelMigrationsPerCluster: 5
                     parallelOutboundMigrationsPerNode: 2
@@ -3023,6 +3024,7 @@ spec:
                     default:
                       allowAutoConverge: false
                       allowPostCopy: false
+                      allowWorkloadDisruption: false
                       completionTimeoutPerGiB: 150
                       parallelMigrationsPerCluster: 5
                       parallelOutboundMigrationsPerNode: 2
@@ -3047,6 +3049,15 @@ spec:
                           destination nodes can cause the migrated VM to crash or reach inconsistency.
                           Enable this option when evicting nodes is more important than keeping VMs
                           alive.
+                          Defaults to false.
+                        type: boolean
+                      allowWorkloadDisruption:
+                        default: false
+                        description: |-
+                          AllowWorkloadDisruption indicates that the migration shouldn't be
+                          canceled after the acceptable completion time is exceeded. Instead, if
+                          permitted, migration will be switched to post-copy or the VMI will be
+                          paused to allow the migration to complete.
                           Defaults to false.
                         type: boolean
                       bandwidthPerMigration:
@@ -7834,6 +7845,15 @@ spec:
                       destination nodes can cause the migrated VM to crash or reach inconsistency.
                       Enable this option when evicting nodes is more important than keeping VMs
                       alive.
+                      Defaults to false.
+                    type: boolean
+                  allowWorkloadDisruption:
+                    default: false
+                    description: |-
+                      AllowWorkloadDisruption indicates that the migration shouldn't be
+                      canceled after the acceptable completion time is exceeded. Instead, if
+                      permitted, migration will be switched to post-copy or the VMI will be
+                      paused to allow the migration to complete.
                       Defaults to false.
                     type: boolean
                   bandwidthPerMigration:

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -21,6 +21,7 @@ spec:
     liveMigrationConfig:
       allowAutoConverge: false
       allowPostCopy: false
+      allowWorkloadDisruption: false
       completionTimeoutPerGiB: 150
       parallelMigrationsPerCluster: 5
       parallelOutboundMigrationsPerNode: 2

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -2750,6 +2750,7 @@ spec:
                   liveMigrationConfig:
                     allowAutoConverge: false
                     allowPostCopy: false
+                    allowWorkloadDisruption: false
                     completionTimeoutPerGiB: 150
                     parallelMigrationsPerCluster: 5
                     parallelOutboundMigrationsPerNode: 2
@@ -3023,6 +3024,7 @@ spec:
                     default:
                       allowAutoConverge: false
                       allowPostCopy: false
+                      allowWorkloadDisruption: false
                       completionTimeoutPerGiB: 150
                       parallelMigrationsPerCluster: 5
                       parallelOutboundMigrationsPerNode: 2
@@ -3047,6 +3049,15 @@ spec:
                           destination nodes can cause the migrated VM to crash or reach inconsistency.
                           Enable this option when evicting nodes is more important than keeping VMs
                           alive.
+                          Defaults to false.
+                        type: boolean
+                      allowWorkloadDisruption:
+                        default: false
+                        description: |-
+                          AllowWorkloadDisruption indicates that the migration shouldn't be
+                          canceled after the acceptable completion time is exceeded. Instead, if
+                          permitted, migration will be switched to post-copy or the VMI will be
+                          paused to allow the migration to complete.
                           Defaults to false.
                         type: boolean
                       bandwidthPerMigration:
@@ -7834,6 +7845,15 @@ spec:
                       destination nodes can cause the migrated VM to crash or reach inconsistency.
                       Enable this option when evicting nodes is more important than keeping VMs
                       alive.
+                      Defaults to false.
+                    type: boolean
+                  allowWorkloadDisruption:
+                    default: false
+                    description: |-
+                      AllowWorkloadDisruption indicates that the migration shouldn't be
+                      canceled after the acceptable completion time is exceeded. Instead, if
+                      permitted, migration will be switched to post-copy or the VMI will be
+                      paused to allow the migration to complete.
                       Defaults to false.
                     type: boolean
                   bandwidthPerMigration:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -2750,6 +2750,7 @@ spec:
                   liveMigrationConfig:
                     allowAutoConverge: false
                     allowPostCopy: false
+                    allowWorkloadDisruption: false
                     completionTimeoutPerGiB: 150
                     parallelMigrationsPerCluster: 5
                     parallelOutboundMigrationsPerNode: 2
@@ -3023,6 +3024,7 @@ spec:
                     default:
                       allowAutoConverge: false
                       allowPostCopy: false
+                      allowWorkloadDisruption: false
                       completionTimeoutPerGiB: 150
                       parallelMigrationsPerCluster: 5
                       parallelOutboundMigrationsPerNode: 2
@@ -3047,6 +3049,15 @@ spec:
                           destination nodes can cause the migrated VM to crash or reach inconsistency.
                           Enable this option when evicting nodes is more important than keeping VMs
                           alive.
+                          Defaults to false.
+                        type: boolean
+                      allowWorkloadDisruption:
+                        default: false
+                        description: |-
+                          AllowWorkloadDisruption indicates that the migration shouldn't be
+                          canceled after the acceptable completion time is exceeded. Instead, if
+                          permitted, migration will be switched to post-copy or the VMI will be
+                          paused to allow the migration to complete.
                           Defaults to false.
                         type: boolean
                       bandwidthPerMigration:
@@ -7834,6 +7845,15 @@ spec:
                       destination nodes can cause the migrated VM to crash or reach inconsistency.
                       Enable this option when evicting nodes is more important than keeping VMs
                       alive.
+                      Defaults to false.
+                    type: boolean
+                  allowWorkloadDisruption:
+                    default: false
+                    description: |-
+                      AllowWorkloadDisruption indicates that the migration shouldn't be
+                      canceled after the acceptable completion time is exceeded. Instead, if
+                      permitted, migration will be switched to post-copy or the VMI will be
+                      paused to allow the migration to complete.
                       Defaults to false.
                     type: boolean
                   bandwidthPerMigration:

--- a/docs/api.md
+++ b/docs/api.md
@@ -179,7 +179,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | ------- | -------- |
 | featureGates | For feature gate details, see [here](#hco-feature-gates) | featuregates.HyperConvergedFeatureGates |  | false |
-| virtualization | Virtualization contains all the configurations for virtualization | [VirtualizationConfig](#virtualizationconfig) | {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10} | false |
+| virtualization | Virtualization contains all the configurations for virtualization | [VirtualizationConfig](#virtualizationconfig) | {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false, "allowWorkloadDisruption": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10} | false |
 | storage | Storage contains all the configurations for storage | *[StorageConfig](#storageconfig) |  | false |
 | networking | Networking contains all the configurations for networking | *[NetworkingConfig](#networkingconfig) |  | false |
 | workloadSources | WorkloadSources contains all the configurations for workload sources | [WorkloadSourcesConfig](#workloadsourcesconfig) |  | false |
@@ -243,6 +243,7 @@ LiveMigrationConfigurations - Live migration limits and timeouts are applied so 
 | network | The migrations will be performed over a dedicated multus network to minimize disruption to tenant workloads due to network saturation when VM live migrations are triggered. | *string |  | false |
 | allowAutoConverge | AllowAutoConverge allows the platform to compromise performance/availability of VMIs to guarantee successful VMI live migrations. Defaults to false | *bool | false | false |
 | allowPostCopy | When enabled, KubeVirt attempts to use post-copy live-migration in case it reaches its completion timeout while attempting pre-copy live-migration. Post-copy migrations allow even the busiest VMs to successfully live-migrate. However, events like a network failure or a failure in any of the source or destination nodes can cause the migrated VM to crash or reach inconsistency. Enable this option when evicting nodes is more important than keeping VMs alive. Defaults to false. | *bool | false | false |
+| allowWorkloadDisruption | AllowWorkloadDisruption indicates that the migration shouldn't be canceled after the acceptable completion time is exceeded. Instead, if permitted, migration will be switched to post-copy or the VMI will be paused to allow the migration to complete. Defaults to false. | *bool | false | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -442,7 +443,7 @@ VirtualizationConfig contains all the virtualization configurations
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | ------- | -------- |
 | tuningPolicy | TuningPolicy allows configuring the mode in which the RateLimits of kubevirt are set. If TuningPolicy is not present the default kubevirt values are used. It can be set to `annotation` for fine-tuning the kubevirt queryPerSeconds (QPS) and burst values. QPS and burst values are taken from the annotation hco.kubevirt.io/tuningPolicy | HyperConvergedTuningPolicy |  | false |
-| liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false} | false |
+| liveMigrationConfig | Live migration limits and timeouts are applied so that migration processes do not overwhelm the cluster. | [LiveMigrationConfigurations](#livemigrationconfigurations) | {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false, "allowWorkloadDisruption": false} | false |
 | permittedHostDevices | PermittedHostDevices holds information about devices allowed for passthrough | *[PermittedHostDevices](#permittedhostdevices) |  | false |
 | mediatedDevicesConfiguration | MediatedDevicesConfiguration holds information about MDEV types to be defined on nodes, if available | *[MediatedDevicesConfiguration](#mediateddevicesconfiguration) |  | false |
 | workloadUpdateStrategy | WorkloadUpdateStrategy defines at the cluster level how to handle automated workload updates | [HyperConvergedWorkloadUpdateStrategy](#hyperconvergedworkloadupdatestrategy) | {"workloadUpdateMethods": {"LiveMigrate"}, "batchEvictionSize": 10, "batchEvictionInterval": "1m0s"} | false |

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -326,6 +326,23 @@ alive.
 
 **default**: false
 
+#### allowWorkloadDisruption
+
+When enabled, the migration controller will not cancel migrations that exceed the
+acceptable completion time (determined by `completionTimeoutPerGiB` and the VM size).
+Instead, it will take action to force migration completion. The action depends on the
+`allowPostCopy` setting:
+
+- If `allowPostCopy` is `true`, the migration switches to post-copy mode.
+- If `allowPostCopy` is `false`, the VMI is paused until the migration completes.
+
+**Backward compatibility:** When `allowWorkloadDisruption` is not set, KubeVirt
+defaults it to the value of `allowPostCopy`. This means existing users with
+`allowPostCopy: true` will continue to get post-copy behavior without needing
+to explicitly set `allowWorkloadDisruption: true`.
+
+**default**: false
+
 #### Example
 
 ```yaml
@@ -343,6 +360,7 @@ spec:
       progressTimeout: 150
       allowAutoConverge: false
       allowPostCopy: false
+      allowWorkloadDisruption: false
 ```
 
 ### Automatic Configuration of Mediated Devices (including vGPUs)

--- a/pkg/upgradepatch/hc.cr.json
+++ b/pkg/upgradepatch/hc.cr.json
@@ -12,7 +12,8 @@
         "completionTimeoutPerGiB": 150,
         "progressTimeout": 150,
         "allowAutoConverge": false,
-        "allowPostCopy": false
+        "allowPostCopy": false,
+        "allowWorkloadDisruption": false
       },
       "workloadUpdateStrategy": {
         "workloadUpdateMethods": [

--- a/tests/func-tests/defaults_test.go
+++ b/tests/func-tests/defaults_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 		defaultLiveMigrationConfig := hcov1.LiveMigrationConfigurations{
 			AllowAutoConverge:                 new(false),
 			AllowPostCopy:                     new(false),
+			AllowWorkloadDisruption:           new(false),
 			CompletionTimeoutPerGiB:           new(int64(150)),
 			ParallelMigrationsPerCluster:      new(uint32(5)),
 			ParallelOutboundMigrationsPerNode: new(uint32(2)),
@@ -122,6 +123,7 @@ var _ = Describe("Check Default values", Label("defaults"), Serial, func() {
 		},
 			Entry("when removing /spec/virtualization/liveMigrationConfig/allowAutoConverge", "/spec/virtualization/liveMigrationConfig/allowAutoConverge"),
 			Entry("when removing /spec/virtualization/liveMigrationConfig/allowPostCopy", "/spec/virtualization/liveMigrationConfig/allowPostCopy"),
+			Entry("when removing /spec/virtualization/liveMigrationConfig/allowWorkloadDisruption", "/spec/virtualization/liveMigrationConfig/allowWorkloadDisruption"),
 			Entry("when removing /spec/virtualization/liveMigrationConfig/completionTimeoutPerGiB", "/spec/virtualization/liveMigrationConfig/completionTimeoutPerGiB"),
 			Entry("when removing /spec/virtualization/liveMigrationConfig/parallelMigrationsPerCluster", "/spec/virtualization/liveMigrationConfig/parallelMigrationsPerCluster"),
 			Entry("when removing /spec/virtualization/liveMigrationConfig/parallelOutboundMigrationsPerNode", "/spec/virtualization/liveMigrationConfig/parallelOutboundMigrationsPerNode"),

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -2750,6 +2750,7 @@ spec:
                   liveMigrationConfig:
                     allowAutoConverge: false
                     allowPostCopy: false
+                    allowWorkloadDisruption: false
                     completionTimeoutPerGiB: 150
                     parallelMigrationsPerCluster: 5
                     parallelOutboundMigrationsPerNode: 2
@@ -3023,6 +3024,7 @@ spec:
                     default:
                       allowAutoConverge: false
                       allowPostCopy: false
+                      allowWorkloadDisruption: false
                       completionTimeoutPerGiB: 150
                       parallelMigrationsPerCluster: 5
                       parallelOutboundMigrationsPerNode: 2
@@ -3047,6 +3049,15 @@ spec:
                           destination nodes can cause the migrated VM to crash or reach inconsistency.
                           Enable this option when evicting nodes is more important than keeping VMs
                           alive.
+                          Defaults to false.
+                        type: boolean
+                      allowWorkloadDisruption:
+                        default: false
+                        description: |-
+                          AllowWorkloadDisruption indicates that the migration shouldn't be
+                          canceled after the acceptable completion time is exceeded. Instead, if
+                          permitted, migration will be switched to post-copy or the VMI will be
+                          paused to allow the migration to complete.
                           Defaults to false.
                         type: boolean
                       bandwidthPerMigration:
@@ -7834,6 +7845,15 @@ spec:
                       destination nodes can cause the migrated VM to crash or reach inconsistency.
                       Enable this option when evicting nodes is more important than keeping VMs
                       alive.
+                      Defaults to false.
+                    type: boolean
+                  allowWorkloadDisruption:
+                    default: false
+                    description: |-
+                      AllowWorkloadDisruption indicates that the migration shouldn't be
+                      canceled after the acceptable completion time is exceeded. Instead, if
+                      permitted, migration will be switched to post-copy or the VMI will be
+                      paused to allow the migration to complete.
                       Defaults to false.
                     type: boolean
                   bandwidthPerMigration:

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -2750,6 +2750,7 @@ spec:
                   liveMigrationConfig:
                     allowAutoConverge: false
                     allowPostCopy: false
+                    allowWorkloadDisruption: false
                     completionTimeoutPerGiB: 150
                     parallelMigrationsPerCluster: 5
                     parallelOutboundMigrationsPerNode: 2
@@ -3023,6 +3024,7 @@ spec:
                     default:
                       allowAutoConverge: false
                       allowPostCopy: false
+                      allowWorkloadDisruption: false
                       completionTimeoutPerGiB: 150
                       parallelMigrationsPerCluster: 5
                       parallelOutboundMigrationsPerNode: 2
@@ -3047,6 +3049,15 @@ spec:
                           destination nodes can cause the migrated VM to crash or reach inconsistency.
                           Enable this option when evicting nodes is more important than keeping VMs
                           alive.
+                          Defaults to false.
+                        type: boolean
+                      allowWorkloadDisruption:
+                        default: false
+                        description: |-
+                          AllowWorkloadDisruption indicates that the migration shouldn't be
+                          canceled after the acceptable completion time is exceeded. Instead, if
+                          permitted, migration will be switched to post-copy or the VMI will be
+                          paused to allow the migration to complete.
                           Defaults to false.
                         type: boolean
                       bandwidthPerMigration:
@@ -7834,6 +7845,15 @@ spec:
                       destination nodes can cause the migrated VM to crash or reach inconsistency.
                       Enable this option when evicting nodes is more important than keeping VMs
                       alive.
+                      Defaults to false.
+                    type: boolean
+                  allowWorkloadDisruption:
+                    default: false
+                    description: |-
+                      AllowWorkloadDisruption indicates that the migration shouldn't be
+                      canceled after the acceptable completion time is exceeded. Instead, if
+                      permitted, migration will be switched to post-copy or the VMI will be
+                      paused to allow the migration to complete.
                       Defaults to false.
                     type: boolean
                   bandwidthPerMigration:


### PR DESCRIPTION
Add the AllowWorkloadDisruption option to the HyperConverged LiveMigrationConfig API and pass it through to the KubeVirt MigrationConfiguration.

When enabled, the migration controller will not cancel migrations that exceed the acceptable completion time. Instead, it will switch to post-copy (if AllowPostCopy is true) or pause the VMI to allow the migration to complete.

Defaults to false, preserving existing behavior.

See: https://github.com/kubevirt/kubevirt/pull/11833

**What this PR does / why we need it**:

Adds the `allowWorkloadDisruption` field to the HyperConverged `liveMigrationConfig` API and passes it through to the KubeVirt `MigrationConfiguration`.

`AllowWorkloadDisruption` controls what happens when a live migration exceeds its acceptable completion time (determined by `completionTimeoutPerGiB` and the VM size):

**When disabled (default):**
- The migration is canceled when the completion timeout is reached.
- This is the current default behavior - no change for existing users.
- Note: `allowPostCopy` has no effect when `allowWorkloadDisruption` is explicitly set to `false`- post-copy will **not** trigger on timeout, even if `allowPostCopy: true`.

**When enabled:**
- The migration controller is allowed to disrupt the workload to force migration completion.
- The action taken depends on the `AllowPostCopy` setting:

| `allowWorkloadDisruption` | `allowPostCopy` | Behavior on timeout |
|---|---|---|
| `false` (default) | any | Migration is **aborted** (post-copy will **not** kick in) |
| `true` | `false` | VMI is **paused** until migration completes (no risk of data loss, but temporary workload inactivity) |
| `true` | `true` | Migration switches to **post-copy** mode (faster completion, but a network failure during post-copy can crash the VMI) |

**Backward compatibility:**

KubeVirt includes a backward-compatibility shim: when `allowWorkloadDisruption` is not set (nil), it defaults to the value of `allowPostCopy`. This means existing users with `allowPostCopy: true` will continue to get post-copy behavior without needing to explicitly set `allowWorkloadDisruption: true`. However, if `allowWorkloadDisruption` is explicitly set to `false`, it takes precedence and post-copy will not activate.

**Jira Ticket**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-81274
```

**Release Note**:

```release-note
Added `allowWorkloadDisruption` field to `liveMigrationConfig`. When enabled, the migration controller will force migration completion by either switching to post-copy mode (if `allowPostCopy` is true) or pausing the VMI, instead of aborting migrations that exceed the completion timeout.
```

Assisted-by: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)