### PR TITLE
test: guard KubeVirt maintenance and Descheduler documentation

### DIFF
--- a/tests/func-tests/descheduler_kubevirt_compatibility_test.go
+++ b/tests/func-tests/descheduler_kubevirt_compatibility_test.go
@@ -4,67 +4,218 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
 )
 
 const (
-	deschedulerCRDName = "kubedeschedulers.operator.openshift.io"
-	graduatedProfile   = "KubeVirtRelieveAndMigrate"
-	legacyProfile      = "DevKubeVirtRelieveAndMigrate"
-	deschedulerMode    = "Automatic"
+	deschedulerCRDName       = "kubedeschedulers.operator.openshift.io"
+	deschedulerLabelSelector = "app.kubernetes.io/name=descheduler"
+	rawPolicyAPIVersion      = "descheduler/v1alpha2"
+	graduatedProfile         = "KubeVirtRelieveAndMigrate"
+	legacyProfile            = "DevKubeVirtRelieveAndMigrate"
+	deschedulerMode          = "Automatic"
 )
+
+type deschedulerPolicyDocument struct {
+	APIVersion string                   `json:"apiVersion"`
+	Kind       string                   `json:"kind"`
+	Profiles   []map[string]interface{} `json:"profiles"`
+}
 
 var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("deschedulerCompatibility"), func() {
 	tests.FlagParse()
 
-	It("should expose the documented KubeVirt profile and fields", func(ctx context.Context) {
+	It("should expose the documented ACP policy and background-eviction contract", func(ctx context.Context) {
+		k8sClient := tests.GetK8sClientSet()
+		configMaps, err := k8sClient.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{LabelSelector: deschedulerLabelSelector})
+		Expect(err).ToNot(HaveOccurred())
+		if len(configMaps.Items) == 0 {
+			Skip("optional Descheduler plugin is not installed; no labeled policy ConfigMap was found")
+		}
+
+		for _, configMap := range configMaps.Items {
+			rawPolicy, ok := configMap.Data["policy.yaml"]
+			Expect(ok).To(BeTrue(), "Descheduler ConfigMap %s/%s has no data.policy.yaml", configMap.Namespace, configMap.Name)
+			Expect(strings.TrimSpace(rawPolicy)).ToNot(BeEmpty(), "Descheduler ConfigMap %s/%s has an empty data.policy.yaml", configMap.Namespace, configMap.Name)
+
+			policy := deschedulerPolicyDocument{}
+			Expect(yaml.Unmarshal([]byte(rawPolicy), &policy)).To(Succeed(),
+				"Descheduler ConfigMap %s/%s contains invalid YAML", configMap.Namespace, configMap.Name)
+			Expect(policy.APIVersion).To(Equal(rawPolicyAPIVersion),
+				"update the policy howto when the ACP raw policy API changes")
+			Expect(policy.Kind).To(Equal("DeschedulerPolicy"),
+				"the policy howto requires a DeschedulerPolicy document")
+			Expect(policy.Profiles).ToNot(BeEmpty(),
+				"DeschedulerPolicy must contain at least one profile")
+		}
+
+		args, found, err := deschedulerWorkloadArgs(ctx, k8sClient)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue(),
+			"a labeled Descheduler ConfigMap exists but no CronJob, Deployment, or Pod consumes it")
+		Expect(hasPolicyConfigFile(args)).To(BeTrue(),
+			"Descheduler workload must read /policy-dir/policy.yaml from the labeled policy ConfigMap")
+		Expect(hasBackgroundEvictionGate(args)).To(BeTrue(),
+			"Descheduler workload must contain --feature-gates=EvictionsInBackground=true for asynchronous KubeVirt eviction")
+	})
+
+	It("should expose documented fields when the optional KubeDescheduler CRD is installed", func(ctx context.Context) {
 		cli := tests.GetControllerRuntimeClient()
 		crd := &apiextensionsv1.CustomResourceDefinition{}
 		if err := cli.Get(ctx, client.ObjectKey{Name: deschedulerCRDName}, crd); apierrors.IsNotFound(err) {
-			Skip(fmt.Sprintf("optional Descheduler plugin is not installed; CRD %q was not found", deschedulerCRDName))
+			Skip(fmt.Sprintf("optional OpenShift Descheduler operator is not installed; CRD %q was not found", deschedulerCRDName))
 		} else {
 			Expect(err).ToNot(HaveOccurred())
 		}
 
-		schema := servedDeschedulerSchema(crd)
-		Expect(schema).ToNot(BeNil(), "the Descheduler CRD has no served OpenAPI schema")
+		schemas := servedDeschedulerSchemas(crd)
+		Expect(schemas).ToNot(BeEmpty(), "the Descheduler CRD has no served OpenAPI schema")
 
-		spec, ok := schema.Properties["spec"]
-		Expect(ok).To(BeTrue(), "KubeDescheduler.spec is missing from the served schema")
-		profiles, ok := spec.Properties["profiles"]
-		Expect(ok).To(BeTrue(), "KubeDescheduler.spec.profiles is missing from the served schema")
-		Expect(profiles.Items).ToNot(BeNil(), "KubeDescheduler.spec.profiles has no item schema")
-		Expect(profileEnum(profiles.Items)).To(Or(ContainElement(graduatedProfile), ContainElement(legacyProfile)),
-			"neither the graduated nor the legacy KubeVirt profile is accepted")
-
-		customizations, ok := spec.Properties["profileCustomizations"]
-		Expect(ok).To(BeTrue(), "KubeDescheduler.spec.profileCustomizations is missing from the served schema")
-		backgroundEvictions, ok := customizations.Properties["devEnableEvictionsInBackground"]
-		Expect(ok).To(BeTrue(), "the documented background-eviction field is missing from the served schema")
-		Expect(backgroundEvictions.Type).To(Equal("boolean"),
-			"the documented background-eviction field is no longer boolean")
-
-		mode, ok := spec.Properties["mode"]
-		Expect(ok).To(BeTrue(), "KubeDescheduler.spec.mode is missing from the served schema")
-		Expect(jsonEnum(mode.Enum)).To(ContainElement(deschedulerMode),
-			"the documented Automatic Descheduler mode is no longer accepted")
+		supported := false
+		for _, schema := range schemas {
+			if deschedulerSchemaSupportsKubeVirtProfile(schema) {
+				supported = true
+				break
+			}
+		}
+		Expect(supported).To(BeTrue(),
+			"the optional KubeDescheduler CRD no longer exposes the documented KubeVirt profile and fields")
 	})
 })
 
