### PR TITLE
CNV-93777: [release-1.16] Fix issue in the DL server's init

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -404,7 +404,7 @@ func addVirtIOVolume(spec *appsv1.DeploymentSpec, params *DeploymentOperatorPara
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: artifactServerMountName, MountPath: initContainerMount},
 		},
-		SecurityContext:          getVirtIOWinInitContainerSecurityContext(),
+		SecurityContext:          GetStdContainerSecurityContext(),
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -460,15 +460,6 @@ func GetStdContainerSecurityContext() *corev1.SecurityContext {
 			Drop: []corev1.Capability{"ALL"},
 		},
 	}
-}
-
-// getVirtIOWinInitContainerSecurityContext returns a security context for the virtiowin init
-// container. It sets runAsUser explicitly so that the pod-level runAsNonRoot constraint is met
-// even when the data-only image has no USER directive and would otherwise run as root.
-func getVirtIOWinInitContainerSecurityContext() *corev1.SecurityContext {
-	sc := GetStdContainerSecurityContext()
-	sc.RunAsUser = ptr.To[int64](1001)
-	return sc
 }
 
 // Currently we are abusing the pod readiness to signal to OLM that HCO is not ready


### PR DESCRIPTION
**What this PR does / why we need it**:
In OpenShift, user 1001 is not allowed for pods. The new init container of the artifacts download server hard codes it's user to 1001, and so the server fails to start.

This PR remove this hard code user definition.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-93777
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
