### PR TITLE
CNV-96764: [1.19] fix observability controller TLS settings

### DIFF
--- a/controllers/handlers/observabilitycontroller/deployment.go
+++ b/controllers/handlers/observabilitycontroller/deployment.go
@@ -69,7 +69,7 @@ func newDeployment(hc *hcov1.HyperConverged) *appsv1.Deployment {
 		args = append(args, "--tls-min-version="+string(profile.Custom.MinTLSVersion))
 
 		if profile.Custom.MinTLSVersion < openshiftconfigv1.VersionTLS13 && len(profile.Custom.Ciphers) > 0 {
-			args = append(args, "--tls-cipher-suites="+strings.Join(profile.Custom.Ciphers, ","))
+			args = append(args, "--tls-ciphers="+strings.Join(profile.Custom.Ciphers, ","))
 		}
 	}
 

--- a/controllers/handlers/observabilitycontroller/deployment_test.go
+++ b/controllers/handlers/observabilitycontroller/deployment_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Observability Controller Deployment", func() {
 			args := containerArgs()
 			Expect(args).To(ContainElement("--tls-security-profile=Custom"))
 			Expect(args).To(ContainElement("--tls-min-version=VersionTLS12"))
-			Expect(args).To(ContainElement("--tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384"))
+			Expect(args).To(ContainElement("--tls-ciphers=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384"))
 		})
 
 		It("should not add cipher suites for Custom profile with TLS 1.3", func() {
@@ -154,7 +154,7 @@ var _ = Describe("Observability Controller Deployment", func() {
 			args := containerArgs()
 			Expect(args).To(ContainElement("--tls-security-profile=Custom"))
 			Expect(args).To(ContainElement("--tls-min-version=VersionTLS13"))
-			Expect(args).ToNot(ContainElement(ContainSubstring("--tls-cipher-suites")))
+			Expect(args).ToNot(ContainElement(ContainSubstring("--tls-ciphers")))
 		})
 
 		It("should not add cipher suites for Custom profile when cipher list is empty", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

HCO sets the TLS cipher configurations in the observability controller deployment, with the wrong command line argument, getting the observability controller pod into crash loop.

This PR fixes the issue by using the correct command line argument of `--tls-ciphers`.

**Jira Ticket**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-96764
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
