### PR TITLE
Add HCO version to kubevirt-ui-features ConfigMap (CNV-93738)

### DIFF
--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
@@ -34,6 +33,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/components"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/ipstacktype"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/ownresources"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -67,6 +67,11 @@ const ( // for network policies
 	openshiftDNSPort              = int32(5353)
 
 	apiServerPort int32 = 6443
+)
+
+const ( // managed data fields
+	ipStackTypeKey = "ipStackType"
+	hcoVersionKey  = "hcoVersion"
 )
 
 // **** Kubevirt UI Plugin Deployment Handler ****
@@ -121,7 +126,7 @@ func NewKvUIUserSettingsCMHandler(cli client.Client, Scheme *runtime.Scheme) ope
 
 // **** UI features config map Handler ****
 func NewKvUIFeaturesCMHandler(cli client.Client, Scheme *runtime.Scheme) operands.Operand {
-	return operands.NewEditableCmHandler(cli, Scheme, NewKvUIFeaturesCM(), "ipStackType")
+	return operands.NewEditableCmHandler(cli, Scheme, NewKvUIFeaturesCM(), ipStackTypeKey, hcoVersionKey)
 }
 
 // **** Kubevirt UI Console Plugin Custom Resource Handler ****
@@ -211,7 +216,7 @@ func getKvUIDeployment(hc *hcov1.HyperConverged, deploymentName string, image st
 			Namespace: hcoutil.GetOperatorNamespaceFromEnv(),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: ptr.To(replicas),
+			Replicas: new(replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
@@ -262,7 +267,7 @@ func getKvUIDeployment(hc *hcov1.HyperConverged, deploymentName string, image st
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  servingCertName,
-									DefaultMode: ptr.To(int32(420)),
+									DefaultMode: new(int32(420)),
 								},
 							},
 						},
@@ -432,11 +437,12 @@ var UIFeaturesConfig = map[string]string{
 	"loadBalancerEnabled":                 "true",
 	"nodePortAddress":                     "",
 	"nodePortEnabled":                     "false",
+	hcoVersionKey:                         ownresources.Version(),
 }
 
 func NewKvUIFeaturesCM() *corev1.ConfigMap {
 	data := maps.Clone(UIFeaturesConfig)
-	data["ipStackType"] = ipstacktype.Get()
+	data[ipStackTypeKey] = ipstacktype.Get()
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvUIFeaturesCMName,
@@ -651,7 +657,7 @@ func newKVConsolePluginNetworkPolicy() *networkingv1.NetworkPolicy {
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
 							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: hcoutil.UIPluginServerPort},
-							Protocol: ptr.To(corev1.ProtocolTCP),
+							Protocol: new(corev1.ProtocolTCP),
 						},
 					},
 					From: []networkingv1.NetworkPolicyPeer{
@@ -702,12 +708,12 @@ func getApiServerEgressRule() networkingv1.NetworkPolicyEgressRule {
 	return networkingv1.NetworkPolicyEgressRule{
 		Ports: []networkingv1.NetworkPolicyPort{
 			{
-				Protocol: ptr.To(corev1.ProtocolTCP),
-				Port:     ptr.To(intstr.FromInt32(dnsPort)),
+				Protocol: new(corev1.ProtocolTCP),
+				Port:     new(intstr.FromInt32(dnsPort)),
 			},
 			{
-				Protocol: ptr.To(corev1.ProtocolUDP),
-				Port:     ptr.To(intstr.FromInt32(dnsPort)),
+				Protocol: new(corev1.ProtocolUDP),
+				Port:     new(intstr.FromInt32(dnsPort)),
 			},
 		},
 		To: []networkingv1.NetworkPolicyPeer{
@@ -746,7 +752,7 @@ func newKVAPIServerProxyNetworkPolicy() *networkingv1.NetworkPolicy {
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
 							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: hcoutil.UIProxyServerPort},
-							Protocol: ptr.To(corev1.ProtocolTCP),
+							Protocol: new(corev1.ProtocolTCP),
 						},
 					},
 				},
@@ -757,7 +763,7 @@ func newKVAPIServerProxyNetworkPolicy() *networkingv1.NetworkPolicy {
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
 							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: apiServerPort},
-							Protocol: ptr.To(corev1.ProtocolTCP),
+							Protocol: new(corev1.ProtocolTCP),
 						},
 					},
 				},

--- a/controllers/handlers/kubevirtConsolePlugin_test.go
+++ b/controllers/handlers/kubevirtConsolePlugin_test.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/reference"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
@@ -31,6 +30,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/commontestutils"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/operands"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/ownresources"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 )
@@ -338,7 +338,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 			outdatedResource.UID = "oldObjectUID"
 			outdatedResource.ResourceVersion = "1234"
 
-			outdatedResource.Spec.Replicas = ptr.To(int32(123))
+			outdatedResource.Spec.Replicas = new(int32(123))
 			outdatedResource.Spec.Template.Spec.Containers[0].Image = "quay.io/fake/image:latest"
 
 			cl := commontestutils.InitClient([]client.Object{hco, outdatedResource})
