### PR TITLE
CNV-94727: Add the conversion webhook settings to the CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ else
 	TEMP_ARCH := $(UNAME_ARCH)
 endif
 
+INSTALLATION_NAMESPACE ?= kubevirt-hyperconverged
+
 ARCH ?= $(TEMP_ARCH)
 
 # Prow doesn't have docker command
@@ -37,7 +39,7 @@ DO=eval
 export JOB_TYPE=prow
 endif
 
-sanity: generate gogenerate prepare-tools-crd go-fix generate-doc validate-no-offensive-lang goimport lint-metrics lint-monitoring update-kv-fg-file
+sanity: generate gogenerate generate-crd generate-crd-for-csv go-fix generate-doc validate-no-offensive-lang goimport lint-metrics lint-monitoring update-kv-fg-file
 	go version
 	go fmt ./...
 	go mod tidy -v
@@ -62,7 +64,7 @@ build: build-operator build-csv-merger build-webhook
 build-operator: $(SOURCES) ## Build binary from source
 	go build -ldflags="${LDFLAGS}" -o _out/hyperconverged-cluster-operator ./cmd/hyperconverged-cluster-operator
 
-build-csv-merger: ## Build binary from source
+build-csv-merger: generate-crd-for-csv ## Build binary from source
 	go build -ldflags="${LDFLAGS}" -o _out/csv-merger ./tools/csv-merger
 
 build-manifest-templator: ## Build binary from source
@@ -77,7 +79,7 @@ sort-feature-gates:
 	jq 'sort_by((if .phase == "beta" then 0 elif .phase == "alpha" then 1 else 2 end), .name)' pkg/featuregatedetails/feature-gates.json > pkg/featuregatedetails/feature-gates.temp
 	mv pkg/featuregatedetails/feature-gates.temp pkg/featuregatedetails/feature-gates.json
 
-build-crd-creator: generate
+build-crd-creator: # this should run from a builder image. and so it assumes that everything is pre generated
 	go build -ldflags="${LDFLAGS}" -o _out/crd-creator ./tools/crd-creator
 
 build-manifest-splitter:
@@ -86,7 +88,7 @@ build-manifest-splitter:
 build-webhook: $(SOURCES) ## Build binary from source
 	go build -ldflags="${LDFLAGS}" -o _out/hyperconverged-cluster-webhook ./cmd/hyperconverged-cluster-webhook
 
-build-manifests: prepare-tools-crd build-csv-merger build-manifest-splitter build-manifest-templator
+build-manifests: generate-crd generate-crd-for-csv build-csv-merger build-manifest-splitter build-manifest-templator
 	DUMP_NETWORK_POLICIES=$(DUMP_NETWORK_POLICIES) ./hack/build-manifests.sh
 
 build-manifests-prev:
@@ -124,10 +126,10 @@ container-build: container-build-operator container-build-webhook container-buil
 
 build-push-multi-arch-images: build-push-multi-arch-operator-image build-push-multi-arch-webhook-image build-push-multi-arch-functest-image build-push-multi-arch-artifacts-server
 
-container-build-operator: gogenerate prepare-tools-crd
+container-build-operator: gogenerate generate-crd-for-csv
 	. "hack/cri-bin.sh" && $$CRI_BIN build --platform=linux/$(ARCH) -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) --build-arg git_sha=$(SHA) .
 
-build-push-multi-arch-operator-image: gogenerate prepare-tools-crd
+build-push-multi-arch-operator-image: gogenerate generate-crd-for-csv
 	IMAGE_NAME=$(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) SHA=SHA DOCKER_FILE=build/Dockerfile ./hack/build-push-multi-arch-images.sh
 
 container-build-webhook:
@@ -254,10 +256,12 @@ gogenerate: generate
 generate-crd: generate build-crd-creator
 	./_out/crd-creator --output-file=config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
 	@echo "the CRD file was generated in config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml"
-
-prepare-tools-crd: generate-crd
-	cp config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml ./tools/csv-merger/generated-crd.yaml
 	cp config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml ./tools/manifest-templator/generated-crd.yaml
+	@echo "the CRD file was generated in tools/manifest-templator/generated-crd.yaml"
+
+generate-crd-for-csv: build-crd-creator # this should run from a builder image. and so it assumes that everything is pre generated
+	./_out/crd-creator --output-file=./tools/csv-merger/generated-crd.yaml --webhook-name=hco-webhook --namespace=$(INSTALLATION_NAMESPACE)
+	@echo "the CRD file was generated in tools/csv-merger/generated-crd.yaml"
 
 generate: generate-feature-gates
 	./hack/generate.sh
@@ -280,10 +284,10 @@ help: ## Show this help screen
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 	@echo ''
 
-test-unit: gogenerate prepare-tools-crd
+test-unit: gogenerate generate-crd
 	./hack/unit-test.sh
 
-test-unit-coverage: gogenerate prepare-tools-crd
+test-unit-coverage: gogenerate generate-crd
 	./hack/unit-test-coverage.sh
 
 test-fuzz-api-conversion: generate

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -4,6 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   name: hyperconvergeds.hco.kubevirt.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: hyperconverged-cluster-webhook-service
+          namespace: kubevirt-hyperconverged
+          path: /convert
+          port: 4343
+      conversionReviewVersions:
+      - v1
+      - v1beta1
   group: hco.kubevirt.io
   names:
     categories:

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -4,6 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   name: hyperconvergeds.hco.kubevirt.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: hyperconverged-cluster-webhook-service
+          namespace: kubevirt-hyperconverged
+          path: /convert
+          port: 4343
+      conversionReviewVersions:
+      - v1
+      - v1beta1
   group: hco.kubevirt.io
   names:
     categories:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
