### PR TITLE
Rename the ConditionNetworkResourcesInjectorReady

### DIFF
--- a/api/v1/hyperconverged_types.go
+++ b/api/v1/hyperconverged_types.go
@@ -962,7 +962,7 @@ const (
 
 	// ConditionNetworkResourcesInjectorReady indicates whether the network resources injector
 	// deployment is fully ready (all replicas running).
-	ConditionNetworkResourcesInjectorReady = "NetworkResourcesInjectorReady"
+	ConditionNetworkResourcesInjectorReady = "VirtNetworkResourcesInjectorReady"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
**What this PR does / why we need it**:
rename the `NetworkResourcesInjectorReady` condition type, to `VirtNetworkResourcesInjectorReady`, in order to set a convention for future planned conditions: the deployment's cabab-case name => CamelCase + "Ready".

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-94235
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