@@ -506,15 +506,20 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 					if managedSet[k] {
 						Expect(foundResource.Data).To(HaveKeyWithValue(k, v))
 					} else {
-						Expect(foundResource.Data).To(HaveKeyWithValue(k, Not(Equal(v))))
+						Expect(foundResource.Data).To(HaveKeyWithValue(k, Equal("modified_"+v)))
 					}
 				}
 
 				Expect(foundResource.Data).To(HaveKeyWithValue(userAddedDataKey, userAddedDataValue))
 			},
 				Entry("user settings config", hcoutil.AppComponentUIConfig, NewKvUIUserSettingsCM, NewKvUIUserSettingsCMHandler, []string(nil)),
-				Entry("UI features config", hcoutil.AppComponentUIConfig, NewKvUIFeaturesCM, NewKvUIFeaturesCMHandler, []string{"ipStackType"}),
+				Entry("UI features config", hcoutil.AppComponentUIConfig, NewKvUIFeaturesCM, NewKvUIFeaturesCMHandler, []string{ipStackTypeKey, hcoVersionKey}),
 			)
+
+			It("should include hcoVersion in UI features ConfigMap", func() {
+				cm := NewKvUIFeaturesCM()
+				Expect(cm.Data).To(HaveKeyWithValue("hcoVersion", ownresources.Version()))
+			})
 		})
 
 		Context("KubeVirt UI Nginx ConfigMap (NewKVUINginxCM)", func() {
@@ -675,7 +680,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				// now, modify HCO's node placement
 				infra := hco.Spec.Deployment.NodePlacements.Infra
 				infra.Tolerations = append(infra.Tolerations, v1.Toleration{
-					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: ptr.To[int64](34),
+					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: new(int64(34)),
 				})
 				infra.NodeSelector["key3"] = "something entirely else"
 
@@ -720,7 +725,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 
 				// now, modify deployment Kubevirt Console Plugin Deployment node placement
 				existingResource.Spec.Template.Spec.Tolerations = append(hco.Spec.Deployment.NodePlacements.Infra.Tolerations, v1.Toleration{
-					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: ptr.To[int64](34),
+					Key: "key34", Operator: "operator34", Value: "value34", Effect: "effect34", TolerationSeconds: new(int64(34)),
 				})
 				existingResource.Spec.Template.Spec.NodeSelector["key3"] = "BADvalue3"
 
@@ -872,7 +877,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 					Infra: nil,
 				}
 				existingResource.Spec.Template.Spec.Affinity = nil
-				existingResource.Spec.Replicas = ptr.To(int32(1))
+				existingResource.Spec.Replicas = new(int32(1))
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := handlerFunc(cl, commontestutils.GetScheme())
@@ -911,7 +916,7 @@ var _ = Describe("Kubevirt Console Plugin", func() {
 				})
 
 				existingResource := deploymentManifestor(hco)
-				existingResource.Spec.Replicas = ptr.To(int32(3))
+				existingResource.Spec.Replicas = new(int32(3))
 
 				cl := commontestutils.InitClient([]client.Object{hco, existingResource})
 				handler := handlerFunc(cl, commontestutils.GetScheme())

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -1,7 +1,6 @@
 package hyperconverged
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"io/fs"
@@ -31,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -56,10 +54,10 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/reqresolver"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/metrics"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/ownresources"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/upgradepatch"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
-	"github.com/kubevirt/hyperconverged-cluster-operator/version"
 )
 
 var (
@@ -118,8 +116,6 @@ func RegisterReconciler(mgr manager.Manager,
 func newReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo, upgradeableCond hcoutil.Condition) reconcile.Reconciler {
 	reqresolver.GeneratePlaceHolders()
 
-	ownVersion := cmp.Or(os.Getenv(hcoutil.HcoKvIoVersionName), version.Version)
-
 	var pwdFS fs.FS
 	pwd, err := os.Getwd()
 	if err != nil {
@@ -133,7 +129,7 @@ func newReconciler(mgr manager.Manager, ci hcoutil.ClusterInfo, upgradeableCond 
 		scheme:               mgr.GetScheme(),
 		operandHandler:       operandhandler.NewOperandHandler(mgr.GetClient(), mgr.GetScheme(), ci, hcoutil.GetEventEmitter()),
 		upgradeMode:          false,
-		ownVersion:           ownVersion,
+		ownVersion:           ownresources.Version(),
 		eventEmitter:         hcoutil.GetEventEmitter(),
 		firstLoop:            true,
 		upgradeableCondition: upgradeableCond,
@@ -486,7 +482,7 @@ func updateStatus(req *common.HcoRequest) {
 			req.Logger.Info("infrastructure became not highly available")
 		}
 
-		req.Instance.Status.InfrastructureHighlyAvailable = ptr.To(infraHighlyAvailable)
+		req.Instance.Status.InfrastructureHighlyAvailable = new(infraHighlyAvailable)
 		req.StatusDirty = true
 	}
 

--- a/pkg/internal/ownresources/own_resources.go
+++ b/pkg/internal/ownresources/own_resources.go
@@ -1,6 +1,7 @@
 package ownresources
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -15,10 +16,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/reference"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
+	"github.com/kubevirt/hyperconverged-cluster-operator/version"
 )
 
 // OwnResources holds the running POd, Deployment and CSV, if exist
@@ -28,6 +29,8 @@ var (
 	csvRef        *corev1.ObjectReference
 
 	initOnce = &sync.Once{}
+
+	ownVersion = findOwnVersion()
 )
 
 // GetPod returns the running pod, or nil if not exists
@@ -58,6 +61,14 @@ func GetCSVRef() *corev1.ObjectReference {
 
 func Init(ctx context.Context, cl client.Reader, scheme *runtime.Scheme, logger logr.Logger) {
 	initOnce.Do(doInit(ctx, cl, scheme, logger))
+}
+
+func Version() string {
+	return ownVersion
+}
+
+func findOwnVersion() string {
+	return cmp.Or(os.Getenv(hcoutil.HcoKvIoVersionName), version.Version)
 }
 
 func doInit(ctx context.Context, cl client.Reader, scheme *runtime.Scheme, logger logr.Logger) func() {
@@ -213,7 +224,7 @@ func buildOwnerReference(ownerDeployment *appsv1.Deployment) *metav1.OwnerRefere
 		Kind:               "Deployment",
 		Name:               ownerDeployment.GetName(),
 		UID:                ownerDeployment.GetUID(),
-		BlockOwnerDeletion: ptr.To(false),
-		Controller:         ptr.To(false),
+		BlockOwnerDeletion: new(false),
+		Controller:         new(false),
 	}
 }

--- a/pkg/internal/ownresources/own_resources_test.go
+++ b/pkg/internal/ownresources/own_resources_test.go
@@ -16,11 +16,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/reference"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	fakeclusterinfo "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util/fake/clusterinfo"
+	"github.com/kubevirt/hyperconverged-cluster-operator/version"
 )
 
 func TestUtil(t *testing.T) {
@@ -94,7 +94,7 @@ var _ = Describe("Test OwnResources", func() {
 			APIVersion: csvv1alpha1.ClusterServiceVersionAPIVersion,
 			Kind:       csvv1alpha1.ClusterServiceVersionKind,
 			Name:       rsName,
-			Controller: ptr.To(true),
+			Controller: new(true),
 		}
 
 		dep := createDeployment(csvOwnerRef)
@@ -141,6 +141,31 @@ var _ = Describe("Test OwnResources", func() {
 		Expect(GetPod()).To(BeNil())
 		Expect(GetDeploymentRef()).To(Equal(*buildOwnerReference(dep)))
 		Expect(GetCSVRef()).To(BeNil())
+	})
+
+	It("should return the current operator version", func() {
+		savedVersion := ownVersion
+		DeferCleanup(func() {
+			ownVersion = savedVersion
+		})
+		const testVersion = "v1.2.3-test"
+		ownVersion = testVersion
+		Expect(Version()).To(Equal(testVersion))
+	})
+
+	It("should use HcoKvIoVersionName env var when set", func() {
+		const testVersion = "v9.9.9"
+		orig := os.Getenv(hcoutil.HcoKvIoVersionName)
+		Expect(os.Setenv(hcoutil.HcoKvIoVersionName, testVersion)).To(Succeed())
+		DeferCleanup(func() { Expect(os.Setenv(hcoutil.HcoKvIoVersionName, orig)).To(Succeed()) })
+		Expect(findOwnVersion()).To(Equal(testVersion))
+	})
+
+	It("should fall back to version.Version when env var is not set", func() {
+		orig := os.Getenv(hcoutil.HcoKvIoVersionName)
+		Expect(os.Unsetenv(hcoutil.HcoKvIoVersionName)).To(Succeed())
+		DeferCleanup(func() { Expect(os.Setenv(hcoutil.HcoKvIoVersionName, orig)).To(Succeed()) })
+		Expect(findOwnVersion()).To(Equal(version.Version))
 	})
 
 	It("should run on a non-standard but allowed namespaces", func(ctx context.Context) {
@@ -207,7 +232,7 @@ func createPod() *corev1.Pod {
 					APIVersion: "apps/v1",
 					Kind:       "ReplicaSet",
 					Name:       rsName,
-					Controller: ptr.To(true),
+					Controller: new(true),
 				},
 			},
 		},
@@ -228,7 +253,7 @@ func createReplicaSet() *appsv1.ReplicaSet {
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       rsName,
-					Controller: ptr.To(true),
+					Controller: new(true),
 				},
 			},
 		},

--- a/pkg/ownresources/own_resources.go
+++ b/pkg/ownresources/own_resources.go
@@ -17,4 +17,6 @@ var (
 
 	// Init collect own references at startup
 	Init = internal.Init
+
+	Version = internal.Version
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Centralize operator version computation in pkg/internal/ownresources and expose it via pkg/ownresources.Version(). Add the version as a managed key in the kubevirt-ui-features ConfigMap so non-admin users can read the HCO version without elevated privileges.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-93738
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add HCO version to kubevirt-ui-features ConfigMap
```
