### PR TITLE
docs: update log verbosity documentation

### DIFF
--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -191,20 +191,52 @@ spec:
                           nodeVerbosity:
                             additionalProperties:
                               type: integer
-                            description: NodeVerbosity represents a map of nodes with
-                              a specific verbosity level
+                            description: |-
+                              NodeVerbosity represents a map of node names to specific log verbosity levels.
+                              Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                              Changes take effect on the fly without triggering a pod restart.
                             type: object
                           virtAPI:
+                            description: |-
+                              VirtAPI specifies the log verbosity level for the virt-api deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtController:
+                            description: |-
+                              VirtController specifies the log verbosity level for the virt-controller deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtHandler:
+                            description: |-
+                              VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtLauncher:
+                            description: |-
+                              VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart or workload rollout.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtOperator:
+                            description: |-
+                              VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtSynchronizationController:
+                            description: |-
+                              VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                         type: object
                     type: object
@@ -8055,20 +8087,52 @@ spec:
                       nodeVerbosity:
                         additionalProperties:
                           type: integer
-                        description: NodeVerbosity represents a map of nodes with
-                          a specific verbosity level
+                        description: |-
+                          NodeVerbosity represents a map of node names to specific log verbosity levels.
+                          Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                          Changes take effect on the fly without triggering a pod restart.
                         type: object
                       virtAPI:
+                        description: |-
+                          VirtAPI specifies the log verbosity level for the virt-api deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtController:
+                        description: |-
+                          VirtController specifies the log verbosity level for the virt-controller deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtHandler:
+                        description: |-
+                          VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtLauncher:
+                        description: |-
+                          VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart or workload rollout.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtOperator:
+                        description: |-
+                          VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtSynchronizationController:
+                        description: |-
+                          VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                     type: object
                 type: object

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -191,20 +191,52 @@ spec:
                           nodeVerbosity:
                             additionalProperties:
                               type: integer
-                            description: NodeVerbosity represents a map of nodes with
-                              a specific verbosity level
+                            description: |-
+                              NodeVerbosity represents a map of node names to specific log verbosity levels.
+                              Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                              Changes take effect on the fly without triggering a pod restart.
                             type: object
                           virtAPI:
+                            description: |-
+                              VirtAPI specifies the log verbosity level for the virt-api deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtController:
+                            description: |-
+                              VirtController specifies the log verbosity level for the virt-controller deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtHandler:
+                            description: |-
+                              VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtLauncher:
+                            description: |-
+                              VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart or workload rollout.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtOperator:
+                            description: |-
+                              VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtSynchronizationController:
+                            description: |-
+                              VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                         type: object
                     type: object
@@ -8055,20 +8087,52 @@ spec:
                       nodeVerbosity:
                         additionalProperties:
                           type: integer
-                        description: NodeVerbosity represents a map of nodes with
-                          a specific verbosity level
+                        description: |-
+                          NodeVerbosity represents a map of node names to specific log verbosity levels.
+                          Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                          Changes take effect on the fly without triggering a pod restart.
                         type: object
                       virtAPI:
+                        description: |-
+                          VirtAPI specifies the log verbosity level for the virt-api deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtController:
+                        description: |-
+                          VirtController specifies the log verbosity level for the virt-controller deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtHandler:
+                        description: |-
+                          VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtLauncher:
+                        description: |-
+                          VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart or workload rollout.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtOperator:
+                        description: |-
+                          VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtSynchronizationController:
+                        description: |-
+                          VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                     type: object
                 type: object

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
@@ -191,20 +191,52 @@ spec:
                           nodeVerbosity:
                             additionalProperties:
                               type: integer
-                            description: NodeVerbosity represents a map of nodes with
-                              a specific verbosity level
+                            description: |-
+                              NodeVerbosity represents a map of node names to specific log verbosity levels.
+                              Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                              Changes take effect on the fly without triggering a pod restart.
                             type: object
                           virtAPI:
+                            description: |-
+                              VirtAPI specifies the log verbosity level for the virt-api deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtController:
+                            description: |-
+                              VirtController specifies the log verbosity level for the virt-controller deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtHandler:
+                            description: |-
+                              VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtLauncher:
+                            description: |-
+                              VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart or workload rollout.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtOperator:
+                            description: |-
+                              VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtSynchronizationController:
+                            description: |-
+                              VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                         type: object
                     type: object
