### PR TITLE
increase memory for the artifact DL init container

### DIFF
--- a/tools/manifests/manifests.go
+++ b/tools/manifests/manifests.go
@@ -337,11 +337,11 @@ func addVirtIOVolume(spec *appsv1.DeploymentSpec, params *DeploymentOperatorPara
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
 			},
 		},
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a copy of the fix from #4451 

The pod sometimes fails to start. It seems that increasing the limit and required memory for the init container helps.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
