### PR TITLE
CNV-97074: [1.19] Always enable the `RebootPolicy` in KubeVirt

### DIFF
--- a/controllers/handlers/kubevirt.go
+++ b/controllers/handlers/kubevirt.go
@@ -100,6 +100,11 @@ const (
 
 	// Enable the installation of the KubeVirt seccomp profile
 	kvKubevirtSeccompProfile = "KubevirtSeccompProfile"
+
+	// Enables setting the RebootPolicy field on VMI's DomainSpec
+	// which allows terminating the VMI on guest reboot instead of silently rebooting,
+	// enabling the VM controller to recreate the VMI with updated configuration.
+	kvRebootPolicy = "RebootPolicy"
 )
 
 // KubeVirt architecture dependant feature gates.
@@ -115,6 +120,7 @@ var (
 		kvSnapshotGate,
 		kvHostDevicesGate,
 		kvKubevirtSeccompProfile,
+		kvRebootPolicy,
 	}
 
 	// holds a list of mandatory KubeVirt feature gates. Some of them are the hard coded feature gates and some of

--- a/controllers/hyperconverged/hyperconverged_controller_test.go
+++ b/controllers/hyperconverged/hyperconverged_controller_test.go
@@ -213,6 +213,7 @@ var _ = Describe("HyperconvergedController", func() {
 					"KubevirtSeccompProfile",
 					"DecentralizedLiveMigration",
 					"Template",
+					"RebootPolicy",
 				}
 				// Get the KV
 				kvList := &kubevirtcorev1.KubeVirtList{}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the CNV-97074 bug: Add the missing `RebootPolicy` feature gate to the KubeVirt CR.

**Jira Ticket**:
```jira-ticket
https://redhat.atlassian.net/browse/CNV-97074
```

**Release note**:
```release-note
Always enable the `RebootPolicy` in KubeVirt
```
