### PR TITLE
prevent pushing wrong file by automation

### DIFF
--- a/automation/nightly/test-nightly-build.sh
+++ b/automation/nightly/test-nightly-build.sh
@@ -57,7 +57,7 @@ git clone https://github.com/kubevirt/kubevirt.git
 )
 
 validate-kv-fg-json-file kv-beta-feature-gates.json
-cp kv-beta-feature-gates.json pkg/internal/kvfeaturegates/kv-beta-feature-gates.json
+mv kv-beta-feature-gates.json pkg/internal/kvfeaturegates/kv-beta-feature-gates.json
 
 # Get latest CDI
 git clone https://github.com/kubevirt/containerized-data-importer.git cdi

--- a/automation/release-bumper/release-bumper.sh
+++ b/automation/release-bumper/release-bumper.sh
@@ -288,12 +288,13 @@ function update_kv_json_file() {
 
   local kv_version
   kv_version="$(cat updated_version.txt)"
+  trap 'rm -f kv-beta-feature-gates.json' EXIT
 
   if gh release download "${kv_version}" -R kubevirt/kubevirt -O kv-beta-feature-gates.json --pattern=feature-gates.json --clobber; then
     if ! diff -q kv-beta-feature-gates.json pkg/internal/kvfeaturegates/kv-beta-feature-gates.json > /dev/null; then
       if declare -F validate-kv-fg-json-file &>/dev/null; then
         validate-kv-fg-json-file kv-beta-feature-gates.json
-        cp kv-beta-feature-gates.json pkg/internal/kvfeaturegates/kv-beta-feature-gates.json
+        mv kv-beta-feature-gates.json pkg/internal/kvfeaturegates/kv-beta-feature-gates.json
         echo "KubeVirt feature gates file was updated in pkg/internal/kvfeaturegates/kv-beta-feature-gates.json"
       fi
     fi

--- a/hack/update-kv-fg-file.sh
+++ b/hack/update-kv-fg-file.sh
@@ -3,6 +3,8 @@ set -ex
 
 source "hack/validate-kv-fg-file.sh"
 
+trap 'rm -f kv-beta-feature-gates.json' EXIT
+
 KV_VERSION=$(grep "KUBEVIRT_VERSION=" hack/config | sed -E 's|^KUBEVIRT_VERSION="(.*)"$|\1|')
 gh release download "${KV_VERSION}" \
    -R kubevirt/kubevirt \


### PR DESCRIPTION
**What this PR does / why we need it**:

The bump kubevirt version automation, downloads the up-to-date kuevirt feature gates json file. It uses the `cp` command instead of the `mv` command to put the file in its right location, leaving the original file in place. That causes to the PR to include the same redandent file in the repo's root directory.

The same is happening when no change is done in this file, and even after chaning from `cp` to `mv`, the temporary file is not removed, and so it becomes part of the PR.

This PR makes sure the temporary file is not part of the PR, and is not pushed to the remote repository.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
