### PR TITLE
Report the default architecture in the status

### DIFF
--- a/api/v1/hyperconverged_types.go
+++ b/api/v1/hyperconverged_types.go
@@ -925,6 +925,9 @@ type NodeInfoStatus struct {
 	WorkloadsArchitectures []string `json:"workloadsArchitectures,omitempty"`
 	// ControlPlaneArchitectures is a distinct list of the CPU architecture of the control-plane nodes.
 	ControlPlaneArchitectures []string `json:"controlPlaneArchitectures,omitempty"`
+
+	// DefaultWorkloadArchitecture is chosen automatically by HCO. This field reports the architecture selected by HCO.
+	DefaultWorkloadArchitecture string `json:"defaultWorkloadArchitecture,omitempty"`
 }
 
 // ApplicationAwareConfigurations holds the AAQ configurations

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -5364,6 +5364,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.
@@ -10717,6 +10721,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.

--- a/controllers/hyperconverged/hyperconverged_controller.go
+++ b/controllers/hyperconverged/hyperconverged_controller.go
@@ -495,6 +495,11 @@ func updateStatus(req *common.HcoRequest) {
 		req.Instance.Status.NodeInfo.WorkloadsArchitectures = workloadsArch
 		req.StatusDirty = true
 	}
+
+	if defaultArch := nodeinfo.GetDefaultArchitecture(); defaultArch != req.Instance.Status.NodeInfo.DefaultWorkloadArchitecture {
+		req.Instance.Status.NodeInfo.DefaultWorkloadArchitecture = defaultArch
+		req.StatusDirty = true
+	}
 }
 
 // getHyperConverged gets the HyperConverged resource from the Kubernetes API.

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/handlers"
 	"github.com/kubevirt/hyperconverged-cluster-operator/controllers/reqresolver"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/monitoring/hyperconverged/metrics"
+	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 	fakeownresources "github.com/kubevirt/hyperconverged-cluster-operator/pkg/ownresources/fake"
 	"github.com/kubevirt/hyperconverged-cluster-operator/pkg/tlssecprofile"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
@@ -2615,6 +2616,60 @@ var _ = Describe("HyperconvergedController", func() {
 						Expect(*ssp.Spec.TemplateValidator.Replicas).To(Equal(int32(5)))
 					})
 				})
+			})
+		})
+
+		Context("nodeInfo status", func() {
+			AfterEach(func() {
+				commontestutils.ResetNodeInfoMocks()
+			})
+
+			It("should report the control plane architectures in the status", func(ctx context.Context) {
+				arches := []string{"aaa", "bbb", "ccc"}
+				nodeinfo.GetControlPlaneArchitectures = func() []string {
+					return arches
+				}
+
+				hco := commontestutils.NewHco()
+				hco.Status.NodeInfo.ControlPlaneArchitectures = []string{"something", "else"}
+				cl := commontestutils.InitClient([]client.Object{hco})
+				r := initReconciler(cl, nil)
+
+				newHCO, _, _ := doReconcile(cl, hco, r)
+
+				Expect(newHCO.Status.NodeInfo.ControlPlaneArchitectures).To(Equal(arches))
+			})
+
+			It("should report the workload architectures in the status", func(ctx context.Context) {
+				arches := []string{"aaa", "bbb", "ccc"}
+				nodeinfo.GetWorkloadsArchitectures = func() []string {
+					return arches
+				}
+
+				hco := commontestutils.NewHco()
+				hco.Status.NodeInfo.WorkloadsArchitectures = []string{"something", "else"}
+				cl := commontestutils.InitClient([]client.Object{hco})
+				r := initReconciler(cl, nil)
+
+				newHCO, _, _ := doReconcile(cl, hco, r)
+
+				Expect(newHCO.Status.NodeInfo.WorkloadsArchitectures).To(Equal(arches))
+			})
+
+			It("should report the default workload architecture in the status", func(ctx context.Context) {
+				const defaultArch = "defaultArch"
+				nodeinfo.GetDefaultArchitecture = func() string {
+					return defaultArch
+				}
+
+				hco := commontestutils.NewHco()
+				hco.Status.NodeInfo.DefaultWorkloadArchitecture = "something-else"
+				cl := commontestutils.InitClient([]client.Object{hco})
+				r := initReconciler(cl, nil)
+
+				newHCO, _, _ := doReconcile(cl, hco, r)
+
+				Expect(newHCO.Status.NodeInfo.DefaultWorkloadArchitecture).To(Equal(defaultArch))
 			})
 		})
 	})

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -5364,6 +5364,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.
@@ -10717,6 +10721,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -5364,6 +5364,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.
@@ -10717,6 +10721,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.19.0/manifests/hco00.crd.yaml
@@ -5364,6 +5364,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.
@@ -10717,6 +10721,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.

--- a/docs/api.md
+++ b/docs/api.md
@@ -307,6 +307,7 @@ NodeInfoStatus holds information about the cluster nodes
 | ----- | ----------- | ------ | ------- | -------- |
 | workloadsArchitectures | WorkloadsArchitectures is a distinct list of the CPU architectures of the workloads nodes in the cluster. | []string |  | false |
 | controlPlaneArchitectures | ControlPlaneArchitectures is a distinct list of the CPU architecture of the control-plane nodes. | []string |  | false |
+| defaultWorkloadArchitecture | DefaultWorkloadArchitecture is chosen automatically by HCO. This field reports the architecture selected by HCO. | string |  | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -5364,6 +5364,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.
@@ -10717,6 +10721,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -5364,6 +5364,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.
@@ -10717,6 +10721,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  defaultWorkloadArchitecture:
+                    description: DefaultWorkloadArchitecture is chosen automatically
+                      by HCO. This field reports the architecture selected by HCO.
+                    type: string
                   workloadsArchitectures:
                     description: WorkloadsArchitectures is a distinct list of the
                       CPU architectures of the workloads nodes in the cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the new `status.nodeInfo.defaultWorkloadArchitecture` field to the HyperConverged CR.

Populate this field with the default workload architecture chosen by HCO.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-94943
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
API: Add the new `status.nodeInfo.defaultWorkloadArchitecture` field to the HyperConverged CR.
```
