### PR TITLE
netresinjector: Re-enable deployment by default

### DIFF
--- a/api/v1/hyperconverged_types.go
+++ b/api/v1/hyperconverged_types.go
@@ -169,7 +169,7 @@ type HyperConvergedSpec struct {
 	Security SecurityConfig `json:"security,omitempty"`
 
 	// Deployment contains all the configurations related to deployment of KubeVirt components
-	// +kubebuilder:default={"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}
+	// +kubebuilder:default={"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}
 	// +optional
 	// +k8s:conversion-gen=false
 	Deployment DeploymentConfig `json:"deployment,omitempty"`
@@ -428,6 +428,8 @@ type DeploymentConfig struct {
 	// When enabled, the network-resources-injector mutating webhook will be deployed to automatically
 	// inject resource requests for custom resources annotated in NetworkAttachmentDefinition.
 	// +optional
+	// +kubebuilder:default=true
+	// +default=true
 	DeployNetworkResourcesInjector *bool `json:"deployNetworkResourcesInjector,omitempty"`
 }
 
@@ -942,7 +944,7 @@ type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:default={"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}}
+	// +kubebuilder:default={"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}}
 	// +optional
 	Spec   HyperConvergedSpec   `json:"spec,omitempty"`
 	Status HyperConvergedStatus `json:"status,omitempty"`

--- a/api/v1/zz_generated.defaults.go
+++ b/api/v1/zz_generated.defaults.go
@@ -144,6 +144,10 @@ func SetObjectDefaults_HyperConverged(in *HyperConverged) {
 		var ptrVar1 bool = false
 		in.Spec.Deployment.DeployVMConsoleProxy = &ptrVar1
 	}
+	if in.Spec.Deployment.DeployNetworkResourcesInjector == nil {
+		var ptrVar1 bool = true
+		in.Spec.Deployment.DeployNetworkResourcesInjector = &ptrVar1
+	}
 }
 
 func SetObjectDefaults_HyperConvergedList(in *HyperConvergedList) {

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/controllers/handlers/netresinjector/common.go
+++ b/controllers/handlers/netresinjector/common.go
@@ -19,5 +19,5 @@ const (
 
 // shouldDeploy checks if network-resources-injector should be deployed
 func shouldDeploy(hc *hcov1.HyperConverged) bool {
-	return ptr.Deref(hc.Spec.Deployment.DeployNetworkResourcesInjector, false)
+	return ptr.Deref(hc.Spec.Deployment.DeployNetworkResourcesInjector, true)
 }

--- a/controllers/handlers/netresinjector/conditional_test.go
+++ b/controllers/handlers/netresinjector/conditional_test.go
@@ -47,21 +47,18 @@ var _ = Describe("Network Resources Injector Conditional Handlers", func() {
 			Expect(foundCR.Name).To(Equal(clusterRoleName))
 		})
 
-		It("should not create ClusterRole when deployNetworkResourcesInjector is not set (default false)", func() {
-			// Don't set deployNetworkResourcesInjector - should default to false
+		It("should create ClusterRole when deployNetworkResourcesInjector is not set (default true)", func() {
+			// Don't set deployNetworkResourcesInjector - should default to true
 			cl = commontestutils.InitClient([]client.Object{hco})
 
 			handler := NewClusterRoleHandler(cl, commontestutils.GetScheme())
 			res := handler.Ensure(req)
 
 			Expect(res.Err).ToNot(HaveOccurred())
-			Expect(res.Created).To(BeFalse())
-			Expect(res.Updated).To(BeFalse())
+			Expect(res.Created).To(BeTrue())
 
 			foundCR := &rbacv1.ClusterRole{}
-			err := cl.Get(context.Background(), client.ObjectKey{Name: clusterRoleName}, foundCR)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(apierrors.IsNotFound, "not found error"))
+			Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterRoleName}, foundCR)).To(Succeed())
 		})
 
 		It("should delete ClusterRole when deployNetworkResourcesInjector is false", func() {

--- a/controllers/handlers/netresinjector/deployment_test.go
+++ b/controllers/handlers/netresinjector/deployment_test.go
@@ -41,7 +41,6 @@ var _ = Describe("Network Resources Injector Deployment", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 		Expect(os.Setenv(hcoutil.NetworkResourcesInjectorImageEnvV, testImage)).To(Succeed())
 

--- a/controllers/handlers/netresinjector/pdb_test.go
+++ b/controllers/handlers/netresinjector/pdb_test.go
@@ -25,7 +25,6 @@ var _ = Describe("Network Resources Injector PodDisruptionBudget", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/rbac_test.go
+++ b/controllers/handlers/netresinjector/rbac_test.go
@@ -24,7 +24,6 @@ var _ = Describe("Network Resources Injector ClusterRole", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 
@@ -95,7 +94,6 @@ var _ = Describe("Network Resources Injector ClusterRoleBinding", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/service_account_test.go
+++ b/controllers/handlers/netresinjector/service_account_test.go
@@ -24,7 +24,6 @@ var _ = Describe("Network Resources Injector ServiceAccount", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/service_test.go
+++ b/controllers/handlers/netresinjector/service_test.go
@@ -25,7 +25,6 @@ var _ = Describe("Network Resources Injector Service", func() {
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/handlers/netresinjector/webhook_config_test.go
+++ b/controllers/handlers/netresinjector/webhook_config_test.go
@@ -24,7 +24,6 @@ var _ = Describe("Network Resources Injector MutatingWebhookConfiguration", func
 
 	BeforeEach(func() {
 		hco = commontestutils.NewHco()
-		hco.Spec.Deployment.DeployNetworkResourcesInjector = new(true)
 		req = commontestutils.NewReq(hco)
 	})
 

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -244,7 +244,7 @@ var _ = Describe("HyperconvergedController", func() {
 						foundResource),
 				).ToNot(HaveOccurred())
 				// Check conditions
-				Expect(foundResource.Status.RelatedObjects).To(HaveLen(32))
+				Expect(foundResource.Status.RelatedObjects).To(HaveLen(39))
 				expectedRef := corev1.ObjectReference{
 					Kind:            "PrometheusRule",
 					Namespace:       namespace,

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/deploy/hco.cr.yaml
+++ b/deploy/hco.cr.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kubevirt-hyperconverged
 spec:
   deployment:
+    deployNetworkResourcesInjector: true
     deployVmConsoleProxy: false
     uninstallStrategy: BlockUninstallIfWorkloadsExist
   security:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,7 +124,7 @@ DataImportCronTemplateStatus is a copy of a dataImportCronTemplate as defined in
 | logVerbosityConfig | LogVerbosityConfig configures the verbosity level of Kubevirt's different components. The higher the value - the higher the log verbosity. | *[LogVerbosityConfiguration](#logverbosityconfiguration) |  | false |
 | applicationAwareConfig | ApplicationAwareConfig set the AAQ configurations | *[ApplicationAwareConfigurations](#applicationawareconfigurations) |  | false |
 | deployVmConsoleProxy | deploy VM console proxy resources in SSP operator | *bool | false | false |
-| deployNetworkResourcesInjector | DeployNetworkResourcesInjector enables deployment of the network-resources-injector component. When enabled, the network-resources-injector mutating webhook will be deployed to automatically inject resource requests for custom resources annotated in NetworkAttachmentDefinition. | *bool |  | false |
+| deployNetworkResourcesInjector | DeployNetworkResourcesInjector enables deployment of the network-resources-injector component. When enabled, the network-resources-injector mutating webhook will be deployed to automatically inject resource requests for custom resources annotated in NetworkAttachmentDefinition. | *bool | true | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -145,7 +145,7 @@ HyperConverged is the Schema for the hyperconvergeds API
 | Field | Description | Scheme | Default | Required |
 | ----- | ----------- | ------ | ------- | -------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectmeta-v1-meta) |  | false |
-| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}}} | false |
+| spec |  | [HyperConvergedSpec](#hyperconvergedspec) | {"security": {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}}, "virtualization": {"liveMigrationConfig": {"completionTimeoutPerGiB": 150, "parallelMigrationsPerCluster": 5, "parallelOutboundMigrationsPerNode": 2, "progressTimeout": 150, "allowAutoConverge": false, "allowPostCopy": false}, "virtualMachineOptions": {"disableFreePageReporting": false, "disableSerialConsoleLog": false}, "vmiCPUAllocationRatio": 10},"workloadSources":{"enableCommonBootImageImport":true}, "deployment": {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}}} | false |
 | status |  | [HyperConvergedStatus](#hyperconvergedstatus) |  | false |
 
 [Back to TOC](#table-of-contents)
@@ -184,7 +184,7 @@ HyperConvergedSpec defines the desired state of HyperConverged
 | networking | Networking contains all the configurations for networking | *[NetworkingConfig](#networkingconfig) |  | false |
 | workloadSources | WorkloadSources contains all the configurations for workload sources | [WorkloadSourcesConfig](#workloadsourcesconfig) |  | false |
 | security | Security contains all the security configurations | [SecurityConfig](#securityconfig) | {"certConfig": {"ca": {"duration": "48h0m0s", "renewBefore": "24h0m0s"}, "server": {"duration": "24h0m0s", "renewBefore": "12h0m0s"}}} | false |
-| deployment | Deployment contains all the configurations related to deployment of KubeVirt components | [DeploymentConfig](#deploymentconfig) | {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "applicationAwareConfig": {"enable": false}} | false |
+| deployment | Deployment contains all the configurations related to deployment of KubeVirt components | [DeploymentConfig](#deploymentconfig) | {"uninstallStrategy": "BlockUninstallIfWorkloadsExist", "deployVmConsoleProxy": false, "deployNetworkResourcesInjector": true, "applicationAwareConfig": {"enable": false}} | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/upgradepatch/hc.cr.json
+++ b/pkg/upgradepatch/hc.cr.json
@@ -47,7 +47,8 @@
     },
     "deployment": {
       "uninstallStrategy": "BlockUninstallIfWorkloadsExist",
-      "deployVmConsoleProxy": false
+      "deployVmConsoleProxy": false,
+      "deployNetworkResourcesInjector": true
     }
   },
   "status": {

--- a/tests/func-tests/netresinjector_test.go
+++ b/tests/func-tests/netresinjector_test.go
@@ -33,21 +33,7 @@ var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Ser
 		restoreNetResInjectorToDefault(ctx, cli)
 	})
 
-	Context("when deployNetworkResourcesInjector is not set (default false)", func() {
-		BeforeAll(func(ctx context.Context) {
-			restoreNetResInjectorToDefault(ctx, cli)
-		})
-
-		It("should not deploy the network resources injector", func(ctx context.Context) {
-			validateNetResInjectorDeleted(ctx, cli)
-		})
-	})
-
-	Context("when deployNetworkResourcesInjector is true", func() {
-		BeforeAll(func(ctx context.Context) {
-			enableNetResInjector(ctx, cli)
-		})
-
+	Context("when deployNetworkResourcesInjector is true (default)", func() {
 		It("should deploy the network resources injector", func(ctx context.Context) {
 			By("verifying the deployment exists and is ready")
 			Eventually(func(g Gomega, ctx context.Context) {
@@ -113,9 +99,20 @@ var _ = Describe("Test Network Resources Injector", Label("NetResInjector"), Ser
 			validateNetResInjectorDeleted(ctx, cli)
 		})
 
-		It("should delete the deployment when set back to default (false)", func(ctx context.Context) {
-			restoreNetResInjectorToDefault(ctx, cli)
-			validateNetResInjectorDeleted(ctx, cli)
+		It("should recreate the deployment when set back to true", func(ctx context.Context) {
+			enableNetResInjector(ctx, cli)
+
+			By("verifying the deployment is recreated and ready")
+			Eventually(func(g Gomega, ctx context.Context) {
+				dep := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      netResInjectorDeploymentName,
+						Namespace: tests.InstallNamespace,
+					},
+				}
+				g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
+				g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
+			}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
 		})
 	})
 })
@@ -158,12 +155,21 @@ func restoreNetResInjectorToDefault(ctx context.Context, cli client.Client) {
 	GinkgoHelper()
 	By("restoring deployNetworkResourcesInjector to default")
 
-	// Read the HyperConverged CR first to check if the field exists
 	hc, err := tests.GetHCO(ctx, cli)
 	Expect(err).ToNot(HaveOccurred())
 	if hc.Spec.Deployment.DeployNetworkResourcesInjector != nil {
-		// Field exists, remove it by setting to null in merge patch
 		patch := []byte(`{"spec":{"deployment":{"deployNetworkResourcesInjector": null}}}`)
 		tests.PatchMergeHCO(ctx, cli, patch)
 	}
+
+	Eventually(func(g Gomega, ctx context.Context) {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      netResInjectorDeploymentName,
+				Namespace: tests.InstallNamespace,
+			},
+		}
+		g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
+		g.Expect(dep.Status.ReadyReplicas).To(Equal(*dep.Spec.Replicas))
+	}).WithTimeout(5 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
 }

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -52,6 +52,7 @@ spec:
               deployment:
                 applicationAwareConfig:
                   enable: false
+                deployNetworkResourcesInjector: true
                 deployVmConsoleProxy: false
                 uninstallStrategy: BlockUninstallIfWorkloadsExist
               security:
@@ -82,6 +83,7 @@ spec:
                 default:
                   applicationAwareConfig:
                     enable: false
+                  deployNetworkResourcesInjector: true
                   deployVmConsoleProxy: false
                   uninstallStrategy: BlockUninstallIfWorkloadsExist
                 description: Deployment contains all the configurations related to
@@ -161,6 +163,7 @@ spec:
                         type: string
                     type: object
                   deployNetworkResourcesInjector:
+                    default: true
                     description: |-
                       DeployNetworkResourcesInjector enables deployment of the network-resources-injector component.
                       When enabled, the network-resources-injector mutating webhook will be deployed to automatically


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Reverts [1] which temporarily disabled network-resources-injector deployment by default. The underlying bug has been fixed in [2].

[1] https://github.com/kubevirt/hyperconverged-cluster-operator/pull/4377
[2] https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/224
**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-93111
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