@@ -8055,20 +8087,52 @@ spec:
                       nodeVerbosity:
                         additionalProperties:
                           type: integer
-                        description: NodeVerbosity represents a map of nodes with
-                          a specific verbosity level
+                        description: |-
+                          NodeVerbosity represents a map of node names to specific log verbosity levels.
+                          Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                          Changes take effect on the fly without triggering a pod restart.
                         type: object
                       virtAPI:
+                        description: |-
+                          VirtAPI specifies the log verbosity level for the virt-api deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtController:
+                        description: |-
+                          VirtController specifies the log verbosity level for the virt-controller deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtHandler:
+                        description: |-
+                          VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtLauncher:
+                        description: |-
+                          VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart or workload rollout.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtOperator:
+                        description: |-
+                          VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtSynchronizationController:
+                        description: |-
+                          VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                     type: object
                 type: object

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
@@ -191,20 +191,52 @@ spec:
                           nodeVerbosity:
                             additionalProperties:
                               type: integer
-                            description: NodeVerbosity represents a map of nodes with
-                              a specific verbosity level
+                            description: |-
+                              NodeVerbosity represents a map of node names to specific log verbosity levels.
+                              Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                              Changes take effect on the fly without triggering a pod restart.
                             type: object
                           virtAPI:
+                            description: |-
+                              VirtAPI specifies the log verbosity level for the virt-api deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtController:
+                            description: |-
+                              VirtController specifies the log verbosity level for the virt-controller deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtHandler:
+                            description: |-
+                              VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtLauncher:
+                            description: |-
+                              VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart or workload rollout.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtOperator:
+                            description: |-
+                              VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtSynchronizationController:
+                            description: |-
+                              VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                         type: object
                     type: object
@@ -8055,20 +8087,52 @@ spec:
                       nodeVerbosity:
                         additionalProperties:
                           type: integer
-                        description: NodeVerbosity represents a map of nodes with
-                          a specific verbosity level
+                        description: |-
+                          NodeVerbosity represents a map of node names to specific log verbosity levels.
+                          Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                          Changes take effect on the fly without triggering a pod restart.
                         type: object
                       virtAPI:
+                        description: |-
+                          VirtAPI specifies the log verbosity level for the virt-api deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtController:
+                        description: |-
+                          VirtController specifies the log verbosity level for the virt-controller deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtHandler:
+                        description: |-
+                          VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtLauncher:
+                        description: |-
+                          VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart or workload rollout.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtOperator:
+                        description: |-
+                          VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtSynchronizationController:
+                        description: |-
+                          VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                     type: object
                 type: object

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -191,20 +191,52 @@ spec:
                           nodeVerbosity:
                             additionalProperties:
                               type: integer
-                            description: NodeVerbosity represents a map of nodes with
-                              a specific verbosity level
+                            description: |-
+                              NodeVerbosity represents a map of node names to specific log verbosity levels.
+                              Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                              Changes take effect on the fly without triggering a pod restart.
                             type: object
                           virtAPI:
+                            description: |-
+                              VirtAPI specifies the log verbosity level for the virt-api deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtController:
+                            description: |-
+                              VirtController specifies the log verbosity level for the virt-controller deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtHandler:
+                            description: |-
+                              VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtLauncher:
+                            description: |-
+                              VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart or workload rollout.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtOperator:
+                            description: |-
+                              VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtSynchronizationController:
+                            description: |-
+                              VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                         type: object
                     type: object
@@ -8055,20 +8087,52 @@ spec:
                       nodeVerbosity:
                         additionalProperties:
                           type: integer
-                        description: NodeVerbosity represents a map of nodes with
-                          a specific verbosity level
+                        description: |-
+                          NodeVerbosity represents a map of node names to specific log verbosity levels.
+                          Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                          Changes take effect on the fly without triggering a pod restart.
                         type: object
                       virtAPI:
+                        description: |-
+                          VirtAPI specifies the log verbosity level for the virt-api deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtController:
+                        description: |-
+                          VirtController specifies the log verbosity level for the virt-controller deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtHandler:
+                        description: |-
+                          VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtLauncher:
+                        description: |-
+                          VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart or workload rollout.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtOperator:
+                        description: |-
+                          VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtSynchronizationController:
+                        description: |-
+                          VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                     type: object
                 type: object

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -191,20 +191,52 @@ spec:
                           nodeVerbosity:
                             additionalProperties:
                               type: integer
