### PR TITLE
[release-1.19] Add openshift.io/required-scc annotation to virt-observability-controller

### DIFF
--- a/controllers/handlers/observabilitycontroller/deployment.go
+++ b/controllers/handlers/observabilitycontroller/deployment.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -94,6 +95,9 @@ func newDeployment(hc *hcov1.HyperConverged) *appsv1.Deployment {
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: podLabels,
+				Annotations: map[string]string{
+					securityv1.RequiredSCCAnnotation: "restricted-v2",
+				},
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: serviceAccountName,

--- a/controllers/handlers/observabilitycontroller/deployment_test.go
+++ b/controllers/handlers/observabilitycontroller/deployment_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,6 +56,8 @@ var _ = Describe("Observability Controller Deployment", func() {
 			Expect(dep.Spec.Replicas).To(HaveValue(Equal(int32(1))))
 			Expect(dep.Spec.Selector.MatchLabels).To(HaveKeyWithValue(hcoutil.AppLabel, hcoutil.HyperConvergedName))
 			Expect(dep.Spec.Selector.MatchLabels).To(HaveKeyWithValue(hcoutil.AppLabelComponent, string(hcoutil.AppComponentObservability)))
+
+			Expect(dep.Spec.Template.Annotations).To(HaveKeyWithValue(securityv1.RequiredSCCAnnotation, "restricted-v2"))
 
 			Expect(dep.Spec.Template.Spec.ServiceAccountName).To(Equal(serviceAccountName))
 			Expect(dep.Spec.Template.Spec.PriorityClassName).To(Equal("system-cluster-critical"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

manual cherry pick of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/4576

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-95828
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add openshift.io/required-scc annotation to virt-observability-controller
```
