### PR TITLE
Automaticly get the KV feature gates json file

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -33,6 +33,8 @@ jobs:
           go-version-file: go.mod # The Go version to download (if necessary) and use.
 
       - name: Do sanity checks
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make sanity
 
       - name: Verify we can actually build the operator and some tools

--- a/.github/workflows/release-bumper.yml
+++ b/.github/workflows/release-bumper.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           UPDATED_COMPONENT: ${{ github.event.inputs.component }}
           UPDATED_VERSION: ${{ github.event.inputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           curl -s https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/automation/release-bumper/release-bumper.sh | bash
           

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DO=eval
 export JOB_TYPE=prow
 endif
 
-sanity: generate gogenerate prepare-tools-crd generate-doc validate-no-offensive-lang goimport lint-metrics lint-monitoring
+sanity: generate gogenerate prepare-tools-crd generate-doc validate-no-offensive-lang goimport lint-metrics lint-monitoring update-kv-fg-file
 	go version
 	go fmt ./...
 	go mod tidy -v
@@ -50,6 +50,8 @@ goimport:
 	go install golang.org/x/tools/cmd/goimports@latest
 	goimports -w -local="kubevirt.io,github.com/kubevirt,github.com/kubevirt/hyperconverged-cluster-operator"  $(shell find . -type f -name '*.go' ! -path "*/vendor/*" ! -path "./_kubevirtci/*" ! -path "*zz_generated*" )
 
+update-kv-fg-file:
+	./hack/update-kv-fg-file.sh
 
 lint:
 	GOTOOLCHAIN=go1.26.3 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANDCI_LINT_VERSION}
@@ -395,6 +397,7 @@ push-builder-image: retag-builder-image
 		lint-monitoring \
 		sanity \
 		goimport \
+		update-kv-fg-file \
 		bump-hco \
 		bump-kubevirtci \
 		build-push-multi-arch-operator-image \

--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -3,6 +3,7 @@
 set -ex
 
 source "hack/cri-bin.sh"
+source "hack/validate-kv-fg-file.sh"
 
 function dump() {
     rv=$?
@@ -52,7 +53,11 @@ git clone https://github.com/kubevirt/kubevirt.git
 (
   cd kubevirt
   git checkout "${latest_kubevirt_commit}"
- )
+  go run ./tools/feature-gate-report > ../kv-beta-feature-gates.json
+)
+
+validate-kv-fg-json-file kv-beta-feature-gates.json
+cp kv-beta-feature-gates.json pkg/internal/kvfeaturegates/kv-beta-feature-gates.json
 
 # Get latest CDI
 git clone https://github.com/kubevirt/containerized-data-importer.git cdi

--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -4,6 +4,10 @@ set -ex
 
 CONFIG_FILE="hack/config"
 
+if [[ -f hack/validate-kv-fg-file.sh ]]; then
+  source hack/validate-kv-fg-file.sh
+fi
+
 function main {
   declare -A CURRENT_VERSIONS
   declare -A UPDATED_VERSIONS
@@ -49,6 +53,8 @@ function main {
   if [[ -n $(git ls-files --others --exclude-standard --deleted vendor) ]]; then
     git add vendor/
   fi
+
+  update_kv_json_file
 
   echo INFO: Executing "build-manifests.sh"...
   make build-manifests
@@ -141,8 +147,7 @@ function get_updated_versions {
       UPDATED_VERSION=$(get_latest_release "$UPDATED_COMPONENT")
     fi
     if [[ -v COMPONENTS_REPOS[${UPDATED_COMPONENT}] ]]; then
-      HTTP_CODE=$(curl "https://api.github.com/repos/${COMPONENTS_REPOS[$UPDATED_COMPONENT]}/releases/tags/${UPDATED_VERSION}" --write-out '%{http_code}' --silent --output /dev/null)
-      if [[ ${HTTP_CODE} == "200" ]]; then
+      if gh release view -R "${COMPONENTS_REPOS[$UPDATED_COMPONENT]}" "${UPDATED_VERSION}" --json=name &> /dev/null; then
         UPDATED_VERSIONS["${UPDATED_COMPONENT}"]="${UPDATED_VERSION}"
       else
         echo "ERROR: unknown version '${UPDATED_VERSION}' for component '${UPDATED_COMPONENT}'"
@@ -170,7 +175,7 @@ function get_latest_release() {
   major=$(echo $current_version | cut -d. -f1)
   minor=$(echo $current_version | cut -d. -f2)
 
-  RELEASES=$(curl -s -L "https://api.github.com/repos/$repo/releases" | jq -r '.[] | select(.tag_name | test("^v?[0-9].*")) | .tag_name')
+  RELEASES=$(gh release list -R "${repo}" --json=tagName --jq '.[] | select(.tagName | test("^v?[0-9].*"))|.tagName')
   releases=(${RELEASES})
 
   semversort "${releases[*]}"
@@ -234,28 +239,24 @@ function version_weight() {
 }
 
 function update_versions() {
-  PR=$(curl -s -L https://api.github.com/repos/kubevirt/hyperconverged-cluster-operator/pulls | jq "[.[] | {title: .title, ref: .base.ref}]" )
-
   for component in "${SHOULD_UPDATED[@]}"; do
     echo INFO: Checking update for "$component";
 
     # Check if pull request for that component and version already exists
-    search_pattern=$(echo "$component.*${UPDATED_VERSIONS[$component]}" | tr -d '"')
-
-    search_pr=$(jq "[.[] | select((.title | test(\"${search_pattern}\")) and (.ref == \"${TARGET_BRANCH}\"))] | length" <<< "$PR")
-
-    if [[ $search_pr -ne 0 ]] ; then
-      echo "INFO: An existing pull request for bumping $component to version ${UPDATED_VERSIONS[$component]} has been found. \
+    search_pattern="in:title \"Bump ${component} to ${UPDATED_VERSIONS[$component]}\""
+    PR=$(gh pr list -R kubevirt/hyperconverged-cluster-operator --search="${search_pattern}" --state=open -B "${TARGET_BRANCH}" --json=number --jq '.[0]|.number')
+    if [[ -n ${PR} ]]; then
+      echo "INFO: Existing pull request ${PR} for bumping $component to version ${UPDATED_VERSIONS[$component]} has been found. \
 Continuing to next component."
       continue
-    else
-      echo "INFO: Updating $component to ${UPDATED_VERSIONS[$component]}."
-      sed -E -i "s|(${component}_VERSION=).*|\1\"${UPDATED_VERSIONS[$component]}\"|" ${CONFIG_FILE}
-      echo "$component" > updated_component.txt
-      echo "${UPDATED_VERSIONS[$component]}" > updated_version.txt
-      UPDATING='true'
-      break
     fi
+
+    echo "INFO: Updating $component to ${UPDATED_VERSIONS[$component]}."
+    sed -E -i "s|(${component}_VERSION=).*|\1\"${UPDATED_VERSIONS[$component]}\"|" ${CONFIG_FILE}
+    echo "$component" > updated_component.txt
+    echo "${UPDATED_VERSIONS[$component]}" > updated_version.txt
+    UPDATING='true'
+    break
   done;
 
   if [ "${UPDATING}" != 'true' ]; then
@@ -278,6 +279,25 @@ function update_go_mod() {
     echo "No need to update go.mod for ${UPDATED_COMPONENT}"
   fi
 
+}
+
+function update_kv_json_file() {
+  if [[ "$(cat updated_component.txt)" != "KUBEVIRT" ]]; then
+    return
+  fi
+
+  local kv_version
+  kv_version="$(cat updated_version.txt)"
+
+  if gh release download "${kv_version}" -R kubevirt/kubevirt -O kv-beta-feature-gates.json --pattern=feature-gates.json --clobber; then
+    if ! diff -q kv-beta-feature-gates.json pkg/internal/kvfeaturegates/kv-beta-feature-gates.json > /dev/null; then
+      if declare -F validate-kv-fg-json-file &>/dev/null; then
+        validate-kv-fg-json-file kv-beta-feature-gates.json
+        cp kv-beta-feature-gates.json pkg/internal/kvfeaturegates/kv-beta-feature-gates.json
+        echo "KubeVirt feature gates file was updated in pkg/internal/kvfeaturegates/kv-beta-feature-gates.json"
+      fi
+    fi
+  fi
 }
 
 main

--- a/hack/update-kv-fg-file.sh
+++ b/hack/update-kv-fg-file.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -ex
+
+source "hack/validate-kv-fg-file.sh"
+
+KV_VERSION=$(grep "KUBEVIRT_VERSION=" hack/config | sed -E 's|^KUBEVIRT_VERSION="(.*)"$|\1|')
+gh release download "${KV_VERSION}" \
+   -R kubevirt/kubevirt \
+   -O kv-beta-feature-gates.json \
+   --pattern=feature-gates.json \
+   --clobber
+
+validate-kv-fg-json-file kv-beta-feature-gates.json
+
+if ! diff -q pkg/internal/kvfeaturegates/kv-beta-feature-gates.json kv-beta-feature-gates.json > /dev/null; then
+  mv kv-beta-feature-gates.json pkg/internal/kvfeaturegates/kv-beta-feature-gates.json
+fi

--- a/hack/validate-kv-fg-file.sh
+++ b/hack/validate-kv-fg-file.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+function validate-kv-fg-json-file {
+  jq -e '
+     type == "array" and
+     all(
+         type == "object" and
+         (keys | sort) == ["name", "state"] and
+         (.name | type) == "string" and
+         (.state | type) == "string")' "$1"
+}

--- a/pkg/internal/kvfeaturegates/kv-beta-feature-gates.json
+++ b/pkg/internal/kvfeaturegates/kv-beta-feature-gates.json
@@ -40,19 +40,11 @@
     "state": "Alpha"
   },
   {
-    "name": "GPUsWithDRA",
-    "state": "Alpha"
-  },
-  {
     "name": "GraceIOVirtualization",
     "state": "Alpha"
   },
   {
     "name": "HostDevices",
-    "state": "Alpha"
-  },
-  {
-    "name": "HostDevicesWithDRA",
     "state": "Alpha"
   },
   {
@@ -137,6 +129,14 @@
   },
   {
     "name": "ExternalNetResourceInjection",
+    "state": "Beta"
+  },
+  {
+    "name": "GPUsWithDRA",
+    "state": "Beta"
+  },
+  {
+    "name": "HostDevicesWithDRA",
     "state": "Beta"
   },
   {


### PR DESCRIPTION
**What this PR does / why we need it**:

When KubeVirt version bumps, also update the KubeVirt feature gate json file.

Also, moved the release-bumper to use the gh cli, for better usability and ux than HTTP calls with curl.

In the nightly build, when we use the latest KubeVirt version from main, regenerate the feature gate file from the KubeVirt tool, to make it up-to-date.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
