### PR TITLE
CNV-94618: Enable GraceIOVirtualization and IOMMUFD FGs when deployAIE annotation is set

### DIFF
--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -144,6 +144,8 @@ const (
 	kvOptOutRoleAggregation        = "OptOutRoleAggregation"
 	kvContainerPathVolumes         = "ContainerPathVolumes"
 	kvPCINUMAAwareTopology         = "PCINUMAAwareTopology"
+	kvGraceIOVirtualization        = "GraceIOVirtualization"
+	kvIOMMUFD                      = "IOMMUFD"
 	kvTemplateFG                   = "Template"
 	kvExternalNetResourceInjection = "ExternalNetResourceInjection"
 )
@@ -967,7 +969,7 @@ func getFeatureGateChecks(hc *hcov1.HyperConverged) []string {
 	}
 
 	if hc.Annotations[aie.DeployAIEAnnotation] == "true" {
-		fgs = append(fgs, kvPCINUMAAwareTopology)
+		fgs = append(fgs, kvGraceIOVirtualization, kvIOMMUFD, kvPCINUMAAwareTopology)
 	}
 
 	if slices.Contains(nodeinfo.GetWorkloadsArchitectures(), nodeinfo.S390X) {

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -2079,24 +2079,24 @@ Version: 1.2.3`)
 						},
 						Not(ContainElement(kvPasstBinding)),
 					),
-					// PCINUMAAwareTopology
-					Entry("should add the PCINUMAAwareTopology FG to KubeVirt CR if deployAIE annotation is true",
+					// AIE feature gates (GraceIOVirtualization, IOMMUFD, PCINUMAAwareTopology)
+					Entry("should add AIE feature gates to KubeVirt CR if deployAIE annotation is true",
 						func(hc *hcov1.HyperConverged) {
 							hc.Annotations[aie.DeployAIEAnnotation] = "true"
 						},
-						ContainElement(kvPCINUMAAwareTopology),
+						And(ContainElement(kvGraceIOVirtualization), ContainElement(kvIOMMUFD), ContainElement(kvPCINUMAAwareTopology)),
 					),
-					Entry("should not add the PCINUMAAwareTopology FG to KubeVirt CR if deployAIE annotation is false",
+					Entry("should not add AIE feature gates to KubeVirt CR if deployAIE annotation is false",
 						func(hc *hcov1.HyperConverged) {
 							hc.Annotations[aie.DeployAIEAnnotation] = "false"
 						},
-						Not(ContainElement(kvPCINUMAAwareTopology)),
+						And(Not(ContainElement(kvGraceIOVirtualization)), Not(ContainElement(kvIOMMUFD)), Not(ContainElement(kvPCINUMAAwareTopology))),
 					),
-					Entry("should not add the PCINUMAAwareTopology FG to KubeVirt CR if deployAIE annotation is not set",
+					Entry("should not add AIE feature gates to KubeVirt CR if deployAIE annotation is not set",
 						func(hc *hcov1.HyperConverged) {
 							delete(hc.Annotations, aie.DeployAIEAnnotation)
 						},
-						Not(ContainElement(kvPCINUMAAwareTopology)),
+						And(Not(ContainElement(kvGraceIOVirtualization)), Not(ContainElement(kvIOMMUFD)), Not(ContainElement(kvPCINUMAAwareTopology))),
 					),
 					Entry("should add the DeclarativeHotplugVolumes feature gate if DeclarativeHotplugVolumes is true in HyperConverged CR",
 						func(hc *hcov1.HyperConverged) {


### PR DESCRIPTION
**What this PR does / why we need it**:

KubeVirt v1.9 upstreamed GPU passthrough for NVIDIA Grace platforms behind
two new Alpha feature gates: `GraceIOVirtualization` (VEP-199) and `IOMMUFD`
(VEP-266). These must be enabled for the upstream code paths to activate.

This PR adds both feature gates to the list enabled by the
`hco.kubevirt.io/deployAIE` annotation, alongside the existing
`PCINUMAAwareTopology`. This follows the same pattern established in #4193.

**Reviewer Checklist**

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-94618
```

**Release note**:
```release-note
Enable GraceIOVirtualization and IOMMUFD KubeVirt feature gates when the deployAIE annotation is set on the HyperConverged CR, activating upstream v1.9 GPU passthrough support for NVIDIA Grace platforms.
```