### PR TITLE
Add the `ObservedGeneration` to the netInject condition

### DIFF
--- a/controllers/handlers/netresinjector/deployment.go
+++ b/controllers/handlers/netresinjector/deployment.go
@@ -92,10 +92,11 @@ func (h *netResInjDeploymentHandler) GetFullCr(hc *hcov1.HyperConverged) (client
 
 func setNetResInjCondition(req *common.HcoRequest, status metav1.ConditionStatus, reason, message string) {
 	cond := metav1.Condition{
-		Type:    hcov1.ConditionNetworkResourcesInjectorReady,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
+		Type:               hcov1.ConditionNetworkResourcesInjectorReady,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: req.Instance.Generation,
 	}
 	changed := meta.SetStatusCondition(&req.Instance.Status.Conditions, cond)
 	if changed {


### PR DESCRIPTION
Add the missing `ObservedGeneration` to the `NetworkResourcesInjectorReady` condition.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
