### PR TITLE
CNV-94424: enable readOnlyRootFilesystem in HCO pods

### DIFF
--- a/build/Dockerfile.artifacts
+++ b/build/Dockerfile.artifacts
@@ -36,16 +36,16 @@ RUN eval $(cat /tmp/config  |grep KUBEVIRT_VERSION=) && \
         done; \
     done
 
-FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/nginx-124
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi9/nginx-126
 ARG TARGETPLATFORM
 
 WORKDIR /opt/app-root/src
 
 COPY --from=downloader ./bin/ ./
+COPY build/assets/artifacts/nginx.conf /etc/nginx/nginx.conf
 
 USER 0
-RUN sed -i -E '/^ +location.*$/a\        }\n\n        location = /health {\n            access_log off;\n            return 200;' /etc/nginx/nginx.conf && \
-    sed '/^\s*listen\s*\[::\]:8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv4 && \
+RUN sed '/^\s*listen\s*\[::\]:8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv4 && \
     sed '/^\s*listen\s*8080/d' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.ipv6
 
 USER 1001
@@ -59,13 +59,13 @@ LABEL multi.GIT_URL=${git_url} \
 
 CMD if [[ -d "/proc/sys/net/ipv4" && -d "/proc/sys/net/ipv6" ]]; \
     then \
-      nginx -g "daemon off;"; \
+      exec nginx -e /dev/stderr -g "daemon off;"; \
     elif [[ -d "/proc/sys/net/ipv4" ]]; \
     then \
-      nginx -c /etc/nginx/nginx.conf.ipv4 -g "daemon off;"; \
+      exec nginx -c /etc/nginx/nginx.conf.ipv4 -e /dev/stderr -g "daemon off;"; \
     elif [[ -d "/proc/sys/net/ipv6" ]]; \
     then \
-      nginx -c /etc/nginx/nginx.conf.ipv6 -g "daemon off;"; \
+      exec nginx -c /etc/nginx/nginx.conf.ipv6 -e /dev/stderr -g "daemon off;"; \
     else \
       echo "unable to identify IP configuration"; \
       exit -1; \