@@ -4,6 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   name: hyperconvergeds.hco.kubevirt.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: hco-webhook-service
+          namespace: kubevirt-hyperconverged
+          path: /convert
+          port: 4343
+      conversionReviewVersions:
+      - v1
+      - v1beta1
   group: hco.kubevirt.io
   names:
     categories:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
@@ -4,6 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   name: hyperconvergeds.hco.kubevirt.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: hco-webhook-service
+          namespace: kubevirt-hyperconverged
+          path: /convert
+          port: 4343
+      conversionReviewVersions:
+      - v1
+      - v1beta1
   group: hco.kubevirt.io
   names:
     categories:

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -460,6 +460,7 @@ rendered_keywords="$(echo "$rendered_csv" |grep 'keywords' -A 3)"
 rm -f ${CRD_DIR}/*
 cp -f ${TEMPDIR}/*.${CRD_EXT} ${CRD_DIR}
 cp -f ${TEMPDIR}/*.${CRD_EXT} ${CSV_DIR}
+cp tools/csv-merger/generated-crd.yaml ${CSV_DIR}/hco00.crd.yaml
 
 # Validate the yaml files
 (cd ${CRD_DIR} && $CRI_BIN run --rm -v "$(pwd)":/yaml quay.io/pusher/yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable}}" /yaml)

--- a/tools/crd-creator/crd-creator.go
+++ b/tools/crd-creator/crd-creator.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 
+	hcov1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1"
 	hcov1beta1 "github.com/kubevirt/hyperconverged-cluster-operator/api/v1beta1"
 	hcoutil "github.com/kubevirt/hyperconverged-cluster-operator/pkg/util"
 	"github.com/kubevirt/hyperconverged-cluster-operator/tools/util"
@@ -22,14 +23,21 @@ import (
 const (
 	objectType = "object"
 	importPath = "github.com/kubevirt/hyperconverged-cluster-operator/api/..."
+
+	defaultNamespace   = "kubevirt-hyperconverged"
+	defaultWebhookName = hcoutil.HCOWebhookName
 )
 
 var (
-	fileName string
+	fileName    string
+	namespace   string
+	webhookName string
 )
 
 func init() {
 	flag.StringVar(&fileName, "output-file", "", "CRD output file name")
+	flag.StringVar(&namespace, "namespace", defaultNamespace, "the installation namespace")
+	flag.StringVar(&webhookName, "webhook-name", defaultWebhookName, "the webhook deployment name, to generate the service name out of it")
 
 	flag.Parse()
 }
@@ -101,11 +109,27 @@ func getOperatorCRD() (*extv1.CustomResourceDefinition, error) {
 			Properties: map[string]extv1.JSONSchemaProps{
 				"name": {
 					Type:    "string",
-					Pattern: hcov1beta1.HyperConvergedName,
+					Pattern: hcov1.HyperConvergedName,
 				},
 			},
 		}
 	}
+
+	c.Spec.Conversion = &extv1.CustomResourceConversion{
+		Strategy: extv1.WebhookConverter,
+		Webhook: &extv1.WebhookConversion{
+			ClientConfig: &extv1.WebhookClientConfig{
+				Service: &extv1.ServiceReference{
+					Namespace: namespace,
+					Name:      webhookName + "-service",
+					Path:      new(hcoutil.HCOConversionWebhookPath),
+					Port:      new(int32(hcoutil.WebhookPort)),
+				},
+			},
+			ConversionReviewVersions: []string{hcov1.APIVersionV1, hcov1beta1.APIVersionBeta},
+		},
+	}
+
 	return &c, nil
 }
 

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -4,6 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   name: hyperconvergeds.hco.kubevirt.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: hco-webhook-service
+          namespace: kubevirt-hyperconverged
+          path: /convert
+          port: 4343
+      conversionReviewVersions:
+      - v1
+      - v1beta1
   group: hco.kubevirt.io
   names:
     categories:

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -4,6 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   name: hyperconvergeds.hco.kubevirt.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: hyperconverged-cluster-webhook-service
+          namespace: kubevirt-hyperconverged
+          path: /convert
+          port: 4343
+      conversionReviewVersions:
+      - v1
+      - v1beta1
   group: hco.kubevirt.io
   names:
     categories:


### PR DESCRIPTION
**What this PR does / why we need it**:

We have a race condition on upgrade, where OLM replaces the CRD with the new version's one. That removes the conversion webhook configurations from the CRD, until the webhook restores them. Since we moved to v1 as the stored API version, any update to the HyperConverged CR at this point, will skip the conversion webhook, and will corrupt the CR.

To fix this, we now adding the webhook configurations to the CRD.

We must use different service name, and to allow modifiying the namespace. For that, the csv generator tool accepts two new parameters. When generating CRD for the CSV generator, we're using the CSV webhook deployment name.

Fixes: #4549

**Jira Ticket**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-94727
```

**Release note**:
```release-note
Fix CNV-94727
```
