### PR TITLE
[release-1.18] Enable PanicDevices feature gate unconditionally

### DIFF
--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -110,6 +110,9 @@ const (
 
 	// Enable updating NAD reference on a running VM
 	kvLiveUpdateNADRef = "LiveUpdateNADRef"
+
+	// Allow defining panic devices for signaling crashes in the guest
+	kvPanicDevices = "PanicDevices"
 )
 
 // KubeVirt architecture dependant feature gates.
@@ -133,6 +136,7 @@ var (
 		kvVMExportGate,
 		kvKubevirtSeccompProfile,
 		kvLiveUpdateNADRef,
+		kvPanicDevices,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -218,6 +218,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"VideoConfig",
 					"DecentralizedLiveMigration",
 					"LiveUpdateNADRef",
+					"PanicDevices",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}


### PR DESCRIPTION
Add PanicDevices to the hard-coded KubeVirt feature gates list so it is always enabled regardless of user configuration. This enables pvpanic device support for all VMs, matching the expected behavior for KubeVirt 1.8 where PanicDevices is at beta phase.

PanicDevices graduates to GA in KubeVirt 1.9 and will no longer require a feature gate.


Assisted-by: claude-4.6-opus

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/VIRTSTRAT-557
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
enables use of pvpanic devices
```
