### PR TITLE
[release-1.18] Use dd with direct I/O for virtio-win data loading to reduce memory

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -339,7 +339,14 @@ func addVirtIOVolume(spec *appsv1.DeploymentSpec, params *DeploymentOperatorPara
 		Name:            "virtiowin-data-loader",
 		Image:           params.VirtIOWinContainer,
 		ImagePullPolicy: corev1.PullPolicy(params.ImagePullPolicy),
-		Command:         []string{"cp", params.VirtIOWinDataFile, initContainerMount},
+		Command: []string{
+			"dd",
+			"if=" + params.VirtIOWinDataFile,
+			"of=" + path.Join(initContainerMount, path.Base(params.VirtIOWinDataFile)),
+			"bs=1M",
+			"iflag=direct",
+			"oflag=direct",
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: artifactServerMountName, MountPath: initContainerMount},
 		},
@@ -348,11 +355,11 @@ func addVirtIOVolume(spec *appsv1.DeploymentSpec, params *DeploymentOperatorPara
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("128Mi"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("256Mi"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
 			},
 		},
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a copy of the fix in #4459, by @tiraboschi 

Replace cp with dd using iflag=direct and oflag=direct to bypass the kernel page cache, allowing the init container memory limits to drop from 128Mi/256Mi to 32Mi/64Mi.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
