### PR TITLE
Fix conversion webhook crash on legacy featureGates empty-object shape

### DIFF
--- a/api/v1/featuregates/feature_gates.go
+++ b/api/v1/featuregates/feature_gates.go
@@ -1,7 +1,9 @@
 package featuregates
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -72,6 +74,38 @@ func (fg *FeatureGate) UnmarshalJSON(bytes []byte) error {
 // +kubebuilder:validation:MaxItems=64
 // +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, x.name.lowerAscii() == y.name.lowerAscii()))",message="feature gate names must be unique (case-insensitive)"
 type HyperConvergedFeatureGates []FeatureGate
+
+// UnmarshalJSON decodes a JSON array into the feature gate list.
+//
+// Some objects persisted before v1.19 have spec.featureGates stored as an empty
+// JSON object ("{}") instead of an empty array, a legacy artifact of an older,
+// struct-based representation. That shape can't be produced by any current
+// code path, but it can still be read back from etcd, and a strict array
+// decode of it fails every caller that unmarshals the object - including the
+// CRD conversion webhook, which has no chance to recover since it decodes the
+// raw bytes before ConvertFrom/ConvertTo ever run (see
+// pkg/webhooks/mutator/hyperConvergedMutator.go's recoverBadFeatureGates for
+// the equivalent admission-webhook-only recovery). Treat an empty object as
+// an empty list so a stale record like that can still be read.
+func (fgs *HyperConvergedFeatureGates) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(trimmed, &obj); err != nil {
+			return err
+		}
+
+		if len(obj) != 0 {
+			return fmt.Errorf("featureGates: got an object with %d field(s), expected a JSON array", len(obj))
+		}
+
+		*fgs = nil
+		return nil
+	}
+
+	type plain HyperConvergedFeatureGates
+	return json.Unmarshal(data, (*plain)(fgs))
+}
 
 // Enable enables a feature gate by its name
 func (fgs *HyperConvergedFeatureGates) Enable(name string) {

--- a/api/v1/featuregates/feature_gates_test.go
+++ b/api/v1/featuregates/feature_gates_test.go
@@ -157,6 +157,32 @@ var _ = Describe("FeatureGate", func() {
 			))
 		})
 
+		It("should unmarshal a legacy empty-object shape as an empty list (issue #4549)", func() {
+			fgs := featuregates.HyperConvergedFeatureGates{
+				{Name: "shouldBeCleared"},
+			}
+
+			Expect(json.Unmarshal([]byte(`{}`), &fgs)).To(Succeed())
+			Expect(fgs).To(BeEmpty())
+		})
+
+		It("should reject a non-empty object shape", func() {
+			fgs := featuregates.HyperConvergedFeatureGates{}
+
+			err := json.Unmarshal([]byte(`{"incrementalBackup":true}`), &fgs)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should unmarshal a legacy empty-object shape nested in a struct field (conversion webhook repro)", func() {
+			type specStub struct {
+				FeatureGates featuregates.HyperConvergedFeatureGates `json:"featureGates"`
+			}
+
+			spec := specStub{}
+			Expect(json.Unmarshal([]byte(`{"featureGates":{}}`), &spec)).To(Succeed())
+			Expect(spec.FeatureGates).To(BeEmpty())
+		})
+
 		It("should unmarshal a yaml array of FGs", func() {
 			fgBytes := []byte(`- name: noEnabledField
 - name: enabledFG

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"testing"
@@ -519,6 +520,23 @@ var _ = Describe("api/v1beta1", func() {
 				// beta defaults stay true
 				Expect(result.DecentralizedLiveMigration).To(HaveValue(BeTrue()))
 				Expect(result.DeclarativeHotplugVolumes).To(HaveValue(BeTrue()))
+			})
+
+			It("should decode a stored hub object whose spec.featureGates is a legacy empty object, not an array (issue #4549)", func() {
+				// The CRD conversion webhook decodes the raw stored (hub, v1) bytes into
+				// hcov1.HyperConverged *before* ConvertFrom/ConvertTo ever run - see
+				// vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/conversion.go's
+				// handleConvertRequest. A pre-v1.19 record with spec.featureGates stored as
+				// "{}" used to fail that decode outright, before our conversion code had any
+				// chance to run.
+				rawHub := []byte(`{"apiVersion":"hco.kubevirt.io/v1","kind":"HyperConverged","metadata":{"name":"kubevirt-hyperconverged"},"spec":{"featureGates":{}}}`)
+
+				hub := &hcov1.HyperConverged{}
+				Expect(json.Unmarshal(rawHub, hub)).To(Succeed())
+				Expect(hub.Spec.FeatureGates).To(BeEmpty())
+
+				v1beta1HC := &HyperConverged{}
+				Expect(v1beta1HC.ConvertFrom(hub)).To(Succeed())
 			})
 
 			It("v1-only feature gates should survive roundtrip", func() {


### PR DESCRIPTION
## Summary

Root cause of #4549: some objects persisted before v1.19 have `spec.featureGates` stored as an empty JSON object (`{}`) instead of an empty array — a legacy artifact of an older, struct-based representation.

The mutating webhook already has a narrow recovery for this shape (`recoverBadFeatureGates` in `pkg/webhooks/mutator/hyperConvergedMutator.go`), but only when it hits an old-object decode failure during an `Update` admission request.

The CRD **conversion** webhook has no equivalent safety net: `controller-runtime` decodes the raw stored (hub, `v1`) bytes into `hcov1.HyperConverged` before `ConvertFrom`/`ConvertTo` ever run (see `vendor/sigs.k8s.io/controller-runtime/pkg/webhook/conversion/conversion.go`'s `handleConvertRequest`), so any `HyperConverged` object with this legacy shape becomes permanently unreadable via the `v1beta1` API — reproducing the exact error from the issue on every read.

## Fix

Give `HyperConvergedFeatureGates` (`api/v1/featuregates/feature_gates.go`) a custom `UnmarshalJSON` that treats an empty JSON object as an empty list, and returns a real error for a non-empty object (so genuine corruption isn't silently swallowed). Since this is a method on the type itself, it fixes every decode path uniformly (conversion webhook, mutating webhook, reconciler, apiserver) instead of only the one admission-webhook code path that already had a workaround.

## Testing

- `api/v1/featuregates/feature_gates_test.go`: unmarshal of `{}` (bare and nested in a struct field, mirroring the webhook decode) now succeeds as an empty list; a non-empty object is still rejected.
- `api/v1beta1/conversion_test.go`: reproduces the exact issue scenario — `json.Unmarshal` of raw hub-version bytes with `"featureGates":{}"` now succeeds, and the object converts via `ConvertFrom` cleanly.
- Verified both new tests fail with the exact quoted error from the issue on `main`, and pass with this fix.

Fixes #4549

> [!Note]
> Responses generated with Claude
