### PR TITLE
[release-1.17] Allow downloading of the virtio-win iso image from the artifacts server

### DIFF
--- a/controllers/handlers/virtio_win_ConfigMap.go
+++ b/controllers/handlers/virtio_win_ConfigMap.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"net/url"
 	"os"
 
 	log "github.com/go-logr/logr"
@@ -13,6 +14,7 @@ import (
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
@@ -20,11 +22,12 @@ const virtioWinCmName = "virtio-win"
 
 // NewVirtioWinCmHandler creates the Virtio-Win ConfigMap Handler
 func NewVirtioWinCmHandler(_ log.Logger, Client client.Client, Scheme *runtime.Scheme, hc *hcov1beta1.HyperConverged) (operands.Operand, error) {
-	virtioWincm, err := NewVirtioWinCm(hc)
+	_, err := getVirtioImageName()
 	if err != nil {
 		return nil, err
 	}
-	return operands.NewCmHandler(Client, Scheme, virtioWincm), nil
+
+	return operands.NewDynamicCmHandler(Client, Scheme, NewVirtioWinCm), nil
 }
 
 // NewVirtioWinCmReaderRoleHandler creates the Virtio-Win ConfigMap Role Handler
@@ -37,10 +40,28 @@ func NewVirtioWinCmReaderRoleBindingHandler(_ log.Logger, Client client.Client, 
 	return operands.NewRoleBindingHandler(Client, Scheme, NewVirtioWinCmReaderRoleBinding(hc)), nil
 }
 
+const (
+	virtioWinImageKey   = "virtio-win-image"
+	virtioWinImageDLKey = "virtio-win-image-download-url"
+)
+
 func NewVirtioWinCm(hc *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {
-	virtiowinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
-	if virtiowinContainer == "" {
-		return nil, errors.New("kv-virtiowin-image-name was not specified")
+	virtiowinContainer, err := getVirtioImageName()
+	if err != nil {
+		return nil, err
+	}
+
+	data := map[string]string{
+		virtioWinImageKey: virtiowinContainer,
+	}
+
+	if imageDLFilePath, envFound := os.LookupEnv(hcoutil.VirtIOWinDataFileEnvV); envFound && imageDLFilePath != "" {
+		downloadURL := url.URL{
+			Scheme: "https",
+			Host:   string(downloadhost.Get().CurrentHost),
+			Path:   imageDLFilePath,
+		}
+		data[virtioWinImageDLKey] = downloadURL.String()
 	}
 
 	return &corev1.ConfigMap{
@@ -49,9 +70,7 @@ func NewVirtioWinCm(hc *hcov1beta1.HyperConverged) (*corev1.ConfigMap, error) {
 			Labels:    operands.GetLabels(hc, hcoutil.AppComponentDeployment),
 			Namespace: hc.Namespace,
 		},
-		Data: map[string]string{
-			"virtio-win-image": virtiowinContainer,
-		},
+		Data: data,
 	}, nil
 }
 
@@ -93,4 +112,13 @@ func NewVirtioWinCmReaderRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.Role
 			},
 		},
 	}
+}
+
+func getVirtioImageName() (string, error) {
+	virtiowinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
+	if virtiowinContainer == "" {
+		return "", errors.New("kv-virtiowin-image-name was not specified")
+	}
+
+	return virtiowinContainer, nil
 }

--- a/controllers/handlers/virtio_win_ConfigMap.go
+++ b/controllers/handlers/virtio_win_ConfigMap.go
@@ -115,7 +115,7 @@ func NewVirtioWinCmReaderRoleBinding(hc *hcov1beta1.HyperConverged) *rbacv1.Role
 }
 
 func getVirtioImageName() (string, error) {
-	virtiowinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
+	virtiowinContainer := os.Getenv(hcoutil.VirtioWinImageEnvV)
 	if virtiowinContainer == "" {
 		return "", errors.New("kv-virtiowin-image-name was not specified")
 	}

--- a/controllers/handlers/virtio_win_ConfigMap_test.go
+++ b/controllers/handlers/virtio_win_ConfigMap_test.go
@@ -30,13 +30,13 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
+			Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, virtioImage)).To(Succeed())
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})
 
 		It("should error if VIRTIOWIN_CONTAINER environment var not specified", func() {
-			os.Unsetenv("VIRTIOWIN_CONTAINER")
+			Expect(os.Unsetenv(hcoutil.VirtioWinImageEnvV)).To(Succeed())
 
 			cl := commontestutils.InitClient([]client.Object{})
 			handler, err := NewVirtioWinCmHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
@@ -288,7 +288,7 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
+			Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, virtioImage)).To(Succeed())
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})
@@ -339,7 +339,7 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
+			Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, virtioImage)).To(Succeed())
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})

