### PR TITLE
Stop using the WASP image in build-manifests

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -373,7 +373,6 @@ ${TOOLS}/manifest-templator \
   --webhook-image="${HCO_WEBHOOK_IMAGE}" \
   --cli-downloads-image="${HCO_DOWNLOADS_IMAGE}" \
   --network-resources-injector-image-name="${NETWORK_RESOURCES_INJECTOR_IMAGE}" \
-  --wasp-agent-image-name="${WASP_AGENT_IMAGE}" \
   --aie-webhook-image-name="${AIE_WEBHOOK_IMAGE}" \
   --observability-controller-image-name="${OBSERVABILITY_CONTROLLER_IMAGE}"
 
@@ -439,7 +438,6 @@ ${TOOLS}/csv-merger \
   --kubevirt-consoleproxy-image-name="${KUBEVIRT_CONSOLE_PROXY_IMAGE}" \
   --cli-downloads-image-name="${HCO_DOWNLOADS_IMAGE}" \
   --network-resources-injector-image-name="${NETWORK_RESOURCES_INJECTOR_IMAGE}" \
-  --wasp-agent-image-name="${WASP_AGENT_IMAGE}" \
   --aie-webhook-image-name="${AIE_WEBHOOK_IMAGE}" \
   --observability-controller-image-name="${OBSERVABILITY_CONTROLLER_IMAGE}" \
   ${NETWORK_POLICIES_PARAMS} \


### PR DESCRIPTION
**What this PR does / why we need it**:
The build manifests script still sends the `--wasp-agent-image-name` parameter to the csv-merger and the manifest-templator tools.

The image name itself is empty because we already removed it. Also this parameter is ignored by both tools.

This PR removes the parameter from the call to these tools.

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
None
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