--- a/build/assets/artifacts/nginx.conf
+++ b/build/assets/artifacts/nginx.conf
@@ -1,0 +1,56 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+
+worker_processes auto;
+error_log /dev/stderr notice;
+pid /tmp/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /dev/stdout  main;
+    client_body_temp_path /tmp/nginx_client_body;
+    proxy_temp_path /tmp/nginx_proxy;
+    fastcgi_temp_path /tmp/nginx_fastcgi;
+    uwsgi_temp_path /tmp/nginx_uwsgi;
+    scgi_temp_path /tmp/nginx_scgi;
+
+    sendfile            on;
+    tcp_nopush          on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /opt/app-root/etc/nginx.d/*.conf;
+
+    server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /opt/app-root/src;
+
+        # Load configuration files for the default server block.
+        include /opt/app-root/etc/nginx.default.d/*.conf;
+
+        location = /health {
+            access_log off;
+            return 200;
+        }
+    }
+}

--- a/controllers/handlers/kubevirtConsolePlugin.go
+++ b/controllers/handlers/kubevirtConsolePlugin.go
@@ -140,6 +140,11 @@ func NewKvUIPluginDeployment(hc *hcov1.HyperConverged) *appsv1.Deployment {
 	deployment := getKvUIDeployment(hc, kvUIPluginDeploymentName, kvUIPluginImage,
 		kvUIPluginServingCertName, kvUIPluginServingCertPath, hcoutil.UIPluginServerPort, hcoutil.AppComponentUIPlugin)
 
+	// The nginx entrypoint, the /usr/libexec/s2i/run script, calls the generate_container_user that writes to the root
+	// file system. We can't set the ReadOnlyRootFilesystem field for this container.
+	// TODO: remove this when the image is fixed.
+	deployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = nil
+
 	nginxVolumeMount := corev1.VolumeMount{
 		Name:      nginxConfigMapName,
 		MountPath: "/etc/nginx/nginx.conf",

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
@@ -4436,6 +4436,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-cluster-critical
               securityContext:
@@ -4521,6 +4522,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-node-critical
               securityContext:
@@ -4584,6 +4586,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-cluster-critical
               securityContext:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
@@ -4436,6 +4436,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-cluster-critical
               securityContext:
@@ -4521,6 +4522,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-node-critical
               securityContext:
@@ -4584,13 +4586,21 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
+                volumeMounts:
+                - mountPath: /tmp
+                  name: nginx-tmp
               priorityClassName: system-cluster-critical
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
               serviceAccountName: hyperconverged-cluster-cli-download
+              volumes:
+              - emptyDir:
+                  sizeLimit: 256Mi
+                name: nginx-tmp
       - label:
           app.kubernetes.io/component: network
           app.kubernetes.io/managed-by: olm

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.19.0-unstable
-    createdAt: "2026-08-11 05:27:05"
+    createdAt: "2026-08-11 14:44:27"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -4436,6 +4436,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-cluster-critical
               securityContext:
@@ -4521,6 +4522,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-node-critical
               securityContext:
@@ -4584,13 +4586,21 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
+                volumeMounts:
+                - mountPath: /tmp
+                  name: nginx-tmp
               priorityClassName: system-cluster-critical
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
               serviceAccountName: hyperconverged-cluster-cli-download
+              volumes:
+              - emptyDir:
+                  sizeLimit: 256Mi
+                name: nginx-tmp
       - label:
           app.kubernetes.io/component: network
           app.kubernetes.io/managed-by: olm

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/kubevirt-hyperconverged-operator.v1.19.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     console.openshift.io/disable-operand-delete: "true"
     containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.19.0-unstable
-    createdAt: "2026-08-06 06:01:35"
+    createdAt: "2026-08-06 13:29:01"
     description: A unified operator deploying and controlling KubeVirt and its supporting
       operators with opinionated defaults
     features.operators.openshift.io/cnf: "false"
@@ -4436,6 +4436,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-cluster-critical
               securityContext:
@@ -4521,6 +4522,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-node-critical
               securityContext:
@@ -4584,6 +4586,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-cluster-critical
               securityContext:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -120,6 +120,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       securityContext:
@@ -207,6 +208,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /apiserver.local.config/certificates
@@ -285,6 +287,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       securityContext:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -120,6 +120,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       securityContext:
@@ -207,6 +208,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /apiserver.local.config/certificates
@@ -285,13 +287,21 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: nginx-tmp
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: hyperconverged-cluster-cli-download
+      volumes:
+      - emptyDir:
+          sizeLimit: 256Mi
+        name: nginx-tmp
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,6 +29,7 @@ func GetStdContainerSecurityContext() *corev1.SecurityContext {
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
+		ReadOnlyRootFilesystem: new(true),
 	}
 }
 

--- a/tools/manifests/manifests.go
+++ b/tools/manifests/manifests.go
@@ -307,6 +307,19 @@ func GetDeploymentSpecCliDownloads(params *DeploymentOperatorParams) appsv1.Depl
 						ReadinessProbe:           getReadinessProbe("/health", util.CliDownloadsServerPort),
 						LivenessProbe:            getLivenessProbe("/health", util.CliDownloadsServerPort),
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "nginx-tmp", MountPath: "/tmp"},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "nginx-tmp",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{
+								SizeLimit: new(resource.MustParse("256Mi")),
+							},
+						},
 					},
 				},
 				PriorityClassName: "system-cluster-critical",


### PR DESCRIPTION
The artifact download server didn't work after adding the readOnlyRootFilesystem setting to its pod. 

This PR also added a new volume to the this pod, mount it to `/tmp`, and move all its write operations to write to `/tmp`. The logs are written to stdout/stderr. now, the server never writes to the root filesysetem, and it's working properly.

To ease this, the nginx.conf file is now added to the repo and copied to the image, instead of generating it from the Dockerfile.

It also allows to bump the nginx base image, because before that, the `sed` command in the Dockerfile, failed for the new base image. Now, when the file is pre-prepared, the server runs with no issues.

**Jira**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-94424
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