--- a/controllers/handlers/virtio_win_ConfigMap_test.go
+++ b/controllers/handlers/virtio_win_ConfigMap_test.go
@@ -13,17 +13,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/common"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
 
 var _ = Describe("VirtioWin", func() {
-
-	var testLogger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).WithName("VirtioWin_test")
+	const virtioImage = "new-virtiowin-container-value"
 
 	Context("Virtio-Win ConfigMap", func() {
 
@@ -31,7 +30,7 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", "new-virtiowin-container-value")
+			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})
@@ -40,7 +39,7 @@ var _ = Describe("VirtioWin", func() {
 			os.Unsetenv("VIRTIOWIN_CONTAINER")
 
 			cl := commontestutils.InitClient([]client.Object{})
-			handler, err := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, err := NewVirtioWinCmHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
 
 			Expect(err).To(HaveOccurred())
 			Expect(handler).To(BeNil())
@@ -50,7 +49,7 @@ var _ = Describe("VirtioWin", func() {
 			expectedResource, err := NewVirtioWinCm(hco)
 			Expect(err).ToNot(HaveOccurred())
 			cl := commontestutils.InitClient([]client.Object{})
-			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -71,7 +70,7 @@ var _ = Describe("VirtioWin", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedResource})
-			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Err).ToNot(HaveOccurred())
@@ -85,9 +84,8 @@ var _ = Describe("VirtioWin", func() {
 		})
 
 		It("should reconcile according to env values and HCO CR", func() {
-			virtiowink := "virtio-win-image"
-			updatableKeys := [...]string{virtiowink}
-			toBeRemovedKey := "toberemoved"
+			updatableKeys := [...]string{virtioWinImageKey}
+			const toBeRemovedKey = "toberemoved"
 
 			expectedResource, err := NewVirtioWinCm(hco)
 			Expect(err).ToNot(HaveOccurred())
@@ -96,13 +94,13 @@ var _ = Describe("VirtioWin", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// values we should update
-			outdatedResource.Data[virtiowink] = "old-virtiowin-container-value-we-have-to-update"
+			outdatedResource.Data[virtioWinImageKey] = "old-virtiowin-container-value-we-have-to-update"
 
 			// add values we should remove
 			outdatedResource.Data[toBeRemovedKey] = "value-we-should-remove"
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -116,8 +114,7 @@ var _ = Describe("VirtioWin", func() {
 			).ToNot(HaveOccurred())
 
 			for _, k := range updatableKeys {
-				Expect(foundResource.Data[k]).ToNot(Equal(outdatedResource.Data[k]))
-				Expect(foundResource.Data[k]).To(Equal(expectedResource.Data[k]))
+				Expect(foundResource.Data).To(HaveKeyWithValue(k, expectedResource.Data[k]))
 			}
 
 			Expect(foundResource.Data).ToNot(HaveKey(toBeRemovedKey))
@@ -144,7 +141,7 @@ var _ = Describe("VirtioWin", func() {
 			outdatedResource.Labels[userLabelKey] = userLabelValue
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -173,7 +170,7 @@ var _ = Describe("VirtioWin", func() {
 			delete(outdatedResource.Labels, hcoutil.AppLabelVersion)
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
-			handler, _ := NewVirtioWinCmHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
 			res := handler.Ensure(req)
 			Expect(res.UpgradeDone).To(BeFalse())
 			Expect(res.Updated).To(BeTrue())
@@ -192,6 +189,98 @@ var _ = Describe("VirtioWin", func() {
 			Expect(foundResource.Labels).To(HaveKeyWithValue(userLabelKey, userLabelValue))
 		})
 
+		It("should not add the download URL if the env var is missing", func() {
+			cl := commontestutils.InitClient([]client.Object{})
+			handler, _ := NewVirtioWinCmHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+
+			foundResource := &corev1.ConfigMap{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: virtioWinCmName, Namespace: commontestutils.Namespace},
+					foundResource),
+			).To(Succeed())
+
+			Expect(foundResource.Data).To(HaveKeyWithValue(virtioWinImageKey, virtioImage))
+			Expect(foundResource.Data).ToNot(HaveKey(virtioWinImageDLKey))
+		})
+
+		It("should not add the download URL if the env var is empty", func() {
+			Expect(os.Setenv(hcoutil.VirtIOWinDataFileEnvV, "")).To(Succeed())
+			DeferCleanup(func() {
+				Expect(os.Unsetenv(hcoutil.VirtIOWinDataFileEnvV)).To(Succeed())
+			})
+
+			cl := commontestutils.InitClient([]client.Object{})
+			handler, _ := NewVirtioWinCmHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+
+			foundResource := &corev1.ConfigMap{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: virtioWinCmName, Namespace: commontestutils.Namespace},
+					foundResource),
+			).To(Succeed())
+
+			Expect(foundResource.Data).To(HaveKeyWithValue(virtioWinImageKey, virtioImage))
+			Expect(foundResource.Data).ToNot(HaveKey(virtioWinImageDLKey))
+		})
+
+		It("should add the download URL if the env var is set", func() {
+			origHost := downloadhost.Get()
+			DeferCleanup(func() {
+				downloadhost.Set(origHost)
+			})
+
+			downloadhost.Set(downloadhost.CLIDownloadHost{
+				DefaultHost: "default-host.com",
+				CurrentHost: "default-host.com",
+				Cert:        "crt",
+				Key:         "key",
+			})
+
+			Expect(os.Setenv(hcoutil.VirtIOWinDataFileEnvV, "virtio-win/virtio-win.iso")).To(Succeed())
+			DeferCleanup(func() {
+				Expect(os.Unsetenv(hcoutil.VirtIOWinDataFileEnvV)).To(Succeed())
+			})
+
+			cl := commontestutils.InitClient([]client.Object{})
+			handler, _ := NewVirtioWinCmHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
+			res := handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+
+			foundResource := &corev1.ConfigMap{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: virtioWinCmName, Namespace: commontestutils.Namespace},
+					foundResource),
+			).To(Succeed())
+
+			Expect(foundResource.Data).To(HaveKeyWithValue(virtioWinImageKey, virtioImage))
+			Expect(foundResource.Data).To(HaveKeyWithValue(virtioWinImageDLKey, "https://default-host.com/virtio-win/virtio-win.iso"))
+
+			By("should update the download URL if it was customized")
+			downloadhost.Set(downloadhost.CLIDownloadHost{
+				DefaultHost: "default-host.com",
+				CurrentHost: "cli-dl.example.com",
+				Cert:        "crt",
+				Key:         "key",
+			})
+
+			handler.Reset()
+			res = handler.Ensure(req)
+			Expect(res.Err).ToNot(HaveOccurred())
+			foundResource = &corev1.ConfigMap{}
+			Expect(
+				cl.Get(context.TODO(),
+					types.NamespacedName{Name: virtioWinCmName, Namespace: commontestutils.Namespace},
+					foundResource),
+			).To(Succeed())
+
+			Expect(foundResource.Data).To(HaveKeyWithValue(virtioWinImageDLKey, "https://cli-dl.example.com/virtio-win/virtio-win.iso"))
+		})
 	})
 
 	Context("ConfigMap Reader Role", func() {
@@ -199,15 +288,16 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", "new-virtiowin-container-value")
+			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})
+
 		It("should do nothing if exists", func() {
 			expectedRole := NewVirtioWinCmReaderRole(hco)
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRole})
 
-			handler, _ := NewVirtioWinCmReaderRoleHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmReaderRoleHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -229,7 +319,7 @@ var _ = Describe("VirtioWin", func() {
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRole})
 
-			handler, _ := NewVirtioWinCmReaderRoleHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmReaderRoleHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -249,16 +339,17 @@ var _ = Describe("VirtioWin", func() {
 		var req *common.HcoRequest
 
 		BeforeEach(func() {
-			os.Setenv("VIRTIOWIN_CONTAINER", "new-virtiowin-container-value")
+			os.Setenv("VIRTIOWIN_CONTAINER", virtioImage)
 			hco = commontestutils.NewHco()
 			req = commontestutils.NewReq(hco)
 		})
+
 		It("should do nothing if exists", func() {
 			expectedRoleBinding := NewVirtioWinCmReaderRoleBinding(hco)
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRoleBinding})
 
-			handler, _ := NewVirtioWinCmReaderRoleBindingHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmReaderRoleBindingHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 
@@ -279,7 +370,7 @@ var _ = Describe("VirtioWin", func() {
 
 			cl := commontestutils.InitClient([]client.Object{hco, expectedRoleBinding})
 
-			handler, _ := NewVirtioWinCmReaderRoleBindingHandler(testLogger, cl, commontestutils.GetScheme(), hco)
+			handler, _ := NewVirtioWinCmReaderRoleBindingHandler(GinkgoLogr, cl, commontestutils.GetScheme(), hco)
 			res := handler.Ensure(req)
 			Expect(res.Err).ToNot(HaveOccurred())
 

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -56,7 +56,7 @@ var _ = Describe("HyperconvergedController", func() {
 	getClusterInfo := hcoutil.GetClusterInfo
 
 	origOperatorCondVarName := os.Getenv(hcoutil.OperatorConditionNameEnvVar)
-	origVirtIOWinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
+	origVirtIOWinContainer := os.Getenv(hcoutil.VirtioWinImageEnvV)
 	origOperatorNS := os.Getenv("OPERATOR_NAMESPACE")
 	origVersion := os.Getenv(hcoutil.HcoKvIoVersionName)
 
@@ -67,7 +67,7 @@ var _ = Describe("HyperconvergedController", func() {
 		fakeownresources.OLMV0OwnResourcesMock()
 
 		Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, "OPERATOR_CONDITION")).To(Succeed())
-		Expect(os.Setenv("VIRTIOWIN_CONTAINER", commontestutils.VirtioWinImage)).To(Succeed())
+		Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, commontestutils.VirtioWinImage)).To(Succeed())
 		Expect(os.Setenv("OPERATOR_NAMESPACE", namespace)).To(Succeed())
 		Expect(os.Setenv(hcoutil.HcoKvIoVersionName, version.Version)).To(Succeed())
 
@@ -78,7 +78,7 @@ var _ = Describe("HyperconvergedController", func() {
 			fakeownresources.ResetOwnResources()
 
 			Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, origOperatorCondVarName)).To(Succeed())
-			Expect(os.Setenv("VIRTIOWIN_CONTAINER", origVirtIOWinContainer)).To(Succeed())
+			Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, origVirtIOWinContainer)).To(Succeed())
 			Expect(os.Setenv("OPERATOR_NAMESPACE", origOperatorNS)).To(Succeed())
 			Expect(os.Setenv(hcoutil.HcoKvIoVersionName, origVersion)).To(Succeed())
 		})
@@ -1693,7 +1693,7 @@ var _ = Describe("HyperconvergedController", func() {
 
 		Context("Update Conflict Error", func() {
 			BeforeEach(func() {
-				Expect(os.Setenv("VIRTIOWIN_CONTAINER", commontestutils.VirtioWinImage)).To(Succeed())
+				Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, commontestutils.VirtioWinImage)).To(Succeed())
 			})
 
 			It("Should requeue in case of update conflict", func() {

--- a/controllers/hyperconverged/upgrade_test.go
+++ b/controllers/hyperconverged/upgrade_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Upgrade Mode", func() {
 		fakeownresources.OLMV0OwnResourcesMock()
 
 		origOperatorCondVarName := os.Getenv(hcoutil.OperatorConditionNameEnvVar)
-		origVirtIOWinContainer := os.Getenv("VIRTIOWIN_CONTAINER")
+		origVirtIOWinContainer := os.Getenv(hcoutil.VirtioWinImageEnvV)
 		origOperatorNS := os.Getenv("OPERATOR_NAMESPACE")
 		origVersion := os.Getenv(hcoutil.HcoKvIoVersionName)
 
@@ -58,7 +58,7 @@ var _ = Describe("Upgrade Mode", func() {
 			return commontestutils.ClusterInfoMock{}
 		}
 		Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, "OPERATOR_CONDITION")).To(Succeed())
-		Expect(os.Setenv("VIRTIOWIN_CONTAINER", commontestutils.VirtioWinImage)).To(Succeed())
+		Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, commontestutils.VirtioWinImage)).To(Succeed())
 		Expect(os.Setenv("OPERATOR_NAMESPACE", namespace)).To(Succeed())
 		Expect(os.Setenv(hcoutil.HcoKvIoVersionName, version.Version)).To(Succeed())
 
@@ -109,7 +109,7 @@ var _ = Describe("Upgrade Mode", func() {
 			fakeownresources.ResetOwnResources()
 
 			Expect(os.Setenv(hcoutil.OperatorConditionNameEnvVar, origOperatorCondVarName)).To(Succeed())
-			Expect(os.Setenv("VIRTIOWIN_CONTAINER", origVirtIOWinContainer)).To(Succeed())
+			Expect(os.Setenv(hcoutil.VirtioWinImageEnvV, origVirtIOWinContainer)).To(Succeed())
 			Expect(os.Setenv("OPERATOR_NAMESPACE", origOperatorNS)).To(Succeed())
 			Expect(os.Setenv(hcoutil.HcoKvIoVersionName, origVersion)).To(Succeed())
 		})

--- a/controllers/operands/cmHandler.go
+++ b/controllers/operands/cmHandler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"maps"
 	"reflect"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,6 +17,12 @@ import (
 
 func NewCmHandler(Client client.Client, Scheme *runtime.Scheme, required *corev1.ConfigMap) *GenericOperand {
 	return NewGenericOperand(Client, Scheme, "ConfigMap", &cmHooks{required: required}, false)
+}
+
+type newDynamicConfigMapFunc func(*hcov1beta1.HyperConverged) (*corev1.ConfigMap, error)
+
+func NewDynamicCmHandler(Client client.Client, Scheme *runtime.Scheme, makeCM newDynamicConfigMapFunc) *GenericOperand {
+	return NewGenericOperand(Client, Scheme, "ConfigMap", &dynamicCmHooks{makeCM: makeCM}, false)
 }
 
 type cmHooks struct {
@@ -60,6 +67,70 @@ func (h cmHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exists r
 			req.Logger.Info("Reconciling an externally updated ConfigMap to its opinionated values", "name", h.required.Name)
 		}
 		found.Data = maps.Clone(h.required.Data)
+		err := Client.Update(req.Ctx, found)
+		if err != nil {
+			return false, false, err
+		}
+		return true, !req.HCOTriggered, nil
+	}
+
+	return labelChanged, false, nil
+}
+
+type dynamicCmHooks struct {
+	sync.Mutex
+	makeCM newDynamicConfigMapFunc
+	cache  *corev1.ConfigMap
+}
+
+func (h *dynamicCmHooks) Reset() {
+	h.Lock()
+	defer h.Unlock()
+
+	h.cache = nil
+}
+
+func (h *dynamicCmHooks) GetFullCr(hc *hcov1beta1.HyperConverged) (client.Object, error) {
+	h.Lock()
+	defer h.Unlock()
+
+	if h.cache == nil {
+		cm, err := h.makeCM(hc)
+		if err != nil {
+			return nil, err
+		}
+		h.cache = cm
+	}
+
+	return h.cache.DeepCopy(), nil
+}
+
+func (*dynamicCmHooks) GetEmptyCr() client.Object {
+	return &corev1.ConfigMap{}
+}
+
+func (*dynamicCmHooks) UpdateCR(req *common.HcoRequest, Client client.Client, exists runtime.Object, desired runtime.Object) (bool, bool, error) {
+	found, ok := exists.(*corev1.ConfigMap)
+	if !ok {
+		return false, false, errors.New("can't convert to ConfigMap")
+	}
+	required, ok := desired.(*corev1.ConfigMap)
+	if !ok {
+		return false, false, errors.New("can't convert desired to ConfigMap")
+	}
+
+	labelChanged := !util.CompareLabels(required, found)
+	if labelChanged {
+		util.MergeLabels(&required.ObjectMeta, &found.ObjectMeta)
+	}
+
+	if !reflect.DeepEqual(found.Data, required.Data) || labelChanged {
+		if req.HCOTriggered {
+			req.Logger.Info("Updating existing ConfigMap to new opinionated values", "name", required.Name)
+		} else {
+			req.Logger.Info("Reconciling an externally updated ConfigMap to its opinionated values", "name", required.Name)
+		}
+		found.Data = maps.Clone(required.Data)
 		err := Client.Update(req.Ctx, found)
 		if err != nil {
 			return false, false, err

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -3,6 +3,7 @@ package components
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 	"strconv"
 	"time"
 
@@ -42,6 +43,8 @@ const (
 
 	kubevirtProjectName = "KubeVirt project"
 	rbacVersionV1       = "rbac.authorization.k8s.io/v1"
+
+	artifactServerMountName = "virtiowin-data"
 )
 
 var deploymentType = metav1.TypeMeta{
@@ -63,6 +66,8 @@ type DeploymentOperatorParams struct {
 	ConversionContainer      string
 	VmwareContainer          string
 	VirtIOWinContainer       string
+	VirtIOWinDataFile        string
+	VirtIOWinMountPath       string
 	Smbios                   string
 	Machinetype              string
 	Amd64MachineType         string
@@ -151,8 +156,6 @@ func GetServiceWebhook() corev1.Service {
 }
 
 func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.DeploymentSpec {
-	envs := buildEnvVars(params)
-
 	return appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
 		Selector: &metav1.LabelSelector{
@@ -178,7 +181,7 @@ func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.Deployme
 						Command:         stringListToSlice(util.HCOOperatorName),
 						ReadinessProbe:  getReadinessProbe(util.ReadinessEndpointName, util.HealthProbePort),
 						LivenessProbe:   getLivenessProbe(util.LivenessEndpointName, util.HealthProbePort),
-						Env:             envs,
+						Env:             buildOperatorEnvVars(params),
 						Resources: corev1.ResourceRequirements{
 							Requests: map[corev1.ResourceName]resource.Quantity{
 								corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -198,7 +201,7 @@ func GetDeploymentSpecOperator(params *DeploymentOperatorParams) appsv1.Deployme
 	}
 }
 
-func buildEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
+func buildOperatorEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
 	envs := append([]corev1.EnvVar{
 		{
 			// deprecated: left here for CI test.
@@ -325,11 +328,19 @@ func buildEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
 		})
 	}
 
+	if params.VirtIOWinDataFile != "" && params.VirtIOWinMountPath != "" {
+		value := path.Join(util.VirtIODownloadDir, path.Base(params.VirtIOWinDataFile))
+		envs = append(envs, corev1.EnvVar{
+			Name:  util.VirtIOWinDataFileEnvV,
+			Value: value,
+		})
+	}
+
 	return envs
 }
 
 func GetDeploymentSpecCliDownloads(params *DeploymentOperatorParams) appsv1.DeploymentSpec {
-	return appsv1.DeploymentSpec{
+	spec := appsv1.DeploymentSpec{
 		Replicas: ptr.To[int32](1),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -374,6 +385,49 @@ func GetDeploymentSpecCliDownloads(params *DeploymentOperatorParams) appsv1.Depl
 			},
 		},
 	}
+
+	addVirtIOVolume(&spec, params)
+
+	return spec
+}
+
+func addVirtIOVolume(spec *appsv1.DeploymentSpec, params *DeploymentOperatorParams) {
+	const initContainerMount = "/mnt/" + artifactServerMountName
+	if params.VirtIOWinDataFile == "" || params.VirtIOWinMountPath == "" {
+		return
+	}
+
+	spec.Template.Spec.Volumes = append(spec.Template.Spec.Volumes, corev1.Volume{
+		Name:         artifactServerMountName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	})
+	spec.Template.Spec.InitContainers = append(spec.Template.Spec.InitContainers, corev1.Container{
+		Name:            "virtiowin-data-loader",
+		Image:           params.VirtIOWinContainer,
+		ImagePullPolicy: corev1.PullPolicy(params.ImagePullPolicy),
+		Command:         []string{"cp", params.VirtIOWinDataFile, initContainerMount},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: artifactServerMountName, MountPath: initContainerMount},
+		},
+		SecurityContext:          getVirtIOWinInitContainerSecurityContext(),
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+		},
+	})
+
+	mountPath := path.Join(params.VirtIOWinMountPath, util.VirtIODownloadDir)
+	spec.Template.Spec.Containers[0].VolumeMounts = append(
+		spec.Template.Spec.Containers[0].VolumeMounts,
+		corev1.VolumeMount{Name: artifactServerMountName, MountPath: mountPath, ReadOnly: true},
+	)
 }
 
 func getLabels(name, hcoKvIoVersion string) map[string]string {
@@ -411,6 +465,15 @@ func GetStdContainerSecurityContext() *corev1.SecurityContext {
 			Drop: []corev1.Capability{"ALL"},
 		},
 	}
+}
+
+// getVirtIOWinInitContainerSecurityContext returns a security context for the virtiowin init
+// container. It sets runAsUser explicitly so that the pod-level runAsNonRoot constraint is met
+// even when the data-only image has no USER directive and would otherwise run as root.
+func getVirtIOWinInitContainerSecurityContext() *corev1.SecurityContext {
+	sc := GetStdContainerSecurityContext()
+	sc.RunAsUser = ptr.To[int64](1001)
+	return sc
 }
 
 // Currently we are abusing the pod readiness to signal to OLM that HCO is not ready
@@ -451,41 +514,7 @@ func GetDeploymentSpecWebhook(params *DeploymentOperatorParams) appsv1.Deploymen
 						Command:         stringListToSlice(util.HCOWebhookName),
 						ReadinessProbe:  getReadinessProbe(util.ReadinessEndpointName, util.HealthProbePort),
 						LivenessProbe:   getLivenessProbe(util.LivenessEndpointName, util.HealthProbePort),
-						Env: append([]corev1.EnvVar{
-							{
-								// deprecated: left here for CI test.
-								Name:  util.OperatorWebhookModeEnv,
-								Value: "true",
-							},
-							{
-								Name:  util.ContainerAppName,
-								Value: util.ContainerWebhookApp,
-							},
-							{
-								Name:  "OPERATOR_IMAGE",
-								Value: params.WebhookImage,
-							},
-							{
-								Name:  "OPERATOR_NAME",
-								Value: util.HCOWebhookName,
-							},
-							{
-								Name:  "OPERATOR_NAMESPACE",
-								Value: params.Namespace,
-							},
-							{
-								Name: "POD_NAME",
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "metadata.name",
-									},
-								},
-							},
-							{
-								Name:  util.HcoKvIoVersionName,
-								Value: params.HcoKvIoVersion,
-							},
-						}, params.Env...),
+						Env:             buildWebhookEnvVars(params),
 						Resources: corev1.ResourceRequirements{
 							Requests: map[corev1.ResourceName]resource.Quantity{
 								corev1.ResourceCPU:    resource.MustParse("5m"),
@@ -504,6 +533,44 @@ func GetDeploymentSpecWebhook(params *DeploymentOperatorParams) appsv1.Deploymen
 			},
 		},
 	}
+}
+
+func buildWebhookEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
+	return append([]corev1.EnvVar{
+		{
+			// deprecated: left here for CI test.
+			Name:  util.OperatorWebhookModeEnv,
+			Value: "true",
+		},
+		{
+			Name:  util.ContainerAppName,
+			Value: util.ContainerWebhookApp,
+		},
+		{
+			Name:  "OPERATOR_IMAGE",
+			Value: params.WebhookImage,
+		},
+		{
+			Name:  "OPERATOR_NAME",
+			Value: util.HCOWebhookName,
+		},
+		{
+			Name:  "OPERATOR_NAMESPACE",
+			Value: params.Namespace,
+		},
+		{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name:  util.HcoKvIoVersionName,
+			Value: params.HcoKvIoVersion,
+		},
+	}, params.Env...)
 }
 
 func GetClusterRole() rbacv1.ClusterRole {

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -237,7 +237,7 @@ func buildOperatorEnvVars(params *DeploymentOperatorParams) []corev1.EnvVar {
 			},
 		},
 		{
-			Name:  "VIRTIOWIN_CONTAINER",
+			Name:  util.VirtioWinImageEnvV,
 			Value: params.VirtIOWinContainer,
 		},
 		{

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -29,6 +29,7 @@ const (
 	KVUIProxyImageEnvV                 = "KV_CONSOLE_PROXY_IMAGE"
 	PasstImageEnvV                     = "PASST_SIDECAR_IMAGE"
 	PasstCNIImageEnvV                  = "PASST_CNI_IMAGE"
+	VirtioWinImageEnvV                 = "VIRTIOWIN_CONTAINER"
 	WaspAgentImageEnvV                 = "WASP_AGENT_IMAGE"
 	DeployNetworkPoliciesEnvV          = "DEPLOY_NETWORK_POLICIES"
 	VirtIOWinDataFileEnvV              = "DEPLOY_VIRT_IO_WIN_DATA_FILE"

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -31,6 +31,8 @@ const (
 	PasstCNIImageEnvV                  = "PASST_CNI_IMAGE"
 	WaspAgentImageEnvV                 = "WASP_AGENT_IMAGE"
 	DeployNetworkPoliciesEnvV          = "DEPLOY_NETWORK_POLICIES"
+	VirtIOWinDataFileEnvV              = "DEPLOY_VIRT_IO_WIN_DATA_FILE"
+	VirtIODownloadDir                  = "virtio-win"
 	HcoValidatingWebhook               = "validate-hco.kubevirt.io"
 	HcoMutatingWebhookNS               = "mutate-ns-hco.kubevirt.io"
 	PrometheusRuleCRDName              = "prometheusrules.monitoring.coreos.com"

--- a/tests/func-tests/cli_download_test.go
+++ b/tests/func-tests/cli_download_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	v1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -23,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/downloadhost"
+	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
@@ -59,6 +62,8 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 
 		Expect(ccd.Spec.Links).To(HaveLen(7))
 
+		httpClient := getHTTPClient()
+
 		for _, link := range ccd.Spec.Links {
 			// virtctl for Windows for ARM 64 is still not shipped, avoid checking it
 			// TODO: remove this once ready
@@ -66,16 +71,19 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 				continue
 			}
 			By("Checking links. Link:" + link.Href)
-			client := &http.Client{Transport: &http.Transport{
-				// ssl of the route is irrelevant
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}}
-			resp, err := client.Get(link.Href)
-			_ = resp.Body.Close()
+			resp, err := httpClient.Head(link.Href)
+
+			Expect(err).NotTo(HaveOccurred(), "HEAD failed for %s", link.Href)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "non OK response for %s", link.Href)
 
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			ExpectWithOffset(1, resp).To(HaveHTTPStatus(http.StatusOK))
 		}
+
+		link, err := url.Parse(ccd.Spec.Links[0].Href)
+		Expect(err).ToNot(HaveOccurred())
+
+		checkVirtioWinDownload(ctx, cli, httpClient, link.Host)
 	})
 
 	Context("URL Download customization", func() {
@@ -122,9 +130,7 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 			patch := []byte(fmt.Sprintf(`[{"op": "add", "path": "/spec/componentRoutes", "value": [{"name": "virt-downloads", "hostname": %q, "namespace": %q}]}]`, newCLIDLHost, tests.InstallNamespace))
 			Expect(cli.Patch(ctx, ingress, client.RawPatch(types.JSONPatchType, patch))).To(Succeed())
 
-			customTransport := http.DefaultTransport.(*http.Transport).Clone()
-			customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-			httpClient := &http.Client{Transport: customTransport, Timeout: time.Second * 1}
+			httpClient := getHTTPClient()
 
 			ccdKey := client.ObjectKey{Name: "virtctl-clidownloads-kubevirt-hyperconverged"}
 
@@ -144,13 +150,17 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 					g.Expect(link.Href).To(ContainSubstring(newCLIDLHost))
 					res, err := httpClient.Head(link.Href)
 					g.Expect(err).NotTo(HaveOccurred(), "HEAD failed for %s", link.Href)
+					if res.Body != nil {
+						g.Expect(res.Body.Close()).To(Succeed())
+					}
 					g.Expect(res.StatusCode).To(Equal(http.StatusOK), "non OK response for %s", link.Href)
 				}
 			}).WithContext(ctx).
 				WithTimeout(60 * time.Second).
