### PR TITLE
[release-1.18] Fix KubeVirt infra replicas forced to 1 on HA HyperShift clusters

### DIFF
--- a/controllers/commontestutils/nodeinfomocks.go
+++ b/controllers/commontestutils/nodeinfomocks.go
@@ -102,6 +102,48 @@ func DualReplicaNodeInfoMock() {
 	}
 }
 
+// HyperShiftHANodeInfoMock mocks a HyperShift (Hosted Control Plane) cluster
+// with highly available infrastructure: no control plane nodes (external CP)
+// and 2+ worker nodes.
+func HyperShiftHANodeInfoMock() {
+	nodeinfo.IsInfrastructureHighlyAvailable = func() bool {
+		return true
+	}
+
+	nodeinfo.IsControlPlaneNodeExists = func() bool {
+		return false
+	}
+
+	nodeinfo.IsControlPlaneHighlyAvailable = func() bool {
+		return false
+	}
+
+	nodeinfo.IsControlPlaneMultiNode = func() bool {
+		return false
+	}
+}
+
+// HyperShiftSingleWorkerNodeInfoMock mocks a HyperShift (Hosted Control Plane)
+// cluster with a single worker node: no control plane nodes (external CP)
+// and only 1 worker.
+func HyperShiftSingleWorkerNodeInfoMock() {
+	nodeinfo.IsInfrastructureHighlyAvailable = func() bool {
+		return false
+	}
+
+	nodeinfo.IsControlPlaneNodeExists = func() bool {
+		return false
+	}
+
+	nodeinfo.IsControlPlaneHighlyAvailable = func() bool {
+		return false
+	}
+
+	nodeinfo.IsControlPlaneMultiNode = func() bool {
+		return false
+	}
+}
+
 // ControlPlaneArchitecturesMock mocks the architecures for ControlPlane nodes
 func ControlPlaneArchitecturesMock(arch ...string) {
 	nodeinfo.GetControlPlaneArchitectures = func() []string {

--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -905,21 +905,16 @@ func hcoConfig2KvConfig(
 
 	kvConfig := &kubevirtcorev1.ComponentConfig{}
 
+	if shouldHaveVirtInfraSingleReplica(infraHighlyAvailable, controlPlaneMultiNode, controlPlaneNodeExists) {
+		kvConfig.Replicas = ptr.To[uint8](1)
+	}
+
 	// In case there are no control plane / master nodes in the cluster, we're setting
 	// an empty struct for NodePlacement so that kubevirt control plane pods won't have
 	// any affinity rules, and they could get scheduled onto worker nodes.
 	if hcoConfig.NodePlacement == nil && !controlPlaneNodeExists {
 		kvConfig.NodePlacement = &kubevirtcorev1.NodePlacement{}
-		if !infraHighlyAvailable {
-			// if there is only one worker node and no control plane nodes,
-			// set the kubevirt control plane replica count to 1.
-			kvConfig.Replicas = ptr.To[uint8](1)
-		}
 		return kvConfig
-	}
-
-	if !controlPlaneMultiNode {
-		kvConfig.Replicas = ptr.To[uint8](1)
 	}
 
 	if hcoConfig.NodePlacement != nil {
@@ -941,6 +936,10 @@ func hcoConfig2KvConfig(
 		}
 	}
 	return kvConfig
+}
+
+func shouldHaveVirtInfraSingleReplica(infraHighlyAvailable, controlPlaneMultiNode, controlPlaneNodeExists bool) bool {
+	return (controlPlaneNodeExists && !controlPlaneMultiNode) || (!controlPlaneNodeExists && !infraHighlyAvailable)
 }
 
 func getFeatureGateChecks(spec hcov1beta1.HyperConvergedSpec, annotations map[string]string) []string {

--- a/controllers/handlers/kubevirt_test.go
+++ b/controllers/handlers/kubevirt_test.go
@@ -3359,6 +3359,124 @@ Version: 1.2.3`)
 			})
 		})
 
+		Context("HyperShift replicas", func() {
+			BeforeEach(func() {
+				commontestutils.HighlyAvailableNodeInfoMocks()
+
+				DeferCleanup(func() {
+					commontestutils.ResetNodeInfoMocks()
+				})
+			})
+
+			Context("Custom Infra placement, default Workloads placement", func() {
+				BeforeEach(func() {
+					hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				})
+
+				It("should not force replica=1 on HyperShift HA (2+ workers, no CP nodes)", func() {
+					commontestutils.HyperShiftHANodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).ToNot(BeNil())
+					Expect(kv.Spec.Infra.Replicas).To(BeNil())
+					Expect(kv.Spec.Workloads).To(BeNil())
+				})
+
+				It("should set replica=1 on HyperShift single worker", func() {
+					commontestutils.HyperShiftSingleWorkerNodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).ToNot(BeNil())
+					Expect(kv.Spec.Infra.Replicas).To(HaveValue(Equal(uint8(1))))
+					Expect(kv.Spec.Workloads).To(BeNil())
+				})
+			})
+
+			Context("Custom Workloads placement, default Infra placement", func() {
+				BeforeEach(func() {
+					hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				})
+
+				It("should not force replica=1 on HyperShift HA (2+ workers, no CP nodes)", func() {
+					commontestutils.HyperShiftHANodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).ToNot(BeNil())
+					Expect(kv.Spec.Infra.Replicas).To(BeNil())
+					Expect(kv.Spec.Infra.NodePlacement).ToNot(BeNil())
+					Expect(kv.Spec.Workloads).ToNot(BeNil())
+					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
+				})
+
+				It("should set replica=1 on HyperShift single worker", func() {
+					commontestutils.HyperShiftSingleWorkerNodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).ToNot(BeNil())
+					Expect(kv.Spec.Infra.Replicas).To(HaveValue(Equal(uint8(1))))
+					Expect(kv.Spec.Workloads).ToNot(BeNil())
+					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
+				})
+			})
+
+			Context("Default Infra and Workload placement", func() {
+				It("should not force replica=1 on HyperShift HA (2+ workers, no CP nodes)", func() {
+					commontestutils.HyperShiftHANodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).ToNot(BeNil())
+					Expect(kv.Spec.Infra.Replicas).To(BeNil())
+					Expect(kv.Spec.Infra.NodePlacement).ToNot(BeNil())
+					Expect(kv.Spec.Workloads).To(BeNil())
+				})
+
+				It("should set replica=1 on HyperShift single worker", func() {
+					commontestutils.HyperShiftSingleWorkerNodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).ToNot(BeNil())
+					Expect(kv.Spec.Infra.Replicas).To(HaveValue(Equal(uint8(1))))
+					Expect(kv.Spec.Infra.NodePlacement).ToNot(BeNil())
+					Expect(kv.Spec.Workloads).To(BeNil())
+				})
+			})
+
+			Context("Custom Infra and Workloads placement", func() {
+				BeforeEach(func() {
+					hco.Spec.Infra = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+					hco.Spec.Workloads = hcov1beta1.HyperConvergedConfig{NodePlacement: commontestutils.NewNodePlacement()}
+				})
+
+				It("should not force replica=1 on HyperShift HA (2+ workers, no CP nodes)", func() {
+					commontestutils.HyperShiftHANodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).ToNot(BeNil())
+					Expect(kv.Spec.Infra.Replicas).To(BeNil())
+					Expect(kv.Spec.Workloads).ToNot(BeNil())
+					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
+				})
+
+				It("should set replica=1 on HyperShift single worker", func() {
+					commontestutils.HyperShiftSingleWorkerNodeInfoMock()
+
+					kv, err := NewKubeVirt(hco)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(kv.Spec.Infra).ToNot(BeNil())
+					Expect(kv.Spec.Infra.Replicas).To(HaveValue(Equal(uint8(1))))
+					Expect(kv.Spec.Workloads).ToNot(BeNil())
+					Expect(kv.Spec.Workloads.Replicas).To(BeNil())
+				})
+			})
+		})
+
 		Context("Cluster level EvictionStrategy", func() {
 			It("should add eviction strategy if missing in KV", func() {
 				existingResource, err := NewKubeVirt(hco)


### PR DESCRIPTION
This is a manual backport of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/4525

---

On HyperShift clusters with no control plane nodes, hcoConfig2KvConfig unconditionally set Replicas=1 when !controlPlaneMultiNode. This flag is always false on HyperShift (zero CP nodes), so HA clusters with 2+ workers were incorrectly pinned to a single replica.

Split the condition so that Replicas=1 is only forced when a single CP node actually exists, or when there are no CP nodes and the infrastructure is not highly available (single worker). HA HyperShift clusters now leave replicas unset, letting KubeVirt default to 2.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-95245
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[release-1.18] Fix KubeVirt infra replicas forced to 1 on HA HyperShift clusters
```