-                            description: NodeVerbosity represents a map of nodes with
-                              a specific verbosity level
+                            description: |-
+                              NodeVerbosity represents a map of node names to specific log verbosity levels.
+                              Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                              Changes take effect on the fly without triggering a pod restart.
                             type: object
                           virtAPI:
+                            description: |-
+                              VirtAPI specifies the log verbosity level for the virt-api deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtController:
+                            description: |-
+                              VirtController specifies the log verbosity level for the virt-controller deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtHandler:
+                            description: |-
+                              VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtLauncher:
+                            description: |-
+                              VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart or workload rollout.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtOperator:
+                            description: |-
+                              VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                           virtSynchronizationController:
+                            description: |-
+                              VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                             type: integer
                         type: object
                     type: object
@@ -8055,20 +8087,52 @@ spec:
                       nodeVerbosity:
                         additionalProperties:
                           type: integer
-                        description: NodeVerbosity represents a map of nodes with
-                          a specific verbosity level
+                        description: |-
+                          NodeVerbosity represents a map of node names to specific log verbosity levels.
+                          Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                          Changes take effect on the fly without triggering a pod restart.
                         type: object
                       virtAPI:
+                        description: |-
+                          VirtAPI specifies the log verbosity level for the virt-api deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtController:
+                        description: |-
+                          VirtController specifies the log verbosity level for the virt-controller deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtHandler:
+                        description: |-
+                          VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtLauncher:
+                        description: |-
+                          VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart or workload rollout.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtOperator:
+                        description: |-
+                          VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                       virtSynchronizationController:
+                        description: |-
+                          VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                          A higher value increases the amount of logged information.
+                          Changes take effect on the fly without triggering a pod restart.
+                          Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
                         type: integer
                     type: object
                 type: object

--- a/vendor/kubevirt.io/api/core/v1/types.go
+++ b/vendor/kubevirt.io/api/core/v1/types.go
@@ -3656,15 +3656,48 @@ type DeveloperConfiguration struct {
 	ClusterProfiler bool `json:"clusterProfiler,omitempty"`
 }
 
-// LogVerbosity sets log verbosity level of  various components
+// LogVerbosity sets log verbosity level of various components.
 type LogVerbosity struct {
-	VirtAPI                       uint `json:"virtAPI,omitempty"`
-	VirtController                uint `json:"virtController,omitempty"`
-	VirtHandler                   uint `json:"virtHandler,omitempty"`
-	VirtLauncher                  uint `json:"virtLauncher,omitempty"`
-	VirtOperator                  uint `json:"virtOperator,omitempty"`
+	// VirtAPI specifies the log verbosity level for the virt-api deployment.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart.
+	// Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
+	// +optional
+	VirtAPI uint `json:"virtAPI,omitempty"`
+	// VirtController specifies the log verbosity level for the virt-controller deployment.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart.
+	// Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
+	// +optional
+	VirtController uint `json:"virtController,omitempty"`
+	// VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart.
+	// Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
+	// +optional
+	VirtHandler uint `json:"virtHandler,omitempty"`
+	// VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart or workload rollout.
+	// Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
+	// +optional
+	VirtLauncher uint `json:"virtLauncher,omitempty"`
+	// VirtOperator specifies the log verbosity level for the virt-operator deployment.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart.
+	// Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
+	// +optional
+	VirtOperator uint `json:"virtOperator,omitempty"`
+	// VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart.
+	// Common values: 2 (Info), 4 (Debug), 5 (Trace). Default: 2.
+	// +optional
 	VirtSynchronizationController uint `json:"virtSynchronizationController,omitempty"`
-	// NodeVerbosity represents a map of nodes with a specific verbosity level
+	// NodeVerbosity represents a map of node names to specific log verbosity levels.
+	// Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+	// Changes take effect on the fly without triggering a pod restart.
+	// +optional
 	NodeVerbosity map[string]uint `json:"nodeVerbosity,omitempty"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Previously, running `oc explain` on `spec.deployment.logVerbosityConfig` subfields returned empty descriptions.

This PR adds Go doc comments across the LogVerbosity API struct and regenerates the OpenAPI/CRD schema files. The updated descriptions explain the purpose of each component verbosity level and list common log levels.


**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-79956
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
