### PR TITLE
net-res-injector: Add readiness probe

### DIFF
--- a/controllers/handlers/netresinjector/common.go
+++ b/controllers/handlers/netresinjector/common.go
@@ -14,6 +14,8 @@ const (
 	tlsCertificateName = "virt-network-resources-injector-cert"
 	tlsMountPath       = "/etc/tls"
 	webhookConfigName  = "virt-network-resources-injector-config"
+	serverPort         = 6443
+	healthCheckPort    = 8444
 )
 
 func shouldDeploy(hc *hcov1.HyperConverged) bool {

--- a/controllers/handlers/netresinjector/deployment.go
+++ b/controllers/handlers/netresinjector/deployment.go
@@ -3,6 +3,8 @@ package netresinjector
 import (
 	"fmt"
 	"os"
+	"path"
+	"strconv"
 	"strings"
 
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
@@ -14,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
@@ -244,7 +247,7 @@ func newDeployment(hc *hcov1.HyperConverged) *appsv1.Deployment {
 						Name:    "webhook-server",
 						Image:   image,
 						Command: []string{"webhook"},
-						Args:    tlsArgs(minTLSVersion, ianaCiphers),
+						Args:    cmdArgs(minTLSVersion, ianaCiphers),
 						Env: []corev1.EnvVar{
 							{
 								Name: "NAMESPACE",
@@ -257,6 +260,32 @@ func newDeployment(hc *hcov1.HyperConverged) *appsv1.Deployment {
 							},
 						},
 						ImagePullPolicy: corev1.PullIfNotPresent,
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/healthz",
+									Port:   intstr.FromInt32(healthCheckPort),
+									Scheme: corev1.URISchemeHTTP,
+								},
+							},
+							InitialDelaySeconds: 15,
+							TimeoutSeconds:      1,
+							PeriodSeconds:       20,
+							SuccessThreshold:    1,
+							FailureThreshold:    3,
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{
+									Port: intstr.FromInt32(serverPort),
+								},
+							},
+							InitialDelaySeconds: 5,
+							TimeoutSeconds:      1,
+							PeriodSeconds:       10,
+							SuccessThreshold:    1,
+							FailureThreshold:    3,
+						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resourceCPURequest,
@@ -302,12 +331,12 @@ func newDeployment(hc *hcov1.HyperConverged) *appsv1.Deployment {
 	return dep
 }
 
-func tlsArgs(minTLSVersion openshiftconfigv1.TLSProtocolVersion, ianaCiphers []string) []string {
+func cmdArgs(minTLSVersion openshiftconfigv1.TLSProtocolVersion, ianaCiphers []string) []string {
 	args := []string{
 		"-bind-address=0.0.0.0",
-		"-port=6443",
-		"-tls-private-key-file=" + tlsMountPath + "/tls.key",
-		"-tls-cert-file=" + tlsMountPath + "/tls.crt",
+		"-port=" + strconv.Itoa(serverPort),
+		"-tls-private-key-file=" + path.Join(tlsMountPath, "tls.key"),
+		"-tls-cert-file=" + path.Join(tlsMountPath, "tls.crt"),
 		"-insecure=true",
 		"-logtostderr=true",
 		"-alsologtostderr=true",


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add readiness and liveness probes to deployment.
Use tcpSocket for readiness as unlike the dummy
/healtz server it actually waits for
TLS load / NAD cache / ListenAndServeTLS hence
assuring that the /mutate endpoint is indeed
ready to serve.

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
