### PR TITLE
CNV-96807: Deprecate the `v1betae1` API version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ generate: generate-feature-gates
 
 generate-doc: build-docgen
 	_out/docgen --in=./api/v1/hyperconverged_types.go --feature-gates=pkg/featuregatedetails/feature-gates.json > docs/api.md
-	_out/docgen --in=./api/v1beta1/hyperconverged_types.go > docs/api-v1beta1.md
+	_out/docgen --in=./api/v1beta1/hyperconverged_types.go --api-version=v1beta1 --deprecated > docs/api-v1beta1.md
 	_out/metricsdocs > docs/metrics.md
 
 build-docgen:

--- a/api/v1beta1/hyperconverged_types.go
+++ b/api/v1beta1/hyperconverged_types.go
@@ -623,6 +623,7 @@ type ApplicationAwareConfigurations struct {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:resource:scope=Namespaced,categories={all},shortName={hco,hcos}
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="The v1beta1 API version is deprecated, and will be removed in a future version of HCO; use the v1 API version instead"
 type HyperConverged struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
+++ b/config/crd/bases/hco.kubevirt.io_hyperconvergeds.yaml
@@ -5534,6 +5534,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1beta1 API version is deprecated, and will be removed
+      in a future version of HCO; use the v1 API version instead
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/deploy/crds/hco00.crd.yaml
+++ b/deploy/crds/hco00.crd.yaml
@@ -5534,6 +5534,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1beta1 API version is deprecated, and will be removed
+      in a future version of HCO; use the v1 API version instead
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/deploy/index-image/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
+++ b/deploy/index-image/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
@@ -5534,6 +5534,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1beta1 API version is deprecated, and will be removed
+      in a future version of HCO; use the v1 API version instead
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/deploy/olm-catalog/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
+++ b/deploy/olm-catalog/community-kubevirt-hyperconverged/1.20.0/manifests/hco00.crd.yaml
@@ -5534,6 +5534,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1beta1 API version is deprecated, and will be removed
+      in a future version of HCO; use the v1 API version instead
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/docs/api-v1beta1.md
+++ b/docs/api-v1beta1.md
@@ -1,8 +1,10 @@
-# API Docs
+# v1beta1 API Documentation
 
-This Document documents the types introduced by the hyperconverged-cluster-operator to be consumed by users.
+This Document documents the `v1beta1` API version's types introduced by the hyperconverged-cluster-operator, to be consumed by users.
 
 > Note this document is generated from code comments. When contributing a change to this document please do so by changing the code comments.
+
+> **WARNING**: The `v1beta1` API version is deprecated and will be removed in a future version of HCO; Use the `v1` API version instead.
 
 ## Table of Contents
 * [ApplicationAwareConfigurations](#applicationawareconfigurations)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
-# API Docs
+# v1 API Documentation
 
-This Document documents the types introduced by the hyperconverged-cluster-operator to be consumed by users.
+This Document documents the `v1` API version's types introduced by the hyperconverged-cluster-operator, to be consumed by users.
 
 > Note this document is generated from code comments. When contributing a change to this document please do so by changing the code comments.
 

--- a/docs/cluster-configuration-v1beta1-api.md
+++ b/docs/cluster-configuration-v1beta1-api.md
@@ -1,4 +1,7 @@
 # Cluster Configuration
+
+> **WARNING**: The `v1beta1` API version of the HyperConverged kind is deprecated and will be removed in a future version of HCO. Use the `v1` API version instead.
+
 ## Introduction
 The HyperConverged Cluster allows modifying the KubeVirt cluster configuration by editing the HyperConverged Cluster CR
 (Custom Resource).

--- a/tools/csv-merger/generated-crd.yaml
+++ b/tools/csv-merger/generated-crd.yaml
@@ -5534,6 +5534,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1beta1 API version is deprecated, and will be removed
+      in a future version of HCO; use the v1 API version instead
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/tools/docgen/api.md.gotemplate
+++ b/tools/docgen/api.md.gotemplate
@@ -42,12 +42,14 @@ A feature gate may be in the following phases:
 {{- end -}}
 {{ define "toc-line" }}* [{{ .Name }}](#{{ .Name | ToLower }}){{ end }}
 {{- /* the document starts here */ -}}
-# API Docs
+# {{.APIVersion}} API Documentation
 
-This Document documents the types introduced by the hyperconverged-cluster-operator to be consumed by users.
+This Document documents the `{{ .APIVersion }}` API version's types introduced by the hyperconverged-cluster-operator, to be consumed by users.
 
 > Note this document is generated from code comments. When contributing a change to this document please do so by changing the code comments.
-
+{{ if .IsDeprecated }}
+> **WARNING**: The `{{.APIVersion}}` API version is deprecated and will be removed in a future version of HCO; Use the `v1` API version instead.
+{{ end }}
 ## Table of Contents
 {{- range .KubeTypes }}
 {{ template "toc-line" . | FirstItem -}}

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -66,8 +66,10 @@ const (
 )
 
 type config struct {
+	apiVersion      string
 	inputFiles      string
 	featureGateFile string
+	isDeprecated    bool
 }
 
 func main() {
@@ -89,7 +91,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = printAPIDocs(os.Stdout, types, cfg.featureGateFile)
+	err = printAPIDocs(os.Stdout, types, cfg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -99,8 +101,10 @@ func main() {
 func getConfig() config {
 	cfg := config{}
 
+	flag.StringVar(&cfg.apiVersion, "api-version", "v1", "the API version for this document")
 	flag.StringVar(&cfg.inputFiles, "in", "", "comma separated list of input files")
 	flag.StringVar(&cfg.featureGateFile, "feature-gates", "", "feature gate file")
+	flag.BoolVar(&cfg.isDeprecated, "deprecated", false, "deprecated flag set to true")
 
 	flag.Parse()
 
@@ -138,6 +142,8 @@ type typeInfo struct {
 type KubeTypes []typeInfo
 
 type DocInfo struct {
+	APIVersion   string
+	IsDeprecated bool
 	KubeTypes    []KubeTypes
 	FeatureGates featuregates.FeatureGates
 }
@@ -411,7 +417,7 @@ func setK8sLinks() error {
 //go:embed api.md.gotemplate
 var templateFile embed.FS
 
-func printAPIDocs(w io.Writer, types []KubeTypes, featureGateFile string) error {
+func printAPIDocs(w io.Writer, types []KubeTypes, cfg config) error {
 	funcMap := template.FuncMap{
 		"ToLower": strings.ToLower,
 		"FirstItem": func(kubeTypes KubeTypes) typeInfo {
@@ -428,11 +434,13 @@ func printAPIDocs(w io.Writer, types []KubeTypes, featureGateFile string) error 
 	}
 
 	docInfo := DocInfo{
-		KubeTypes: types,
+		APIVersion:   cfg.apiVersion,
+		IsDeprecated: cfg.isDeprecated,
+		KubeTypes:    types,
 	}
 
-	if featureGateFile != "" {
-		err2 := handleFeatureGates(featureGateFile, types, &docInfo)
+	if cfg.featureGateFile != "" {
+		err2 := handleFeatureGates(cfg.featureGateFile, types, &docInfo)
 		if err2 != nil {
 			return err2
 		}

--- a/tools/manifest-templator/generated-crd.yaml
+++ b/tools/manifest-templator/generated-crd.yaml
@@ -5534,6 +5534,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1beta1 API version is deprecated, and will be removed
+      in a future version of HCO; use the v1 API version instead
     name: v1beta1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a deprecation warning to the `v1beta1` version in the CRD. Add deprecation warning to the v1beta1 documents.

This will trigger a warning to the user when using the v1beta1 API version.

**Jira Ticket**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-96807
```

**Release note**:
```release-note
Deprecate the `v1betae1` API version
```