-func servedDeschedulerSchema(crd *apiextensionsv1.CustomResourceDefinition) *apiextensionsv1.JSONSchemaProps {
-	for _, version := range crd.Spec.Versions {
-		if version.Served && version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
-			return version.Schema.OpenAPIV3Schema
+func deschedulerWorkloadArgs(ctx context.Context, k8sClient kubernetes.Interface) ([]string, bool, error) {
+	args := make([]string, 0)
+
+	cronJobs, err := k8sClient.BatchV1().CronJobs("").List(ctx, metav1.ListOptions{LabelSelector: deschedulerLabelSelector})
+	if err != nil {
+		return nil, false, err
+	}
+	for _, cronJob := range cronJobs.Items {
+		args = append(args, containerArgs(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers)...)
+	}
+
+	deployments, err := k8sClient.AppsV1().Deployments("").List(ctx, metav1.ListOptions{LabelSelector: deschedulerLabelSelector})
+	if err != nil {
+		return nil, false, err
+	}
+	for _, deployment := range deployments.Items {
+		args = append(args, containerArgs(deployment.Spec.Template.Spec.Containers)...)
+	}
+
+	pods, err := k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{LabelSelector: deschedulerLabelSelector})
+	if err != nil {
+		return nil, false, err
+	}
+	for _, pod := range pods.Items {
+		args = append(args, containerArgs(pod.Spec.Containers)...)
+	}
+
+	return args, len(args) > 0, nil
+}
+
+func containerArgs(containers []corev1.Container) []string {
+	args := make([]string, 0)
+	for _, container := range containers {
+		args = append(args, container.Command...)
+		args = append(args, container.Args...)
+	}
+	return args
+}
+
+func hasBackgroundEvictionGate(args []string) bool {
+	for index, arg := range args {
+		if strings.HasPrefix(arg, "--feature-gates=") {
+			arg = strings.TrimPrefix(arg, "--feature-gates=")
+			if containsBackgroundEvictionGate(arg) {
+				return true
+			}
+		}
+		if arg == "--feature-gates" && index+1 < len(args) && containsBackgroundEvictionGate(args[index+1]) {
+			return true
 		}
 	}
-	return nil
+	return false
+}
+
+func hasPolicyConfigFile(args []string) bool {
+	for index, arg := range args {
+		if strings.HasPrefix(arg, "--policy-config-file=") && strings.TrimPrefix(arg, "--policy-config-file=") == "/policy-dir/policy.yaml" {
+			return true
+		}
+		if arg == "--policy-config-file" && index+1 < len(args) && args[index+1] == "/policy-dir/policy.yaml" {
+			return true
+		}
+	}
+	return false
+}
+
+func containsBackgroundEvictionGate(value string) bool {
+	for _, gate := range strings.Split(value, ",") {
+		if strings.TrimSpace(gate) == "EvictionsInBackground=true" {
+			return true
+		}
+	}
+	return false
+}
+
+func servedDeschedulerSchemas(crd *apiextensionsv1.CustomResourceDefinition) []*apiextensionsv1.JSONSchemaProps {
+	schemas := make([]*apiextensionsv1.JSONSchemaProps, 0, len(crd.Spec.Versions))
+	for _, version := range crd.Spec.Versions {
+		if version.Served && version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
+			schemas = append(schemas, version.Schema.OpenAPIV3Schema)
+		}
+	}
+	return schemas
+}
+
+func deschedulerSchemaSupportsKubeVirtProfile(schema *apiextensionsv1.JSONSchemaProps) bool {
+	spec, ok := schema.Properties["spec"]
+	if !ok {
+		return false
+	}
+	profiles, ok := spec.Properties["profiles"]
+	if !ok || profiles.Items == nil {
+		return false
+	}
+	profilesAccepted := profileEnum(profiles.Items)
+	if !containsAny(profilesAccepted, graduatedProfile, legacyProfile) {
+		return false
+	}
+
+	customizations, ok := spec.Properties["profileCustomizations"]
+	if !ok {
+		return false
+	}
+	backgroundEvictions, ok := customizations.Properties["devEnableEvictionsInBackground"]
+	if !ok || backgroundEvictions.Type != "boolean" {
+		return false
+	}
+
+	mode, ok := spec.Properties["mode"]
+	return ok && containsAny(jsonEnum(mode.Enum), deschedulerMode)
+}
+
+func containsAny(values []string, expected ...string) bool {
+	for _, value := range values {
+		for _, candidate := range expected {
+			if value == candidate {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func profileEnum(items *apiextensionsv1.JSONSchemaPropsOrArray) []string {

--- a/tests/func-tests/descheduler_kubevirt_compatibility_test.go
+++ b/tests/func-tests/descheduler_kubevirt_compatibility_test.go
@@ -61,14 +61,21 @@ var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("desc
 				"DeschedulerPolicy must contain at least one profile")
 		}
 
-		args, found, err := deschedulerWorkloadArgs(ctx, k8sClient)
+		workloads, found, err := deschedulerWorkloads(ctx, k8sClient)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(found).To(BeTrue(),
 			"a labeled Descheduler ConfigMap exists but no CronJob, Deployment, or Pod consumes it")
-		Expect(hasPolicyConfigFile(args)).To(BeTrue(),
+		policyWorkloads := 0
+		for _, workload := range workloads {
+			if !workloadHasPolicyConfigFile(workload) {
+				continue
+			}
+			policyWorkloads++
+			Expect(workloadPolicyContainersHaveBackgroundGate(workload)).To(BeTrue(),
+				"Descheduler workload %s must contain --feature-gates=EvictionsInBackground=true in every policy-consuming container", workload.identity)
+		}
+		Expect(policyWorkloads).To(BeNumerically(">", 0),
 			"Descheduler workload must read /policy-dir/policy.yaml from the labeled policy ConfigMap")
-		Expect(hasBackgroundEvictionGate(args)).To(BeTrue(),
-			"Descheduler workload must contain --feature-gates=EvictionsInBackground=true for asynchronous KubeVirt eviction")
 	})
 
 	It("should expose documented fields when the optional KubeDescheduler CRD is installed", func(ctx context.Context) {
@@ -95,15 +102,23 @@ var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("desc
 	})
 })
 
-func deschedulerWorkloadArgs(ctx context.Context, k8sClient kubernetes.Interface) ([]string, bool, error) {
-	args := make([]string, 0)
+type deschedulerWorkload struct {
+	identity   string
+	containers [][]string
+}
+
+func deschedulerWorkloads(ctx context.Context, k8sClient kubernetes.Interface) ([]deschedulerWorkload, bool, error) {
+	workloads := make([]deschedulerWorkload, 0)
 
 	cronJobs, err := k8sClient.BatchV1().CronJobs("").List(ctx, metav1.ListOptions{LabelSelector: deschedulerLabelSelector})
 	if err != nil {
 		return nil, false, err
 	}
 	for _, cronJob := range cronJobs.Items {
-		args = append(args, containerArgs(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers)...)
+		workloads = append(workloads, deschedulerWorkload{
+			identity:   fmt.Sprintf("CronJob %s/%s", cronJob.Namespace, cronJob.Name),
+			containers: containerArgsByContainer(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers),
+		})
 	}
 
 	deployments, err := k8sClient.AppsV1().Deployments("").List(ctx, metav1.ListOptions{LabelSelector: deschedulerLabelSelector})
@@ -111,7 +126,10 @@ func deschedulerWorkloadArgs(ctx context.Context, k8sClient kubernetes.Interface
 		return nil, false, err
 	}
 	for _, deployment := range deployments.Items {
-		args = append(args, containerArgs(deployment.Spec.Template.Spec.Containers)...)
+		workloads = append(workloads, deschedulerWorkload{
+			identity:   fmt.Sprintf("Deployment %s/%s", deployment.Namespace, deployment.Name),
+			containers: containerArgsByContainer(deployment.Spec.Template.Spec.Containers),
+		})
 	}
 
 	pods, err := k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{LabelSelector: deschedulerLabelSelector})
@@ -119,19 +137,50 @@ func deschedulerWorkloadArgs(ctx context.Context, k8sClient kubernetes.Interface
 		return nil, false, err
 	}
 	for _, pod := range pods.Items {
-		args = append(args, containerArgs(pod.Spec.Containers)...)
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		workloads = append(workloads, deschedulerWorkload{
+			identity:   fmt.Sprintf("Pod %s/%s", pod.Namespace, pod.Name),
+			containers: containerArgsByContainer(pod.Spec.Containers),
+		})
 	}
 
-	return args, len(args) > 0, nil
+	return workloads, len(workloads) > 0, nil
 }
 
-func containerArgs(containers []corev1.Container) []string {
-	args := make([]string, 0)
+func containerArgsByContainer(containers []corev1.Container) [][]string {
+	result := make([][]string, 0, len(containers))
 	for _, container := range containers {
+		args := make([]string, 0, len(container.Command)+len(container.Args))
 		args = append(args, container.Command...)
 		args = append(args, container.Args...)
+		result = append(result, args)
 	}
-	return args
+	return result
+}
+
+func workloadHasPolicyConfigFile(workload deschedulerWorkload) bool {
+	for _, args := range workload.containers {
+		if hasPolicyConfigFile(args) {
+			return true
+		}
+	}
+	return false
+}
+
+func workloadPolicyContainersHaveBackgroundGate(workload deschedulerWorkload) bool {
+	policyContainerFound := false
+	for _, args := range workload.containers {
+		if !hasPolicyConfigFile(args) {
+			continue
+		}
+		policyContainerFound = true
+		if !hasBackgroundEvictionGate(args) {
+			return false
+		}
+	}
+	return policyContainerFound
 }
 
 func hasBackgroundEvictionGate(args []string) bool {

--- a/tests/func-tests/descheduler_kubevirt_compatibility_test.go
+++ b/tests/func-tests/descheduler_kubevirt_compatibility_test.go
@@ -46,8 +46,10 @@ var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("desc
 
 		customizations, ok := spec.Properties["profileCustomizations"]
 		Expect(ok).To(BeTrue(), "KubeDescheduler.spec.profileCustomizations is missing from the served schema")
-		_, ok = customizations.Properties["devEnableEvictionsInBackground"]
+		backgroundEvictions, ok := customizations.Properties["devEnableEvictionsInBackground"]
 		Expect(ok).To(BeTrue(), "the documented background-eviction field is missing from the served schema")
+		Expect(backgroundEvictions.Type).To(Equal("boolean"),
+			"the documented background-eviction field is no longer boolean")
 
 		mode, ok := spec.Properties["mode"]
 		Expect(ok).To(BeTrue(), "KubeDescheduler.spec.mode is missing from the served schema")

--- a/tests/func-tests/descheduler_kubevirt_compatibility_test.go
+++ b/tests/func-tests/descheduler_kubevirt_compatibility_test.go
@@ -47,7 +47,7 @@ var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("desc
 		policyConfigMaps := make(map[string]struct{}, len(configMaps.Items))
 
 		for _, configMap := range configMaps.Items {
-			policyConfigMaps[configMap.Name] = struct{}{}
+			policyConfigMaps[configMap.Namespace+"/"+configMap.Name] = struct{}{}
 			rawPolicy, ok := configMap.Data["policy.yaml"]
 			Expect(ok).To(BeTrue(), "Descheduler ConfigMap %s/%s has no data.policy.yaml", configMap.Namespace, configMap.Name)
 			Expect(strings.TrimSpace(rawPolicy)).ToNot(BeEmpty(), "Descheduler ConfigMap %s/%s has an empty data.policy.yaml", configMap.Namespace, configMap.Name)
@@ -106,6 +106,7 @@ var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("desc
 
 type deschedulerWorkload struct {
 	identity   string
+	namespace  string
 	containers [][]string
 	volumes    []corev1.Volume
 	mounts     [][]corev1.VolumeMount
@@ -121,6 +122,7 @@ func deschedulerWorkloads(ctx context.Context, k8sClient kubernetes.Interface) (
 	for _, cronJob := range cronJobs.Items {
 		workloads = append(workloads, deschedulerWorkload{
 			identity:   fmt.Sprintf("CronJob %s/%s", cronJob.Namespace, cronJob.Name),
+			namespace:  cronJob.Namespace,
 			containers: containerArgsByContainer(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers),
 			volumes:    cronJob.Spec.JobTemplate.Spec.Template.Spec.Volumes,
 			mounts:     volumeMountsByContainer(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers),
@@ -134,6 +136,7 @@ func deschedulerWorkloads(ctx context.Context, k8sClient kubernetes.Interface) (
 	for _, deployment := range deployments.Items {
 		workloads = append(workloads, deschedulerWorkload{
 			identity:   fmt.Sprintf("Deployment %s/%s", deployment.Namespace, deployment.Name),
+			namespace:  deployment.Namespace,
 			containers: containerArgsByContainer(deployment.Spec.Template.Spec.Containers),
 			volumes:    deployment.Spec.Template.Spec.Volumes,
 			mounts:     volumeMountsByContainer(deployment.Spec.Template.Spec.Containers),
@@ -150,6 +153,7 @@ func deschedulerWorkloads(ctx context.Context, k8sClient kubernetes.Interface) (
 		}
 		workloads = append(workloads, deschedulerWorkload{
 			identity:   fmt.Sprintf("Pod %s/%s", pod.Namespace, pod.Name),
+			namespace:  pod.Namespace,
 			containers: containerArgsByContainer(pod.Spec.Containers),
 			volumes:    pod.Spec.Volumes,
 			mounts:     volumeMountsByContainer(pod.Spec.Containers),
@@ -213,7 +217,7 @@ func policyMountIsConfigMap(workload deschedulerWorkload, containerIndex int, po
 			if volume.Name != mount.Name || volume.ConfigMap == nil {
 				continue
 			}
-			_, found := policyConfigMaps[volume.ConfigMap.LocalObjectReference.Name]
+			_, found := policyConfigMaps[workload.namespace+"/"+volume.ConfigMap.LocalObjectReference.Name]
 			if found {
 				return true
 			}

--- a/tests/func-tests/descheduler_kubevirt_compatibility_test.go
+++ b/tests/func-tests/descheduler_kubevirt_compatibility_test.go
@@ -44,8 +44,10 @@ var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("desc
 		if len(configMaps.Items) == 0 {
 			Skip("optional Descheduler plugin is not installed; no labeled policy ConfigMap was found")
 		}
+		policyConfigMaps := make(map[string]struct{}, len(configMaps.Items))
 
 		for _, configMap := range configMaps.Items {
+			policyConfigMaps[configMap.Name] = struct{}{}
 			rawPolicy, ok := configMap.Data["policy.yaml"]
 			Expect(ok).To(BeTrue(), "Descheduler ConfigMap %s/%s has no data.policy.yaml", configMap.Namespace, configMap.Name)
 			Expect(strings.TrimSpace(rawPolicy)).ToNot(BeEmpty(), "Descheduler ConfigMap %s/%s has an empty data.policy.yaml", configMap.Namespace, configMap.Name)
@@ -67,11 +69,11 @@ var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("desc
 			"a labeled Descheduler ConfigMap exists but no CronJob, Deployment, or Pod consumes it")
 		policyWorkloads := 0
 		for _, workload := range workloads {
-			if !workloadHasPolicyConfigFile(workload) {
+			if !workloadHasPolicyConfigFile(workload, policyConfigMaps) {
 				continue
 			}
 			policyWorkloads++
-			Expect(workloadPolicyContainersHaveBackgroundGate(workload)).To(BeTrue(),
+			Expect(workloadPolicyContainersHaveBackgroundGate(workload, policyConfigMaps)).To(BeTrue(),
 				"Descheduler workload %s must contain --feature-gates=EvictionsInBackground=true in every policy-consuming container", workload.identity)
 		}
 		Expect(policyWorkloads).To(BeNumerically(">", 0),
@@ -80,7 +82,7 @@ var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("desc
 
 	It("should expose documented fields when the optional KubeDescheduler CRD is installed", func(ctx context.Context) {
 		cli := tests.GetControllerRuntimeClient()
-		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd := new(apiextensionsv1.CustomResourceDefinition)
 		if err := cli.Get(ctx, client.ObjectKey{Name: deschedulerCRDName}, crd); apierrors.IsNotFound(err) {
 			Skip(fmt.Sprintf("optional OpenShift Descheduler operator is not installed; CRD %q was not found", deschedulerCRDName))
 		} else {
@@ -105,6 +107,8 @@ var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("desc
 type deschedulerWorkload struct {
 	identity   string
 	containers [][]string
+	volumes    []corev1.Volume
+	mounts     [][]corev1.VolumeMount
 }
 
 func deschedulerWorkloads(ctx context.Context, k8sClient kubernetes.Interface) ([]deschedulerWorkload, bool, error) {
@@ -118,6 +122,8 @@ func deschedulerWorkloads(ctx context.Context, k8sClient kubernetes.Interface) (
 		workloads = append(workloads, deschedulerWorkload{
 			identity:   fmt.Sprintf("CronJob %s/%s", cronJob.Namespace, cronJob.Name),
 			containers: containerArgsByContainer(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers),
+			volumes:    cronJob.Spec.JobTemplate.Spec.Template.Spec.Volumes,
+			mounts:     volumeMountsByContainer(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers),
 		})
 	}
 
@@ -129,6 +135,8 @@ func deschedulerWorkloads(ctx context.Context, k8sClient kubernetes.Interface) (
 		workloads = append(workloads, deschedulerWorkload{
 			identity:   fmt.Sprintf("Deployment %s/%s", deployment.Namespace, deployment.Name),
 			containers: containerArgsByContainer(deployment.Spec.Template.Spec.Containers),
+			volumes:    deployment.Spec.Template.Spec.Volumes,
+			mounts:     volumeMountsByContainer(deployment.Spec.Template.Spec.Containers),
 		})
 	}
 
@@ -143,6 +151,8 @@ func deschedulerWorkloads(ctx context.Context, k8sClient kubernetes.Interface) (
 		workloads = append(workloads, deschedulerWorkload{
 			identity:   fmt.Sprintf("Pod %s/%s", pod.Namespace, pod.Name),
 			containers: containerArgsByContainer(pod.Spec.Containers),
+			volumes:    pod.Spec.Volumes,
+			mounts:     volumeMountsByContainer(pod.Spec.Containers),
 		})
 	}
 
@@ -160,27 +170,56 @@ func containerArgsByContainer(containers []corev1.Container) [][]string {
 	return result
 }
 
-func workloadHasPolicyConfigFile(workload deschedulerWorkload) bool {
-	for _, args := range workload.containers {
-		if hasPolicyConfigFile(args) {
+func volumeMountsByContainer(containers []corev1.Container) [][]corev1.VolumeMount {
+	result := make([][]corev1.VolumeMount, 0, len(containers))
+	for _, container := range containers {
+		result = append(result, container.VolumeMounts)
+	}
+	return result
+}
+
+func workloadHasPolicyConfigFile(workload deschedulerWorkload, policyConfigMaps map[string]struct{}) bool {
+	for index, args := range workload.containers {
+		if hasPolicyConfigFile(args) && policyMountIsConfigMap(workload, index, policyConfigMaps) {
 			return true
 		}
 	}
 	return false
 }
 
-func workloadPolicyContainersHaveBackgroundGate(workload deschedulerWorkload) bool {
+func workloadPolicyContainersHaveBackgroundGate(workload deschedulerWorkload, policyConfigMaps map[string]struct{}) bool {
 	policyContainerFound := false
-	for _, args := range workload.containers {
+	for index, args := range workload.containers {
 		if !hasPolicyConfigFile(args) {
 			continue
 		}
 		policyContainerFound = true
-		if !hasBackgroundEvictionGate(args) {
+		if !policyMountIsConfigMap(workload, index, policyConfigMaps) || !hasBackgroundEvictionGate(args) {
 			return false
 		}
 	}
 	return policyContainerFound
+}
+
+func policyMountIsConfigMap(workload deschedulerWorkload, containerIndex int, policyConfigMaps map[string]struct{}) bool {
+	if containerIndex >= len(workload.mounts) {
+		return false
+	}
+	for _, mount := range workload.mounts[containerIndex] {
+		if mount.MountPath != "/policy-dir" {
+			continue
+		}
+		for _, volume := range workload.volumes {
+			if volume.Name != mount.Name || volume.ConfigMap == nil {
+				continue
+			}
+			_, found := policyConfigMaps[volume.ConfigMap.LocalObjectReference.Name]
+			if found {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func hasBackgroundEvictionGate(args []string) bool {

--- a/tests/func-tests/descheduler_kubevirt_compatibility_test.go
+++ b/tests/func-tests/descheduler_kubevirt_compatibility_test.go
@@ -1,0 +1,92 @@
+package tests_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
+)
+
+const (
+	deschedulerCRDName = "kubedeschedulers.operator.openshift.io"
+	graduatedProfile   = "KubeVirtRelieveAndMigrate"
+	legacyProfile      = "DevKubeVirtRelieveAndMigrate"
+	deschedulerMode    = "Automatic"
+)
+
+var _ = Describe("KubeVirt Descheduler documentation compatibility", Label("deschedulerCompatibility"), func() {
+	tests.FlagParse()
+
+	It("should expose the documented KubeVirt profile and fields", func(ctx context.Context) {
+		cli := tests.GetControllerRuntimeClient()
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		if err := cli.Get(ctx, client.ObjectKey{Name: deschedulerCRDName}, crd); apierrors.IsNotFound(err) {
+			Skip(fmt.Sprintf("optional Descheduler plugin is not installed; CRD %q was not found", deschedulerCRDName))
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		schema := servedDeschedulerSchema(crd)
+		Expect(schema).ToNot(BeNil(), "the Descheduler CRD has no served OpenAPI schema")
+
+		spec, ok := schema.Properties["spec"]
+		Expect(ok).To(BeTrue(), "KubeDescheduler.spec is missing from the served schema")
+		profiles, ok := spec.Properties["profiles"]
+		Expect(ok).To(BeTrue(), "KubeDescheduler.spec.profiles is missing from the served schema")
+		Expect(profiles.Items).ToNot(BeNil(), "KubeDescheduler.spec.profiles has no item schema")
+		Expect(profileEnum(profiles.Items)).To(Or(ContainElement(graduatedProfile), ContainElement(legacyProfile)),
+			"neither the graduated nor the legacy KubeVirt profile is accepted")
+
+		customizations, ok := spec.Properties["profileCustomizations"]
+		Expect(ok).To(BeTrue(), "KubeDescheduler.spec.profileCustomizations is missing from the served schema")
+		_, ok = customizations.Properties["devEnableEvictionsInBackground"]
+		Expect(ok).To(BeTrue(), "the documented background-eviction field is missing from the served schema")
+
+		mode, ok := spec.Properties["mode"]
+		Expect(ok).To(BeTrue(), "KubeDescheduler.spec.mode is missing from the served schema")
+		Expect(jsonEnum(mode.Enum)).To(ContainElement(deschedulerMode),
+			"the documented Automatic Descheduler mode is no longer accepted")
+	})
+})
+
+func servedDeschedulerSchema(crd *apiextensionsv1.CustomResourceDefinition) *apiextensionsv1.JSONSchemaProps {
+	for _, version := range crd.Spec.Versions {
+		if version.Served && version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
+			return version.Schema.OpenAPIV3Schema
+		}
+	}
+	return nil
+}
+
+func profileEnum(items *apiextensionsv1.JSONSchemaPropsOrArray) []string {
+	if items == nil {
+		return nil
+	}
+	if items.Schema != nil {
+		return jsonEnum(items.Schema.Enum)
+	}
+	for i := range items.JSONSchemas {
+		if len(items.JSONSchemas[i].Enum) > 0 {
+			return jsonEnum(items.JSONSchemas[i].Enum)
+		}
+	}
+	return nil
+}
+
+func jsonEnum(values []apiextensionsv1.JSON) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		var decoded string
+		if err := json.Unmarshal(value.Raw, &decoded); err == nil {
+			result = append(result, decoded)
+		}
+	}
+	return result
+}

--- a/tests/func-tests/kubevirt_documentation_compatibility_test.go
+++ b/tests/func-tests/kubevirt_documentation_compatibility_test.go
@@ -24,8 +24,11 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 	It("should expose the eviction strategy fields used by the node maintenance howto", func(ctx context.Context) {
 		cli := tests.GetControllerRuntimeClient()
 
-		hcoSchema, err := getStorageServedCRDSchema(ctx, cli, hcoCRDName)
+		hcoSchema, hcoVersion, err := getStorageServedCRDSchema(ctx, cli, hcoCRDName)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(hcoVersion).ToNot(BeEmpty(), "the documented kubectl explain command requires a served HCO API version")
+		Expect(fmt.Sprintf("hco.kubevirt.io/%s", hcoVersion)).To(Equal("hco.kubevirt.io/v1beta1"),
+			"update the node maintenance howto when the ACP HCO API version changes")
 		hcoEviction := schemaProperty(hcoSchema, "spec", "evictionStrategy")
 		if hcoEviction == nil {
 			hcoEviction = schemaProperty(hcoSchema, "spec", "virtualization", "evictionStrategy")
@@ -35,7 +38,7 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 		Expect(documentationJSONEnum(hcoEviction.Enum)).To(ContainElement("LiveMigrate"),
 			"the documented HCO evictionStrategy path no longer accepts LiveMigrate")
 
-		vmSchema, err := getStorageServedCRDSchema(ctx, cli, vmCRDName)
+		vmSchema, _, err := getStorageServedCRDSchema(ctx, cli, vmCRDName)
 		Expect(err).ToNot(HaveOccurred())
 		vmEviction := schemaProperty(vmSchema, "spec", "template", "spec", "evictionStrategy")
 		Expect(vmEviction).ToNot(BeNil(),
@@ -49,18 +52,18 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 	})
 })
 
-func getStorageServedCRDSchema(ctx context.Context, cli client.Client, name string) (*apiextensionsv1.JSONSchemaProps, error) {
+func getStorageServedCRDSchema(ctx context.Context, cli client.Client, name string) (*apiextensionsv1.JSONSchemaProps, string, error) {
 	GinkgoHelper()
 	crd := new(apiextensionsv1.CustomResourceDefinition)
 	if err := cli.Get(ctx, client.ObjectKey{Name: name}, crd); err != nil {
-		return nil, fmt.Errorf("CRD %q must be installed for KubeVirt documentation compatibility checks: %w", name, err)
+		return nil, "", fmt.Errorf("CRD %q must be installed for KubeVirt documentation compatibility checks: %w", name, err)
 	}
 	for _, version := range crd.Spec.Versions {
 		if version.Storage && version.Served && version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
-			return version.Schema.OpenAPIV3Schema, nil
+			return version.Schema.OpenAPIV3Schema, version.Name, nil
 		}
 	}
-	return nil, fmt.Errorf("CRD %q has no storage=true, served=true OpenAPI schema", name)
+	return nil, "", fmt.Errorf("CRD %q has no storage=true, served=true OpenAPI schema", name)
 }
 
 func schemaProperty(schema *apiextensionsv1.JSONSchemaProps, path ...string) *apiextensionsv1.JSONSchemaProps {

--- a/tests/func-tests/kubevirt_documentation_compatibility_test.go
+++ b/tests/func-tests/kubevirt_documentation_compatibility_test.go
@@ -27,8 +27,9 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 		hcoSchema, hcoVersion, err := getStorageServedCRDSchema(ctx, cli, hcoCRDName)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hcoVersion).ToNot(BeEmpty(), "the documented kubectl explain command requires a served HCO API version")
-		Expect(fmt.Sprintf("hco.kubevirt.io/%s", hcoVersion)).To(Equal("hco.kubevirt.io/v1beta1"),
-			"update the node maintenance howto when the ACP HCO API version changes")
+		// The howto discovers the storage+served version at runtime. Keep this
+		// check version-agnostic so an upstream HCO storage-version change does
+		// not fail the compatibility suite before the documented field is tested.
 		hcoEviction := schemaProperty(hcoSchema, "spec", "evictionStrategy")
 		if hcoEviction == nil {
 			hcoEviction = schemaProperty(hcoSchema, "spec", "virtualization", "evictionStrategy")

--- a/tests/func-tests/kubevirt_documentation_compatibility_test.go
+++ b/tests/func-tests/kubevirt_documentation_compatibility_test.go
@@ -24,7 +24,8 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 	It("should expose the eviction strategy fields used by the node maintenance howto", func(ctx context.Context) {
 		cli := tests.GetControllerRuntimeClient()
 
-		hcoSchema := getStorageServedCRDSchema(ctx, cli, hcoCRDName)
+		hcoSchema, err := getStorageServedCRDSchema(ctx, cli, hcoCRDName)
+		Expect(err).ToNot(HaveOccurred())
 		hcoEviction := schemaProperty(hcoSchema, "spec", "evictionStrategy")
 		if hcoEviction == nil {
 			hcoEviction = schemaProperty(hcoSchema, "spec", "virtualization", "evictionStrategy")
@@ -34,7 +35,8 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 		Expect(documentationJSONEnum(hcoEviction.Enum)).To(ContainElement("LiveMigrate"),
 			"the documented HCO evictionStrategy path no longer accepts LiveMigrate")
 
-		vmSchema := getStorageServedCRDSchema(ctx, cli, vmCRDName)
+		vmSchema, err := getStorageServedCRDSchema(ctx, cli, vmCRDName)
+		Expect(err).ToNot(HaveOccurred())
 		vmEviction := schemaProperty(vmSchema, "spec", "template", "spec", "evictionStrategy")
 		Expect(vmEviction).ToNot(BeNil(),
 			"the node maintenance howto uses vm.spec.template.spec.evictionStrategy")
@@ -47,17 +49,18 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 	})
 })
 
-func getStorageServedCRDSchema(ctx context.Context, cli client.Client, name string) *apiextensionsv1.JSONSchemaProps {
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-	ExpectWithOffset(1, cli.Get(ctx, client.ObjectKey{Name: name}, crd)).To(Succeed(),
-		fmt.Sprintf("CRD %q must be installed for KubeVirt documentation compatibility checks", name))
+func getStorageServedCRDSchema(ctx context.Context, cli client.Client, name string) (*apiextensionsv1.JSONSchemaProps, error) {
+	GinkgoHelper()
+	crd := new(apiextensionsv1.CustomResourceDefinition)
+	if err := cli.Get(ctx, client.ObjectKey{Name: name}, crd); err != nil {
+		return nil, fmt.Errorf("CRD %q must be installed for KubeVirt documentation compatibility checks: %w", name, err)
+	}
 	for _, version := range crd.Spec.Versions {
 		if version.Storage && version.Served && version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
-			return version.Schema.OpenAPIV3Schema
+			return version.Schema.OpenAPIV3Schema, nil
 		}
 	}
-	Fail(fmt.Sprintf("CRD %q has no storage=true, served=true OpenAPI schema", name))
-	return nil
+	return nil, fmt.Errorf("CRD %q has no storage=true, served=true OpenAPI schema", name)
 }
 
 func schemaProperty(schema *apiextensionsv1.JSONSchemaProps, path ...string) *apiextensionsv1.JSONSchemaProps {

--- a/tests/func-tests/kubevirt_documentation_compatibility_test.go
+++ b/tests/func-tests/kubevirt_documentation_compatibility_test.go
@@ -1,0 +1,79 @@
+package tests_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
+)
+
+const (
+	hcoCRDName = "hyperconvergeds.hco.kubevirt.io"
+	vmCRDName  = "virtualmachines.kubevirt.io"
+)
+
+var _ = Describe("KubeVirt documentation API compatibility", Label("documentationCompatibility"), func() {
+	tests.FlagParse()
+
+	It("should expose the eviction strategy fields used by the node maintenance howto", func(ctx context.Context) {
+		cli := tests.GetControllerRuntimeClient()
+
+		hcoSchema := getServedCRDSchema(ctx, cli, hcoCRDName)
+		hcoEviction := schemaProperty(hcoSchema, "spec", "evictionStrategy")
+		Expect(hcoEviction).ToNot(BeNil(),
+			"the node maintenance howto uses hco.spec.evictionStrategy")
+		Expect(documentationJSONEnum(hcoEviction.Enum)).To(ContainElement("LiveMigrate"),
+			"hco.spec.evictionStrategy no longer accepts LiveMigrate")
+
+		vmSchema := getServedCRDSchema(ctx, cli, vmCRDName)
+		vmEviction := schemaProperty(vmSchema, "spec", "template", "spec", "evictionStrategy")
+		Expect(vmEviction).ToNot(BeNil(),
+			"the node maintenance howto uses vm.spec.template.spec.evictionStrategy")
+		Expect(vmEviction.Description).To(ContainSubstring("LiveMigrate"),
+			"vm.spec.template.spec.evictionStrategy no longer documents LiveMigrate")
+	})
+})
+
+func getServedCRDSchema(ctx context.Context, cli client.Client, name string) *apiextensionsv1.JSONSchemaProps {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	ExpectWithOffset(1, cli.Get(ctx, client.ObjectKey{Name: name}, crd)).To(Succeed(),
+		fmt.Sprintf("CRD %q must be installed for KubeVirt documentation compatibility checks", name))
+	for _, version := range crd.Spec.Versions {
+		if version.Served && version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
+			return version.Schema.OpenAPIV3Schema
+		}
+	}
+	Fail(fmt.Sprintf("CRD %q has no served OpenAPI schema", name))
+	return nil
+}
+
+func schemaProperty(schema *apiextensionsv1.JSONSchemaProps, path ...string) *apiextensionsv1.JSONSchemaProps {
+	for _, field := range path {
+		if schema == nil {
+			return nil
+		}
+		next, ok := schema.Properties[field]
+		if !ok {
+			return nil
+		}
+		schema = &next
+	}
+	return schema
+}
+
+func documentationJSONEnum(values []apiextensionsv1.JSON) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		var decoded string
+		if err := json.Unmarshal(value.Raw, &decoded); err == nil {
+			result = append(result, decoded)
+		}
+	}
+	return result
+}

--- a/tests/func-tests/kubevirt_documentation_compatibility_test.go
+++ b/tests/func-tests/kubevirt_documentation_compatibility_test.go
@@ -24,15 +24,18 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 	It("should expose the eviction strategy fields used by the node maintenance howto", func(ctx context.Context) {
 		cli := tests.GetControllerRuntimeClient()
 
-		hcoSchema := getServedCRDSchema(ctx, cli, hcoCRDName)
-		hcoEviction := schemaProperty(hcoSchema, "spec", "evictionStrategy")
+		hcoSchemas := getServedCRDSchemas(ctx, cli, hcoCRDName)
+		hcoEviction := findSchemaProperty(hcoSchemas, "spec", "evictionStrategy")
+		if hcoEviction == nil {
+			hcoEviction = findSchemaProperty(hcoSchemas, "spec", "virtualization", "evictionStrategy")
+		}
 		Expect(hcoEviction).ToNot(BeNil(),
-			"the node maintenance howto uses hco.spec.evictionStrategy")
+			"the node maintenance howto has no supported HCO evictionStrategy path")
 		Expect(documentationJSONEnum(hcoEviction.Enum)).To(ContainElement("LiveMigrate"),
-			"hco.spec.evictionStrategy no longer accepts LiveMigrate")
+			"the documented HCO evictionStrategy path no longer accepts LiveMigrate")
 
-		vmSchema := getServedCRDSchema(ctx, cli, vmCRDName)
-		vmEviction := schemaProperty(vmSchema, "spec", "template", "spec", "evictionStrategy")
+		vmSchemas := getServedCRDSchemas(ctx, cli, vmCRDName)
+		vmEviction := findSchemaProperty(vmSchemas, "spec", "template", "spec", "evictionStrategy")
 		Expect(vmEviction).ToNot(BeNil(),
 			"the node maintenance howto uses vm.spec.template.spec.evictionStrategy")
 		Expect(vmEviction.Description).To(ContainSubstring("LiveMigrate"),
@@ -40,16 +43,26 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 	})
 })
 
-func getServedCRDSchema(ctx context.Context, cli client.Client, name string) *apiextensionsv1.JSONSchemaProps {
+func getServedCRDSchemas(ctx context.Context, cli client.Client, name string) []*apiextensionsv1.JSONSchemaProps {
 	crd := &apiextensionsv1.CustomResourceDefinition{}
 	ExpectWithOffset(1, cli.Get(ctx, client.ObjectKey{Name: name}, crd)).To(Succeed(),
 		fmt.Sprintf("CRD %q must be installed for KubeVirt documentation compatibility checks", name))
+	schemas := make([]*apiextensionsv1.JSONSchemaProps, 0, len(crd.Spec.Versions))
 	for _, version := range crd.Spec.Versions {
 		if version.Served && version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
-			return version.Schema.OpenAPIV3Schema
+			schemas = append(schemas, version.Schema.OpenAPIV3Schema)
 		}
 	}
-	Fail(fmt.Sprintf("CRD %q has no served OpenAPI schema", name))
+	ExpectWithOffset(1, schemas).ToNot(BeEmpty(), fmt.Sprintf("CRD %q has no served OpenAPI schema", name))
+	return schemas
+}
+
+func findSchemaProperty(schemas []*apiextensionsv1.JSONSchemaProps, path ...string) *apiextensionsv1.JSONSchemaProps {
+	for _, schema := range schemas {
+		if property := schemaProperty(schema, path...); property != nil {
+			return property
+		}
+	}
 	return nil
 }
 

--- a/tests/func-tests/kubevirt_documentation_compatibility_test.go
+++ b/tests/func-tests/kubevirt_documentation_compatibility_test.go
@@ -24,45 +24,37 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 	It("should expose the eviction strategy fields used by the node maintenance howto", func(ctx context.Context) {
 		cli := tests.GetControllerRuntimeClient()
 
-		hcoSchemas := getServedCRDSchemas(ctx, cli, hcoCRDName)
-		hcoEviction := findSchemaProperty(hcoSchemas, "spec", "evictionStrategy")
+		hcoSchema := getStorageServedCRDSchema(ctx, cli, hcoCRDName)
+		hcoEviction := schemaProperty(hcoSchema, "spec", "evictionStrategy")
 		if hcoEviction == nil {
-			hcoEviction = findSchemaProperty(hcoSchemas, "spec", "virtualization", "evictionStrategy")
+			hcoEviction = schemaProperty(hcoSchema, "spec", "virtualization", "evictionStrategy")
 		}
 		Expect(hcoEviction).ToNot(BeNil(),
 			"the node maintenance howto has no supported HCO evictionStrategy path")
 		Expect(documentationJSONEnum(hcoEviction.Enum)).To(ContainElement("LiveMigrate"),
 			"the documented HCO evictionStrategy path no longer accepts LiveMigrate")
 
-		vmSchemas := getServedCRDSchemas(ctx, cli, vmCRDName)
-		vmEviction := findSchemaProperty(vmSchemas, "spec", "template", "spec", "evictionStrategy")
+		vmSchema := getStorageServedCRDSchema(ctx, cli, vmCRDName)
+		vmEviction := schemaProperty(vmSchema, "spec", "template", "spec", "evictionStrategy")
 		Expect(vmEviction).ToNot(BeNil(),
 			"the node maintenance howto uses vm.spec.template.spec.evictionStrategy")
+		Expect(documentationJSONEnum(vmEviction.Enum)).To(ContainElement("LiveMigrate"),
+			"vm.spec.template.spec.evictionStrategy no longer accepts LiveMigrate")
 		Expect(vmEviction.Description).To(ContainSubstring("LiveMigrate"),
 			"vm.spec.template.spec.evictionStrategy no longer documents LiveMigrate")
 	})
 })
 
-func getServedCRDSchemas(ctx context.Context, cli client.Client, name string) []*apiextensionsv1.JSONSchemaProps {
+func getStorageServedCRDSchema(ctx context.Context, cli client.Client, name string) *apiextensionsv1.JSONSchemaProps {
 	crd := &apiextensionsv1.CustomResourceDefinition{}
 	ExpectWithOffset(1, cli.Get(ctx, client.ObjectKey{Name: name}, crd)).To(Succeed(),
 		fmt.Sprintf("CRD %q must be installed for KubeVirt documentation compatibility checks", name))
-	schemas := make([]*apiextensionsv1.JSONSchemaProps, 0, len(crd.Spec.Versions))
 	for _, version := range crd.Spec.Versions {
-		if version.Served && version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
-			schemas = append(schemas, version.Schema.OpenAPIV3Schema)
+		if version.Storage && version.Served && version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
+			return version.Schema.OpenAPIV3Schema
 		}
 	}
-	ExpectWithOffset(1, schemas).ToNot(BeEmpty(), fmt.Sprintf("CRD %q has no served OpenAPI schema", name))
-	return schemas
-}
-
-func findSchemaProperty(schemas []*apiextensionsv1.JSONSchemaProps, path ...string) *apiextensionsv1.JSONSchemaProps {
-	for _, schema := range schemas {
-		if property := schemaProperty(schema, path...); property != nil {
-			return property
-		}
-	}
+	Fail(fmt.Sprintf("CRD %q has no storage=true, served=true OpenAPI schema", name))
 	return nil
 }
 

--- a/tests/func-tests/kubevirt_documentation_compatibility_test.go
+++ b/tests/func-tests/kubevirt_documentation_compatibility_test.go
@@ -38,8 +38,11 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 		vmEviction := schemaProperty(vmSchema, "spec", "template", "spec", "evictionStrategy")
 		Expect(vmEviction).ToNot(BeNil(),
 			"the node maintenance howto uses vm.spec.template.spec.evictionStrategy")
-		Expect(documentationJSONEnum(vmEviction.Enum)).To(ContainElement("LiveMigrate"),
-			"vm.spec.template.spec.evictionStrategy no longer accepts LiveMigrate")
+		vmEnum := documentationJSONEnum(vmEviction.Enum)
+		if len(vmEnum) > 0 {
+			Expect(vmEnum).To(ContainElement("LiveMigrate"),
+				"vm.spec.template.spec.evictionStrategy enum no longer accepts LiveMigrate")
+		}
 		Expect(vmEviction.Description).To(ContainSubstring("LiveMigrate"),
 			"vm.spec.template.spec.evictionStrategy no longer documents LiveMigrate")
 	})

--- a/tests/func-tests/kubevirt_documentation_compatibility_test.go
+++ b/tests/func-tests/kubevirt_documentation_compatibility_test.go
@@ -38,9 +38,8 @@ var _ = Describe("KubeVirt documentation API compatibility", Label("documentatio
 		vmEviction := schemaProperty(vmSchema, "spec", "template", "spec", "evictionStrategy")
 		Expect(vmEviction).ToNot(BeNil(),
 			"the node maintenance howto uses vm.spec.template.spec.evictionStrategy")
-		vmEnum := documentationJSONEnum(vmEviction.Enum)
-		if len(vmEnum) > 0 {
-			Expect(vmEnum).To(ContainElement("LiveMigrate"),
+		if vmEviction.Enum != nil {
+			Expect(documentationJSONEnum(vmEviction.Enum)).To(ContainElement("LiveMigrate"),
 				"vm.spec.template.spec.evictionStrategy enum no longer accepts LiveMigrate")
 		}
 		Expect(vmEviction.Description).To(ContainSubstring("LiveMigrate"),

--- a/tests/func-tests/node_maintenance_test.go
+++ b/tests/func-tests/node_maintenance_test.go
@@ -91,7 +91,14 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, vmi)).To(Succeed())
 			g.Expect(vmi.Status.Phase).To(Equal(kubevirtcorev1.Running), vmiFailureMessage(vmi))
 			g.Expect(vmi.Status.NodeName).ToNot(BeEmpty())
+			g.Expect(vmiReady(vmi)).To(BeTrue(), vmiFailureMessage(vmi))
 			g.Expect(vmi.IsMigratable()).To(BeTrue(), vmiFailureMessage(vmi))
+		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Succeed())
+		vmStatus := &kubevirtcorev1.VirtualMachine{}
+		Eventually(func(g Gomega, pollCtx context.Context) {
+			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, vmStatus)).To(Succeed())
+			g.Expect(vmStatus.Status.Ready).To(BeTrue())
+			g.Expect(vmStatus.Status.PrintableStatus).To(Equal(kubevirtcorev1.VirtualMachineStatusRunning))
 		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Succeed())
 
 		sourceNode := vmi.Status.NodeName
@@ -138,11 +145,17 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 
 		By("verifying that the same VMI UID is Running on a different node")
 		var observedMigration *kubevirtcorev1.VirtualMachineInstanceMigration
+		observedMigrationNames := map[string]struct{}{}
 		Eventually(func(g Gomega, pollCtx context.Context) bool {
 			// Capture the VMIM before checking the VMI node: completed migrations may be
 			// garbage-collected shortly after the VMI is observed on its target node.
 			migrations := &kubevirtcorev1.VirtualMachineInstanceMigrationList{}
 			g.Expect(cli.List(pollCtx, migrations, client.InNamespace(tests.TestNamespace))).To(Succeed())
+			for i := range migrations.Items {
+				if migrations.Items[i].Spec.VMIName == vm.Name {
+					observedMigrationNames[migrations.Items[i].Name] = struct{}{}
+				}
+			}
 			if candidate := preferredMigrationForVMI(migrations.Items, vm.Name); candidate != nil && shouldRecordMigration(candidate, observedMigration) {
 				observedMigration = candidate.DeepCopy()
 			}
@@ -151,6 +164,7 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, current)).To(Succeed())
 			g.Expect(current.UID).To(Equal(vmiUID), vmiFailureMessage(current))
 			g.Expect(current.Status.Phase).To(Equal(kubevirtcorev1.Running), vmiFailureMessage(current))
+			g.Expect(vmiReady(current)).To(BeTrue(), vmiFailureMessage(current))
 			g.Expect(current.IsMigratable()).To(BeTrue(), vmiFailureMessage(current))
 			if current.Status.NodeName == sourceNode {
 				return false
@@ -164,6 +178,7 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 			return fmt.Sprintf("VMI did not complete migration from cordoned node %s; VMIM=%s phase=%s", sourceNode, observedMigration.Name, observedMigration.Status.Phase)
 		})
 		Expect(observedMigration).ToNot(BeNil(), "the eviction did not create a VMIM for the test VMI")
+		Expect(observedMigrationNames).To(HaveLen(1), "the eviction should produce exactly one VMIM for the test VMI")
 		Expect(observedMigration.Status.Phase).To(Equal(kubevirtcorev1.MigrationSucceeded),
 			fmt.Sprintf("VMIM %s did not complete successfully", observedMigration.Name))
 		observedMigrationState := observedMigration.Status.MigrationState
@@ -183,6 +198,11 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 			g.Expect(cli.List(pollCtx, pods, client.InNamespace(tests.TestNamespace))).To(Succeed())
 			return activeVirtLauncherCount(pods, vm.Name, vmiUID)
 		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Equal(1))
+		Eventually(func(g Gomega, pollCtx context.Context) {
+			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, vmStatus)).To(Succeed())
+			g.Expect(vmStatus.Status.Ready).To(BeTrue())
+			g.Expect(vmStatus.Status.PrintableStatus).To(Equal(kubevirtcorev1.VirtualMachineStatusRunning))
+		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Succeed())
 	})
 })
 
@@ -282,6 +302,15 @@ func shouldRecordMigration(candidate, observed *kubevirtcorev1.VirtualMachineIns
 func nodeReady(node *corev1.Node) bool {
 	for _, condition := range node.Status.Conditions {
 		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func vmiReady(vmi *kubevirtcorev1.VirtualMachineInstance) bool {
+	for _, condition := range vmi.Status.Conditions {
+		if condition.Type == kubevirtcorev1.VirtualMachineInstanceReady {
 			return condition.Status == corev1.ConditionTrue
 		}
 	}

--- a/tests/func-tests/node_maintenance_test.go
+++ b/tests/func-tests/node_maintenance_test.go
@@ -137,12 +137,16 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(BeTrue())
 
 		By("verifying that the same VMI UID is Running on a different node")
-		var (
-			observedMigrationName  string
-			observedMigrationPhase kubevirtcorev1.VirtualMachineInstanceMigrationPhase
-			observedMigrationState *kubevirtcorev1.VirtualMachineInstanceMigrationState
-		)
+		var observedMigration *kubevirtcorev1.VirtualMachineInstanceMigration
 		Eventually(func(g Gomega, pollCtx context.Context) bool {
+			// Capture the VMIM before checking the VMI node: completed migrations may be
+			// garbage-collected shortly after the VMI is observed on its target node.
+			migrations := &kubevirtcorev1.VirtualMachineInstanceMigrationList{}
+			g.Expect(cli.List(pollCtx, migrations, client.InNamespace(tests.TestNamespace))).To(Succeed())
+			if candidate := preferredMigrationForVMI(migrations.Items, vm.Name); candidate != nil && shouldRecordMigration(candidate, observedMigration) {
+				observedMigration = candidate.DeepCopy()
+			}
+
 			current := &kubevirtcorev1.VirtualMachineInstance{}
 			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, current)).To(Succeed())
 			g.Expect(current.UID).To(Equal(vmiUID), vmiFailureMessage(current))
@@ -152,28 +156,25 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 				return false
 			}
 
-			migrations := &kubevirtcorev1.VirtualMachineInstanceMigrationList{}
-			g.Expect(cli.List(pollCtx, migrations, client.InNamespace(tests.TestNamespace))).To(Succeed())
-			for i := range migrations.Items {
-				migration := &migrations.Items[i]
-				if migration.Spec.VMIName != vm.Name {
-					continue
-				}
-				observedMigrationName = migration.Name
-				observedMigrationPhase = migration.Status.Phase
-				observedMigrationState = migration.Status.MigrationState
-				if migration.Status.Phase == kubevirtcorev1.MigrationSucceeded {
-					return true
-				}
-			}
-			return false
+			return observedMigration != nil && observedMigration.Status.Phase == kubevirtcorev1.MigrationSucceeded
 		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(BeTrue(), func() string {
-			return fmt.Sprintf("VMI did not complete migration from cordoned node %s; VMIM=%s phase=%s", sourceNode, observedMigrationName, observedMigrationPhase)
+			if observedMigration == nil {
+				return fmt.Sprintf("VMI did not complete migration from cordoned node %s; no matching VMIM was observed", sourceNode)
+			}
+			return fmt.Sprintf("VMI did not complete migration from cordoned node %s; VMIM=%s phase=%s", sourceNode, observedMigration.Name, observedMigration.Status.Phase)
 		})
-		Expect(observedMigrationName).ToNot(BeEmpty(), "the eviction did not create a VMIM for the test VMI")
-		Expect(observedMigrationState).ToNot(BeNil(), "the completed VMIM did not expose migration state")
-		Expect(observedMigrationState.SourceNode).To(Equal(sourceNode))
-		Expect(observedMigrationState.TargetNode).ToNot(BeEmpty())
+		Expect(observedMigration).ToNot(BeNil(), "the eviction did not create a VMIM for the test VMI")
+		Expect(observedMigration.Status.Phase).To(Equal(kubevirtcorev1.MigrationSucceeded),
+			fmt.Sprintf("VMIM %s did not complete successfully", observedMigration.Name))
+		observedMigrationState := observedMigration.Status.MigrationState
+		Expect(observedMigrationState).ToNot(BeNil(),
+			fmt.Sprintf("completed VMIM %s did not expose migrationState with sourceNode and targetNode", observedMigration.Name))
+		Expect(observedMigrationState.SourceNode).ToNot(BeEmpty(),
+			fmt.Sprintf("completed VMIM %s migrationState.sourceNode is empty", observedMigration.Name))
+		Expect(observedMigrationState.SourceNode).To(Equal(sourceNode),
+			fmt.Sprintf("completed VMIM %s migrationState.sourceNode does not match the VMI source", observedMigration.Name))
+		Expect(observedMigrationState.TargetNode).ToNot(BeEmpty(),
+			fmt.Sprintf("completed VMIM %s migrationState.targetNode is empty", observedMigration.Name))
 		Expect(observedMigrationState.TargetNode).ToNot(Equal(sourceNode))
 
 		By("verifying that exactly one virt-launcher remains active")
@@ -241,6 +242,41 @@ func activeVirtLauncherCount(pods *corev1.PodList, vmName string, vmiUID types.U
 		}
 	}
 	return count
+}
+
+func preferredMigrationForVMI(migrations []kubevirtcorev1.VirtualMachineInstanceMigration, vmiName string) *kubevirtcorev1.VirtualMachineInstanceMigration {
+	var preferred *kubevirtcorev1.VirtualMachineInstanceMigration
+	for i := range migrations {
+		candidate := &migrations[i]
+		if candidate.Spec.VMIName != vmiName {
+			continue
+		}
+		if preferred == nil || migrationIsPreferred(candidate, preferred) {
+			preferred = candidate
+		}
+	}
+	return preferred
+}
+
+func migrationIsPreferred(candidate, current *kubevirtcorev1.VirtualMachineInstanceMigration) bool {
+	candidateSucceeded := candidate.Status.Phase == kubevirtcorev1.MigrationSucceeded
+	currentSucceeded := current.Status.Phase == kubevirtcorev1.MigrationSucceeded
+	if candidateSucceeded != currentSucceeded {
+		return candidateSucceeded
+	}
+	return candidate.CreationTimestamp.Time.After(current.CreationTimestamp.Time)
+}
+
+func shouldRecordMigration(candidate, observed *kubevirtcorev1.VirtualMachineInstanceMigration) bool {
+	if observed == nil {
+		return true
+	}
+	// Keep updating the same object as its phase/state changes, while retaining
+	// a previously observed successful migration if that object is garbage-collected.
+	if candidate.Name == observed.Name {
+		return true
+	}
+	return migrationIsPreferred(candidate, observed)
 }
 
 func nodeReady(node *corev1.Node) bool {

--- a/tests/func-tests/node_maintenance_test.go
+++ b/tests/func-tests/node_maintenance_test.go
@@ -91,7 +91,6 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, vmi)).To(Succeed())
 			g.Expect(vmi.Status.Phase).To(Equal(kubevirtcorev1.Running), vmiFailureMessage(vmi))
 			g.Expect(vmi.Status.NodeName).ToNot(BeEmpty())
-			g.Expect(vmi.Status.MigrationMethod).To(Equal(kubevirtcorev1.LiveMigration), vmiFailureMessage(vmi))
 			g.Expect(vmi.IsMigratable()).To(BeTrue(), vmiFailureMessage(vmi))
 		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Succeed())
 

--- a/tests/func-tests/node_maintenance_test.go
+++ b/tests/func-tests/node_maintenance_test.go
@@ -49,7 +49,9 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 		tests.FailIfSingleNodeCluster(len(workers) < 2)
 
 		availableWorkers := 0
+		workerNodeNames := make(map[string]struct{}, len(workers))
 		for i := range workers {
+			workerNodeNames[workers[i].Name] = struct{}{}
 			if !workers[i].Spec.Unschedulable && nodeReady(&workers[i]) {
 				availableWorkers++
 			}
@@ -104,6 +106,7 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 		sourceNode := vmi.Status.NodeName
 		vmiUID := vmi.UID
 		Expect(sourceNode).ToNot(BeEmpty())
+		Expect(workerNodeNames).To(HaveKey(sourceNode), "VMI must start on a worker node")
 		Expect(vmiUID).ToNot(BeEmpty())
 		sourceNodeObject, err := cliSet.CoreV1().Nodes().Get(ctx, sourceNode, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -191,6 +194,7 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 		Expect(observedMigrationState.TargetNode).ToNot(BeEmpty(),
 			fmt.Sprintf("completed VMIM %s migrationState.targetNode is empty", observedMigration.Name))
 		Expect(observedMigrationState.TargetNode).ToNot(Equal(sourceNode))
+		Expect(workerNodeNames).To(HaveKey(observedMigrationState.TargetNode), "VMI must migrate to a worker node")
 
 		By("verifying that exactly one virt-launcher remains active")
 		Eventually(func(g Gomega, pollCtx context.Context) int {
@@ -222,6 +226,7 @@ func nodeMaintenanceVM(name string) *kubevirtcorev1.VirtualMachine {
 				},
 				Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
 					EvictionStrategy: &strategy,
+					NodeSelector:     map[string]string{libnode.WorkerNodeLabel: ""},
 					Domain: kubevirtcorev1.DomainSpec{
 						Resources: kubevirtcorev1.ResourceRequirements{
 							Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")},

--- a/tests/func-tests/node_maintenance_test.go
+++ b/tests/func-tests/node_maintenance_test.go
@@ -87,7 +87,7 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 			}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(cleanupCtx).Should(Succeed())
 		})
 
-		vmi := &kubevirtcorev1.VirtualMachineInstance{}
+		vmi := new(kubevirtcorev1.VirtualMachineInstance)
 		By("waiting for the VM's VMI to become Running and live-migratable")
 		Eventually(func(g Gomega, pollCtx context.Context) {
 			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, vmi)).To(Succeed())
@@ -96,7 +96,7 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 			g.Expect(vmiReady(vmi)).To(BeTrue(), vmiFailureMessage(vmi))
 			g.Expect(vmi.IsMigratable()).To(BeTrue(), vmiFailureMessage(vmi))
 		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Succeed())
-		vmStatus := &kubevirtcorev1.VirtualMachine{}
+		vmStatus := new(kubevirtcorev1.VirtualMachine)
 		Eventually(func(g Gomega, pollCtx context.Context) {
 			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, vmStatus)).To(Succeed())
 			g.Expect(vmStatus.Status.Ready).To(BeTrue())
@@ -114,10 +114,10 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 		sourceWasUnschedulable = sourceNodeObject.Spec.Unschedulable
 		Expect(sourceWasUnschedulable).To(BeFalse(), "VMI started on an already cordoned node")
 
-		launcherPod := &corev1.Pod{}
+		launcherPod := new(corev1.Pod)
 		By("finding the virt-launcher pod on the source node")
 		Eventually(func(g Gomega, pollCtx context.Context) {
-			pods := &corev1.PodList{}
+			pods := new(corev1.PodList)
 			g.Expect(cli.List(pollCtx, pods, client.InNamespace(tests.TestNamespace))).To(Succeed())
 			for i := range pods.Items {
 				if pods.Items[i].Spec.NodeName == sourceNode && pods.Items[i].Status.Phase == corev1.PodRunning && isVirtLauncherForVMI(&pods.Items[i], vm.Name, vmiUID) {
@@ -152,7 +152,7 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 		Eventually(func(g Gomega, pollCtx context.Context) bool {
 			// Capture the VMIM before checking the VMI node: completed migrations may be
 			// garbage-collected shortly after the VMI is observed on its target node.
-			migrations := &kubevirtcorev1.VirtualMachineInstanceMigrationList{}
+			migrations := new(kubevirtcorev1.VirtualMachineInstanceMigrationList)
 			g.Expect(cli.List(pollCtx, migrations, client.InNamespace(tests.TestNamespace))).To(Succeed())
 			for i := range migrations.Items {
 				if migrations.Items[i].Spec.VMIName == vm.Name {
@@ -163,7 +163,7 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 				observedMigration = candidate.DeepCopy()
 			}
 
-			current := &kubevirtcorev1.VirtualMachineInstance{}
+			current := new(kubevirtcorev1.VirtualMachineInstance)
 			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, current)).To(Succeed())
 			g.Expect(current.UID).To(Equal(vmiUID), vmiFailureMessage(current))
 			g.Expect(current.Status.Phase).To(Equal(kubevirtcorev1.Running), vmiFailureMessage(current))
@@ -195,10 +195,15 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 			fmt.Sprintf("completed VMIM %s migrationState.targetNode is empty", observedMigration.Name))
 		Expect(observedMigrationState.TargetNode).ToNot(Equal(sourceNode))
 		Expect(workerNodeNames).To(HaveKey(observedMigrationState.TargetNode), "VMI must migrate to a worker node")
+		finalVMI := new(kubevirtcorev1.VirtualMachineInstance)
+		Eventually(func(g Gomega, pollCtx context.Context) {
+			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, finalVMI)).To(Succeed())
+			g.Expect(finalVMI.Status.NodeName).To(Equal(observedMigrationState.TargetNode), vmiFailureMessage(finalVMI))
+		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Succeed())
 
 		By("verifying that exactly one virt-launcher remains active")
 		Eventually(func(g Gomega, pollCtx context.Context) int {
-			pods := &corev1.PodList{}
+			pods := new(corev1.PodList)
 			g.Expect(cli.List(pollCtx, pods, client.InNamespace(tests.TestNamespace))).To(Succeed())
 			return activeVirtLauncherCount(pods, vm.Name, vmiUID)
 		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Equal(1))
@@ -211,21 +216,23 @@ var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailabl
 })
 
 func nodeMaintenanceVM(name string) *kubevirtcorev1.VirtualMachine {
-	strategy := kubevirtcorev1.EvictionStrategyLiveMigrate
-	runStrategy := kubevirtcorev1.RunStrategyAlways
+	strategy := new(kubevirtcorev1.EvictionStrategy)
+	*strategy = kubevirtcorev1.EvictionStrategyLiveMigrate
+	runStrategy := new(kubevirtcorev1.VirtualMachineRunStrategy)
+	*runStrategy = kubevirtcorev1.RunStrategyAlways
 	return &kubevirtcorev1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: tests.TestNamespace,
 		},
 		Spec: kubevirtcorev1.VirtualMachineSpec{
-			RunStrategy: &runStrategy,
+			RunStrategy: runStrategy,
 			Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{virtLauncherDomainLabel: name},
 				},
 				Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
-					EvictionStrategy: &strategy,
+					EvictionStrategy: strategy,
 					NodeSelector:     map[string]string{libnode.WorkerNodeLabel: ""},
 					Domain: kubevirtcorev1.DomainSpec{
 						Resources: kubevirtcorev1.ResourceRequirements{
@@ -233,7 +240,7 @@ func nodeMaintenanceVM(name string) *kubevirtcorev1.VirtualMachine {
 						},
 						Devices: kubevirtcorev1.Devices{Interfaces: []kubevirtcorev1.Interface{{
 							Name:                   kubevirtcorev1.DefaultPodNetwork().Name,
-							InterfaceBindingMethod: kubevirtcorev1.InterfaceBindingMethod{Masquerade: &kubevirtcorev1.InterfaceMasquerade{}},
+							InterfaceBindingMethod: kubevirtcorev1.InterfaceBindingMethod{Masquerade: new(kubevirtcorev1.InterfaceMasquerade)},
 						}}},
 					},
 					Networks: []kubevirtcorev1.Network{*kubevirtcorev1.DefaultPodNetwork()},

--- a/tests/func-tests/node_maintenance_test.go
+++ b/tests/func-tests/node_maintenance_test.go
@@ -1,0 +1,268 @@
+package tests_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubevirtcorev1 "kubevirt.io/api/core/v1"
+
+	tests "github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests"
+	"github.com/kubevirt/hyperconverged-cluster-operator/tests/func-tests/libnode"
+)
+
+const (
+	nodeMaintenanceTimeout  = 10 * time.Minute
+	nodeMaintenancePolling  = 5 * time.Second
+	virtLauncherDomainLabel = kubevirtcorev1.DomainAnnotation
+)
+
+var _ = Describe("KubeVirt node maintenance", Serial, Label(tests.HighlyAvailableClusterLabel, tests.DestructiveLabel, "nodeMaintenance"), func() {
+	tests.FlagParse()
+
+	var (
+		cli    client.Client
+		cliSet *kubernetes.Clientset
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		cli = tests.GetControllerRuntimeClient()
+		cliSet = tests.GetK8sClientSet()
+		tests.BeforeEach(ctx)
+	})
+
+	It("should live migrate a VM after its node is cordoned and its launcher is evicted", func(ctx context.Context) {
+		workers, err := libnode.ListWorkerNodes(ctx, cli)
+		Expect(err).ToNot(HaveOccurred())
+		tests.FailIfSingleNodeCluster(len(workers) < 2)
+
+		availableWorkers := 0
+		for i := range workers {
+			if !workers[i].Spec.Unschedulable && nodeReady(&workers[i]) {
+				availableWorkers++
+			}
+		}
+		Expect(availableWorkers).To(BeNumerically(">=", 2), "node maintenance requires two Ready, schedulable worker nodes")
+
+		vm := nodeMaintenanceVM(fmt.Sprintf("node-maintenance-vm-%d", time.Now().UnixNano()))
+		By("creating a VM with an explicit LiveMigrate eviction strategy")
+		Eventually(cli.Create).
+			WithContext(ctx).
+			WithArguments(vm).
+			WithTimeout(nodeMaintenanceTimeout).
+			WithPolling(nodeMaintenancePolling).
+			Should(Succeed())
+
+		cordonedNode := ""
+		sourceWasUnschedulable := false
+		DeferCleanup(func(cleanupCtx context.Context) {
+			if cordonedNode != "" && !sourceWasUnschedulable {
+				By(fmt.Sprintf("uncordoning node %s", cordonedNode))
+				Eventually(func() error {
+					return patchNodeUnschedulable(cleanupCtx, cliSet, cordonedNode, false)
+				}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(cleanupCtx).Should(Succeed())
+			}
+
+			By("deleting the test VM")
+			Eventually(func() error {
+				err := cli.Delete(cleanupCtx, vm)
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(cleanupCtx).Should(Succeed())
+		})
+
+		vmi := &kubevirtcorev1.VirtualMachineInstance{}
+		By("waiting for the VM's VMI to become Running and live-migratable")
+		Eventually(func(g Gomega, pollCtx context.Context) {
+			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, vmi)).To(Succeed())
+			g.Expect(vmi.Status.Phase).To(Equal(kubevirtcorev1.Running), vmiFailureMessage(vmi))
+			g.Expect(vmi.Status.NodeName).ToNot(BeEmpty())
+			g.Expect(vmi.Status.MigrationMethod).To(Equal(kubevirtcorev1.LiveMigration), vmiFailureMessage(vmi))
+			g.Expect(vmi.IsMigratable()).To(BeTrue(), vmiFailureMessage(vmi))
+		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Succeed())
+
+		sourceNode := vmi.Status.NodeName
+		vmiUID := vmi.UID
+		Expect(sourceNode).ToNot(BeEmpty())
+		Expect(vmiUID).ToNot(BeEmpty())
+		sourceNodeObject, err := cliSet.CoreV1().Nodes().Get(ctx, sourceNode, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nodeReady(sourceNodeObject)).To(BeTrue(), "VMI source node %s is no longer Ready", sourceNode)
+		sourceWasUnschedulable = sourceNodeObject.Spec.Unschedulable
+		Expect(sourceWasUnschedulable).To(BeFalse(), "VMI started on an already cordoned node")
+
+		launcherPod := &corev1.Pod{}
+		By("finding the virt-launcher pod on the source node")
+		Eventually(func(g Gomega, pollCtx context.Context) {
+			pods := &corev1.PodList{}
+			g.Expect(cli.List(pollCtx, pods, client.InNamespace(tests.TestNamespace))).To(Succeed())
+			for i := range pods.Items {
+				if pods.Items[i].Spec.NodeName == sourceNode && pods.Items[i].Status.Phase == corev1.PodRunning && isVirtLauncherForVMI(&pods.Items[i], vm.Name, vmiUID) {
+					*launcherPod = pods.Items[i]
+					return
+				}
+			}
+			g.Expect(launcherPod.Name).ToNot(BeEmpty(), "virt-launcher pod was not Running on VMI source node")
+		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Succeed())
+
+		cordonedNode = sourceNode
+		By(fmt.Sprintf("cordoning source node %s", sourceNode))
+		Eventually(func() error {
+			return patchNodeUnschedulable(ctx, cliSet, sourceNode, true)
+		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Succeed())
+
+		By(fmt.Sprintf("evicting virt-launcher pod %s through the Kubernetes eviction API", launcherPod.Name))
+		Eventually(func() bool {
+			err := cliSet.PolicyV1().Evictions(tests.TestNamespace).Evict(ctx, &policyv1.Eviction{
+				ObjectMeta: metav1.ObjectMeta{Name: launcherPod.Name, Namespace: tests.TestNamespace},
+			})
+			if err == nil || apierrors.IsNotFound(err) {
+				return true
+			}
+			GinkgoWriter.Printf("waiting for eviction of %s: %v\n", launcherPod.Name, err)
+			return false
+		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(BeTrue())
+
+		By("verifying that the same VMI UID is Running on a different node")
+		var (
+			observedMigrationName  string
+			observedMigrationPhase kubevirtcorev1.VirtualMachineInstanceMigrationPhase
+			observedMigrationState *kubevirtcorev1.VirtualMachineInstanceMigrationState
+		)
+		Eventually(func(g Gomega, pollCtx context.Context) bool {
+			current := &kubevirtcorev1.VirtualMachineInstance{}
+			g.Expect(cli.Get(pollCtx, client.ObjectKey{Namespace: tests.TestNamespace, Name: vm.Name}, current)).To(Succeed())
+			g.Expect(current.UID).To(Equal(vmiUID), vmiFailureMessage(current))
+			g.Expect(current.Status.Phase).To(Equal(kubevirtcorev1.Running), vmiFailureMessage(current))
+			g.Expect(current.IsMigratable()).To(BeTrue(), vmiFailureMessage(current))
+			if current.Status.NodeName == sourceNode {
+				return false
+			}
+
+			migrations := &kubevirtcorev1.VirtualMachineInstanceMigrationList{}
+			g.Expect(cli.List(pollCtx, migrations, client.InNamespace(tests.TestNamespace))).To(Succeed())
+			for i := range migrations.Items {
+				migration := &migrations.Items[i]
+				if migration.Spec.VMIName != vm.Name {
+					continue
+				}
+				observedMigrationName = migration.Name
+				observedMigrationPhase = migration.Status.Phase
+				observedMigrationState = migration.Status.MigrationState
+				if migration.Status.Phase == kubevirtcorev1.MigrationSucceeded {
+					return true
+				}
+			}
+			return false
+		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(BeTrue(), func() string {
+			return fmt.Sprintf("VMI did not complete migration from cordoned node %s; VMIM=%s phase=%s", sourceNode, observedMigrationName, observedMigrationPhase)
+		})
+		Expect(observedMigrationName).ToNot(BeEmpty(), "the eviction did not create a VMIM for the test VMI")
+		Expect(observedMigrationState).ToNot(BeNil(), "the completed VMIM did not expose migration state")
+		Expect(observedMigrationState.SourceNode).To(Equal(sourceNode))
+		Expect(observedMigrationState.TargetNode).ToNot(BeEmpty())
+		Expect(observedMigrationState.TargetNode).ToNot(Equal(sourceNode))
+
+		By("verifying that exactly one virt-launcher remains active")
+		Eventually(func(g Gomega, pollCtx context.Context) int {
+			pods := &corev1.PodList{}
+			g.Expect(cli.List(pollCtx, pods, client.InNamespace(tests.TestNamespace))).To(Succeed())
+			return activeVirtLauncherCount(pods, vm.Name, vmiUID)
+		}).WithTimeout(nodeMaintenanceTimeout).WithPolling(nodeMaintenancePolling).WithContext(ctx).Should(Equal(1))
+	})
+})
+
+func nodeMaintenanceVM(name string) *kubevirtcorev1.VirtualMachine {
+	strategy := kubevirtcorev1.EvictionStrategyLiveMigrate
+	runStrategy := kubevirtcorev1.RunStrategyAlways
+	return &kubevirtcorev1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tests.TestNamespace,
+		},
+		Spec: kubevirtcorev1.VirtualMachineSpec{
+			RunStrategy: &runStrategy,
+			Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{virtLauncherDomainLabel: name},
+				},
+				Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+					EvictionStrategy: &strategy,
+					Domain: kubevirtcorev1.DomainSpec{
+						Resources: kubevirtcorev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")},
+						},
+						Devices: kubevirtcorev1.Devices{Interfaces: []kubevirtcorev1.Interface{{
+							Name:                   kubevirtcorev1.DefaultPodNetwork().Name,
+							InterfaceBindingMethod: kubevirtcorev1.InterfaceBindingMethod{Masquerade: &kubevirtcorev1.InterfaceMasquerade{}},
+						}}},
+					},
+					Networks: []kubevirtcorev1.Network{*kubevirtcorev1.DefaultPodNetwork()},
+				},
+			},
+		},
+	}
+}
+
+func isVirtLauncherForVMI(pod *corev1.Pod, vmName string, vmiUID types.UID) bool {
+	if pod.Annotations[virtLauncherDomainLabel] == vmName || pod.Labels[virtLauncherDomainLabel] == vmName {
+		return true
+	}
+	if pod.Labels[kubevirtcorev1.CreatedByLabel] == string(vmiUID) {
+		return true
+	}
+	for _, owner := range pod.OwnerReferences {
+		if owner.Kind == "VirtualMachineInstance" && (owner.Name == vmName || owner.UID == vmiUID) {
+			return true
+		}
+	}
+	return false
+}
+
+func activeVirtLauncherCount(pods *corev1.PodList, vmName string, vmiUID types.UID) int {
+	count := 0
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Status.Phase == corev1.PodRunning && isVirtLauncherForVMI(pod, vmName, vmiUID) {
+			count++
+		}
+	}
+	return count
+}
+
+func nodeReady(node *corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func patchNodeUnschedulable(ctx context.Context, cli *kubernetes.Clientset, nodeName string, unschedulable bool) error {
+	patch := []byte(fmt.Sprintf(`{"spec":{"unschedulable":%t}}`, unschedulable))
+	_, err := cli.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patch, metav1.PatchOptions{})
+	return err
+}
+
+func vmiFailureMessage(vmi *kubevirtcorev1.VirtualMachineInstance) string {
+	conditions := make([]string, 0, len(vmi.Status.Conditions))
+	for _, condition := range vmi.Status.Conditions {
+		conditions = append(conditions, fmt.Sprintf("%s=%s (%s): %s", condition.Type, condition.Status, condition.Reason, condition.Message))
+	}
+	return fmt.Sprintf("VMI phase=%s node=%s migrationMethod=%s conditions=%s", vmi.Status.Phase, vmi.Status.NodeName, vmi.Status.MigrationMethod, strings.Join(conditions, "; "))
+}


### PR DESCRIPTION
## Summary
- add a destructive HA functional test that cordons a worker, evicts a virt-launcher through the Kubernetes Eviction API, and verifies live migration with VMIM/VMI/launcher evidence
- add a served/storage CRD schema compatibility test for the HCO and VM evictionStrategy paths used by the node-maintenance howto
- add optional Descheduler compatibility checks for KubeVirt profiles, policy YAML, policy volume wiring, and EvictionsInBackground
- accept the graduated and legacy KubeVirt Descheduler profile names while keeping the documented fields version-aware

## Validation
- `gofmt -d` (clean)
- `go test ./tests/func-tests -run '^$'` (package compile passed; no live tests run)\n- `go vet ./tests/func-tests` (passed)\n- `git diff --check` (passed)\n\nThe live functional tests require a configured HA workload cluster with KubeVirt and, for the optional checks, Descheduler installed. This environment does not currently have a valid workload-cluster context, so no live migration or Descheduler rebalance result is claimed.