-				WithPolling(time.Second).
+				WithPolling(5 * time.Second).
 				Should(Succeed())
 
+			By("check route")
 			routeKey := client.ObjectKey{Name: downloadhost.CLIDownloadsServiceName, Namespace: tests.InstallNamespace}
 			Eventually(func(g Gomega, ctx context.Context) {
 				route := &v1.Route{}
@@ -160,6 +170,51 @@ var _ = Describe("[rfe_id:5100][crit:medium][vendor:cnv-qe@redhat.com][level:sys
 				WithTimeout(60 * time.Second).
 				WithPolling(time.Second).
 				Should(Succeed())
+
+			checkVirtioWinDownload(ctx, cli, httpClient, newCLIDLHost)
 		})
 	})
 })
+
+func getHTTPClient() *http.Client {
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	return &http.Client{Transport: customTransport, Timeout: time.Second * 3}
+}
+
+func checkVirtioWinDownload(ctx context.Context, cli client.Client, httpClient *http.Client, cliDLHost string) {
+	GinkgoHelper()
+
+	By("check the virtio-win iso download")
+	var hcoPods corev1.PodList
+	Expect(cli.List(ctx, &hcoPods, &client.MatchingLabels{
+		"name": "hyperconverged-cluster-operator",
+	})).To(Succeed())
+	Expect(hcoPods.Items).ToNot(BeEmpty())
+
+	pod := hcoPods.Items[0]
+	idx := slices.IndexFunc(pod.Spec.Containers[0].Env, func(env corev1.EnvVar) bool {
+		return env.Name == hcoutil.VirtIOWinDataFileEnvV
+	})
+
+	if idx < 0 {
+		GinkgoLogr.Info(fmt.Sprintf("The HCO pod does not have the %s env var; virtio-win image download is not implemented", hcoutil.VirtIOWinDataFileEnvV))
+		return
+	}
+
+	virtioWinDLPath := pod.Spec.Containers[0].Env[idx].Value
+
+	virtioWinCM := &corev1.ConfigMap{}
+	Expect(cli.Get(ctx, client.ObjectKey{Namespace: tests.InstallNamespace, Name: "virtio-win"}, virtioWinCM)).To(Succeed())
+
+	virtioWinDLPathURL, urlExists := virtioWinCM.Data["virtio-win-image-download-url"]
+	Expect(urlExists).To(BeTrue())
+	Expect(virtioWinDLPathURL).To(ContainSubstring(cliDLHost))
+	Expect(virtioWinDLPathURL).To(HaveSuffix(virtioWinDLPath))
+	res, err := httpClient.Head(virtioWinDLPathURL)
+	Expect(err).NotTo(HaveOccurred(), "HEAD failed for %s", virtioWinDLPathURL)
+	if res.Body != nil {
+		Expect(res.Body.Close()).To(Succeed())
+	}
+	Expect(res.StatusCode).To(Equal(http.StatusOK), "non OK response for %s", virtioWinDLPathURL)
+}

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -80,34 +80,36 @@ func (i *EnvVarFlags) Set(value string) error {
 }
 
 var (
-	outputMode          = flag.String("output-mode", CSVMode, "Working mode: "+validOutputModes)
-	operatorImage       = flag.String("operator-image-name", "", "HyperConverged Cluster Operator image")
-	webhookImage        = flag.String("webhook-image-name", "", "HyperConverged Cluster Webhook image")
-	cliDownloadsImage   = flag.String("cli-downloads-image-name", "", "Downloads Server image")
-	kvUIPluginImage     = flag.String("kubevirt-consoleplugin-image-name", "", "KubeVirt Console Plugin image")
-	kvUIProxyImage      = flag.String("kubevirt-consoleproxy-image-name", "", "KubeVirt Console Proxy image")
-	kvVirtIOWinImage    = flag.String("kv-virtiowin-image-name", "", "KubeVirt VirtIO Win image")
-	passtImage          = flag.String("network-passt-binding-image-name", "", "Passt binding image")
-	passtCNIImage       = flag.String("network-passt-binding-cni-image-name", "", "Passt binding cni image")
-	waspAgentImage      = flag.String("wasp-agent-image-name", "", "Wasp Agent image")
-	smbios              = flag.String("smbios", "", "Custom SMBIOS string, used by HCO to configure the SMBIOS in KubeVirt CR")
-	smbiosFile          = flag.String("smbios-file", "", "Custom SMBIOS file name, used by HCO to configure the SMBIOS in KubeVirt CR")
-	machinetype         = flag.String("machinetype", "", "Custom MACHINETYPE string for KubeVirt ConfigMap (Deprecated, use amd64-machinetype)")
-	amd64MachineType    = flag.String("amd64-machinetype", "", "Custom AMD64_MACHINETYPE string for KubeVirt ConfigMap")
-	arm64MachineType    = flag.String("arm64-machinetype", "", "Custom ARM64_MACHINETYPE string for KubeVirt ConfigMap")
-	s390xMachineType    = flag.String("s390x-machinetype", "", "Custom S390X_MACHINETYPE string for KubeVirt ConfigMap")
-	csvVersion          = flag.String("csv-version", "", "CSV version")
-	replacesCsvVersion  = flag.String("replaces-csv-version", "", "CSV version to replace")
-	metadataDescription = flag.String("metadata-description", "", "One-Liner Description")
-	specDescription     = flag.String("spec-description", "", "Description")
-	specDescriptionFile = flag.String("spec-description-file", "", "Description file")
-	specDisplayName     = flag.String("spec-displayname", "", "Display Name")
-	icon                = flag.String("icon", defaultIcon, "The project logo, as base64 text, in image/svg+xml format")
-	namespace           = flag.String("namespace", "kubevirt-hyperconverged", "Namespace")
-	crdDisplay          = flag.String("crd-display", "KubeVirt HyperConverged Cluster", "Label show in OLM UI about the primary CRD")
-	csvOverrides        = flag.String("csv-overrides", "", "CSV-like string with punctual changes that will be recursively applied (if possible)")
-	csvOverridesFile    = flag.String("csv-overrides-file", "", "path of file with CSV-like format, with punctual changes that will be recursively applied (if possible)")
-	visibleCRDList      = flag.String("visible-crds-list", "hyperconvergeds.hco.kubevirt.io,hostpathprovisioners.hostpathprovisioner.kubevirt.io",
+	outputMode           = flag.String("output-mode", CSVMode, "Working mode: "+validOutputModes)
+	operatorImage        = flag.String("operator-image-name", "", "HyperConverged Cluster Operator image")
+	webhookImage         = flag.String("webhook-image-name", "", "HyperConverged Cluster Webhook image")
+	cliDownloadsImage    = flag.String("cli-downloads-image-name", "", "Downloads Server image")
+	kvUIPluginImage      = flag.String("kubevirt-consoleplugin-image-name", "", "KubeVirt Console Plugin image")
+	kvUIProxyImage       = flag.String("kubevirt-consoleproxy-image-name", "", "KubeVirt Console Proxy image")
+	kvVirtIOWinImage     = flag.String("kv-virtiowin-image-name", "", "KubeVirt VirtIO Win image")
+	kvVirtIOWinDataFile  = flag.String("kv-virtiowin-data-file", "", "Path to the data file inside the VirtIO Win image")
+	kvVirtIOWinMountPath = flag.String("kv-virtiowin-data-mount-path", "", "Absolute mount path for the VirtIO Win data file in the server container")
+	passtImage           = flag.String("network-passt-binding-image-name", "", "Passt binding image")
+	passtCNIImage        = flag.String("network-passt-binding-cni-image-name", "", "Passt binding cni image")
+	waspAgentImage       = flag.String("wasp-agent-image-name", "", "Wasp Agent image")
+	smbios               = flag.String("smbios", "", "Custom SMBIOS string, used by HCO to configure the SMBIOS in KubeVirt CR")
+	smbiosFile           = flag.String("smbios-file", "", "Custom SMBIOS file name, used by HCO to configure the SMBIOS in KubeVirt CR")
+	machinetype          = flag.String("machinetype", "", "Custom MACHINETYPE string for KubeVirt ConfigMap (Deprecated, use amd64-machinetype)")
+	amd64MachineType     = flag.String("amd64-machinetype", "", "Custom AMD64_MACHINETYPE string for KubeVirt ConfigMap")
+	arm64MachineType     = flag.String("arm64-machinetype", "", "Custom ARM64_MACHINETYPE string for KubeVirt ConfigMap")
+	s390xMachineType     = flag.String("s390x-machinetype", "", "Custom S390X_MACHINETYPE string for KubeVirt ConfigMap")
+	csvVersion           = flag.String("csv-version", "", "CSV version")
+	replacesCsvVersion   = flag.String("replaces-csv-version", "", "CSV version to replace")
+	metadataDescription  = flag.String("metadata-description", "", "One-Liner Description")
+	specDescription      = flag.String("spec-description", "", "Description")
+	specDescriptionFile  = flag.String("spec-description-file", "", "Description file")
+	specDisplayName      = flag.String("spec-displayname", "", "Display Name")
+	icon                 = flag.String("icon", defaultIcon, "The project logo, as base64 text, in image/svg+xml format")
+	namespace            = flag.String("namespace", "kubevirt-hyperconverged", "Namespace")
+	crdDisplay           = flag.String("crd-display", "KubeVirt HyperConverged Cluster", "Label show in OLM UI about the primary CRD")
+	csvOverrides         = flag.String("csv-overrides", "", "CSV-like string with punctual changes that will be recursively applied (if possible)")
+	csvOverridesFile     = flag.String("csv-overrides-file", "", "path of file with CSV-like format, with punctual changes that will be recursively applied (if possible)")
+	visibleCRDList       = flag.String("visible-crds-list", "hyperconvergeds.hco.kubevirt.io,hostpathprovisioners.hostpathprovisioner.kubevirt.io",
 		"Comma separated list of all the CRDs that should be visible in OLM console")
 	relatedImagesList = flag.String("related-images-list", "",
 		"Comma separated list of all the images referred in the CSV (just the image pull URLs or eventually a set of 'image|name' collations)")
@@ -298,8 +300,8 @@ func processOneCsv(c util.CsvWithComponent, installStrategyBase *csvv1alpha1.Str
 	}
 	csvBaseAlmString := csvBase.Annotations[almExamplesAnnotation]
 	csvStructAlmString := csvStruct.Annotations[almExamplesAnnotation]
-	var baseAlmcrs []interface{}
-	var structAlmcrs []interface{}
+	var baseAlmcrs []any
+	var structAlmcrs []any
 
 	if !strings.HasPrefix(csvBaseAlmString, "[") {
 		csvBaseAlmString = "[" + csvBaseAlmString + "]"
@@ -396,6 +398,8 @@ func getDeploymentParams() *components.DeploymentOperatorParams {
 		KVUIProxyImage:           *kvUIProxyImage,
 		ImagePullPolicy:          "IfNotPresent",
 		VirtIOWinContainer:       *kvVirtIOWinImage,
+		VirtIOWinDataFile:        *kvVirtIOWinDataFile,
+		VirtIOWinMountPath:       *kvVirtIOWinMountPath,
 		Smbios:                   *smbios,
 		Machinetype:              *machinetype,
 		Amd64MachineType:         *amd64MachineType,

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -55,6 +55,8 @@ var (
 	webhookImage             = flag.String("webhook-image", "", "HyperConverged Cluster Webhook image")
 	cliDownloadsImage        = flag.String("cli-downloads-image", "", "Downloads Server image")
 	kvVirtIOWinImage         = flag.String("kv-virtiowin-image-name", "", "KubeVirt VirtIO Win image")
+	kvVirtIOWinDataFile      = flag.String("kv-virtiowin-data-file", "", "Path to the data file inside the VirtIO Win image")
+	kvVirtIOWinMountPath     = flag.String("kv-virtiowin-data-mount-path", "", "Absolute mount path for the VirtIO Win data file in the server container")
 	waspAgentImage           = flag.String("wasp-agent-image-name", "", "wasp-agent image")
 	smbios                   = flag.String("smbios", "", "Custom SMBIOS string for KubeVirt ConfigMap")
 	machinetype              = flag.String("machinetype", "", "Custom MACHINETYPE string for KubeVirt ConfigMap (Deprecated, use amd64-machinetype)")
@@ -374,6 +376,8 @@ func getOperatorParameters() *components.DeploymentOperatorParams {
 		CliDownloadsImage:        *cliDownloadsImage,
 		ImagePullPolicy:          "IfNotPresent",
 		VirtIOWinContainer:       *kvVirtIOWinImage,
+		VirtIOWinDataFile:        *kvVirtIOWinDataFile,
+		VirtIOWinMountPath:       *kvVirtIOWinMountPath,
 		WaspAgentImage:           *waspAgentImage,
 		Smbios:                   *smbios,
 		Machinetype:              *machinetype,


### PR DESCRIPTION
**What this PR does / why we need it**:

*This is a manual cherry pick of #4419*

Windows virtual machine users need the virtio-win iso file for debugging of their VMs. The purpose of this PR is to make this image available for download using the existing artifact download server.

The csv-merger and the manifest-templator tools were modified to accept new optional parameters:
* `kv-virtiowin-data-mount-path` - The mount point of the image.
* `kv-virtiowin-data-file`- The location of the iso file within the image.

If these new parameter are sent, the artifacts download server deployment manifest will mount run the virtio-win image, as an init container, to copy the file to new mounted volume. The server will allow downloading the iso file from `${kv-virtiowin-data-mount-path}/virtio-win` path.

If the new `DEPLOY_VIRT_IO_WIN_DATA_FILE` environment variable is set, HCO will add the download URL of the virtio-win iso file, to the existing `virtio-win` ConfigMap, under the new optional `"virtio-win-image-download-url"` key.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow downloading of the virtio-win iso image from the artifacts server
```
