### PR TITLE
CNV-95652: [1.18] Don't force single-replica KubeVirt infra on 2-node control planes

### DIFF
--- a/controllers/commontestutils/nodeinfomocks.go
+++ b/controllers/commontestutils/nodeinfomocks.go
@@ -4,6 +4,7 @@ import "github.com/kubevirt/hyperconverged-cluster-operator/pkg/nodeinfo"
 
 var (
 	origIsControlPlaneHighlyAvailable = nodeinfo.IsControlPlaneHighlyAvailable
+	origIsControlPlaneMultiNode       = nodeinfo.IsControlPlaneMultiNode
 	origIsControlPlaneNodeExists      = nodeinfo.IsControlPlaneNodeExists
 	origIsInfraHighlyAvailable        = nodeinfo.IsInfrastructureHighlyAvailable
 	origGetControlPlaneArchitectures  = nodeinfo.GetControlPlaneArchitectures
@@ -13,6 +14,7 @@ var (
 
 func ResetNodeInfoMocks() {
 	nodeinfo.IsControlPlaneHighlyAvailable = origIsControlPlaneHighlyAvailable
+	nodeinfo.IsControlPlaneMultiNode = origIsControlPlaneMultiNode
 	nodeinfo.IsControlPlaneNodeExists = origIsControlPlaneNodeExists
 	nodeinfo.IsInfrastructureHighlyAvailable = origIsInfraHighlyAvailable
 	nodeinfo.GetControlPlaneArchitectures = origGetControlPlaneArchitectures
@@ -33,6 +35,10 @@ func HighlyAvailableNodeInfoMocks() {
 	nodeinfo.IsControlPlaneHighlyAvailable = func() bool {
 		return true
 	}
+
+	nodeinfo.IsControlPlaneMultiNode = func() bool {
+		return true
+	}
 }
 
 // SNONodeInfoMock mocks Openshift SNO
@@ -46,6 +52,10 @@ func SNONodeInfoMock() {
 	}
 
 	nodeinfo.IsControlPlaneHighlyAvailable = func() bool {
+		return false
+	}
+
+	nodeinfo.IsControlPlaneMultiNode = func() bool {
 		return false
 	}
 }
@@ -62,6 +72,33 @@ func SRCPHAINodeInfoMock() {
 
 	nodeinfo.IsControlPlaneHighlyAvailable = func() bool {
 		return false
+	}
+
+	nodeinfo.IsControlPlaneMultiNode = func() bool {
+		return false
+	}
+}
+
+// DualReplicaNodeInfoMock mocks Openshift with the DualReplica (two-node
+// control plane, no arbiter) topology: two control plane nodes without a
+// third node or arbiter to form etcd quorum, so IsControlPlaneHighlyAvailable
+// is false, but there are still two nodes to spread KubeVirt infra replicas
+// across.
+func DualReplicaNodeInfoMock() {
+	nodeinfo.IsInfrastructureHighlyAvailable = func() bool {
+		return false
+	}
+
+	nodeinfo.IsControlPlaneNodeExists = func() bool {
+		return true
+	}
+
+	nodeinfo.IsControlPlaneHighlyAvailable = func() bool {
+		return false
+	}
+
+	nodeinfo.IsControlPlaneMultiNode = func() bool {
+		return true
 	}
 }
 

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -308,7 +308,7 @@ func NewKubeVirt(hc *hcov1beta1.HyperConverged, opts ...string) (*kubevirtcorev1
 
 	kvCertConfig := hcoCertConfig2KvCertificateRotateStrategy(hc.Spec.CertConfig)
 
-	controlPlaneHighlyAvailable := nodeinfo.IsControlPlaneHighlyAvailable()
+	controlPlaneMultiNode := nodeinfo.IsControlPlaneMultiNode()
 	controlPlaneNodeExists := nodeinfo.IsControlPlaneNodeExists()
 	infraHighlyAvailable := nodeinfo.IsInfrastructureHighlyAvailable()
 
@@ -319,7 +319,7 @@ func NewKubeVirt(hc *hcov1beta1.HyperConverged, opts ...string) (*kubevirtcorev1
 
 	spec := kubevirtcorev1.KubeVirtSpec{
 		UninstallStrategy:           uninstallStrategy,
-		Infra:                       hcoConfig2KvConfig(hc.Spec.Infra, infraHighlyAvailable, controlPlaneHighlyAvailable, controlPlaneNodeExists),
+		Infra:                       hcoConfig2KvConfig(hc.Spec.Infra, infraHighlyAvailable, controlPlaneMultiNode, controlPlaneNodeExists),
 		Workloads:                   hcoConfig2KvConfig(hc.Spec.Workloads, true, true, true),
 		Configuration:               *config,
 		CertificateRotationStrategy: *kvCertConfig,
@@ -898,8 +898,8 @@ func NewKubeVirtWithNameOnly() *kubevirtcorev1.KubeVirt {
 }
 
 func hcoConfig2KvConfig(
-	hcoConfig hcov1beta1.HyperConvergedConfig, infraHighlyAvailable, controlPlaneHighlyAvailable, controlPlaneNodeExists bool) *kubevirtcorev1.ComponentConfig {
-	if hcoConfig.NodePlacement == nil && controlPlaneHighlyAvailable {
+	hcoConfig hcov1beta1.HyperConvergedConfig, infraHighlyAvailable, controlPlaneMultiNode, controlPlaneNodeExists bool) *kubevirtcorev1.ComponentConfig {
+	if hcoConfig.NodePlacement == nil && controlPlaneMultiNode {
 		return nil
 	}
 
@@ -918,7 +918,7 @@ func hcoConfig2KvConfig(
 		return kvConfig
 	}
 
-	if !controlPlaneHighlyAvailable {
+	if !controlPlaneMultiNode {
 		kvConfig.Replicas = ptr.To[uint8](1)
 	}
 

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -3202,6 +3202,15 @@ Version: 1.2.3`)
 					Expect(kv.Spec.Workloads).To(BeNil())
 				})
 
+				It("should not force replica=1 on DualReplica (two CP nodes, no arbiter)", func() {
+					commontestutils.DualReplicaNodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).ToNot(BeNil())
+					Expect(kv.Spec.Infra.Replicas).To(BeNil())
+					Expect(kv.Spec.Workloads).To(BeNil())
+				})
 			})
 
 			Context("Custom Workloads placement, default Infra placement", func() {
@@ -3243,6 +3252,15 @@ Version: 1.2.3`)
 					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
 				})
 
+				It("should not force replica=1 on DualReplica (two CP nodes, no arbiter)", func() {
+					commontestutils.DualReplicaNodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).To(BeNil())
+					Expect(kv.Spec.Workloads).ToNot(BeNil())
+					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
+				})
 			})
 
 			Context("Default Infra and Workload placement", func() {
@@ -3278,6 +3296,14 @@ Version: 1.2.3`)
 					Expect(kv.Spec.Workloads).To(BeNil())
 				})
 
+				It("should not force replica=1 on DualReplica (two CP nodes, no arbiter)", func() {
+					commontestutils.DualReplicaNodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).To(BeNil())
+					Expect(kv.Spec.Workloads).To(BeNil())
+				})
 			})
 
 			Context("Custom Infra and Workloads placement", func() {
@@ -3320,8 +3346,17 @@ Version: 1.2.3`)
 					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
 				})
 
-			})
+				It("should not force replica=1 on DualReplica (two CP nodes, no arbiter)", func() {
+					commontestutils.DualReplicaNodeInfoMock()
 
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).ToNot(BeNil())
+					Expect(kv.Spec.Infra.Replicas).To(BeNil())
+					Expect(kv.Spec.Workloads).ToNot(BeNil())
+					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
+				})
+			})
 		})
 
 		Context("Cluster level EvictionStrategy", func() {

--- a/pkg/internal/nodeinfo/high_availability.go
+++ b/pkg/internal/nodeinfo/high_availability.go
@@ -20,12 +20,21 @@ const (
 
 var (
 	controlPlaneHighlyAvailable   atomic.Bool
+	controlPlaneMultiNode         atomic.Bool
 	controlPlaneNodeExist         atomic.Bool
 	infrastructureHighlyAvailable atomic.Bool
 )
 
 func IsControlPlaneHighlyAvailable() bool {
 	return controlPlaneHighlyAvailable.Load()
+}
+
+// IsControlPlaneMultiNode reports whether there is more than one control
+// plane node to spread replicas across. Unlike IsControlPlaneHighlyAvailable,
+// this does not require an arbiter or a third node, so it also covers
+// two-node control planes (e.g. Dual Replica / TNF topologies).
+func IsControlPlaneMultiNode() bool {
+	return controlPlaneMultiNode.Load()
 }
 
 func IsControlPlaneNodeExists() bool {

--- a/pkg/internal/nodeinfo/nodeinfo.go
+++ b/pkg/internal/nodeinfo/nodeinfo.go
@@ -71,6 +71,9 @@ func processNodeInfo(nodes []corev1.Node, hc *v1beta1.HyperConverged) bool {
 	newValue := cpNodeCount >= 3 || (cpNodeCount >= 2 && arbiterNodeCount >= 1)
 	changed := controlPlaneHighlyAvailable.Swap(newValue) != newValue
 
+	newValue = cpNodeCount >= 2
+	changed = controlPlaneMultiNode.Swap(newValue) != newValue || changed
+
 	newValue = cpNodeCount >= 1
 	changed = controlPlaneNodeExist.Swap(newValue) != newValue || changed
 

--- a/pkg/nodeinfo/nodeinfo.go
+++ b/pkg/nodeinfo/nodeinfo.go
@@ -21,6 +21,7 @@ var (
 	HandleNodeChanges = internal.HandleNodeChanges
 
 	IsControlPlaneHighlyAvailable   = internal.IsControlPlaneHighlyAvailable
+	IsControlPlaneMultiNode         = internal.IsControlPlaneMultiNode
 	IsControlPlaneNodeExists        = internal.IsControlPlaneNodeExists
 	IsInfrastructureHighlyAvailable = internal.IsInfrastructureHighlyAvailable
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Note**: this is a manual cherry pick of PR #4450

Currently HCO Forces `spec.infra.replicas: 1` on the KubeVirt CR (virt-api, virt-controller, virt-exportproxy, virt-synchronization-controller) whenever `IsControlPlaneHighlyAvailable()` is false. That flag requires 3+ control plane nodes, or 2 nodes plus an arbiter — so a 2-node control plane without an arbiter (Two Node OpenShift with Fencing / `DualReplica` topology) gets treated like a single-node cluster, even though there are 2 real nodes to spread replicas across.

Single `virt-api` replica removes redundancy for the eviction-interceptor webhook: draining the node hosting the only `virt-api` pod evicts it before the webhook can redirect `virt-launcher` eviction into a live migration. Eviction fails (`no endpoints available for service "virt-api"`) or force-kills the VM instead of migrating it.

This is a replica-count bug, not an "HCO doesn't know TNF is HA" bug. `IsControlPlaneHighlyAvailable()` is untouched — its degraded-cluster semantics (3→2 nodes still reports false) stay as-is. HCO has no visibility into fencing/quorum health; not claiming it now understands TNF topology.

`hcoConfig2KvConfig`'s replica decision never needed "is the control plane HA" — it needs "how many nodes can we spread infra pods across." Added `nodeinfo.IsControlPlaneMultiNode()` (`cpNodeCount >= 2`) as that narrower signal and swapped it in for `IsControlPlaneHighlyAvailable()` at that call site.

**Changes in this PR**:
Renamed the parameter (`controlPlaneHighlyAvailable` → `controlPlaneMultiNode`) in the same commit as the behavior change, since the old name no longer matched what it gated. Flagging that explicitly: a rename plus behavior change in one diff hides the actual delta on skim. The delta is: `Replicas` is no longer forced to `1` on exactly 2 control-plane nodes without an arbiter.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-95652
```

**Release note**:
```release-note
Don't force single-replica KubeVirt infra on 2-node control planes
```
