### PR TITLE
Skip observability controller deployment when image is not configured

### DIFF
--- a/controllers/operandhandler/operandHandler.go
+++ b/controllers/operandhandler/operandHandler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"os"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -73,7 +74,7 @@ func NewOperandHandler(client client.Client, scheme *runtime.Scheme, ci hcoutil.
 		netresinjector.NewMutatingWebhookConfigurationHandler(client, scheme),
 	}
 
-	if ci.IsMonitoringAvailable() {
+	if ci.IsMonitoringAvailable() && os.Getenv(hcoutil.ObservabilityControllerImageEnvV) != "" {
 		operandList = append(operandList, []operands.Operand{
 			observabilitycontroller.NewServiceAccountHandler(client, scheme),
 			observabilitycontroller.NewClusterRoleHandler(client, scheme),

--- a/tests/func-tests/observability_controller_test.go
+++ b/tests/func-tests/observability_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -120,10 +121,15 @@ var _ = Describe("Observability Controller Deployment", Label(tests.OpenshiftLab
 
 	BeforeAll(func(ctx context.Context) {
 		cli = tests.GetControllerRuntimeClient()
-	})
 
-	AfterAll(func(ctx context.Context) {
-		tests.RestoreDefaultFeatureGates(ctx, cli)
+		By("checking the observability controller image is configured")
+		configured, err := isObservabilityImageConfigured(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(configured).To(BeTrueBecause(`the OBSERVABILITY_CONTROLLER_IMAGE environment variable should be configured in operator deployment. Use the "!observability-controller" label filter in order to skip this test`))
+
+		DeferCleanup(func(ctx context.Context) {
+			tests.RestoreDefaultFeatureGates(ctx, cli)
+		})
 	})
 
 	When("deployObservabilityController feature gate is enabled", func() {
@@ -216,8 +222,18 @@ var _ = Describe("Observability Controller Allowlist Configuration", Label(tests
 	BeforeAll(func(ctx context.Context) {
 		cli = tests.GetControllerRuntimeClient()
 
+		By("checking the observability controller image is configured")
+		configured, err := isObservabilityImageConfigured(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(configured).To(BeTrueBecause(`the OBSERVABILITY_CONTROLLER_IMAGE environment variable should be configured in operator deployment. Use the "!observability-controller" label filter in order to skip this test`))
+
 		By("enabling the deployObservabilityController feature gate")
 		Expect(tests.EnableFG(ctx, cli, observabilityControllerFGName)).To(Succeed())
+
+		DeferCleanup(func(ctx context.Context) {
+			tests.PatchHCO(ctx, cli, []byte(`[{"op": "remove", "path": "/spec/observability"}]`))
+			tests.RestoreDefaultFeatureGates(ctx, cli)
+		})
 
 		By("waiting for the deployment to be created")
 		Eventually(func(ctx context.Context) error {
@@ -229,11 +245,6 @@ var _ = Describe("Observability Controller Allowlist Configuration", Label(tests
 			}
 			return cli.Get(ctx, client.ObjectKeyFromObject(dep), dep)
 		}).WithTimeout(2 * time.Minute).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
-	})
-
-	AfterAll(func(ctx context.Context) {
-		tests.PatchHCO(ctx, cli, []byte(`[{"op": "remove", "path": "/spec/observability"}]`))
-		tests.RestoreDefaultFeatureGates(ctx, cli)
 	})
 
 	getDeploymentArgs := func(ctx context.Context) ([]string, error) {
@@ -326,4 +337,24 @@ func getServiceAccountToken(ctx context.Context) (string, error) {
 	}
 
 	return treq.Status.Token, nil
+}
+
+func isObservabilityImageConfigured(ctx context.Context, cli client.Client) (bool, error) {
+	depList := &appsv1.DeploymentList{}
+	err := cli.List(ctx, depList, client.InNamespace(tests.InstallNamespace), client.MatchingLabels{"name": "hyperconverged-cluster-operator"})
+	if err != nil {
+		return false, fmt.Errorf("failed to list operator deployments: %w", err)
+	}
+	if len(depList.Items) == 0 {
+		return false, fmt.Errorf("no hyperconverged-cluster-operator deployment found in namespace %s", tests.InstallNamespace)
+	}
+
+	if len(depList.Items[0].Spec.Template.Spec.Containers) == 0 {
+		return false, fmt.Errorf("operator deployment has no containers")
+	}
+
+	container := depList.Items[0].Spec.Template.Spec.Containers[0]
+	return slices.ContainsFunc(container.Env, func(e v1.EnvVar) bool {
+		return e.Name == "OBSERVABILITY_CONTROLLER_IMAGE" && e.Value != ""
+	}), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When `OBSERVABILITY_CONTROLLER_IMAGE` is set to an empty string in the operator pod (as is the case in downstream builds that do not yet ship the alpha observability controller image), enabling the `deployObservabilityController` feature gate causes the operator to attempt creating a deployment with an empty image field. The deployment object is never actually created, and the functional tests time out waiting for it (120s per test).

This PR adds an image availability check to `shouldDeploy` so the operator gracefully skips deployment when the image is not configured. It also updates the functional tests to detect this condition upfront and skip with a clear message, avoiding unnecessary timeouts.

Reproduced on both x86_64 (Jul 30) and s390x (Aug 5) downstream CI runs.

This PR was created with the help of AI, but every change has been manually tested and verified

**Reviewer Checklist**

- [x] PR Message
- [x] Commit Messages
- [x] How to test - Run func tests with `--ginkgo.label-filter="observability-controller"` against a cluster where `OBSERVABILITY_CONTROLLER_IMAGE` is empty in the operator deployment. Tests should skip gracefully instead of timing out.
- [x] Unit Tests - Added test case for "should not create when image env var is not set"
- [x] Functional Tests - Updated existing tests to skip when image is not configured
- [ ] User Documentation -> N/A
- [ ] Developer Documentation -> N/A
- [ ] Upgrade Scenario -> N/A (graceful degradation, no state change)
- [ ] Uninstallation Scenario -> N/A
- [ ] Backward Compatibility - Fully backward compatible; no behavior change when image is configured
- [ ] Troubleshooting Friendly -> N/A

**Jira Ticket**:
```jira-ticket
NONE
```

**Release note**:
```release-note
NONE
```