### PR TITLE
Enable MigrationDowntimeTuning feature gate unconditionally

### DIFF
--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -102,6 +102,9 @@ const (
 
 	// Enable the installation of the KubeVirt seccomp profile
 	kvKubevirtSeccompProfile = "KubevirtSeccompProfile"
+
+	// Enable iteration-aware downtime ramping for live migration convergence
+	kvMigrationDowntimeTuning = "MigrationDowntimeTuning"
 )
 
 // KubeVirt architecture dependant feature gates.
@@ -117,6 +120,7 @@ var (
 		kvSnapshotGate,
 		kvHostDevicesGate,
 		kvKubevirtSeccompProfile,
+		kvMigrationDowntimeTuning,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -213,6 +213,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"KubevirtSeccompProfile",
 					"DecentralizedLiveMigration",
 					"Template",
+					"MigrationDowntimeTuning",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}


### PR DESCRIPTION
Add MigrationDowntimeTuning to the hard-coded KubeVirt feature gates list so it is always enabled regardless of user configuration. This enables iteration-aware downtime ramping for live migration convergence via the ExperimentalMigrationOptions.DowntimeTuning field in MigrationPolicy.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/VIRTSTRAT-697
https://redhat.atlassian.net/browse/CNV-83817
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The MigrationDowntimeTuning feature gate is now enabled unconditionally, allowing iteration-aware downtime ramping for live migration convergence via MigrationPolicy's .spec.experimental.downtimeTuning field.

```
